### PR TITLE
Add History view for completed and archived items

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,16 +84,3 @@ Tests run outside VS Code via vitest. The `vscode` import is aliased to `src/tes
 
 Items in Inbox and Sources are read live from the provider's in-memory data. The only persisted state is the `inboxState` enum. This keeps data fresh and avoids stale copies.
 
-### PR workflow — use the `create-pr` skill
-
-When creating pull requests, **always invoke the `create-pr` skill** and follow its full multi-phase lifecycle. Do NOT hand-roll a simplified version. The skill enforces:
-
-- **Phase 1 (Local Loop):** Rebase on `dev`, run full test suite, dispatch `superpowers:code-reviewer` agent, fix findings, re-test, and repeat until tests pass AND review is clean.
-- **Phase 2 (Create PR):** Push branch and open PR via `gh pr create --base dev`.
-- **Phase 3 (Remote Loop):** Run Copilot PR review via `copilot-pr-review` skill, fix comments (one commit per comment), verify CI, resolve merge conflicts. Any code change in this phase triggers a re-run of Phase 1.
-
-Key rules:
-- **Never skip or shortcut the process.** Every PR goes through all phases.
-- **Any code change re-triggers the local loop** — whether from code review, Copilot feedback, CI fix, or conflict resolution.
-- **Use `superpowers:code-reviewer` agent** for code review, not a generic code-review agent.
-- When working on multiple issues in parallel, each issue goes through this full cycle independently in its own worktree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,20 +33,21 @@ WorkCenter is a VS Code extension that acts as a **hub** for managing work items
 Providers (GitHub, future)          User (manual)
         │                                │
         ▼                                ▼
-  ProviderRegistry ──▶ Inbox ──▶ Queue ──▶ Focus
-  (live references)    (unseen)  (accepted) (in progress)
+  ProviderRegistry ──▶ Inbox ──▶ Queue ──▶ Focus ──▶ History
+  (live references)    (unseen)  (accepted) (in progress) (done/archived)
         │
         ▼
      Sources
   (browsable library)
 ```
 
-### Four views
+### Five views
 
 1. **Inbox** — Newly discovered provider items (state: `unseen`). Accept → Queue or Dismiss.
 2. **Queue** — User's curated backlog. Manual items land here directly.
 3. **Focus** — Active work (`InProgress`, `Blocked`, `WaitingOn`).
-4. **Sources** — Everything providers know about, grouped by provider → sub-group. Always browsable.
+4. **History** — Completed and archived items (`Done`, `Archived`).
+5. **Sources** — Everything providers know about, grouped by provider → sub-group. Always browsable.
 
 ### Two data stores (both JSON files in `globalStorageUri`)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,12 +44,12 @@
           "name": "Focus"
         },
         {
-          "id": "workcenter.sources",
-          "name": "Sources"
-        },
-        {
           "id": "workcenter.history",
           "name": "History"
+        },
+        {
+          "id": "workcenter.sources",
+          "name": "Sources"
         }
       ]
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,8 @@
     "onView:workcenter.inbox",
     "onView:workcenter.queue",
     "onView:workcenter.focus",
-    "onView:workcenter.sources"
+    "onView:workcenter.sources",
+    "onView:workcenter.history"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -45,6 +46,10 @@
         {
           "id": "workcenter.sources",
           "name": "Sources"
+        },
+        {
+          "id": "workcenter.history",
+          "name": "History"
         }
       ]
     },
