### PR TITLE
Add repo sub-grouping to Inbox provider nodes

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -232,12 +232,12 @@
         },
         {
           "command": "workcenter.acceptFromInbox",
-          "when": "view == workcenter.inbox",
+          "when": "view == workcenter.inbox && viewItem =~ /inboxItem/",
           "group": "inline"
         },
         {
           "command": "workcenter.dismissFromInbox",
-          "when": "view == workcenter.inbox",
+          "when": "view == workcenter.inbox && viewItem =~ /inboxItem/",
           "group": "1_actions"
         },
         {

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { EventEmitter, TreeItemCollapsibleState, ThemeIcon } from 'vscode';
+import { EventEmitter, TreeItemCollapsibleState } from 'vscode';
 import { DiscoveredItem } from '../api/types';
 import { InboxTreeProvider, InboxProviderNode, InboxGroupNode, InboxItem } from '../views/inboxTreeProvider';
 

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventEmitter, TreeItemCollapsibleState, ThemeIcon } from 'vscode';
 import { DiscoveredItem } from '../api/types';
-import { InboxTreeProvider, InboxProviderNode, InboxItem } from '../views/inboxTreeProvider';
+import { InboxTreeProvider, InboxProviderNode, InboxGroupNode, InboxItem } from '../views/inboxTreeProvider';
 
 function createMockStateStore() {
   const cache = new Map<string, string>();
@@ -144,6 +144,92 @@ describe('InboxTreeProvider', () => {
     });
   });
 
