### PR TITLE
Allow reordering items in Queue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3906,6 +3906,9 @@
       "name": "workcenter",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@workcenter/shared": "*"
+      },
       "devDependencies": {
         "@types/node": "^20.11.0",
         "@types/vscode": "^1.85.0",
@@ -3924,6 +3927,9 @@
       "name": "workcenter-github",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@workcenter/shared": "*"
+      },
       "devDependencies": {
         "@types/node": "^20.11.0",
         "@types/vscode": "^1.85.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -121,6 +121,18 @@
         "icon": "$(play)"
       },
       {
+        "command": "workcenter.moveUp",
+        "title": "Move Up",
+        "category": "WorkCenter",
+        "icon": "$(arrow-up)"
+      },
+      {
+        "command": "workcenter.moveDown",
+        "title": "Move Down",
+        "category": "WorkCenter",
+        "icon": "$(arrow-down)"
+      },
+      {
         "command": "workcenter.acceptFromInbox",
         "title": "Accept to Queue",
         "category": "WorkCenter",
@@ -187,6 +199,16 @@
           "command": "workcenter.editItem",
           "when": "view == workcenter.focus",
           "group": "1_actions"
+        },
+        {
+          "command": "workcenter.moveUp",
+          "when": "view == workcenter.queue",
+          "group": "3_reorder"
+        },
+        {
+          "command": "workcenter.moveDown",
+          "when": "view == workcenter.queue",
+          "group": "3_reorder"
         },
         {
           "command": "workcenter.openInBrowser",

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -77,6 +77,12 @@ export function registerCommands(
         }
       }
     }),
+    vscode.commands.registerCommand('workcenter.moveUp', (item) =>
+      workGraph.moveItem(item.id, 'up'),
+    ),
+    vscode.commands.registerCommand('workcenter.moveDown', (item) =>
+      workGraph.moveItem(item.id, 'down'),
+    ),
     vscode.commands.registerCommand('workcenter.acceptFromInbox', async (item: InboxItem) => {
       logger.info(`Accepting inbox item: ${item.externalId} from ${item.providerId}`);
       const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -77,12 +77,20 @@ export function registerCommands(
         }
       }
     }),
-    vscode.commands.registerCommand('workcenter.moveUp', (item) =>
-      workGraph.moveItem(item.id, 'up'),
-    ),
-    vscode.commands.registerCommand('workcenter.moveDown', (item) =>
-      workGraph.moveItem(item.id, 'down'),
-    ),
+    vscode.commands.registerCommand('workcenter.moveUp', (item) => {
+      if (!item?.id) {
+        vscode.window.showInformationMessage('WorkCenter: Select an item in the Queue to move.');
+        return;
+      }
+      return workGraph.moveItem(item.id, 'up');
+    }),
+    vscode.commands.registerCommand('workcenter.moveDown', (item) => {
+      if (!item?.id) {
+        vscode.window.showInformationMessage('WorkCenter: Select an item in the Queue to move.');
+        return;
+      }
+      return workGraph.moveItem(item.id, 'down');
+    }),
     vscode.commands.registerCommand('workcenter.acceptFromInbox', async (item: InboxItem) => {
       logger.info(`Accepting inbox item: ${item.externalId} from ${item.providerId}`);
       const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -104,7 +104,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
       inboxTreeView.message = hasInboxItems ? undefined : 'No new items';
     }
   };