@@ -195,6 +200,11 @@
         {
           "command": "workcenter.dismissFromInbox",
           "when": "view == workcenter.inbox",
+          "group": "1_actions"
+        },
+        {
+          "command": "workcenter.archiveItem",
+          "when": "view == workcenter.history && viewItem =~ /historyItem/",
           "group": "1_actions"
         },
         {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -203,11 +203,6 @@
           "group": "1_actions"
         },
         {
-          "command": "workcenter.archiveItem",
-          "when": "view == workcenter.history && viewItem =~ /historyItemDone/",
-          "group": "1_actions"
-        },
-        {
           "command": "workcenter.acceptFromSources",
           "when": "view == workcenter.sources && viewItem =~ /sourceItem/",
           "group": "inline"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -204,7 +204,7 @@
         },
         {
           "command": "workcenter.archiveItem",
-          "when": "view == workcenter.history && viewItem =~ /historyItem/",
+          "when": "view == workcenter.history && viewItem =~ /historyItemDone/",
           "group": "1_actions"
         },
         {

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -82,13 +82,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   const focusTreeView = vscode.window.createTreeView('workcenter.focus', { treeDataProvider: focusProvider });
   const historyTreeView = vscode.window.createTreeView('workcenter.history', { treeDataProvider: historyProvider });
 
-  const updateQueueFocusMessages = () => {
+  const updateWorkViewMessages = () => {
     queueTreeView.message = queueProvider.getChildren().length > 0 ? undefined : 'No items in queue';
     focusTreeView.message = focusProvider.getChildren().length > 0 ? undefined : 'No active work';
     historyTreeView.message = historyProvider.getChildren().length > 0 ? undefined : 'No completed items';
   };
-  updateQueueFocusMessages();
-  const workGraphSub = workGraph.onDidChange(updateQueueFocusMessages);
+  updateWorkViewMessages();
+  const workGraphSub = workGraph.onDidChange(updateWorkViewMessages);
 
   updateViewMessages();
 

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -85,7 +85,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   const updateWorkViewMessages = () => {
     queueTreeView.message = queueProvider.getChildren().length > 0 ? undefined : 'No items in queue';
     focusTreeView.message = focusProvider.getChildren().length > 0 ? undefined : 'No active work';
-    historyTreeView.message = historyProvider.getChildren().length > 0 ? undefined : 'No completed items';
+    historyTreeView.message = historyProvider.getChildren().length > 0 ? undefined : 'No history items';
   };
   updateWorkViewMessages();
   const workGraphSub = workGraph.onDidChange(updateWorkViewMessages);

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -10,6 +10,7 @@ import { InboxTreeProvider } from './views/inboxTreeProvider';
 import { QueueTreeProvider } from './views/queueTreeProvider';
 import { FocusTreeProvider } from './views/focusTreeProvider';
 import { SourcesTreeProvider } from './views/sourcesTreeProvider';
+import { HistoryTreeProvider } from './views/historyTreeProvider';
 import { registerCommands } from './commands/commands';
 
 export type { WorkCenterApi, WorkCenterProvider, WorkCenterAction, DiscoveredItem, Disposable } from './api/types';
@@ -55,6 +56,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   const queueProvider = new QueueTreeProvider(workGraph);
   const focusProvider = new FocusTreeProvider(workGraph);
   const sourcesProvider = new SourcesTreeProvider(providerRegistry, stateStore);
+  const historyProvider = new HistoryTreeProvider(workGraph);
 
   const inboxTreeView = vscode.window.createTreeView('workcenter.inbox', { treeDataProvider: inboxProvider });
   const sourcesTreeView = vscode.window.createTreeView('workcenter.sources', { treeDataProvider: sourcesProvider });
@@ -78,10 +80,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   };
   const queueTreeView = vscode.window.createTreeView('workcenter.queue', { treeDataProvider: queueProvider });
   const focusTreeView = vscode.window.createTreeView('workcenter.focus', { treeDataProvider: focusProvider });
+  const historyTreeView = vscode.window.createTreeView('workcenter.history', { treeDataProvider: historyProvider });
 
   const updateQueueFocusMessages = () => {
     queueTreeView.message = queueProvider.getChildren().length > 0 ? undefined : 'No items in queue';
     focusTreeView.message = focusProvider.getChildren().length > 0 ? undefined : 'No active work';
+    historyTreeView.message = historyProvider.getChildren().length > 0 ? undefined : 'No completed items';
   };
   updateQueueFocusMessages();
   const workGraphSub = workGraph.onDidChange(updateQueueFocusMessages);
@@ -97,6 +101,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
     queueTreeView,
     focusTreeView,
     sourcesTreeView,
+    historyTreeView,
     discoveredSub,
     providerRegSub,
     stateStoreSub,
@@ -107,6 +112,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
     { dispose: () => queueProvider.dispose() },
     { dispose: () => focusProvider.dispose() },
     { dispose: () => sourcesProvider.dispose() },
+    { dispose: () => historyProvider.dispose() },
     { dispose: () => providerRegistry.dispose() },
     { dispose: () => actionRegistry.dispose() },
   );

--- a/packages/core/src/test/historyTreeProvider.test.ts
+++ b/packages/core/src/test/historyTreeProvider.test.ts
@@ -83,14 +83,24 @@ describe('HistoryTreeProvider', () => {
       expect((treeItem.iconPath as any).id).toBe('archive');
     });
 