+  describe('group sub-grouping', () => {
+    it('should group items by their group field under provider', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Issue A', group: 'repo-one' },
+        { externalId: '2', title: 'Issue B', group: 'repo-one' },
+        { externalId: '3', title: 'Issue C', group: 'repo-two' },
+      ]);
+
+      const children = provider.getChildren(providerNode('gh'));
+      expect(children).toHaveLength(2);
+      expect(children[0].kind).toBe('group');
+      expect((children[0] as InboxGroupNode).groupName).toBe('repo-one');
+      expect(children[1].kind).toBe('group');
+      expect((children[1] as InboxGroupNode).groupName).toBe('repo-two');
+    });
+
+    it('should return items under a group node', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Issue A', group: 'repo-one' },
+        { externalId: '2', title: 'Issue B', group: 'repo-one' },
+        { externalId: '3', title: 'Issue C', group: 'repo-two' },
+      ]);
+
+      const groupNode: InboxGroupNode = { kind: 'group', providerId: 'gh', groupName: 'repo-one' };
+      const items = provider.getChildren(groupNode);
+      expect(items).toHaveLength(2);
+      expect(items.map((i) => (i as InboxItem).title)).toEqual(['Issue A', 'Issue B']);
+    });
+
+    it('should show ungrouped items directly under provider alongside group nodes', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Grouped', group: 'repo-one' },
+        { externalId: '2', title: 'Ungrouped' },
+      ]);
+
+      const children = provider.getChildren(providerNode('gh'));
+      expect(children).toHaveLength(2);
+      const kinds = children.map((c) => c.kind);
+      expect(kinds).toContain('group');
+      expect(kinds).toContain('item');
+    });
+
+    it('should sort groups and ungrouped items alphabetically', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Zebra item' },
+        { externalId: '2', title: 'Issue', group: 'beta-repo' },
+        { externalId: '3', title: 'Issue', group: 'alpha-repo' },
+      ]);
+
+      const children = provider.getChildren(providerNode('gh'));
+      expect(children).toHaveLength(3);
+      expect(children[0].kind).toBe('group');
+      expect((children[0] as InboxGroupNode).groupName).toBe('alpha-repo');
+      expect(children[1].kind).toBe('group');
+      expect((children[1] as InboxGroupNode).groupName).toBe('beta-repo');
+      expect(children[2].kind).toBe('item');
+      expect((children[2] as InboxItem).title).toBe('Zebra item');
+    });
+
+    it('should filter out accepted items from groups', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Unseen', group: 'repo' },
+        { externalId: '2', title: 'Accepted', group: 'repo' },
+      ]);
+      stateStore._set('gh', '2', 'accepted');
+
+      const groupNode: InboxGroupNode = { kind: 'group', providerId: 'gh', groupName: 'repo' };
+      const items = provider.getChildren(groupNode);
+      expect(items).toHaveLength(1);
+      expect((items[0] as InboxItem).title).toBe('Unseen');
+    });
+
+    it('should not show group node when all its items are accepted/dismissed', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Accepted', group: 'repo' },
+        { externalId: '2', title: 'Ungrouped' },
+      ]);
+      stateStore._set('gh', '1', 'accepted');
+
+      const children = provider.getChildren(providerNode('gh'));
+      expect(children).toHaveLength(1);
+      expect(children[0].kind).toBe('item');
+      expect((children[0] as InboxItem).title).toBe('Ungrouped');
+    });
+  });
+
   describe('getTreeItem', () => {
     it('should render provider node with plug icon and item count', () => {
       registry._setLabel('gh', 'GitHub Issues');
@@ -175,6 +261,21 @@ describe('InboxTreeProvider', () => {
 
       expect(treeItem.label).toBe('Bug');
       expect((treeItem.iconPath as any).id).toBe('circle-outline');
+    });
+
+    it('should render group node with folder icon and unseen count', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'A', group: 'my-repo' },
+        { externalId: '2', title: 'B', group: 'my-repo' },
+      ]);
+
+      const groupNode: InboxGroupNode = { kind: 'group', providerId: 'gh', groupName: 'my-repo' };
+      const treeItem = provider.getTreeItem(groupNode);
+      expect(treeItem.label).toBe('my-repo');
+      expect(treeItem.description).toBe('2');
+      expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Expanded);
+      expect(treeItem.contextValue).toBe('inboxGroup');
+      expect((treeItem.iconPath as any).id).toBe('folder');
     });
 
     it('should set contextValue with hasUrl when item has url', () => {

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -167,7 +167,7 @@ describe('InboxTreeProvider', () => {
         { externalId: '3', title: 'Issue C', group: 'repo-two' },
       ]);
 
-      const groupNode: InboxGroupNode = { kind: 'group', providerId: 'gh', groupName: 'repo-one' };
+      const groupNode: InboxGroupNode = { kind: 'group', providerId: 'gh', groupName: 'repo-one', unseenCount: 2 };
       const items = provider.getChildren(groupNode);
       expect(items).toHaveLength(2);
       expect(items.map((i) => (i as InboxItem).title)).toEqual(['Issue A', 'Issue B']);
@@ -210,7 +210,7 @@ describe('InboxTreeProvider', () => {
       ]);
       stateStore._set('gh', '2', 'accepted');
 
-      const groupNode: InboxGroupNode = { kind: 'group', providerId: 'gh', groupName: 'repo' };
+      const groupNode: InboxGroupNode = { kind: 'group', providerId: 'gh', groupName: 'repo', unseenCount: 1 };
       const items = provider.getChildren(groupNode);
       expect(items).toHaveLength(1);
       expect((items[0] as InboxItem).title).toBe('Unseen');
@@ -269,7 +269,7 @@ describe('InboxTreeProvider', () => {
         { externalId: '2', title: 'B', group: 'my-repo' },
       ]);
 
-      const groupNode: InboxGroupNode = { kind: 'group', providerId: 'gh', groupName: 'my-repo' };
+      const groupNode: InboxGroupNode = { kind: 'group', providerId: 'gh', groupName: 'my-repo', unseenCount: 2 };
       const treeItem = provider.getTreeItem(groupNode);
       expect(treeItem.label).toBe('my-repo');
       expect(treeItem.description).toBe('2');

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -252,7 +252,7 @@ describe('InboxTreeProvider', () => {
 
       expect(treeItem.label).toBe('Bug');
       expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.None);
-      expect((treeItem.iconPath as any).id).toBe('mail');
+      expect((treeItem.iconPath as any).id).toBe('circle-filled');
     });
 
     it('should render seen inbox item with circle-outline icon', () => {

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -252,7 +252,7 @@ describe('InboxTreeProvider', () => {
 
       expect(treeItem.label).toBe('Bug');
       expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.None);
-      expect((treeItem.iconPath as any).id).toBe('circle-filled');
+      expect((treeItem.iconPath as any).id).toBe('mail');
     });
 
     it('should render seen inbox item with circle-outline icon', () => {

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -115,7 +115,8 @@ describe('InboxTreeProvider', () => {
     it('should pass through group field from discovered item', () => {
       registry._setItems('gh', [{ externalId: 'issue-1', title: 'Bug fix', group: 'dotnet/runtime' }]);
 
-      const items = provider.getChildren(providerNode('gh'));
+      const groupNode: InboxGroupNode = { kind: 'group', providerId: 'gh', groupName: 'dotnet/runtime', unseenCount: 1 };
+      const items = provider.getChildren(groupNode);
       expect(items).toHaveLength(1);
       expect((items[0] as InboxItem).group).toBe('dotnet/runtime');
     });
@@ -297,6 +298,46 @@ describe('InboxTreeProvider', () => {
     it('should return false if item is already seen', () => {
       provider.markSeen('gh', '1');
       expect(provider.markSeen('gh', '1')).toBe(false);
+    });
+  });
+
+  describe('getParent', () => {
+    it('should return undefined for provider nodes', () => {
+      expect(provider.getParent(providerNode('gh'))).toBeUndefined();
+    });
+
+    it('should return provider node for group nodes', () => {
+      registry._setLabel('gh', 'GitHub Issues');
+      const groupNode: InboxGroupNode = { kind: 'group', providerId: 'gh', groupName: 'repo-one', unseenCount: 2 };
+      const parent = provider.getParent(groupNode);
+      expect(parent).toBeDefined();
+      expect(parent!.kind).toBe('provider');
+      expect((parent as InboxProviderNode).providerId).toBe('gh');
+      expect((parent as InboxProviderNode).label).toBe('GitHub Issues');
+    });
+
+    it('should return group node for item with group', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Issue A', group: 'repo-one' },
+        { externalId: '2', title: 'Issue B', group: 'repo-one' },
+      ]);
+      const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Issue A', group: 'repo-one' };
+      const parent = provider.getParent(item);
+      expect(parent).toBeDefined();
+      expect(parent!.kind).toBe('group');
+      expect((parent as InboxGroupNode).groupName).toBe('repo-one');
+      expect((parent as InboxGroupNode).unseenCount).toBe(2);
+    });
+
+    it('should return provider node for ungrouped item', () => {
+      registry._setLabel('gh', 'GitHub Issues');
+      registry._setItems('gh', [{ externalId: '1', title: 'Bug fix' }]);
+      const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug fix' };
+      const parent = provider.getParent(item);
+      expect(parent).toBeDefined();
+      expect(parent!.kind).toBe('provider');
+      expect((parent as InboxProviderNode).providerId).toBe('gh');
+      expect((parent as InboxProviderNode).label).toBe('GitHub Issues');
     });
   });
 

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -241,7 +241,7 @@ describe('InboxTreeProvider', () => {
       const treeItem = provider.getTreeItem(providerNode('gh'));
       expect(treeItem.label).toBe('GitHub Issues');
       expect(treeItem.description).toBe('2');
-      expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Expanded);
+      expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
       expect((treeItem.iconPath as any).id).toBe('plug');
     });
 
@@ -273,7 +273,7 @@ describe('InboxTreeProvider', () => {
       const treeItem = provider.getTreeItem(groupNode);
       expect(treeItem.label).toBe('my-repo');
       expect(treeItem.description).toBe('2');
-      expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Expanded);
+      expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
       expect(treeItem.contextValue).toBe('inboxGroup');
       expect((treeItem.iconPath as any).id).toBe('folder');
     });

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -82,7 +82,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       const count = this.getUnseenCount(element.providerId);
       const treeItem = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.Collapsed);
       treeItem.description = `${count}`;