-  const queueTreeView = vscode.window.createTreeView('workcenter.queue', { treeDataProvider: queueProvider });
+  const queueTreeView = vscode.window.createTreeView('workcenter.queue', { treeDataProvider: queueProvider, dragAndDropController: queueProvider });
   const focusTreeView = vscode.window.createTreeView('workcenter.focus', { treeDataProvider: focusProvider });
 
   const updateQueueFocusMessages = () => {

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -16,6 +16,7 @@ export interface WorkItem {
   providerId?: string;
   externalId?: string;
   url?: string;
+  sortOrder?: number;
   createdAt: number;
   updatedAt: number;
 }

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -99,6 +99,16 @@ export class WorkGraph {
     const siblings = this.getItemsByState(item.state)
       .sort((a, b) => (a.sortOrder ?? Infinity) - (b.sortOrder ?? Infinity));
 
+    // Normalize any missing sortOrder values so swaps are consistent
+    for (let i = 0; i < siblings.length; i++) {
+      if (siblings[i].sortOrder === undefined) {
+        const normalized = { ...siblings[i], sortOrder: i, updatedAt: Date.now() };
+        siblings[i] = normalized;
+        this.items.set(normalized.id, normalized);
+        await this.store.save(normalized);
+      }
+    }
+
     const index = siblings.findIndex((s) => s.id === id);
     if (index === -1) {
       return;
@@ -109,13 +119,11 @@ export class WorkGraph {
       return;
     }
 
-    // Only swap the two items' sortOrders - don't touch others
-    const itemOrder = item.sortOrder ?? index;
+    const currentItem = siblings[index];
     const swapItem = siblings[swapIndex];
-    const swapOrder = swapItem.sortOrder ?? swapIndex;
 
-    const updatedItem = { ...item, sortOrder: swapOrder, updatedAt: Date.now() };
-    const updatedSwap = { ...swapItem, sortOrder: itemOrder, updatedAt: Date.now() };
+    const updatedItem = { ...currentItem, sortOrder: swapItem.sortOrder, updatedAt: Date.now() };
+    const updatedSwap = { ...swapItem, sortOrder: currentItem.sortOrder, updatedAt: Date.now() };
 
     await this.store.save(updatedItem);
     await this.store.save(updatedSwap);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -175,11 +175,16 @@ export class WorkGraph {
     const siblings = this.getItemsByState(dragged.state)
       .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
 
-    const withoutDragged = siblings.filter(s => s.id !== draggedId);
-    const targetIndex = withoutDragged.findIndex(s => s.id === targetId);
-    if (targetIndex === -1) { return; }
+    const draggedIndex = siblings.findIndex(s => s.id === draggedId);
+    const targetIndex = siblings.findIndex(s => s.id === targetId);
+    if (draggedIndex === -1 || targetIndex === -1) { return; }
 
-    withoutDragged.splice(targetIndex, 0, dragged);
+    const withoutDragged = siblings.filter(s => s.id !== draggedId);
+    const newTargetIndex = withoutDragged.findIndex(s => s.id === targetId);
+
+    // Insert after target when dragging down, before target when dragging up
+    const insertIndex = draggedIndex < targetIndex ? newTargetIndex + 1 : newTargetIndex;
+    withoutDragged.splice(insertIndex, 0, dragged);
 
     const itemsToSave: WorkItem[] = [];
     withoutDragged.forEach((item, i) => {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -160,6 +160,35 @@ export class WorkGraph {
     this._onDidChange.fire();
   }
 
+  async reorderItem(draggedId: string, targetId: string): Promise<void> {
+    const dragged = this.items.get(draggedId);
+    const target = this.items.get(targetId);
+    if (!dragged || !target) { return; }
+
+    const siblings = this.getItemsByState(dragged.state)
+      .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
+
+    const withoutDragged = siblings.filter(s => s.id !== draggedId);
+    const targetIndex = withoutDragged.findIndex(s => s.id === targetId);
+    if (targetIndex === -1) { return; }
+
+    withoutDragged.splice(targetIndex, 0, dragged);
+
+    const itemsToSave: WorkItem[] = [];
+    withoutDragged.forEach((item, i) => {
+      if (item.sortOrder !== i) {
+        const updated = { ...item, sortOrder: i, updatedAt: Date.now() };
+        this.items.set(updated.id, updated);
+        itemsToSave.push(updated);
+      }
+    });
+
+    if (itemsToSave.length > 0) {
+      await this.store.saveAll(itemsToSave);
+      this._onDidChange.fire();
+    }
+  }
+
   async deleteItem(id: string): Promise<void> {
     await this.store.delete(id);
     this.items.delete(id);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -41,6 +41,8 @@ export class WorkGraph {
     input: WorkItemInput,
     provenance?: { providerId: string; externalId: string; url?: string },
   ): Promise<WorkItem> {
+    const existingItems = this.getItemsByState(WorkItemState.New);
+    const maxOrder = existingItems.reduce((max, i) => Math.max(max, i.sortOrder ?? -1), -1);
     const item: WorkItem = {
       id: generateId(),
       title: input.title,
@@ -49,6 +51,7 @@ export class WorkGraph {
       providerId: provenance?.providerId,
       externalId: provenance?.externalId,
       url: provenance?.url,
+      sortOrder: maxOrder + 1,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     };
@@ -81,6 +84,43 @@ export class WorkGraph {
     this.items.set(id, updated);
     this._onDidChange.fire();
     logger.info(`Transitioned work item ${id} to ${newState}`);
+  }
+
+  async moveItem(id: string, direction: 'up' | 'down'): Promise<void> {
+    const item = this.items.get(id);
+    if (!item) {
+      throw new Error(`Work item not found: ${id}`);
+    }
+
+    const siblings = this.getItemsByState(item.state)
+      .sort((a, b) => (a.sortOrder ?? Infinity) - (b.sortOrder ?? Infinity));
+
+    const index = siblings.findIndex((s) => s.id === id);
+    if (index === -1) {
+      return;
+    }
+
+    const swapIndex = direction === 'up' ? index - 1 : index + 1;
+    if (swapIndex < 0 || swapIndex >= siblings.length) {
+      return;
+    }
+
+    // Normalize sort orders before swapping
+    siblings.forEach((s, i) => {
+      s.sortOrder = i;
+    });
+
+    const temp = siblings[index].sortOrder!;
+    siblings[index].sortOrder = siblings[swapIndex].sortOrder!;
+    siblings[swapIndex].sortOrder = temp;
+
+    siblings[index].updatedAt = Date.now();
+    siblings[swapIndex].updatedAt = Date.now();
+    await this.store.save(siblings[index]);
+    await this.store.save(siblings[swapIndex]);
+    this.items.set(siblings[index].id, siblings[index]);
+    this.items.set(siblings[swapIndex].id, siblings[swapIndex]);
+    this._onDidChange.fire();
   }
 
   async deleteItem(id: string): Promise<void> {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -197,11 +197,28 @@ export class WorkGraph {
     const siblings = this.getItemsByState(item.state)
       .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
 
-    const maxOrder = siblings.length > 0 ? Math.max(...siblings.map(s => s.sortOrder ?? 0)) : 0;
-    const updated = { ...item, sortOrder: maxOrder + 1, updatedAt: Date.now() };
-    await this.store.save(updated);
-    this.items.set(id, updated);
-    this._onDidChange.fire();
+    if (siblings.length === 0) { return; }
+
+    const lastSibling = siblings[siblings.length - 1];
+    if (lastSibling.id === item.id) { return; }
+
+    // Re-index siblings with the item moved to the end to keep orders compact
+    const withoutItem = siblings.filter(s => s.id !== item.id);
+    withoutItem.push(item);
+
+    const itemsToSave: WorkItem[] = [];
+    withoutItem.forEach((sibling, index) => {
+      if (sibling.sortOrder !== index) {
+        const updated = { ...sibling, sortOrder: index, updatedAt: Date.now() };
+        this.items.set(updated.id, updated);
+        itemsToSave.push(updated);
+      }
+    });
+
+    if (itemsToSave.length > 0) {
+      await this.store.saveAll(itemsToSave);
+      this._onDidChange.fire();
+    }
   }
 
   async deleteItem(id: string): Promise<void> {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -100,13 +100,17 @@ export class WorkGraph {
       .sort((a, b) => (a.sortOrder ?? Infinity) - (b.sortOrder ?? Infinity));
 
     // Normalize any missing sortOrder values so swaps are consistent
+    const toNormalize: WorkItem[] = [];
     for (let i = 0; i < siblings.length; i++) {
       if (siblings[i].sortOrder === undefined) {
         const normalized = { ...siblings[i], sortOrder: i, updatedAt: Date.now() };
         siblings[i] = normalized;
         this.items.set(normalized.id, normalized);
-        await this.store.save(normalized);
+        toNormalize.push(normalized);
       }
+    }
+    if (toNormalize.length > 0) {
+      await this.store.saveAll(toNormalize);
     }
 
     const index = siblings.findIndex((s) => s.id === id);
@@ -125,8 +129,7 @@ export class WorkGraph {
     const updatedItem = { ...currentItem, sortOrder: swapItem.sortOrder, updatedAt: Date.now() };
     const updatedSwap = { ...swapItem, sortOrder: currentItem.sortOrder, updatedAt: Date.now() };
 
-    await this.store.save(updatedItem);
-    await this.store.save(updatedSwap);
+    await this.store.saveAll([updatedItem, updatedSwap]);
     this.items.set(updatedItem.id, updatedItem);
     this.items.set(updatedSwap.id, updatedSwap);
     this._onDidChange.fire();

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -164,6 +164,7 @@ export class WorkGraph {
     const dragged = this.items.get(draggedId);
     const target = this.items.get(targetId);
     if (!dragged || !target) { return; }
+    if (dragged.state !== target.state) { return; }
 
     const siblings = this.getItemsByState(dragged.state)
       .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
@@ -187,6 +188,20 @@ export class WorkGraph {
       await this.store.saveAll(itemsToSave);
       this._onDidChange.fire();
     }
+  }
+
+  async moveToEnd(id: string): Promise<void> {
+    const item = this.items.get(id);
+    if (!item) { return; }
+
+    const siblings = this.getItemsByState(item.state)
+      .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
+
+    const maxOrder = siblings.length > 0 ? Math.max(...siblings.map(s => s.sortOrder ?? 0)) : 0;
+    const updated = { ...item, sortOrder: maxOrder + 1, updatedAt: Date.now() };
+    await this.store.save(updated);
+    this.items.set(id, updated);
+    this._onDidChange.fire();
   }
 
   async deleteItem(id: string): Promise<void> {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -38,10 +38,14 @@ export class WorkGraph {
     const toSave: WorkItem[] = [];
     for (let i = 0; i < unordered.length; i++) {
       const updated = { ...unordered[i], sortOrder: maxExisting + 1 + i, updatedAt: Date.now() };
-      this.items.set(updated.id, updated);
       toSave.push(updated);
     }
+
     await this.store.saveAll(toSave);
+
+    for (const updated of toSave) {
+      this.items.set(updated.id, updated);
+    }
   }
 
   getAll(): WorkItem[] {
@@ -130,12 +134,14 @@ export class WorkGraph {
       if (siblings[i].sortOrder === undefined) {
         const normalized = { ...siblings[i], sortOrder: i, updatedAt: Date.now() };
         siblings[i] = normalized;
-        this.items.set(normalized.id, normalized);
         toNormalize.push(normalized);
       }
     }
     if (toNormalize.length > 0) {
       await this.store.saveAll(toNormalize);
+      for (const normalized of toNormalize) {
+        this.items.set(normalized.id, normalized);
+      }
     }
 
     const index = siblings.findIndex((s) => s.id === id);
@@ -179,13 +185,15 @@ export class WorkGraph {
     withoutDragged.forEach((item, i) => {
       if (item.sortOrder !== i) {
         const updated = { ...item, sortOrder: i, updatedAt: Date.now() };
-        this.items.set(updated.id, updated);
         itemsToSave.push(updated);
       }
     });
 
     if (itemsToSave.length > 0) {
       await this.store.saveAll(itemsToSave);
+      for (const updated of itemsToSave) {
+        this.items.set(updated.id, updated);
+      }
       this._onDidChange.fire();
     }
   }
@@ -210,13 +218,15 @@ export class WorkGraph {
     withoutItem.forEach((sibling, index) => {
       if (sibling.sortOrder !== index) {
         const updated = { ...sibling, sortOrder: index, updatedAt: Date.now() };
-        this.items.set(updated.id, updated);
         itemsToSave.push(updated);
       }
     });
 
     if (itemsToSave.length > 0) {
       await this.store.saveAll(itemsToSave);
+      for (const updated of itemsToSave) {
+        this.items.set(updated.id, updated);
+      }
       this._onDidChange.fire();
     }
   }

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -171,8 +171,9 @@ export class WorkGraph {
     const target = this.items.get(targetId);
     if (!dragged || !target) { return; }
     if (dragged.state !== target.state) { return; }
+    if (draggedId === targetId) { return; }
 
-    const siblings = this.getItemsByState(dragged.state)
+    const siblings= this.getItemsByState(dragged.state)
       .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
 
     const draggedIndex = siblings.findIndex(s => s.id === draggedId);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -42,7 +42,11 @@ export class WorkGraph {
     provenance?: { providerId: string; externalId: string; url?: string },
   ): Promise<WorkItem> {
     const existingItems = this.getItemsByState(WorkItemState.New);
-    const maxOrder = existingItems.reduce((max, i) => Math.max(max, i.sortOrder ?? -1), -1);
+    // Account for legacy items that may not have sortOrder assigned
+    const maxOrder = Math.max(
+      existingItems.length - 1,
+      existingItems.reduce((max, i) => Math.max(max, i.sortOrder ?? -1), -1),
+    );
     const item: WorkItem = {
       id: generateId(),
       title: input.title,

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -17,6 +17,31 @@ export class WorkGraph {
       this.items.set(item.id, item);
     }
     logger.debug(`Loaded ${items.length} work items from store`);
+    await this.backfillSortOrder();
+  }
+
+  private async backfillSortOrder(): Promise<void> {
+    const newItems = this.getItemsByState(WorkItemState.New);
+    const unordered = newItems.filter((i) => i.sortOrder === undefined);
+    if (unordered.length === 0) {
+      return;
+    }
+
+    const maxExisting = newItems.reduce(
+      (max, i) => Math.max(max, i.sortOrder ?? -1),
+      -1,
+    );
+
+    // Sort unordered items by title for a stable initial ordering
+    unordered.sort((a, b) => a.title.localeCompare(b.title));
+
+    const toSave: WorkItem[] = [];
+    for (let i = 0; i < unordered.length; i++) {
+      const updated = { ...unordered[i], sortOrder: maxExisting + 1 + i, updatedAt: Date.now() };
+      this.items.set(updated.id, updated);
+      toSave.push(updated);
+    }
+    await this.store.saveAll(toSave);
   }
 
   getAll(): WorkItem[] {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -97,7 +97,7 @@ export class WorkGraph {
     }
 
     const siblings = this.getItemsByState(item.state)
-      .sort((a, b) => (a.sortOrder ?? Infinity) - (b.sortOrder ?? Infinity));
+      .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
 
     // Normalize any missing sortOrder values so swaps are consistent
     const toNormalize: WorkItem[] = [];

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -105,21 +105,18 @@ export class WorkGraph {
       return;
     }
 
-    // Normalize sort orders before swapping
-    siblings.forEach((s, i) => {
-      s.sortOrder = i;
-    });
+    // Only swap the two items' sortOrders - don't touch others
+    const itemOrder = item.sortOrder ?? index;
+    const swapItem = siblings[swapIndex];
+    const swapOrder = swapItem.sortOrder ?? swapIndex;
 
-    const temp = siblings[index].sortOrder!;
-    siblings[index].sortOrder = siblings[swapIndex].sortOrder!;
-    siblings[swapIndex].sortOrder = temp;
+    const updatedItem = { ...item, sortOrder: swapOrder, updatedAt: Date.now() };
+    const updatedSwap = { ...swapItem, sortOrder: itemOrder, updatedAt: Date.now() };
 
-    siblings[index].updatedAt = Date.now();
-    siblings[swapIndex].updatedAt = Date.now();
-    await this.store.save(siblings[index]);
-    await this.store.save(siblings[swapIndex]);
-    this.items.set(siblings[index].id, siblings[index]);
-    this.items.set(siblings[swapIndex].id, siblings[swapIndex]);
+    await this.store.save(updatedItem);
+    await this.store.save(updatedSwap);
+    this.items.set(updatedItem.id, updatedItem);
+    this.items.set(updatedSwap.id, updatedSwap);
     this._onDidChange.fire();
   }
 

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -61,6 +61,33 @@ export class JsonTaskStore implements ITaskStore {
     });
   }
 
+  async saveAll(items: WorkItem[]): Promise<void> {
+    return this.enqueue(async () => {
+      if (this.cache === null) {
+        await this.loadAll();
+      }
+      const previousValues = new Map(items.map(i => [i.id, this.cache!.get(i.id)]));
+      try {
+        const ids = new Set(items.map(i => i.id));
+        const remaining = Array.from(this.cache!.values()).filter(i => !ids.has(i.id));
+        remaining.push(...items);
+        await this.writeFile(remaining);
+        for (const item of items) {
+          this.cache!.set(item.id, item);
+        }
+      } catch (err) {
+        for (const [id, prev] of previousValues) {
+          if (prev) {
+            this.cache!.set(id, prev);
+          } else {
+            this.cache!.delete(id);
+          }
+        }
+        throw err;
+      }
+    });
+  }
+
   async delete(id: string): Promise<void> {
     return this.enqueue(async () => {
       if (this.cache === null) {

--- a/packages/core/src/storage/taskStore.ts
+++ b/packages/core/src/storage/taskStore.ts
@@ -3,5 +3,6 @@ import { WorkItem } from '../models/workItem';
 export interface ITaskStore {
   loadAll(): Promise<WorkItem[]>;
   save(item: WorkItem): Promise<void>;
+  saveAll(items: WorkItem[]): Promise<void>;
   delete(id: string): Promise<void>;
 }

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -35,6 +35,7 @@ const TreeItemCollapsibleState = {
 class MockTreeItem {
   label: string;
   collapsibleState: number;
+  id?: string;
   description?: string;
   tooltip?: any;
   contextValue?: string;

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -78,6 +78,16 @@ const Uri = {
   parse: vi.fn((s: string) => ({ toString: () => s })),
 };
 
+class MockDataTransferItem {
+  constructor(public value: any) {}
+}
+
+class MockDataTransfer {
+  private items = new Map<string, MockDataTransferItem>();
+  get(mimeType: string): MockDataTransferItem | undefined { return this.items.get(mimeType); }
+  set(mimeType: string, value: MockDataTransferItem): void { this.items.set(mimeType, value); }
+}
+
 class MockDisposable {
   private callback: () => void;
   constructor(callback: () => void) { this.callback = callback; }
@@ -96,6 +106,8 @@ export {
   MockThemeIcon as ThemeIcon,
   MockMarkdownString as MarkdownString,
   MockTreeItem as TreeItem,
+  MockDataTransferItem as DataTransferItem,
+  MockDataTransfer as DataTransfer,
   MockDisposable as Disposable,
   TreeItemCollapsibleState,
   window,

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -80,6 +80,71 @@ describe('JsonTaskStore', () => {
     expect(items).toHaveLength(1);
   });
 
+  describe('saveAll', () => {
+    it('inserts multiple items in one call', async () => {
+      const a = makeItem({ id: 'a', title: 'A' });
+      const b = makeItem({ id: 'b', title: 'B' });
+      await store.saveAll([a, b]);
+
+      const items = await store.loadAll();
+      expect(items).toHaveLength(2);
+      expect(items.map(i => i.id).sort()).toEqual(['a', 'b']);
+    });
+
+    it('updates existing items', async () => {
+      await store.save(makeItem({ id: 'a', title: 'Original A' }));
+      await store.save(makeItem({ id: 'b', title: 'Original B' }));
+
+      await store.saveAll([
+        makeItem({ id: 'a', title: 'Updated A' }),
+        makeItem({ id: 'b', title: 'Updated B' }),
+      ]);
+
+      const items = await store.loadAll();
+      expect(items).toHaveLength(2);
+      expect(items.find(i => i.id === 'a')!.title).toBe('Updated A');
+      expect(items.find(i => i.id === 'b')!.title).toBe('Updated B');
+    });
+
+    it('handles a mix of inserts and updates', async () => {
+      await store.save(makeItem({ id: 'existing', title: 'Old' }));
+
+      await store.saveAll([
+        makeItem({ id: 'existing', title: 'Updated' }),
+        makeItem({ id: 'new-item', title: 'Brand New' }),
+      ]);
+
+      const items = await store.loadAll();
+      expect(items).toHaveLength(2);
+      expect(items.find(i => i.id === 'existing')!.title).toBe('Updated');
+      expect(items.find(i => i.id === 'new-item')!.title).toBe('Brand New');
+    });
+
+    it('persists all items to disk', async () => {
+      await store.saveAll([
+        makeItem({ id: 'x', title: 'X' }),
+        makeItem({ id: 'y', title: 'Y' }),
+      ]);
+
+      const filePath = path.join(tmpDir, 'workitems.json');
+      const raw = await fs.readFile(filePath, 'utf-8');
+      const parsed = JSON.parse(raw);
+      expect(parsed).toHaveLength(2);
+      expect(parsed.map((i: WorkItem) => i.id).sort()).toEqual(['x', 'y']);
+    });
+
+    it('preserves items not included in the saveAll call', async () => {
+      await store.save(makeItem({ id: 'keep-me', title: 'Kept' }));
+
+      await store.saveAll([makeItem({ id: 'added', title: 'Added' })]);
+
+      const items = await store.loadAll();
+      expect(items).toHaveLength(2);
+      expect(items.find(i => i.id === 'keep-me')!.title).toBe('Kept');
+      expect(items.find(i => i.id === 'added')!.title).toBe('Added');
+    });
+  });
+
   it('persists data to a JSON file', async () => {
     await store.save(makeItem());
     const filePath = path.join(tmpDir, 'workitems.json');

--- a/packages/core/src/test/migration.test.ts
+++ b/packages/core/src/test/migration.test.ts
@@ -13,6 +13,7 @@ function createMockStore(items: WorkItem[]): ITaskStore {
   return {
     loadAll: vi.fn(async () => Array.from(map.values())),
     save: vi.fn(async (item) => { map.set(item.id, item); }),
+    saveAll: vi.fn(async (batch) => { for (const item of batch) { map.set(item.id, item); } }),
     delete: vi.fn(async (id) => { map.delete(id); }),
   };
 }

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -11,6 +11,7 @@ function createMockStore(): ITaskStore {
   return {
     loadAll: vi.fn(async () => Array.from(items.values())),
     save: vi.fn(async (item) => { items.set(item.id, item); }),
+    saveAll: vi.fn(async (batch) => { for (const item of batch) { items.set(item.id, item); } }),
     delete: vi.fn(async (id) => { items.delete(id); }),
   };
 }

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -62,7 +62,7 @@ describe('QueueTreeProvider', () => {
       await provider.handleDrop(a, dataTransfer);
 
       const items = graph.getItemsByState(WorkItemState.New)
-        .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+        .sort((x, y) => (x.sortOrder ?? Number.MAX_SAFE_INTEGER) - (y.sortOrder ?? Number.MAX_SAFE_INTEGER));
       expect(items.map((i) => i.title)).toEqual(['C', 'A', 'B']);
     });
 
@@ -77,7 +77,7 @@ describe('QueueTreeProvider', () => {
       await provider.handleDrop(undefined, dataTransfer);
 
       const items = graph.getItemsByState(WorkItemState.New)
-        .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+        .sort((x, y) => (x.sortOrder ?? Number.MAX_SAFE_INTEGER) - (y.sortOrder ?? Number.MAX_SAFE_INTEGER));
       expect(items.map((i) => i.title)).toEqual(['B', 'C', 'A']);
     });
 

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { DataTransfer, DataTransferItem } from 'vscode';
+import { WorkGraph } from '../services/workGraph';
+import { WorkItemState } from '../models/workItem';
+import { ITaskStore } from '../storage/taskStore';
+import { QueueTreeProvider } from '../views/queueTreeProvider';
+
+function createMockStore(): ITaskStore {
+  const items: Map<string, any> = new Map();
+  return {
+    loadAll: vi.fn(async () => Array.from(items.values())),
+    save: vi.fn(async (item) => { items.set(item.id, item); }),
+    saveAll: vi.fn(async (batch) => { for (const item of batch) { items.set(item.id, item); } }),
+    delete: vi.fn(async (id) => { items.delete(id); }),
+  };
+}
+
+const DRAG_MIME_TYPE = 'application/vnd.code.tree.workcenter.queue';
+
+describe('QueueTreeProvider', () => {
+  let store: ITaskStore;
+  let graph: WorkGraph;
+  let provider: QueueTreeProvider;
+
+  beforeEach(async () => {
+    store = createMockStore();
+    graph = new WorkGraph(store);
+    await graph.load();
+    provider = new QueueTreeProvider(graph);
+  });
+
+  describe('getTreeItem', () => {
+    it('sets treeItem.id to work item id', async () => {
+      const item = await graph.createItem({ title: 'Test' });
+      const treeItem = provider.getTreeItem(item);
+      expect(treeItem.id).toBe(item.id);
+    });
+  });
+
+  describe('handleDrag', () => {
+    it('serializes dragged item ids into data transfer', async () => {
+      const item = await graph.createItem({ title: 'Drag me' });
+      const dataTransfer = new DataTransfer();
+
+      provider.handleDrag([item], dataTransfer);
+
+      const transferItem = dataTransfer.get(DRAG_MIME_TYPE);
+      expect(transferItem).toBeDefined();
+      expect(transferItem!.value).toEqual([item.id]);
+    });
+  });
+
+  describe('handleDrop', () => {
+    it('reorders when dropped on a target item', async () => {
+      const a = await graph.createItem({ title: 'A' });
+      const b = await graph.createItem({ title: 'B' });
+      const c = await graph.createItem({ title: 'C' });
+
+      const dataTransfer = new DataTransfer();
+      dataTransfer.set(DRAG_MIME_TYPE, new DataTransferItem([c.id]));
+
+      await provider.handleDrop(a, dataTransfer);
+
+      const items = graph.getItemsByState(WorkItemState.New)
+        .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+      expect(items.map((i) => i.title)).toEqual(['C', 'A', 'B']);
+    });
+
+    it('moves to end when dropped on empty space (target undefined)', async () => {
+      const a = await graph.createItem({ title: 'A' });
+      const b = await graph.createItem({ title: 'B' });
+      const c = await graph.createItem({ title: 'C' });
+
+      const dataTransfer = new DataTransfer();
+      dataTransfer.set(DRAG_MIME_TYPE, new DataTransferItem([a.id]));
+
+      await provider.handleDrop(undefined, dataTransfer);
+
+      const items = graph.getItemsByState(WorkItemState.New)
+        .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+      expect(items.map((i) => i.title)).toEqual(['B', 'C', 'A']);
+    });
+
+    it('ignores drop when no transfer item', async () => {
+      const a = await graph.createItem({ title: 'A' });
+      const dataTransfer = new DataTransfer();
+
+      await provider.handleDrop(a, dataTransfer);
+      // No error thrown, no-op
+    });
+
+    it('ignores drop when dragging multiple items', async () => {
+      const a = await graph.createItem({ title: 'A' });
+      const b = await graph.createItem({ title: 'B' });
+
+      const dataTransfer = new DataTransfer();
+      dataTransfer.set(DRAG_MIME_TYPE, new DataTransferItem([a.id, b.id]));
+
+      await provider.handleDrop(a, dataTransfer);
+      // No error thrown, no-op
+    });
+
+    it('ignores drop on self', async () => {
+      const a = await graph.createItem({ title: 'A' });
+      const b = await graph.createItem({ title: 'B' });
+
+      const listener = vi.fn();
+      graph.onDidChange(listener);
+
+      const dataTransfer = new DataTransfer();
+      dataTransfer.set(DRAG_MIME_TYPE, new DataTransferItem([a.id]));
+
+      await provider.handleDrop(a, dataTransfer);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -133,4 +133,65 @@ describe('WorkGraph', () => {
 
     expect(item.description).toBe('A detailed bug report');
   });
+
+  it('assigns sortOrder on creation', async () => {
+    const a = await graph.createItem({ title: 'A' });
+    const b = await graph.createItem({ title: 'B' });
+    const c = await graph.createItem({ title: 'C' });
+
+    expect(a.sortOrder).toBe(0);
+    expect(b.sortOrder).toBe(1);
+    expect(c.sortOrder).toBe(2);
+  });
+
+  it('moves an item down', async () => {
+    const a = await graph.createItem({ title: 'A' });
+    const b = await graph.createItem({ title: 'B' });
+    const c = await graph.createItem({ title: 'C' });
+
+    await graph.moveItem(a.id, 'down');
+
+    const items = graph.getItemsByState(WorkItemState.New)
+      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+    expect(items.map((i) => i.title)).toEqual(['B', 'A', 'C']);
+  });
+
+  it('moves an item up', async () => {
+    const a = await graph.createItem({ title: 'A' });
+    const b = await graph.createItem({ title: 'B' });
+    const c = await graph.createItem({ title: 'C' });
+
+    await graph.moveItem(c.id, 'up');
+
+    const items = graph.getItemsByState(WorkItemState.New)
+      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+    expect(items.map((i) => i.title)).toEqual(['A', 'C', 'B']);
+  });
+
+  it('moving the first item up is a no-op', async () => {
+    const a = await graph.createItem({ title: 'A' });
+    const b = await graph.createItem({ title: 'B' });
+
+    await graph.moveItem(a.id, 'up');
+
+    const items = graph.getItemsByState(WorkItemState.New)
+      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+    expect(items.map((i) => i.title)).toEqual(['A', 'B']);
+  });
+
+  it('moving the last item down is a no-op', async () => {
+    const a = await graph.createItem({ title: 'A' });
+    const b = await graph.createItem({ title: 'B' });
+
+    await graph.moveItem(b.id, 'down');
+
+    const items = graph.getItemsByState(WorkItemState.New)
+      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+    expect(items.map((i) => i.title)).toEqual(['A', 'B']);
+  });
+
+  it('throws when moving unknown item', async () => {
+    await expect(graph.moveItem('nonexistent', 'up'))
+      .rejects.toThrow('Work item not found');
+  });
 });

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -153,7 +153,7 @@ describe('WorkGraph', () => {
     await graph.moveItem(a.id, 'down');
 
     const items = graph.getItemsByState(WorkItemState.New)
-      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+      .sort((x, y) => (x.sortOrder ?? Number.MAX_SAFE_INTEGER) - (y.sortOrder ?? Number.MAX_SAFE_INTEGER));
     expect(items.map((i) => i.title)).toEqual(['B', 'A', 'C']);
   });
 
@@ -165,7 +165,7 @@ describe('WorkGraph', () => {
     await graph.moveItem(c.id, 'up');
 
     const items = graph.getItemsByState(WorkItemState.New)
-      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+      .sort((x, y) => (x.sortOrder ?? Number.MAX_SAFE_INTEGER) - (y.sortOrder ?? Number.MAX_SAFE_INTEGER));
     expect(items.map((i) => i.title)).toEqual(['A', 'C', 'B']);
   });
 
@@ -176,7 +176,7 @@ describe('WorkGraph', () => {
     await graph.moveItem(a.id, 'up');
 
     const items = graph.getItemsByState(WorkItemState.New)
-      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+      .sort((x, y) => (x.sortOrder ?? Number.MAX_SAFE_INTEGER) - (y.sortOrder ?? Number.MAX_SAFE_INTEGER));
     expect(items.map((i) => i.title)).toEqual(['A', 'B']);
   });
 
@@ -187,7 +187,7 @@ describe('WorkGraph', () => {
     await graph.moveItem(b.id, 'down');
 
     const items = graph.getItemsByState(WorkItemState.New)
-      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+      .sort((x, y) => (x.sortOrder ?? Number.MAX_SAFE_INTEGER) - (y.sortOrder ?? Number.MAX_SAFE_INTEGER));
     expect(items.map((i) => i.title)).toEqual(['A', 'B']);
   });
 
@@ -230,7 +230,7 @@ describe('WorkGraph', () => {
     await graph.reorderItem(c.id, a.id);
 
     const items = graph.getItemsByState(WorkItemState.New)
-      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+      .sort((x, y) => (x.sortOrder ?? Number.MAX_SAFE_INTEGER) - (y.sortOrder ?? Number.MAX_SAFE_INTEGER));
     expect(items.map((i) => i.title)).toEqual(['C', 'A', 'B']);
   });
 
@@ -242,7 +242,7 @@ describe('WorkGraph', () => {
     await graph.reorderItem(a.id, c.id);
 
     const items = graph.getItemsByState(WorkItemState.New)
-      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+      .sort((x, y) => (x.sortOrder ?? Number.MAX_SAFE_INTEGER) - (y.sortOrder ?? Number.MAX_SAFE_INTEGER));
     expect(items.map((i) => i.title)).toEqual(['B', 'A', 'C']);
   });
 
@@ -277,7 +277,7 @@ describe('WorkGraph', () => {
     await graph.moveToEnd(a.id);
 
     const items = graph.getItemsByState(WorkItemState.New)
-      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+      .sort((x, y) => (x.sortOrder ?? Number.MAX_SAFE_INTEGER) - (y.sortOrder ?? Number.MAX_SAFE_INTEGER));
     expect(items.map((i) => i.title)).toEqual(['B', 'C', 'A']);
   });
 
@@ -330,7 +330,7 @@ describe('WorkGraph', () => {
     await legacyGraph.moveItem('legacy-a', 'down');
 
     const ordered = legacyGraph.getItemsByState(WorkItemState.New)
-      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+      .sort((x, y) => (x.sortOrder ?? Number.MAX_SAFE_INTEGER) - (y.sortOrder ?? Number.MAX_SAFE_INTEGER));
     expect(ordered.map((i) => i.title)).toEqual(['B', 'A', 'C']);
   });
 });

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -8,6 +8,7 @@ function createMockStore(): ITaskStore {
   return {
     loadAll: vi.fn(async () => Array.from(items.values())),
     save: vi.fn(async (item) => { items.set(item.id, item); }),
+    saveAll: vi.fn(async (batch) => { for (const item of batch) { items.set(item.id, item); } }),
     delete: vi.fn(async (id) => { items.delete(id); }),
   };
 }

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -222,7 +222,7 @@ describe('WorkGraph', () => {
     expect(c.sortOrder).toBe(2);
   });
 
-  it('reorders item from position 2 to position 0', async () => {
+  it('reorders item from position 2 to position 0 (drag up inserts before target)', async () => {
     const a = await graph.createItem({ title: 'A' });
     const b = await graph.createItem({ title: 'B' });
     const c = await graph.createItem({ title: 'C' });
@@ -234,7 +234,7 @@ describe('WorkGraph', () => {
     expect(items.map((i) => i.title)).toEqual(['C', 'A', 'B']);
   });
 
-  it('reorders item from position 0 to position 2', async () => {
+  it('reorders item from position 0 to position 2 (drag down inserts after target)', async () => {
     const a = await graph.createItem({ title: 'A' });
     const b = await graph.createItem({ title: 'B' });
     const c = await graph.createItem({ title: 'C' });
@@ -243,7 +243,19 @@ describe('WorkGraph', () => {
 
     const items = graph.getItemsByState(WorkItemState.New)
       .sort((x, y) => (x.sortOrder ?? Number.MAX_SAFE_INTEGER) - (y.sortOrder ?? Number.MAX_SAFE_INTEGER));
-    expect(items.map((i) => i.title)).toEqual(['B', 'A', 'C']);
+    expect(items.map((i) => i.title)).toEqual(['B', 'C', 'A']);
+  });
+
+  it('dragging first item onto last places it at the end', async () => {
+    const a = await graph.createItem({ title: 'A' });
+    const b = await graph.createItem({ title: 'B' });
+    const c = await graph.createItem({ title: 'C' });
+
+    await graph.reorderItem(a.id, c.id);
+
+    const items = graph.getItemsByState(WorkItemState.New)
+      .sort((x, y) => (x.sortOrder ?? Number.MAX_SAFE_INTEGER) - (y.sortOrder ?? Number.MAX_SAFE_INTEGER));
+    expect(items[items.length - 1].title).toBe('A');
   });
 
   it('reorder to same position is a no-op', async () => {

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -195,4 +195,61 @@ describe('WorkGraph', () => {
     await expect(graph.moveItem('nonexistent', 'up'))
       .rejects.toThrow('Work item not found');
   });
+
+  it('creates item after legacy items without sortOrder', async () => {
+    const legacyStore = createMockStore();
+
+    await legacyStore.save({
+      id: 'legacy-a',
+      title: 'A',
+      state: WorkItemState.New,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    } as any);
+
+    await legacyStore.save({
+      id: 'legacy-b',
+      title: 'B',
+      state: WorkItemState.New,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    } as any);
+
+    const legacyGraph = new WorkGraph(legacyStore);
+    await legacyGraph.load();
+
+    const c = await legacyGraph.createItem({ title: 'C' });
+    expect(c.sortOrder).toBe(2);
+  });
+
+  it('moves legacy items without sortOrder correctly', async () => {
+    const legacyStore = createMockStore();
+
+    await legacyStore.save({
+      id: 'legacy-a',
+      title: 'A',
+      state: WorkItemState.New,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    } as any);
+
+    await legacyStore.save({
+      id: 'legacy-b',
+      title: 'B',
+      state: WorkItemState.New,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    } as any);
+
+    const legacyGraph = new WorkGraph(legacyStore);
+    await legacyGraph.load();
+
+    const c = await legacyGraph.createItem({ title: 'C' });
+
+    await legacyGraph.moveItem('legacy-a', 'down');
+
+    const ordered = legacyGraph.getItemsByState(WorkItemState.New)
+      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+    expect(ordered.map((i) => i.title)).toEqual(['B', 'A', 'C']);
+  });
 });

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -269,6 +269,40 @@ describe('WorkGraph', () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
+  it('moveToEnd places item at end of its state group', async () => {
+    const a = await graph.createItem({ title: 'A' });
+    const b = await graph.createItem({ title: 'B' });
+    const c = await graph.createItem({ title: 'C' });
+
+    await graph.moveToEnd(a.id);
+
+    const items = graph.getItemsByState(WorkItemState.New)
+      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+    expect(items.map((i) => i.title)).toEqual(['B', 'C', 'A']);
+  });
+
+  it('moveToEnd on non-existent item is a no-op', async () => {
+    const listener = vi.fn();
+    graph.onDidChange(listener);
+
+    await graph.moveToEnd('nonexistent');
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('reorder across different states is a no-op', async () => {
+    const a = await graph.createItem({ title: 'A' });
+    const b = await graph.createItem({ title: 'B' });
+    await graph.transitionState(b.id, WorkItemState.InProgress);
+
+    const listener = vi.fn();
+    graph.onDidChange(listener);
+
+    await graph.reorderItem(a.id, b.id);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
   it('moves legacy items without sortOrder correctly', async () => {
     const legacyStore = createMockStore();
 

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -222,6 +222,53 @@ describe('WorkGraph', () => {
     expect(c.sortOrder).toBe(2);
   });
 
+  it('reorders item from position 2 to position 0', async () => {
+    const a = await graph.createItem({ title: 'A' });
+    const b = await graph.createItem({ title: 'B' });
+    const c = await graph.createItem({ title: 'C' });
+
+    await graph.reorderItem(c.id, a.id);
+
+    const items = graph.getItemsByState(WorkItemState.New)
+      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+    expect(items.map((i) => i.title)).toEqual(['C', 'A', 'B']);
+  });
+
+  it('reorders item from position 0 to position 2', async () => {
+    const a = await graph.createItem({ title: 'A' });
+    const b = await graph.createItem({ title: 'B' });
+    const c = await graph.createItem({ title: 'C' });
+
+    await graph.reorderItem(a.id, c.id);
+
+    const items = graph.getItemsByState(WorkItemState.New)
+      .sort((x, y) => (x.sortOrder ?? Infinity) - (y.sortOrder ?? Infinity));
+    expect(items.map((i) => i.title)).toEqual(['B', 'A', 'C']);
+  });
+
+  it('reorder to same position is a no-op', async () => {
+    const a = await graph.createItem({ title: 'A' });
+    const b = await graph.createItem({ title: 'B' });
+
+    const listener = vi.fn();
+    graph.onDidChange(listener);
+
+    await graph.reorderItem(a.id, a.id);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('reorder non-existent item is a no-op', async () => {
+    const a = await graph.createItem({ title: 'A' });
+
+    const listener = vi.fn();
+    graph.onDidChange(listener);
+
+    await graph.reorderItem('nonexistent', a.id);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
   it('moves legacy items without sortOrder correctly', async () => {
     const legacyStore = createMockStore();
 

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -21,6 +21,7 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem>, vsc
 
   getTreeItem(item: WorkItem): vscode.TreeItem {
     const treeItem = new vscode.TreeItem(item.title, vscode.TreeItemCollapsibleState.None);
+    treeItem.id = item.id;
     treeItem.description = item.providerId;
     treeItem.tooltip = this.buildTooltip(item);
     treeItem.contextValue = item.url ? 'queueItem.hasUrl' : 'queueItem';
@@ -47,12 +48,18 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem>, vsc
 
   async handleDrop(target: WorkItem | undefined, dataTransfer: vscode.DataTransfer): Promise<void> {
     const transferItem = dataTransfer.get(DRAG_MIME_TYPE);
-    if (!transferItem || !target) { return; }
+    if (!transferItem) { return; }
 
     const draggedIds: string[] = transferItem.value;
     if (draggedIds.length !== 1) { return; }
 
     const draggedId = draggedIds[0];
+
+    if (!target) {
+      await this.workGraph.moveToEnd(draggedId);
+      return;
+    }
+
     if (draggedId === target.id) { return; }
 
     await this.workGraph.reorderItem(draggedId, target.id);

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -2,7 +2,11 @@ import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 
-export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem> {
+const DRAG_MIME_TYPE = 'application/vnd.code.tree.workcenter.queue';
+
+export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem>, vscode.TreeDragAndDropController<WorkItem> {
+  readonly dropMimeTypes = [DRAG_MIME_TYPE];
+  readonly dragMimeTypes = [DRAG_MIME_TYPE];
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private readonly disposables: vscode.Disposable[] = [];
@@ -35,6 +39,23 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem> {
     if (item.description) { md.appendText(`${item.description}\n\n`); }
     md.appendMarkdown(`Created: ${new Date(item.createdAt).toLocaleString()}`);
     return md;
+  }
+
+  handleDrag(source: readonly WorkItem[], dataTransfer: vscode.DataTransfer): void {
+    dataTransfer.set(DRAG_MIME_TYPE, new vscode.DataTransferItem(source.map(s => s.id)));
+  }
+
+  async handleDrop(target: WorkItem | undefined, dataTransfer: vscode.DataTransfer): Promise<void> {
+    const transferItem = dataTransfer.get(DRAG_MIME_TYPE);
+    if (!transferItem || !target) { return; }
+
+    const draggedIds: string[] = transferItem.value;
+    if (draggedIds.length !== 1) { return; }
+
+    const draggedId = draggedIds[0];
+    if (draggedId === target.id) { return; }
+
+    await this.workGraph.reorderItem(draggedId, target.id);
   }
 
   dispose(): void {

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -50,8 +50,10 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem>, vsc
     const transferItem = dataTransfer.get(DRAG_MIME_TYPE);
     if (!transferItem) { return; }
 
-    const draggedIds: string[] = transferItem.value;
-    if (draggedIds.length !== 1) { return; }
+    const rawValue: unknown = transferItem.value;
+    if (!Array.isArray(rawValue) || rawValue.length !== 1 || typeof rawValue[0] !== 'string') { return; }
+
+    const draggedIds: string[] = rawValue;
 
     const draggedId = draggedIds[0];
 

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -26,7 +26,7 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem> {
 
   getChildren(): WorkItem[] {
     return this.workGraph.getItemsByState(WorkItemState.New)
-      .sort((a, b) => a.title.localeCompare(b.title));
+      .sort((a, b) => (a.sortOrder ?? Infinity) - (b.sortOrder ?? Infinity));
   }
 
   private buildTooltip(item: WorkItem): vscode.MarkdownString {

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -26,7 +26,7 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem> {
 
   getChildren(): WorkItem[] {
     return this.workGraph.getItemsByState(WorkItemState.New)
-      .sort((a, b) => (a.sortOrder ?? Infinity) - (b.sortOrder ?? Infinity));
+      .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
   }
 
   private buildTooltip(item: WorkItem): vscode.MarkdownString {


### PR DESCRIPTION
Add `sortOrder` field to WorkItem and move up/down commands for the Queue view. Sort order is persisted and assigned automatically on item creation.

Closes #4