### PR TITLE
Add notification mechanism for new Inbox items

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3906,6 +3906,9 @@
       "name": "workcenter",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@workcenter/shared": "*"
+      },
       "devDependencies": {
         "@types/node": "^20.11.0",
         "@types/vscode": "^1.85.0",
@@ -3924,6 +3927,9 @@
       "name": "workcenter-github",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "@workcenter/shared": "*"
+      },
       "devDependencies": {
         "@types/node": "^20.11.0",
         "@types/vscode": "^1.85.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,11 @@
           "enum": ["debug", "info", "warn", "error"],
           "default": "info",
           "description": "Log level for WorkCenter output channel"
+        },
+        "workcenter.showInboxNotifications": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show a notification when new items arrive in the Inbox"
         }
       }
     },
@@ -144,16 +149,6 @@
         "icon": "$(arrow-down)"
       }
     ],
-    "configuration": {
-      "title": "WorkCenter",
-      "properties": {
-        "workcenter.showInboxNotifications": {
-          "type": "boolean",
-          "default": true,
-          "description": "Show a notification when new items arrive in the Inbox"
-        }
-      }
-    },
     "menus": {
       "view/title": [
         {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -144,6 +144,16 @@
         "icon": "$(arrow-down)"
       }
     ],
+    "configuration": {
+      "title": "WorkCenter",
+      "properties": {
+        "workcenter.showInboxNotifications": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show a notification when new items arrive in the Inbox"
+        }
+      }
+    },
     "menus": {
       "view/title": [
         {

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -131,24 +131,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   updateWorkViewMessages();
   const workGraphSub = workGraph.onDidChange(updateWorkViewMessages);
 
-  let previousInboxCount = 0;
   let initialLoadComplete = false;
 
   const updateInboxBadge = () => {
     const count = getInboxUnseenCount(providerRegistry, stateStore);
     inboxTreeView.badge = count > 0 ? { value: count, tooltip: `${count} unseen item${count === 1 ? '' : 's'}` } : undefined;
-
-    if (initialLoadComplete && count > previousInboxCount) {
-      const newCount = count - previousInboxCount;
-      const config = vscode.workspace.getConfiguration('workcenter');
-      const showNotifications = config.get<boolean>('showInboxNotifications', true);
-      if (showNotifications && newCount > 0) {
-        vscode.window.showInformationMessage(
-          `WorkCenter: ${newCount} new item${newCount === 1 ? '' : 's'} in Inbox`
-        );
-      }
-    }
-    previousInboxCount = count;
   };
 
   updateViewMessages();
@@ -159,6 +146,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   const discoveredSub = providerRegistry.onDidChangeDiscoveredItems(() => {
     updateViewMessages();
     updateInboxBadge();
+  });
+  const newItemsSub = providerRegistry.onDidAddNewUnseenItems((newCount) => {
+    if (!initialLoadComplete) { return; }
+    const config = vscode.workspace.getConfiguration('workcenter');
+    const showNotifications = config.get<boolean>('showInboxNotifications', true);
+    if (showNotifications && newCount > 0) {
+      vscode.window.showInformationMessage(
+        `WorkCenter: ${newCount} new item${newCount === 1 ? '' : 's'} in Inbox`
+      );
+    }
   });
   const stateStoreSub = stateStore.onDidChange(() => {
     updateViewMessages();
@@ -172,6 +169,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
     sourcesTreeView,
     historyTreeView,
     discoveredSub,
+    newItemsSub,
     providerRegSub,
     stateStoreSub,
     workGraphSub,

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -136,7 +136,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
 
   const updateInboxBadge = () => {
     const count = getInboxUnseenCount(providerRegistry, stateStore);
-    inboxTreeView.badge = count > 0 ? { value: count, tooltip: `${count} new item${count === 1 ? '' : 's'}` } : undefined;
+    inboxTreeView.badge = count > 0 ? { value: count, tooltip: `${count} unseen item${count === 1 ? '' : 's'}` } : undefined;
 
     if (initialLoadComplete && count > previousInboxCount) {
       const newCount = count - previousInboxCount;

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -91,10 +91,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   const sourcesTreeView = vscode.window.createTreeView('workcenter.sources', { treeDataProvider: sourcesProvider });
 
   const inboxSelectionSub = inboxTreeView.onDidChangeSelection((e) => {
+    let changed = false;
     for (const item of e.selection) {
       if (item.kind === 'item') {
-        inboxProvider.markSeen(item.providerId, item.externalId);
+        changed = inboxProvider.markSeen(item.providerId, item.externalId) || changed;
       }
+    }
+    if (changed) {
+      inboxProvider.refresh();
     }
   });
 

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -90,6 +90,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   const inboxTreeView = vscode.window.createTreeView('workcenter.inbox', { treeDataProvider: inboxProvider });
   const sourcesTreeView = vscode.window.createTreeView('workcenter.sources', { treeDataProvider: sourcesProvider });
 
+  const inboxSelectionSub = inboxTreeView.onDidChangeSelection((e) => {
+    for (const item of e.selection) {
+      if (item.kind === 'item') {
+        inboxProvider.markSeen(item.providerId, item.externalId);
+      }
+    }
+  });
+
   // View message state: empty by default, loading when providers are fetching
   const updateViewMessages = () => {
     if (providerRegistry.loading) {
@@ -174,6 +182,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
     focusTreeView,
     sourcesTreeView,
     historyTreeView,
+    inboxSelectionSub,
     discoveredSub,
     newItemsSub,
     providerRegSub,

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -127,13 +127,26 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
     inboxTreeView.badge = count > 0 ? { value: count, tooltip: `${count} unseen item${count === 1 ? '' : 's'}` } : undefined;
   };
 
+  // Coalesce UI updates so that when both onDidChangeDiscoveredItems and
+  // stateStore.onDidChange fire in the same microtask (e.g. during a discovery
+  // batch that calls setStates), we only run the full unseen-count scan once.
+  let uiUpdateScheduled = false;
+  const scheduleUiUpdate = () => {
+    if (uiUpdateScheduled) { return; }
+    uiUpdateScheduled = true;
+    queueMicrotask(() => {
+      uiUpdateScheduled = false;
+      updateViewMessages();
+      updateInboxBadge();
+    });
+  };
+
   updateViewMessages();
   updateInboxBadge();
 
-  const providerRegSub = providerRegistry.onDidRegisterProvider(updateViewMessages);
+  const providerRegSub = providerRegistry.onDidRegisterProvider(scheduleUiUpdate);
   const discoveredSub = providerRegistry.onDidChangeDiscoveredItems(() => {
-    updateViewMessages();
-    updateInboxBadge();
+    scheduleUiUpdate();
 
     // Mark initial load complete when loading transitions from true to false
     if (!initialLoadComplete) {
@@ -153,10 +166,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
       );
     }
   });
-  const stateStoreSub = stateStore.onDidChange(() => {
-    updateViewMessages();
-    updateInboxBadge();
-  });
+  const stateStoreSub = stateStore.onDidChange(scheduleUiUpdate);
 
   context.subscriptions.push(
     inboxTreeView,

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -132,12 +132,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   const workGraphSub = workGraph.onDidChange(updateWorkViewMessages);
 
   let previousInboxCount = 0;
+  let initialLoadComplete = false;
 
   const updateInboxBadge = () => {
     const count = getInboxUnseenCount(providerRegistry, stateStore);
     inboxTreeView.badge = count > 0 ? { value: count, tooltip: `${count} new item${count === 1 ? '' : 's'}` } : undefined;
 
-    if (count > previousInboxCount && previousInboxCount >= 0) {
+    if (initialLoadComplete && count > previousInboxCount) {
       const newCount = count - previousInboxCount;
       const config = vscode.workspace.getConfiguration('workcenter');
       const showNotifications = config.get<boolean>('showInboxNotifications', true);
@@ -152,6 +153,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
 
   updateViewMessages();
   updateInboxBadge();
+  initialLoadComplete = true;
 
   const providerRegSub = providerRegistry.onDidRegisterProvider(updateViewMessages);
   const discoveredSub = providerRegistry.onDidChangeDiscoveredItems(() => {

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -17,6 +17,19 @@ import { initLogger, setLogLevel, logger, LogLevel } from './services/logger';
 export type { WorkCenterApi, WorkCenterProvider, WorkCenterAction, DiscoveredItem, Disposable } from './api/types';
 export { logger } from './services/logger';
 
+export function getInboxUnseenCount(providerRegistry: ProviderRegistry, stateStore: DiscoveredStateStore): number {
+  let count = 0;
+  for (const [providerId, items] of providerRegistry.getAllDiscoveredItems()) {
+    for (const item of items) {
+      const state = stateStore.getState(providerId, item.externalId);
+      if (state === undefined || state === 'unseen') {
+        count++;
+      }
+    }
+  }
+  return count;
+}
+
 export async function activate(context: vscode.ExtensionContext): Promise<WorkCenterApi> {
   const outputChannel = vscode.window.createOutputChannel('WorkCenter');
   context.subscriptions.push(outputChannel);
@@ -118,11 +131,37 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   updateWorkViewMessages();
   const workGraphSub = workGraph.onDidChange(updateWorkViewMessages);
 
+  let previousInboxCount = 0;
+
+  const updateInboxBadge = () => {
+    const count = getInboxUnseenCount(providerRegistry, stateStore);
+    inboxTreeView.badge = count > 0 ? { value: count, tooltip: `${count} new item${count === 1 ? '' : 's'}` } : undefined;
+
+    if (count > previousInboxCount && previousInboxCount >= 0) {
+      const newCount = count - previousInboxCount;
+      const config = vscode.workspace.getConfiguration('workcenter');
+      const showNotifications = config.get<boolean>('showInboxNotifications', true);
+      if (showNotifications && newCount > 0) {
+        vscode.window.showInformationMessage(
+          `WorkCenter: ${newCount} new item${newCount === 1 ? '' : 's'} in Inbox`
+        );
+      }
+    }
+    previousInboxCount = count;
+  };
+
   updateViewMessages();
+  updateInboxBadge();
 
   const providerRegSub = providerRegistry.onDidRegisterProvider(updateViewMessages);
-  const discoveredSub = providerRegistry.onDidChangeDiscoveredItems(updateViewMessages);
-  const stateStoreSub = stateStore.onDidChange(updateViewMessages);
+  const discoveredSub = providerRegistry.onDidChangeDiscoveredItems(() => {
+    updateViewMessages();
+    updateInboxBadge();
+  });
+  const stateStoreSub = stateStore.onDidChange(() => {
+    updateViewMessages();
+    updateInboxBadge();
+  });
 
   context.subscriptions.push(
     inboxTreeView,

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -13,22 +13,10 @@ import { SourcesTreeProvider } from './views/sourcesTreeProvider';
 import { HistoryTreeProvider } from './views/historyTreeProvider';
 import { registerCommands } from './commands/commands';
 import { initLogger, setLogLevel, logger, LogLevel } from './services/logger';
+import { getInboxUnseenCount } from './services/inboxBadge';
 
 export type { WorkCenterApi, WorkCenterProvider, WorkCenterAction, DiscoveredItem, Disposable } from './api/types';
 export { logger } from './services/logger';
-
-export function getInboxUnseenCount(providerRegistry: ProviderRegistry, stateStore: DiscoveredStateStore): number {
-  let count = 0;
-  for (const [providerId, items] of providerRegistry.getAllDiscoveredItems()) {
-    for (const item of items) {
-      const state = stateStore.getState(providerId, item.externalId);
-      if (state === undefined || state === 'unseen') {
-        count++;
-      }
-    }
-  }
-  return count;
-}
 
 export async function activate(context: vscode.ExtensionContext): Promise<WorkCenterApi> {
   const outputChannel = vscode.window.createOutputChannel('WorkCenter');

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -132,6 +132,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   const workGraphSub = workGraph.onDidChange(updateWorkViewMessages);
 
   let initialLoadComplete = false;
+  let wasLoading = false;
 
   const updateInboxBadge = () => {
     const count = getInboxUnseenCount(providerRegistry, stateStore);
@@ -140,12 +141,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
 
   updateViewMessages();
   updateInboxBadge();
-  initialLoadComplete = true;
 
   const providerRegSub = providerRegistry.onDidRegisterProvider(updateViewMessages);
   const discoveredSub = providerRegistry.onDidChangeDiscoveredItems(() => {
     updateViewMessages();
     updateInboxBadge();
+
+    // Mark initial load complete when loading transitions from true to false
+    if (!initialLoadComplete) {
+      if (wasLoading && !providerRegistry.loading) {
+        initialLoadComplete = true;
+      }
+      wasLoading = wasLoading || providerRegistry.loading;
+    }
   });
   const newItemsSub = providerRegistry.onDidAddNewUnseenItems((newCount) => {
     if (!initialLoadComplete) { return; }

--- a/packages/core/src/services/inboxBadge.ts
+++ b/packages/core/src/services/inboxBadge.ts
@@ -1,0 +1,15 @@
+import { ProviderRegistry } from './providerRegistry';
+import { DiscoveredStateStore } from '../storage/discoveredStateStore';
+
+export function getInboxUnseenCount(providerRegistry: ProviderRegistry, stateStore: DiscoveredStateStore): number {
+  let count = 0;
+  for (const [providerId, items] of providerRegistry.getAllDiscoveredItems()) {
+    for (const item of items) {
+      const state = stateStore.getState(providerId, item.externalId);
+      if (state === undefined || state === 'unseen') {
+        count++;
+      }
+    }
+  }
+  return count;
+}

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -106,13 +106,12 @@ export class ProviderRegistry {
       }
     }
     if (updates.length > 0) {
-      await this.stateStore.setStates(updates)
-        .then(() => {
-          this._onDidAddNewUnseenItems.fire(updates.length);
-        })
-        .catch((err) => {
-          logger.error('Failed to persist discovered states', err);
-        });
+      try {
+        await this.stateStore.setStates(updates);
+        this._onDidAddNewUnseenItems.fire(updates.length);
+      } catch (err) {
+        logger.error('Failed to persist discovered states', err);
+      }
     }
     this._onDidChangeDiscoveredItems.fire();
   }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -106,10 +106,13 @@ export class ProviderRegistry {
       }
     }
     if (updates.length > 0) {
-      await this.stateStore.setStates(updates).catch((err) => {
-        logger.error('Failed to persist discovered states', err);
-      });
-      this._onDidAddNewUnseenItems.fire(updates.length);
+      await this.stateStore.setStates(updates)
+        .then(() => {
+          this._onDidAddNewUnseenItems.fire(updates.length);
+        })
+        .catch((err) => {
+          logger.error('Failed to persist discovered states', err);
+        });
     }
     this._onDidChangeDiscoveredItems.fire();
   }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -11,6 +11,8 @@ export class ProviderRegistry {
   readonly onDidChangeDiscoveredItems = this._onDidChangeDiscoveredItems.event;
   private readonly _onDidRegisterProvider = new vscode.EventEmitter<void>();
   readonly onDidRegisterProvider = this._onDidRegisterProvider.event;
+  private readonly _onDidAddNewUnseenItems = new vscode.EventEmitter<number>();
+  readonly onDidAddNewUnseenItems = this._onDidAddNewUnseenItems.event;
   private readonly _loadingProviders = new Set<string>();
 
   get loading(): boolean {
@@ -107,6 +109,7 @@ export class ProviderRegistry {
       await this.stateStore.setStates(updates).catch((err) => {
         logger.error('Failed to persist discovered states', err);
       });
+      this._onDidAddNewUnseenItems.fire(updates.length);
     }
     this._onDidChangeDiscoveredItems.fire();
   }
@@ -119,5 +122,6 @@ export class ProviderRegistry {
     this.subscriptions.clear();
     this._onDidChangeDiscoveredItems.dispose();
     this._onDidRegisterProvider.dispose();
+    this._onDidAddNewUnseenItems.dispose();
   }
 }

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -33,13 +33,13 @@ const TreeItemCollapsibleState = {
 };
 
 class MockTreeItem {
-  label: string;
+  label: string | { label: string; highlights?: [number, number][] };
   collapsibleState: number;
   description?: string;
   tooltip?: any;
   contextValue?: string;
   iconPath?: any;
-  constructor(label: string, collapsibleState?: number) {
+  constructor(label: string | { label: string; highlights?: [number, number][] }, collapsibleState?: number) {
     this.label = label;
     this.collapsibleState = collapsibleState ?? 0;
   }
@@ -52,7 +52,16 @@ const window = {
   showErrorMessage: vi.fn(),
   showQuickPick: vi.fn(),
   registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })),
-  createTreeView: vi.fn(() => ({ dispose: vi.fn(), message: undefined, badge: undefined })),
+  createTreeView: vi.fn(() => {
+    const selectionEmitter = new MockEventEmitter();
+    return {
+      dispose: vi.fn(),
+      message: undefined,
+      badge: undefined,
+      onDidChangeSelection: selectionEmitter.event,
+      _selectionEmitter: selectionEmitter,
+    };
+  }),
   createWebviewPanel: vi.fn(),
   createOutputChannel: vi.fn(() => ({
     appendLine: vi.fn(),

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -52,7 +52,7 @@ const window = {
   showErrorMessage: vi.fn(),
   showQuickPick: vi.fn(),
   registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })),
-  createTreeView: vi.fn(() => ({ dispose: vi.fn(), message: undefined })),
+  createTreeView: vi.fn(() => ({ dispose: vi.fn(), message: undefined, badge: undefined })),
   createWebviewPanel: vi.fn(),
   createOutputChannel: vi.fn(() => ({
     appendLine: vi.fn(),
@@ -76,6 +76,12 @@ const env = {
 
 const Uri = {
   parse: vi.fn((s: string) => ({ toString: () => s })),
+};
+
+const workspace = {
+  getConfiguration: vi.fn(() => ({
+    get: vi.fn((_key: string, defaultValue?: any) => defaultValue),
+  })),
 };
 
 class MockDisposable {

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -87,12 +87,6 @@ const Uri = {
   parse: vi.fn((s: string) => ({ toString: () => s })),
 };
 
-const workspace = {
-  getConfiguration: vi.fn(() => ({
-    get: vi.fn((_key: string, defaultValue?: any) => defaultValue),
-  })),
-};
-
 class MockDisposable {
   private callback: () => void;
   constructor(callback: () => void) { this.callback = callback; }

--- a/packages/core/src/test/getInboxUnseenCount.test.ts
+++ b/packages/core/src/test/getInboxUnseenCount.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventEmitter } from 'vscode';
 import { WorkCenterProvider, DiscoveredItem } from '../api/types';
 import { ProviderRegistry } from '../services/providerRegistry';
-import { getInboxUnseenCount } from '../extension';
+import { getInboxUnseenCount } from '../services/inboxBadge';
 
 function createMockStateStore() {
   const cache = new Map<string, string>();

--- a/packages/core/src/test/getInboxUnseenCount.test.ts
+++ b/packages/core/src/test/getInboxUnseenCount.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventEmitter } from 'vscode';
+import { WorkCenterProvider, DiscoveredItem } from '../api/types';
+import { ProviderRegistry } from '../services/providerRegistry';
+import { getInboxUnseenCount } from '../extension';
+
+function createMockStateStore() {
+  const cache = new Map<string, string>();
+  return {
+    getState: vi.fn((providerId: string, externalId: string) =>
+      cache.get(`${providerId}::${externalId}`) as any,
+    ),
+    setState: vi.fn(async (providerId: string, externalId: string, state: string) => {
+      cache.set(`${providerId}::${externalId}`, state);
+    }),
+    setStates: vi.fn(async (items: Array<{ providerId: string; externalId: string; state: string }>) => {
+      for (const item of items) {
+        cache.set(`${item.providerId}::${item.externalId}`, item.state);
+      }
+    }),
+    load: vi.fn(async () => {}),
+    loadAll: vi.fn(async () => []),
+    onDidChange: vi.fn(() => ({ dispose: vi.fn() })),
+    dispose: vi.fn(),
+    _set: (providerId: string, externalId: string, state: string) => {
+      cache.set(`${providerId}::${externalId}`, state);
+    },
+  };
+}
+
+function createMockProvider(id: string): WorkCenterProvider & { fireItems: (items: DiscoveredItem[]) => void } {
+  const emitter = new EventEmitter<DiscoveredItem[]>();
+  return {
+    id,
+    label: `Provider ${id}`,
+    onDidDiscoverItems: emitter.event,
+    refresh: vi.fn(async () => {}),
+    fireItems: (items) => emitter.fire(items),
+  };
+}
+
+describe('getInboxUnseenCount', () => {
+  let stateStore: ReturnType<typeof createMockStateStore>;
+  let registry: ProviderRegistry;
+
+  beforeEach(() => {
+    stateStore = createMockStateStore();
+    registry = new ProviderRegistry(stateStore as any);
+  });
+
+  it('returns 0 when no providers registered', () => {
+    expect(getInboxUnseenCount(registry, stateStore as any)).toBe(0);
+  });
+
+  it('counts items with no state as unseen', () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+    provider.fireItems([
+      { externalId: '1', title: 'Issue 1' },
+      { externalId: '2', title: 'Issue 2' },
+    ]);
+
+    expect(getInboxUnseenCount(registry, stateStore as any)).toBe(2);
+  });
+
+  it('counts items with explicit unseen state', () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+    provider.fireItems([
+      { externalId: '1', title: 'Issue 1' },
+    ]);
+    stateStore._set('gh', '1', 'unseen');
+
+    expect(getInboxUnseenCount(registry, stateStore as any)).toBe(1);
+  });
+
+  it('excludes accepted items', () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+    provider.fireItems([
+      { externalId: '1', title: 'Issue 1' },
+      { externalId: '2', title: 'Issue 2' },
+    ]);
+    stateStore._set('gh', '1', 'accepted');
+
+    expect(getInboxUnseenCount(registry, stateStore as any)).toBe(1);
+  });
+
+  it('excludes dismissed items', () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+    provider.fireItems([
+      { externalId: '1', title: 'Issue 1' },
+      { externalId: '2', title: 'Issue 2' },
+    ]);
+    stateStore._set('gh', '1', 'dismissed');
+    stateStore._set('gh', '2', 'dismissed');
+
+    expect(getInboxUnseenCount(registry, stateStore as any)).toBe(0);
+  });
+
+  it('counts across multiple providers', () => {
+    const p1 = createMockProvider('gh');
+    const p2 = createMockProvider('jira');
+    registry.register(p1);
+    registry.register(p2);
+    p1.fireItems([{ externalId: '1', title: 'GH Issue' }]);
+    p2.fireItems([{ externalId: 'A', title: 'Jira Issue' }]);
+
+    stateStore._set('gh', '1', 'accepted');
+
+    expect(getInboxUnseenCount(registry, stateStore as any)).toBe(1);
+  });
+});

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -172,19 +172,13 @@ describe('InboxTreeProvider', () => {
   });
 
   describe('markSeen', () => {
-    it('should fire tree data change event', () => {
-      const listener = vi.fn();
-      provider.onDidChangeTreeData(listener);
-      provider.markSeen('gh', '1');
-      expect(listener).toHaveBeenCalledTimes(1);
+    it('should return true for a newly seen item', () => {
+      expect(provider.markSeen('gh', '1')).toBe(true);
     });
 
-    it('should not fire event if item is already seen', () => {
+    it('should return false if item is already seen', () => {
       provider.markSeen('gh', '1');
-      const listener = vi.fn();
-      provider.onDidChangeTreeData(listener);
-      provider.markSeen('gh', '1');
-      expect(listener).not.toHaveBeenCalled();
+      expect(provider.markSeen('gh', '1')).toBe(false);
     });
   });
 
@@ -196,17 +190,32 @@ describe('InboxTreeProvider', () => {
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
-    it('should clear seenItems when providerRegistry fires change event', () => {
+    it('should retain seenItems for items still in inbox after provider refresh', () => {
+      registry._setItems('gh', [{ externalId: '1', title: 'Bug' }]);
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
       provider.markSeen('gh', '1');
 
       // Before refresh, item should be seen (plain label)
       expect(provider.getTreeItem(item).label).toBe('Bug');
 
-      // Provider refresh fires → seenItems should be cleared
+      // Provider refresh fires → item is still in inbox, so seenItems should be retained
       registry._fire();
 
-      // After refresh, item should appear highlighted again
+      // After refresh, item should still appear as seen (plain label)
+      expect(provider.getTreeItem(item).label).toBe('Bug');
+    });
+
+    it('should prune seenItems for items no longer in inbox after provider refresh', () => {
+      registry._setItems('gh', [{ externalId: '1', title: 'Bug' }]);
+      provider.markSeen('gh', '1');
+
+      // Remove item from provider
+      registry._setItems('gh', []);
+      registry._fire();
+
+      // Re-add item — should appear as unseen (highlighted)
+      registry._setItems('gh', [{ externalId: '1', title: 'Bug' }]);
+      const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
       expect(provider.getTreeItem(item).label).toEqual({ label: 'Bug', highlights: [[0, 3]] });
     });
 

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -196,6 +196,20 @@ describe('InboxTreeProvider', () => {
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
+    it('should clear seenItems when providerRegistry fires change event', () => {
+      const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
+      provider.markSeen('gh', '1');
+
+      // Before refresh, item should be seen (plain label)
+      expect(provider.getTreeItem(item).label).toBe('Bug');
+
+      // Provider refresh fires → seenItems should be cleared
+      registry._fire();
+
+      // After refresh, item should appear highlighted again
+      expect(provider.getTreeItem(item).label).toEqual({ label: 'Bug', highlights: [[0, 3]] });
+    });
+
     it('should refresh when stateStore fires change event', () => {
       const listener = vi.fn();
       provider.onDidChangeTreeData(listener);

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -143,13 +143,21 @@ describe('InboxTreeProvider', () => {
       expect((treeItem.iconPath as any).id).toBe('plug');
     });
 
-    it('should render inbox item with mail icon', () => {
+    it('should render new inbox item with highlighted label', () => {
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
       const treeItem = provider.getTreeItem(item);
 
-      expect(treeItem.label).toBe('Bug');
+      expect(treeItem.label).toEqual({ label: 'Bug', highlights: [[0, 3]] });
       expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.None);
       expect((treeItem.iconPath as any).id).toBe('mail');
+    });
+
+    it('should render seen inbox item with plain label', () => {
+      const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
+      provider.markSeen('gh', '1');
+      const treeItem = provider.getTreeItem(item);
+
+      expect(treeItem.label).toBe('Bug');
     });
 
     it('should set contextValue with hasUrl when item has url', () => {
@@ -160,6 +168,23 @@ describe('InboxTreeProvider', () => {
     it('should set contextValue without hasUrl when item lacks url', () => {
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'X' };
       expect(provider.getTreeItem(item).contextValue).toBe('inboxItem');
+    });
+  });
+
+  describe('markSeen', () => {
+    it('should fire tree data change event', () => {
+      const listener = vi.fn();
+      provider.onDidChangeTreeData(listener);
+      provider.markSeen('gh', '1');
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not fire event if item is already seen', () => {
+      provider.markSeen('gh', '1');
+      const listener = vi.fn();
+      provider.onDidChangeTreeData(listener);
+      provider.markSeen('gh', '1');
+      expect(listener).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -143,21 +143,22 @@ describe('InboxTreeProvider', () => {
       expect((treeItem.iconPath as any).id).toBe('plug');
     });
 
-    it('should render new inbox item with highlighted label', () => {
+    it('should render unseen inbox item with circle-filled icon', () => {
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
       const treeItem = provider.getTreeItem(item);
 
-      expect(treeItem.label).toEqual({ label: 'Bug', highlights: [[0, 3]] });
+      expect(treeItem.label).toBe('Bug');
       expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.None);
-      expect((treeItem.iconPath as any).id).toBe('mail');
+      expect((treeItem.iconPath as any).id).toBe('circle-filled');
     });
 
-    it('should render seen inbox item with plain label', () => {
+    it('should render seen inbox item with circle-outline icon', () => {
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
       provider.markSeen('gh', '1');
       const treeItem = provider.getTreeItem(item);
 
       expect(treeItem.label).toBe('Bug');
+      expect((treeItem.iconPath as any).id).toBe('circle-outline');
     });
 
     it('should set contextValue with hasUrl when item has url', () => {
@@ -195,14 +196,16 @@ describe('InboxTreeProvider', () => {
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
       provider.markSeen('gh', '1');
 
-      // Before refresh, item should be seen (plain label)
+      // Before refresh, item should be seen (circle-outline icon)
       expect(provider.getTreeItem(item).label).toBe('Bug');
+      expect((provider.getTreeItem(item).iconPath as any).id).toBe('circle-outline');
 
       // Provider refresh fires → item is still in inbox, so seenItems should be retained
       registry._fire();
 
-      // After refresh, item should still appear as seen (plain label)
+      // After refresh, item should still appear as seen (circle-outline icon)
       expect(provider.getTreeItem(item).label).toBe('Bug');
+      expect((provider.getTreeItem(item).iconPath as any).id).toBe('circle-outline');
     });
 
     it('should prune seenItems for items no longer in inbox after provider refresh', () => {
@@ -213,10 +216,11 @@ describe('InboxTreeProvider', () => {
       registry._setItems('gh', []);
       registry._fire();
 
-      // Re-add item — should appear as unseen (highlighted)
+      // Re-add item — should appear as unseen (circle-filled icon)
       registry._setItems('gh', [{ externalId: '1', title: 'Bug' }]);
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
-      expect(provider.getTreeItem(item).label).toEqual({ label: 'Bug', highlights: [[0, 3]] });
+      expect(provider.getTreeItem(item).label).toBe('Bug');
+      expect((provider.getTreeItem(item).iconPath as any).id).toBe('circle-filled');
     });
 
     it('should refresh when stateStore fires change event', () => {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -238,6 +238,42 @@ describe('ProviderRegistry', () => {
     expect(all.get('jira')).toHaveLength(1);
   });
 
+  it('fires onDidAddNewUnseenItems with count of newly unseen items', async () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+
+    const listener = vi.fn();
+    registry.onDidAddNewUnseenItems(listener);
+
+    provider.fireItems([
+      { externalId: 'issue-1', title: 'Bug fix' },
+      { externalId: 'issue-2', title: 'Feature' },
+    ]);
+
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledWith(2));
+  });
+
+  it('does not fire onDidAddNewUnseenItems when no new unseen items', async () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+
+    // Simulate items already accepted
+    stateStore._set('gh', 'issue-1', 'accepted');
+
+    const listener = vi.fn();
+    registry.onDidAddNewUnseenItems(listener);
+
+    provider.fireItems([
+      { externalId: 'issue-1', title: 'Bug fix' },
+    ]);
+
+    // Wait for handleDiscoveredItems to complete, then verify no fire
+    await vi.waitFor(() => {
+      expect(stateStore.setStates).not.toHaveBeenCalled();
+    });
+    expect(listener).not.toHaveBeenCalled();
+  });
+
   it('fires onDidChangeDiscoveredItems when provider discovers items', async () => {
     const provider = createMockProvider('gh');
     registry.register(provider);

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -324,6 +324,26 @@ describe('ProviderRegistry', () => {
     createSpy.mockRestore();
   });
 
+  it('does not fire onDidAddNewUnseenItems when setStates fails', async () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+
+    stateStore.setStates.mockRejectedValueOnce(new Error('disk full'));
+
+    const listener = vi.fn();
+    registry.onDidAddNewUnseenItems(listener);
+
+    provider.fireItems([
+      { externalId: 'issue-1', title: 'Bug fix' },
+    ]);
+
+    // Wait for handleDiscoveredItems to complete
+    await vi.waitFor(() =>
+      expect(registry.getDiscoveredItems('gh')).toHaveLength(1),
+    );
+    expect(listener).not.toHaveBeenCalled();
+  });
+
   describe('resurfaceDismissed', () => {
     function createResurfaceProvider(id: string): WorkCenterProvider & { fireItems: (items: DiscoveredItem[]) => void } {
       const emitter = new EventEmitter<DiscoveredItem[]>();

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -267,10 +267,11 @@ describe('ProviderRegistry', () => {
       { externalId: 'issue-1', title: 'Bug fix' },
     ]);
 
-    // Wait for handleDiscoveredItems to complete, then verify no fire
-    await vi.waitFor(() => {
-      expect(stateStore.setStates).not.toHaveBeenCalled();
-    });
+    // Wait for handleDiscoveredItems to complete by checking items are stored
+    await vi.waitFor(() =>
+      expect(registry.getDiscoveredItems('gh')).toHaveLength(1),
+    );
+    expect(stateStore.setStates).not.toHaveBeenCalled();
     expect(listener).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -31,25 +31,31 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   ) {
     this.disposables.push(
       providerRegistry.onDidChangeDiscoveredItems(() => {
-        // Prune seenItems to only retain keys for items still visible in the Inbox
-        const currentKeys = new Set<string>();
-        for (const [providerId, items] of this.providerRegistry.getAllDiscoveredItems()) {
-          for (const item of items) {
-            const state = this.stateStore.getState(providerId, item.externalId);
-            if (state === undefined || state === 'unseen') {
-              currentKeys.add(`${providerId}::${item.externalId}`);
-            }
-          }
-        }
-        for (const key of this.seenItems) {
-          if (!currentKeys.has(key)) {
-            this.seenItems.delete(key);
-          }
-        }
+        this.pruneSeenItems();
         this._onDidChangeTreeData.fire();
       }),
-      stateStore.onDidChange(() => this._onDidChangeTreeData.fire())
+      stateStore.onDidChange(() => {
+        this.pruneSeenItems();
+        this._onDidChangeTreeData.fire();
+      })
     );
+  }
+
+  private pruneSeenItems(): void {
+    const currentKeys = new Set<string>();
+    for (const [providerId, items] of this.providerRegistry.getAllDiscoveredItems()) {
+      for (const item of items) {
+        const state = this.stateStore.getState(providerId, item.externalId);
+        if (state === undefined || state === 'unseen') {
+          currentKeys.add(`${providerId}::${item.externalId}`);
+        }
+      }
+    }
+    for (const key of this.seenItems) {
+      if (!currentKeys.has(key)) {
+        this.seenItems.delete(key);
+      }
+    }
   }
 
   refresh(): void { this._onDidChangeTreeData.fire(); }

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -23,6 +23,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private readonly disposables: vscode.Disposable[] = [];
+  private readonly seenItems = new Set<string>();
 
   constructor(
     private readonly providerRegistry: ProviderRegistry,
@@ -36,6 +37,14 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   refresh(): void { this._onDidChangeTreeData.fire(); }
 
+  markSeen(providerId: string, externalId: string): void {
+    const key = `${providerId}:${externalId}`;
+    if (!this.seenItems.has(key)) {
+      this.seenItems.add(key);
+      this._onDidChangeTreeData.fire();
+    }
+  }
+
   getTreeItem(element: InboxElement): vscode.TreeItem {
     if (element.kind === 'provider') {
       const count = this.getUnseenCount(element.providerId);
@@ -46,7 +55,13 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       return treeItem;
     }
 
-    const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
+    const key = `${element.providerId}:${element.externalId}`;
+    const isSeen = this.seenItems.has(key);
+
+    const treeItem = new vscode.TreeItem(
+      isSeen ? element.title : { label: element.title, highlights: [[0, element.title.length]] },
+      vscode.TreeItemCollapsibleState.None,
+    );
     treeItem.tooltip = this.buildTooltip(element);
     treeItem.contextValue = element.url ? 'inboxItem.hasUrl' : 'inboxItem';
     treeItem.iconPath = new vscode.ThemeIcon('mail');

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -30,7 +30,10 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     private readonly stateStore: DiscoveredStateStore,
   ) {
     this.disposables.push(
-      providerRegistry.onDidChangeDiscoveredItems(() => this._onDidChangeTreeData.fire()),
+      providerRegistry.onDidChangeDiscoveredItems(() => {
+        this.seenItems.clear();
+        this._onDidChangeTreeData.fire();
+      }),
       stateStore.onDidChange(() => this._onDidChangeTreeData.fire())
     );
   }

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -31,7 +31,21 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   ) {
     this.disposables.push(
       providerRegistry.onDidChangeDiscoveredItems(() => {
-        this.seenItems.clear();
+        // Prune seenItems to only retain keys for items still visible in the Inbox
+        const currentKeys = new Set<string>();
+        for (const [providerId, items] of this.providerRegistry.getAllDiscoveredItems()) {
+          for (const item of items) {
+            const state = this.stateStore.getState(providerId, item.externalId);
+            if (state === undefined || state === 'unseen') {
+              currentKeys.add(`${providerId}::${item.externalId}`);
+            }
+          }
+        }
+        for (const key of this.seenItems) {
+          if (!currentKeys.has(key)) {
+            this.seenItems.delete(key);
+          }
+        }
         this._onDidChangeTreeData.fire();
       }),
       stateStore.onDidChange(() => this._onDidChangeTreeData.fire())
@@ -40,12 +54,13 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   refresh(): void { this._onDidChangeTreeData.fire(); }
 
-  markSeen(providerId: string, externalId: string): void {
-    const key = `${providerId}:${externalId}`;
+  markSeen(providerId: string, externalId: string): boolean {
+    const key = `${providerId}::${externalId}`;
     if (!this.seenItems.has(key)) {
       this.seenItems.add(key);
-      this._onDidChangeTreeData.fire();
+      return true;
     }
+    return false;
   }
 
   getTreeItem(element: InboxElement): vscode.TreeItem {
@@ -58,7 +73,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       return treeItem;
     }
 
-    const key = `${element.providerId}:${element.externalId}`;
+    const key = `${element.providerId}::${element.externalId}`;
     const isSeen = this.seenItems.has(key);
 
     const treeItem = new vscode.TreeItem(

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -82,13 +82,10 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     const key = `${element.providerId}::${element.externalId}`;
     const isSeen = this.seenItems.has(key);
 
-    const treeItem = new vscode.TreeItem(
-      isSeen ? element.title : { label: element.title, highlights: [[0, element.title.length]] },
-      vscode.TreeItemCollapsibleState.None,
-    );
+    const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
     treeItem.tooltip = this.buildTooltip(element);
     treeItem.contextValue = element.url ? 'inboxItem.hasUrl' : 'inboxItem';
-    treeItem.iconPath = new vscode.ThemeIcon('mail');
+    treeItem.iconPath = new vscode.ThemeIcon(isSeen ? 'circle-outline' : 'circle-filled');
     return treeItem;
   }
 


### PR DESCRIPTION
Show badge count on the Inbox tree view with unseen item count. Display optional toast notification when new items arrive. Add `workcenter.showInboxNotifications` configuration setting.

Closes #6