-      treeItem.id = `inbox-provider-${element.providerId}`;
+      treeItem.id = `inbox::provider::${element.providerId}`;
       treeItem.contextValue = 'inboxProvider';
       treeItem.iconPath = new vscode.ThemeIcon('plug');
       return treeItem;
@@ -90,7 +90,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
     if (element.kind === 'group') {
       const treeItem = new vscode.TreeItem(element.groupName, vscode.TreeItemCollapsibleState.Collapsed);
-      treeItem.id = `inbox-group-${element.providerId}-${element.groupName}`;
+      treeItem.id = `inbox::group::${element.providerId}::${element.groupName}`;
       treeItem.description = `${element.unseenCount}`;
       treeItem.contextValue = 'inboxGroup';
       treeItem.iconPath = new vscode.ThemeIcon('folder');
@@ -101,7 +101,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     const isSeen = this.seenItems.has(key);
 
     const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
-    treeItem.id = `inbox-item-${element.providerId}-${element.externalId}`;
+    treeItem.id = `inbox::item::${element.providerId}::${element.externalId}`;
     treeItem.tooltip = this.buildTooltip(element);
     treeItem.contextValue = element.url ? 'inboxItem.hasUrl' : 'inboxItem';
     treeItem.iconPath = new vscode.ThemeIcon(isSeen ? 'circle-outline' : 'circle-filled');
@@ -119,14 +119,12 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
           label: this.providerRegistry.getProviderLabel(element.providerId),
         };
       case 'item': {
-        const items = this.providerRegistry.getDiscoveredItems(element.providerId);
-        const discoveredItem = items.find(i => i.externalId === element.externalId);
-        if (discoveredItem?.group) {
-          const unseenCount = this.getGroupUnseenCount(element.providerId, discoveredItem.group);
+        if (element.group) {
+          const unseenCount = this.getGroupUnseenCount(element.providerId, element.group);
           return {
             kind: 'group',
             providerId: element.providerId,
-            groupName: discoveredItem.group,
+            groupName: element.group,
             unseenCount,
           };
         }

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { DiscoveredItem } from '../api/types';
 import { ProviderRegistry } from '../services/providerRegistry';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 
@@ -209,7 +210,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     return result.sort((a, b) => a.title.localeCompare(b.title));
   }
 
-  private toItemNode(providerId: string, item: { externalId: string; title: string; description?: string; url?: string; group?: string }): InboxItem {
+  private toItemNode(providerId: string, item: DiscoveredItem): InboxItem {
     return {
       kind: 'item',
       providerId,

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -79,7 +79,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   getTreeItem(element: InboxElement): vscode.TreeItem {
     if (element.kind === 'provider') {
       const count = this.getUnseenCount(element.providerId);
-      const treeItem = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.Expanded);
+      const treeItem = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.Collapsed);
       treeItem.description = `${count}`;
       treeItem.contextValue = 'inboxProvider';
       treeItem.iconPath = new vscode.ThemeIcon('plug');
@@ -88,7 +88,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
     if (element.kind === 'group') {
       const count = this.getGroupUnseenCount(element.providerId, element.groupName);
-      const treeItem = new vscode.TreeItem(element.groupName, vscode.TreeItemCollapsibleState.Expanded);
+      const treeItem = new vscode.TreeItem(element.groupName, vscode.TreeItemCollapsibleState.Collapsed);
       treeItem.description = `${count}`;
       treeItem.contextValue = 'inboxGroup';
       treeItem.iconPath = new vscode.ThemeIcon('folder');

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -122,7 +122,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
         const items = this.providerRegistry.getDiscoveredItems(element.providerId);
         const discoveredItem = items.find(i => i.externalId === element.externalId);
         if (discoveredItem?.group) {
-          const unseenCount = this.getGroupChildren(element.providerId, discoveredItem.group).length;
+          const unseenCount = this.getGroupUnseenCount(element.providerId, discoveredItem.group);
           return {
             kind: 'group',
             providerId: element.providerId,
@@ -221,6 +221,15 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       url: item.url,
       group: item.group,
     };
+  }
+
+  private getGroupUnseenCount(providerId: string, groupName: string): number {
+    const items = this.providerRegistry.getDiscoveredItems(providerId);
+    return items.filter((item) => {
+      if (item.group !== groupName) { return false; }
+      const state = this.stateStore.getState(providerId, item.externalId);
+      return state === undefined || state === 'unseen';
+    }).length;
   }
 
   private getUnseenCount(providerId: string): number {

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -155,14 +155,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     }
 
     for (const item of ungrouped) {
-      result.push({
-        kind: 'item',
-        providerId,
-        externalId: item.externalId,
-        title: item.title,
-        description: item.description,
-        url: item.url,
-      });
+      result.push(this.toItemNode(providerId, item));
     }
 
     return result.sort((a, b) => {
@@ -179,17 +172,21 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       if (item.group !== groupName) { continue; }
       const state = this.stateStore.getState(providerId, item.externalId);
       if (state !== undefined && state !== 'unseen') { continue; }
-      result.push({
-        kind: 'item',
-        providerId,
-        externalId: item.externalId,
-        title: item.title,
-        description: item.description,
-        url: item.url,
-        group: item.group,
-      });
+      result.push(this.toItemNode(providerId, item));
     }
     return result.sort((a, b) => a.title.localeCompare(b.title));
+  }
+
+  private toItemNode(providerId: string, item: { externalId: string; title: string; description?: string; url?: string; group?: string }): InboxItem {
+    return {
+      kind: 'item',
+      providerId,
+      externalId: item.externalId,
+      title: item.title,
+      description: item.description,
+      url: item.url,
+      group: item.group,
+    };
   }
 
   private getUnseenCount(providerId: string): number {

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -122,11 +122,12 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
         const items = this.providerRegistry.getDiscoveredItems(element.providerId);
         const discoveredItem = items.find(i => i.externalId === element.externalId);
         if (discoveredItem?.group) {
+          const unseenCount = this.getGroupChildren(element.providerId, discoveredItem.group).length;
           return {
             kind: 'group',
             providerId: element.providerId,
             groupName: discoveredItem.group,
-            unseenCount: 0,
+            unseenCount,
           };
         }
         return {

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -8,6 +8,12 @@ export interface InboxProviderNode {
   label: string;
 }
 
+export interface InboxGroupNode {
+  kind: 'group';
+  providerId: string;
+  groupName: string;
+}
+
 export interface InboxItem {
   kind: 'item';
   providerId: string;
@@ -18,7 +24,7 @@ export interface InboxItem {
   group?: string;
 }
 
-export type InboxElement = InboxProviderNode | InboxItem;
+export type InboxElement = InboxProviderNode | InboxGroupNode | InboxItem;
 
 export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> {
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
@@ -80,6 +86,15 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       return treeItem;
     }
 
+    if (element.kind === 'group') {
+      const count = this.getGroupUnseenCount(element.providerId, element.groupName);
+      const treeItem = new vscode.TreeItem(element.groupName, vscode.TreeItemCollapsibleState.Expanded);
+      treeItem.description = `${count}`;
+      treeItem.contextValue = 'inboxGroup';
+      treeItem.iconPath = new vscode.ThemeIcon('folder');
+      return treeItem;
+    }
+
     const key = `${element.providerId}::${element.externalId}`;
     const isSeen = this.seenItems.has(key);
 
@@ -110,25 +125,71 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       return this.getProviderChildren(element.providerId);
     }
 
+    if (element.kind === 'group') {
+      return this.getGroupChildren(element.providerId, element.groupName);
+    }
+
     return [];
   }
 
-  private getProviderChildren(providerId: string): InboxItem[] {
+  private getProviderChildren(providerId: string): (InboxGroupNode | InboxItem)[] {
+    const items = this.providerRegistry.getDiscoveredItems(providerId);
+    const groups = new Map<string, typeof items>();
+    const ungrouped: typeof items = [];
+
+    for (const item of items) {
+      const state = this.stateStore.getState(providerId, item.externalId);
+      if (state !== undefined && state !== 'unseen') { continue; }
+
+      if (item.group) {
+        const list = groups.get(item.group) ?? [];
+        list.push(item);
+        groups.set(item.group, list);
+      } else {
+        ungrouped.push(item);
+      }
+    }
+
+    const result: (InboxGroupNode | InboxItem)[] = [];
+
+    for (const [groupName] of groups) {
+      result.push({ kind: 'group', providerId, groupName });
+    }
+
+    for (const item of ungrouped) {
+      result.push({
+        kind: 'item',
+        providerId,
+        externalId: item.externalId,
+        title: item.title,
+        description: item.description,
+        url: item.url,
+      });
+    }
+
+    return result.sort((a, b) => {
+      const aLabel = a.kind === 'group' ? a.groupName : a.title;
+      const bLabel = b.kind === 'group' ? b.groupName : b.title;
+      return aLabel.localeCompare(bLabel);
+    });
+  }
+
+  private getGroupChildren(providerId: string, groupName: string): InboxItem[] {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
     const result: InboxItem[] = [];
     for (const item of items) {
+      if (item.group !== groupName) { continue; }
       const state = this.stateStore.getState(providerId, item.externalId);
-      if (state === undefined || state === 'unseen') {
-        result.push({
-          kind: 'item',
-          providerId,
-          externalId: item.externalId,
-          title: item.title,
-          description: item.description,
-          url: item.url,
-          group: item.group,
-        });
-      }
+      if (state !== undefined && state !== 'unseen') { continue; }
+      result.push({
+        kind: 'item',
+        providerId,
+        externalId: item.externalId,
+        title: item.title,
+        description: item.description,
+        url: item.url,
+        group: item.group,
+      });
     }
     return result.sort((a, b) => a.title.localeCompare(b.title));
   }
@@ -136,6 +197,15 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   private getUnseenCount(providerId: string): number {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
     return items.filter((item) => {
+      const state = this.stateStore.getState(providerId, item.externalId);
+      return state === undefined || state === 'unseen';
+    }).length;
+  }
+
+  private getGroupUnseenCount(providerId: string, groupName: string): number {
+    const items = this.providerRegistry.getDiscoveredItems(providerId);
+    return items.filter((item) => {
+      if (item.group !== groupName) { return false; }
       const state = this.stateStore.getState(providerId, item.externalId);
       return state === undefined || state === 'unseen';
     }).length;

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -82,6 +82,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       const count = this.getUnseenCount(element.providerId);
       const treeItem = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.Collapsed);
       treeItem.description = `${count}`;
+      treeItem.id = `inbox-provider-${element.providerId}`;
       treeItem.contextValue = 'inboxProvider';
       treeItem.iconPath = new vscode.ThemeIcon('plug');
       return treeItem;
@@ -89,6 +90,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
     if (element.kind === 'group') {
       const treeItem = new vscode.TreeItem(element.groupName, vscode.TreeItemCollapsibleState.Collapsed);
+      treeItem.id = `inbox-group-${element.providerId}-${element.groupName}`;
       treeItem.description = `${element.unseenCount}`;
       treeItem.contextValue = 'inboxGroup';
       treeItem.iconPath = new vscode.ThemeIcon('folder');
@@ -99,10 +101,41 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     const isSeen = this.seenItems.has(key);
 
     const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
+    treeItem.id = `inbox-item-${element.providerId}-${element.externalId}`;
     treeItem.tooltip = this.buildTooltip(element);
     treeItem.contextValue = element.url ? 'inboxItem.hasUrl' : 'inboxItem';
     treeItem.iconPath = new vscode.ThemeIcon(isSeen ? 'circle-outline' : 'circle-filled');
     return treeItem;
+  }
+
+  getParent(element: InboxElement): InboxElement | undefined {
+    switch (element.kind) {
+      case 'provider':
+        return undefined;
+      case 'group':
+        return {
+          kind: 'provider',
+          providerId: element.providerId,
+          label: this.providerRegistry.getProviderLabel(element.providerId),
+        };
+      case 'item': {
+        const items = this.providerRegistry.getDiscoveredItems(element.providerId);
+        const discoveredItem = items.find(i => i.externalId === element.externalId);
+        if (discoveredItem?.group) {
+          return {
+            kind: 'group',
+            providerId: element.providerId,
+            groupName: discoveredItem.group,
+            unseenCount: 0,
+          };
+        }
+        return {
+          kind: 'provider',
+          providerId: element.providerId,
+          label: this.providerRegistry.getProviderLabel(element.providerId),
+        };
+      }
+    }
   }
 
   getChildren(element?: InboxElement): InboxElement[] {

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -12,6 +12,7 @@ export interface InboxGroupNode {
   kind: 'group';
   providerId: string;
   groupName: string;
+  unseenCount: number;
 }
 
 export interface InboxItem {
@@ -87,9 +88,8 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     }
 
     if (element.kind === 'group') {
-      const count = this.getGroupUnseenCount(element.providerId, element.groupName);
       const treeItem = new vscode.TreeItem(element.groupName, vscode.TreeItemCollapsibleState.Collapsed);
-      treeItem.description = `${count}`;
+      treeItem.description = `${element.unseenCount}`;
       treeItem.contextValue = 'inboxGroup';
       treeItem.iconPath = new vscode.ThemeIcon('folder');
       return treeItem;
@@ -134,7 +134,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   private getProviderChildren(providerId: string): (InboxGroupNode | InboxItem)[] {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
-    const groups = new Map<string, typeof items>();
+    const groupCounts = new Map<string, number>();
     const ungrouped: typeof items = [];
 
     for (const item of items) {
@@ -142,9 +142,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       if (state !== undefined && state !== 'unseen') { continue; }
 
       if (item.group) {
-        const list = groups.get(item.group) ?? [];
-        list.push(item);
-        groups.set(item.group, list);
+        groupCounts.set(item.group, (groupCounts.get(item.group) ?? 0) + 1);
       } else {
         ungrouped.push(item);
       }
@@ -152,8 +150,8 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
     const result: (InboxGroupNode | InboxItem)[] = [];
 
-    for (const [groupName] of groups) {
-      result.push({ kind: 'group', providerId, groupName });
+    for (const [groupName, unseenCount] of groupCounts) {
+      result.push({ kind: 'group', providerId, groupName, unseenCount });
     }
 
     for (const item of ungrouped) {
@@ -197,15 +195,6 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   private getUnseenCount(providerId: string): number {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
     return items.filter((item) => {
-      const state = this.stateStore.getState(providerId, item.externalId);
-      return state === undefined || state === 'unseen';
-    }).length;
-  }
-
-  private getGroupUnseenCount(providerId: string, groupName: string): number {
-    const items = this.providerRegistry.getDiscoveredItems(providerId);
-    return items.filter((item) => {
-      if (item.group !== groupName) { return false; }
       const state = this.stateStore.getState(providerId, item.externalId);
       return state === undefined || state === 'unseen';
     }).length;


### PR DESCRIPTION
Group Inbox items by their DiscoveredItem.group field, matching the grouping pattern used in Sources. Items without a group remain directly under the provider node.

Closes #8