### PR TITLE
Rename WorkItem description field to notes

### DIFF
--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -107,7 +107,7 @@ export function registerCommands(
         return;
       }
       await workGraph.createItem(
-        { title: formatItemTitle(item), notes: item.description },
+        { title: formatItemTitle(item) },
         { providerId: item.providerId, externalId: item.externalId, url: item.url },
       );
       try {
@@ -143,7 +143,7 @@ export function registerCommands(
       }
       try {
         await workGraph.createItem(
-          { title: formatItemTitle(item), notes: item.description },
+          { title: formatItemTitle(item) },
           { providerId: item.providerId, externalId: item.externalId, url: item.url },
         );
         await stateStore.setState(item.providerId, item.externalId, 'accepted');

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -107,7 +107,7 @@ export function registerCommands(
         return;
       }
       await workGraph.createItem(
-        { title: formatItemTitle(item), description: item.description },
+        { title: formatItemTitle(item), notes: item.description },
         { providerId: item.providerId, externalId: item.externalId, url: item.url },
       );
       try {
@@ -143,7 +143,7 @@ export function registerCommands(
       }
       try {
         await workGraph.createItem(
-          { title: formatItemTitle(item), description: item.description },
+          { title: formatItemTitle(item), notes: item.description },
           { providerId: item.providerId, externalId: item.externalId, url: item.url },
         );
         await stateStore.setState(item.providerId, item.externalId, 'accepted');

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -11,7 +11,7 @@ export enum WorkItemState {
 export interface WorkItem {
   id: string;
   title: string;
-  description?: string;
+  notes?: string;
   state: WorkItemState;
   providerId?: string;
   externalId?: string;
@@ -23,5 +23,5 @@ export interface WorkItem {
 
 export interface WorkItemInput {
   title: string;
-  description?: string;
+  notes?: string;
 }

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -79,7 +79,7 @@ export class WorkGraph {
     const item: WorkItem = {
       id: generateId(),
       title: input.title,
-      description: input.description,
+      notes: input.notes,
       state: WorkItemState.New,
       providerId: provenance?.providerId,
       externalId: provenance?.externalId,

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -40,8 +40,10 @@ export class JsonTaskStore implements ITaskStore {
       let needsMigration = false;
       for (const item of items) {
         const legacy = item as WorkItem & { description?: string };
-        if (legacy.description !== undefined && item.notes === undefined) {
-          item.notes = legacy.description;
+        if (legacy.description !== undefined) {
+          if (item.notes === undefined) {
+            item.notes = legacy.description;
+          }
           delete legacy.description;
           needsMigration = true;
         }
@@ -60,6 +62,7 @@ export class JsonTaskStore implements ITaskStore {
       }
       // Allow retry on failure
       this.loadPromise = null;
+      this.cache = null;
       throw err;
     }
   }

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -28,12 +28,17 @@ export class JsonTaskStore implements ITaskStore {
         throw new Error('Failed to parse work items file');
       }
       // Migrate legacy 'description' field to 'notes'
+      let needsMigration = false;
       for (const item of items) {
         const legacy = item as WorkItem & { description?: string };
         if (legacy.description !== undefined && item.notes === undefined) {
           item.notes = legacy.description;
           delete legacy.description;
+          needsMigration = true;
         }
+      }
+      if (needsMigration) {
+        await this.writeFile(items);
       }
       this.cache = new Map(items.map((item) => [item.id, item]));
       return items;

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -8,6 +8,7 @@ export class JsonTaskStore implements ITaskStore {
   private readonly filePath: string;
   private writeQueue: Promise<void> = Promise.resolve();
   private cache: Map<string, WorkItem> | null = null;
+  private loadPromise: Promise<WorkItem[]> | null = null;
 
   constructor(storagePath: string) {
     this.filePath = path.join(storagePath, 'workitems.json');
@@ -17,6 +18,14 @@ export class JsonTaskStore implements ITaskStore {
     if (this.cache !== null) {
       return Array.from(this.cache.values());
     }
+    // Guard against concurrent loads: reuse the same in-flight promise
+    if (this.loadPromise === null) {
+      this.loadPromise = this.doLoad();
+    }
+    return this.loadPromise;
+  }
+
+  private async doLoad(): Promise<WorkItem[]> {
     logger.debug(`Loading work items from ${this.filePath}`);
     try {
       const data = await fs.readFile(this.filePath, 'utf-8');
@@ -49,6 +58,8 @@ export class JsonTaskStore implements ITaskStore {
         this.cache = new Map();
         return [];
       }
+      // Allow retry on failure
+      this.loadPromise = null;
       throw err;
     }
   }

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -27,6 +27,14 @@ export class JsonTaskStore implements ITaskStore {
         logger.warn('Failed to parse work items file');
         throw new Error('Failed to parse work items file');
       }
+      // Migrate legacy 'description' field to 'notes'
+      for (const item of items) {
+        const legacy = item as WorkItem & { description?: string };
+        if (legacy.description !== undefined && item.notes === undefined) {
+          item.notes = legacy.description;
+          delete legacy.description;
+        }
+      }
       this.cache = new Map(items.map((item) => [item.id, item]));
       return items;
     } catch (err: unknown) {

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -37,10 +37,12 @@ export class JsonTaskStore implements ITaskStore {
           needsMigration = true;
         }
       }
-      if (needsMigration) {
-        await this.writeFile(items);
-      }
       this.cache = new Map(items.map((item) => [item.id, item]));
+      if (needsMigration) {
+        await this.enqueue(async () => {
+          await this.writeFile(items);
+        });
+      }
       return items;
     } catch (err: unknown) {
       if (isNodeError(err) && err.code === 'ENOENT') {
@@ -53,10 +55,10 @@ export class JsonTaskStore implements ITaskStore {
 
   async save(item: WorkItem): Promise<void> {
     logger.debug(`Saving work item: ${item.id}`);
+    if (this.cache === null) {
+      await this.loadAll();
+    }
     return this.enqueue(async () => {
-      if (this.cache === null) {
-        await this.loadAll();
-      }
       const previousValue = this.cache!.get(item.id);
       try {
         const items = Array.from(this.cache!.values()).filter(i => i.id !== item.id);
@@ -102,10 +104,10 @@ export class JsonTaskStore implements ITaskStore {
   }
 
   async delete(id: string): Promise<void> {
+    if (this.cache === null) {
+      await this.loadAll();
+    }
     return this.enqueue(async () => {
-      if (this.cache === null) {
-        await this.loadAll();
-      }
       const previousValue = this.cache!.get(id);
       try {
         this.cache!.delete(id);

--- a/packages/core/src/test/historyTreeProvider.test.ts
+++ b/packages/core/src/test/historyTreeProvider.test.ts
@@ -103,8 +103,8 @@ describe('HistoryTreeProvider', () => {
       expect(provider.getTreeItem(item).contextValue).toBe('historyItem.hasUrl');
     });
 
-    it('should include description in tooltip when present', () => {
-      const item = makeItem({ id: '1', title: 'Task', description: 'Details here' });
+    it('should include notes in tooltip when present', () => {
+      const item = makeItem({ id: '1', title: 'Task', notes: 'Details here' });
       const treeItem = provider.getTreeItem(item);
       expect((treeItem.tooltip as any).value).toContain('Details here');
     });

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -153,4 +153,23 @@ describe('JsonTaskStore', () => {
     expect(parsed).toHaveLength(1);
     expect(parsed[0].id).toBe('test-1');
   });
+
+  it('migrates legacy description field to notes on load', async () => {
+    const filePath = path.join(tmpDir, 'workitems.json');
+    const legacy = [{
+      id: 'legacy-1',
+      title: 'Old item',
+      description: 'Legacy description',
+      state: 'New',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }];
+    await fs.mkdir(tmpDir, { recursive: true });
+    await fs.writeFile(filePath, JSON.stringify(legacy), 'utf-8');
+
+    const items = await store.loadAll();
+    expect(items).toHaveLength(1);
+    expect(items[0].notes).toBe('Legacy description');
+    expect((items[0] as any).description).toBeUndefined();
+  });
 });

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -172,4 +172,26 @@ describe('JsonTaskStore', () => {
     expect(items[0].notes).toBe('Legacy description');
     expect((items[0] as any).description).toBeUndefined();
   });
+
+  it('persists migrated description→notes back to disk', async () => {
+    const filePath = path.join(tmpDir, 'workitems.json');
+    const legacy = [{
+      id: 'legacy-1',
+      title: 'Old item',
+      description: 'Legacy description',
+      state: 'New',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }];
+    await fs.mkdir(tmpDir, { recursive: true });
+    await fs.writeFile(filePath, JSON.stringify(legacy), 'utf-8');
+
+    await store.loadAll();
+
+    const raw = await fs.readFile(filePath, 'utf-8');
+    const persisted = JSON.parse(raw);
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].notes).toBe('Legacy description');
+    expect(persisted[0].description).toBeUndefined();
+  });
 });

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -126,13 +126,13 @@ describe('WorkGraph', () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
-  it('sets description on create', async () => {
+  it('sets notes on create', async () => {
     const item = await graph.createItem({
       title: 'Detailed',
-      description: 'A detailed bug report',
+      notes: 'A detailed bug report',
     });
 
-    expect(item.description).toBe('A detailed bug report');
+    expect(item.notes).toBe('A detailed bug report');
   });
 
   it('assigns sortOrder on creation', async () => {

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -72,9 +72,9 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<WorkItem> {
     md.appendMarkdown(`**Title:** `);
     md.appendText(item.title);
     md.appendMarkdown(`\n\n`);
-    if (item.description) {
-      md.appendMarkdown(`**Description:** `);
-      md.appendText(item.description);
+    if (item.notes) {
+      md.appendMarkdown(`**Notes:** `);
+      md.appendText(item.notes);
       md.appendMarkdown(`\n\n`);
     }
     md.appendMarkdown(`**State:** ${item.state}\n\n`);

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -60,9 +60,9 @@ export class HistoryTreeProvider implements vscode.TreeDataProvider<WorkItem> {
     md.appendMarkdown(`**Title:** `);
     md.appendText(item.title);
     md.appendMarkdown(`\n\n`);
-    if (item.description) {
-      md.appendMarkdown(`**Description:** `);
-      md.appendText(item.description);
+    if (item.notes) {
+      md.appendMarkdown(`**Notes:** `);
+      md.appendText(item.notes);
       md.appendMarkdown(`\n\n`);
     }
     md.appendMarkdown(`**State:** ${item.state}\n\n`);

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -37,7 +37,7 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem>, vsc
   private buildTooltip(item: WorkItem): vscode.MarkdownString {
     const md = new vscode.MarkdownString();
     md.appendMarkdown(`**${item.title}**\n\n`);
-    if (item.description) { md.appendText(`${item.description}\n\n`); }
+    if (item.notes) { md.appendText(`${item.notes}\n\n`); }
     md.appendMarkdown(`Created: ${new Date(item.createdAt).toLocaleString()}`);
     return md;
   }

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -62,7 +62,7 @@ export class WorkItemEditorPanel {
     }
     await this.workGraph.updateItem(this.itemId, {
       title: data.title,
-      description: data.description || undefined,
+      notes: data.notes || undefined,
     });
     if (!this.disposed) {
       this.panel.title = `Edit: ${data.title}`;
@@ -181,19 +181,19 @@ export class WorkItemEditorPanel {
       <input type="text" id="title" value="${escapeAttr(item.title)}" />
     </div>
     <div class="field">
-      <label for="description">Description</label>
-      <textarea id="description">${escapeHtml(item.description ?? '')}</textarea>
+      <label for="notes">Notes</label>
+      <textarea id="notes">${escapeHtml(item.notes ?? '')}</textarea>
     </div>
   </div>
   <script nonce="${nonce}">
     const vscode = acquireVsCodeApi();
-    const fields = ['title', 'description'];
+    const fields = ['title', 'notes'];
     let debounceTimer = null;
 
     function getData() {
       return {
         title: document.getElementById('title').value.trim(),
-        description: document.getElementById('description').value.trim(),
+        notes: document.getElementById('notes').value.trim(),
       };
     }
 

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { WorkItem } from '../models/workItem';
+import { WorkItem, WorkItemInput } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 
 export class WorkItemEditorPanel {
@@ -60,10 +60,11 @@ export class WorkItemEditorPanel {
     if (!data.title) {
       return;
     }
-    await this.workGraph.updateItem(this.itemId, {
-      title: data.title,
-      notes: data.notes || undefined,
-    });
+    const patch: Partial<WorkItemInput> = { title: data.title };
+    if ('notes' in data) {
+      patch.notes = data.notes || undefined;
+    }
+    await this.workGraph.updateItem(this.itemId, patch);
     if (!this.disposed) {
       this.panel.title = `Edit: ${data.title}`;
     }

--- a/packages/github/src/startWorkAction.ts
+++ b/packages/github/src/startWorkAction.ts
@@ -11,7 +11,7 @@ const execFileAsync = promisify(execFile);
 interface WorkItem {
   id: string;
   title: string;
-  description?: string;
+  notes?: string;
   state: string;
   providerId?: string;
   externalId?: string;


### PR DESCRIPTION
Rename the `description` field to `notes` on WorkItem and WorkItemInput to better reflect its purpose as user-added context. Provider-owned fields (DiscoveredItem.description) remain unchanged. Includes data migration for existing persisted items.

Closes #7