-    it('should set contextValue with hasUrl when item has url', () => {
-      const item = makeItem({ id: '1', title: 'X', url: 'https://example.com' });
-      expect(provider.getTreeItem(item).contextValue).toBe('historyItem.hasUrl');
+    it('should set contextValue with hasUrl when Done item has url', () => {
+      const item = makeItem({ id: '1', title: 'X', url: 'https://example.com', state: WorkItemState.Done });
+      expect(provider.getTreeItem(item).contextValue).toBe('historyItemDone.hasUrl');
     });
 
-    it('should set contextValue without hasUrl when item lacks url', () => {
-      const item = makeItem({ id: '1', title: 'X' });
-      expect(provider.getTreeItem(item).contextValue).toBe('historyItem');
+    it('should set contextValue without hasUrl when Done item lacks url', () => {
+      const item = makeItem({ id: '1', title: 'X', state: WorkItemState.Done });
+      expect(provider.getTreeItem(item).contextValue).toBe('historyItemDone');
+    });
+
+    it('should set contextValue with Archived tag for Archived item', () => {
+      const item = makeItem({ id: '1', title: 'X', state: WorkItemState.Archived });
+      expect(provider.getTreeItem(item).contextValue).toBe('historyItemArchived');
+    });
+
+    it('should set contextValue with Archived tag and hasUrl for Archived item with url', () => {
+      const item = makeItem({ id: '1', title: 'X', state: WorkItemState.Archived, url: 'https://example.com' });
+      expect(provider.getTreeItem(item).contextValue).toBe('historyItemArchived.hasUrl');
     });
 
     it('should include description in tooltip when present', () => {

--- a/packages/core/src/test/historyTreeProvider.test.ts
+++ b/packages/core/src/test/historyTreeProvider.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventEmitter, TreeItemCollapsibleState } from 'vscode';
+import { WorkItem, WorkItemState } from '../models/workItem';
+import { HistoryTreeProvider } from '../views/historyTreeProvider';
+
+function createMockWorkGraph(items: WorkItem[] = []) {
+  const emitter = new EventEmitter<void>();
+  return {
+    getItemsByState: vi.fn((...states: WorkItemState[]) =>
+      items.filter(i => states.includes(i.state)),
+    ),
+    onDidChange: emitter.event,
+    _fire: () => emitter.fire(),
+    _setItems: (newItems: WorkItem[]) => { items = newItems; },
+  };
+}
+
+function makeItem(overrides: Partial<WorkItem> & { id: string; title: string }): WorkItem {
+  return {
+    state: WorkItemState.Done,
+    createdAt: 1000,
+    updatedAt: 2000,
+    ...overrides,
+  };
+}
+
+describe('HistoryTreeProvider', () => {
+  let workGraph: ReturnType<typeof createMockWorkGraph>;
+  let provider: HistoryTreeProvider;
+
+  beforeEach(() => {
+    workGraph = createMockWorkGraph();
+    provider = new HistoryTreeProvider(workGraph as any);
+  });
+
+  describe('getChildren', () => {
+    it('should return empty when no done or archived items exist', () => {
+      expect(provider.getChildren()).toEqual([]);
+    });
+
+    it('should return only Done and Archived items', () => {
+      workGraph._setItems([
+        makeItem({ id: '1', title: 'Done item', state: WorkItemState.Done }),
+        makeItem({ id: '2', title: 'Archived item', state: WorkItemState.Archived }),
+        makeItem({ id: '3', title: 'In progress', state: WorkItemState.InProgress }),
+        makeItem({ id: '4', title: 'New', state: WorkItemState.New }),
+      ]);
+
+      const children = provider.getChildren();
+      expect(children).toHaveLength(2);
+      expect(children.map(c => c.title)).toContain('Done item');
+      expect(children.map(c => c.title)).toContain('Archived item');
+    });
+
+    it('should sort by updatedAt descending (most recent first)', () => {
+      workGraph._setItems([
+        makeItem({ id: '1', title: 'Older', state: WorkItemState.Done, updatedAt: 1000 }),
+        makeItem({ id: '2', title: 'Newer', state: WorkItemState.Done, updatedAt: 3000 }),
+        makeItem({ id: '3', title: 'Middle', state: WorkItemState.Archived, updatedAt: 2000 }),
+      ]);
+
+      const children = provider.getChildren();
+      expect(children.map(c => c.title)).toEqual(['Newer', 'Middle', 'Older']);
+    });
+  });
+
+  describe('getTreeItem', () => {
+    it('should render Done item with check icon and done label', () => {
+      const item = makeItem({ id: '1', title: 'Completed task', state: WorkItemState.Done });
+      const treeItem = provider.getTreeItem(item);
+
+      expect(treeItem.label).toBe('Completed task');
+      expect(treeItem.description).toBe('✓ done');
+      expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.None);
+      expect((treeItem.iconPath as any).id).toBe('check');
+    });
+
+    it('should render Archived item with archive icon and archived label', () => {
+      const item = makeItem({ id: '1', title: 'Old task', state: WorkItemState.Archived });
+      const treeItem = provider.getTreeItem(item);
+
+      expect(treeItem.description).toBe('📦 archived');
+      expect((treeItem.iconPath as any).id).toBe('archive');
+    });
+
+    it('should set contextValue with hasUrl when item has url', () => {
+      const item = makeItem({ id: '1', title: 'X', url: 'https://example.com' });
+      expect(provider.getTreeItem(item).contextValue).toBe('historyItem.hasUrl');
+    });
+
+    it('should set contextValue without hasUrl when item lacks url', () => {
+      const item = makeItem({ id: '1', title: 'X' });
+      expect(provider.getTreeItem(item).contextValue).toBe('historyItem');
+    });
+
+    it('should include description in tooltip when present', () => {
+      const item = makeItem({ id: '1', title: 'Task', description: 'Details here' });
+      const treeItem = provider.getTreeItem(item);
+      expect((treeItem.tooltip as any).value).toContain('Details here');
+    });
+  });
+
+  describe('events', () => {
+    it('should refresh when workGraph fires change event', () => {
+      const listener = vi.fn();
+      provider.onDidChangeTreeData(listener);
+      workGraph._fire();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('dispose', () => {
+    it('should not throw on dispose', () => {
+      expect(() => provider.dispose()).not.toThrow();
+    });
+  });
+});

--- a/packages/core/src/test/historyTreeProvider.test.ts
+++ b/packages/core/src/test/historyTreeProvider.test.ts
@@ -83,24 +83,24 @@ describe('HistoryTreeProvider', () => {
       expect((treeItem.iconPath as any).id).toBe('archive');
     });
 
-    it('should set contextValue with hasUrl when Done item has url', () => {
+    it('should set contextValue with hasUrl when item has url', () => {
       const item = makeItem({ id: '1', title: 'X', url: 'https://example.com', state: WorkItemState.Done });
-      expect(provider.getTreeItem(item).contextValue).toBe('historyItemDone.hasUrl');
+      expect(provider.getTreeItem(item).contextValue).toBe('historyItem.hasUrl');
     });
 
-    it('should set contextValue without hasUrl when Done item lacks url', () => {
+    it('should set contextValue without hasUrl when item lacks url', () => {
       const item = makeItem({ id: '1', title: 'X', state: WorkItemState.Done });
-      expect(provider.getTreeItem(item).contextValue).toBe('historyItemDone');
+      expect(provider.getTreeItem(item).contextValue).toBe('historyItem');
     });
 
-    it('should set contextValue with Archived tag for Archived item', () => {
+    it('should set same contextValue for Archived item without url', () => {
       const item = makeItem({ id: '1', title: 'X', state: WorkItemState.Archived });
-      expect(provider.getTreeItem(item).contextValue).toBe('historyItemArchived');
+      expect(provider.getTreeItem(item).contextValue).toBe('historyItem');
     });
 
-    it('should set contextValue with Archived tag and hasUrl for Archived item with url', () => {
+    it('should set same contextValue with hasUrl for Archived item with url', () => {
       const item = makeItem({ id: '1', title: 'X', state: WorkItemState.Archived, url: 'https://example.com' });
-      expect(provider.getTreeItem(item).contextValue).toBe('historyItemArchived.hasUrl');
+      expect(provider.getTreeItem(item).contextValue).toBe('historyItem.hasUrl');
     });
 
     it('should include description in tooltip when present', () => {

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -22,7 +22,8 @@ export class HistoryTreeProvider implements vscode.TreeDataProvider<WorkItem> {
     treeItem.description = this.getStateLabel(item.state);
     treeItem.tooltip = this.buildTooltip(item);
     treeItem.iconPath = this.getIcon(item.state);
-    treeItem.contextValue = item.url ? 'historyItem.hasUrl' : 'historyItem';
+    const stateTag = item.state === WorkItemState.Done ? 'Done' : 'Archived';
+    treeItem.contextValue = item.url ? `historyItem${stateTag}.hasUrl` : `historyItem${stateTag}`;
     return treeItem;
   }
 

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -1,0 +1,77 @@
+import * as vscode from 'vscode';
+import { WorkItem, WorkItemState } from '../models/workItem';
+import { WorkGraph } from '../services/workGraph';
+
+export class HistoryTreeProvider implements vscode.TreeDataProvider<WorkItem> {
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+  private readonly disposables: vscode.Disposable[] = [];
+
+  constructor(private readonly workGraph: WorkGraph) {
+    this.disposables.push(
+      workGraph.onDidChange(() => this._onDidChangeTreeData.fire())
+    );
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(item: WorkItem): vscode.TreeItem {
+    const treeItem = new vscode.TreeItem(item.title, vscode.TreeItemCollapsibleState.None);
+    treeItem.description = this.getStateLabel(item.state);
+    treeItem.tooltip = this.buildTooltip(item);
+    treeItem.iconPath = this.getIcon(item.state);
+    treeItem.contextValue = item.url ? 'historyItem.hasUrl' : 'historyItem';
+    return treeItem;
+  }
+
+  getChildren(): WorkItem[] {
+    return this.workGraph.getItemsByState(
+      WorkItemState.Done,
+      WorkItemState.Archived,
+    ).sort((a, b) => b.updatedAt - a.updatedAt);
+  }
+
+  private getStateLabel(state: WorkItemState): string {
+    switch (state) {
+      case WorkItemState.Done:
+        return '✓ done';
+      case WorkItemState.Archived:
+        return '📦 archived';
+      default:
+        return state;
+    }
+  }
+
+  private getIcon(state: WorkItemState): vscode.ThemeIcon {
+    switch (state) {
+      case WorkItemState.Done:
+        return new vscode.ThemeIcon('check');
+      case WorkItemState.Archived:
+        return new vscode.ThemeIcon('archive');
+      default:
+        return new vscode.ThemeIcon('circle-outline');
+    }
+  }
+
+  private buildTooltip(item: WorkItem): vscode.MarkdownString {
+    const md = new vscode.MarkdownString();
+    md.appendMarkdown(`**Title:** `);
+    md.appendText(item.title);
+    md.appendMarkdown(`\n\n`);
+    if (item.description) {
+      md.appendMarkdown(`**Description:** `);
+      md.appendText(item.description);
+      md.appendMarkdown(`\n\n`);
+    }
+    md.appendMarkdown(`**State:** ${item.state}\n\n`);
+    md.appendMarkdown(`**Completed:** ${new Date(item.updatedAt).toLocaleString()}`);
+    return md;
+  }
+
+  dispose(): void {
+    this._onDidChangeTreeData.dispose();
+    this.disposables.forEach(d => d.dispose());
+  }
+}

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -22,8 +22,7 @@ export class HistoryTreeProvider implements vscode.TreeDataProvider<WorkItem> {
     treeItem.description = this.getStateLabel(item.state);
     treeItem.tooltip = this.buildTooltip(item);
     treeItem.iconPath = this.getIcon(item.state);
-    const stateTag = item.state === WorkItemState.Done ? 'Done' : 'Archived';
-    treeItem.contextValue = item.url ? `historyItem${stateTag}.hasUrl` : `historyItem${stateTag}`;
+    treeItem.contextValue = item.url ? 'historyItem.hasUrl' : 'historyItem';
     return treeItem;
   }
 

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -66,7 +66,8 @@ export class HistoryTreeProvider implements vscode.TreeDataProvider<WorkItem> {
       md.appendMarkdown(`\n\n`);
     }
     md.appendMarkdown(`**State:** ${item.state}\n\n`);
-    md.appendMarkdown(`**Completed:** ${new Date(item.updatedAt).toLocaleString()}`);
+    const timestampLabel = item.state === WorkItemState.Done ? 'Completed at' : item.state === WorkItemState.Archived ? 'Archived at' : 'Last updated';
+    md.appendMarkdown(`**${timestampLabel}:** ${new Date(item.updatedAt).toLocaleString()}`);
     return md;
   }
 


### PR DESCRIPTION
Add a new History tree view showing work items in Done and Archived states, sorted by most recently updated. Includes state labels, icons, and Open in Browser support for items with URLs.

Closes #5