### PR TITLE
Make title readonly for provider-owned work items

### DIFF
--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -68,9 +68,10 @@ export class WorkItemEditorPanel {
         return;
       }
       patch.title = data.title;
-      if ('notes' in data) {
-        patch.notes = data.notes || undefined;
-      }
+    }
+
+    if ('notes' in data) {
+      patch.notes = data.notes || undefined;
     }
 
     if (Object.keys(patch).length === 0) {
@@ -208,8 +209,7 @@ ${item.providerId ? '      <span class="hint">Title is managed by the provider</
     </div>
     <div class="field">
       <label for="notes">Notes</label>
-      <textarea id="notes" ${item.providerId ? 'readonly' : ''}>${escapeHtml(item.notes ?? '')}</textarea>
-${item.providerId ? '      <span class="hint">Notes are managed by the provider</span>' : ''}
+      <textarea id="notes">${escapeHtml(item.notes ?? '')}</textarea>
     </div>
   </div>
   <script nonce="${nonce}">
@@ -235,8 +235,10 @@ ${item.providerId ? '      <span class="hint">Notes are managed by the provider<
 
     fields.forEach(f => {
       const el = document.getElementById(f);
-      if (!el.readOnly) {
-        el.addEventListener('input', scheduleAutosave);
+      if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+        if (!el.readOnly) {
+          el.addEventListener('input', scheduleAutosave);
+        }
       }
     });
   </script>

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -73,6 +73,10 @@ export class WorkItemEditorPanel {
       }
     }
 
+    if (Object.keys(patch).length === 0) {
+      return;
+    }
+
     await this.workGraph.updateItem(this.itemId, patch);
     if (!this.disposed && data.title && !item.providerId) {
       this.panel.title = `Edit: ${data.title}`;

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -59,7 +59,7 @@ export class WorkItemEditorPanel {
   private async saveData(data: Record<string, string>): Promise<void> {
     const item = this.workGraph.getItem(this.itemId);
     if (!item) {
-      return;
+      throw new Error('Work item no longer exists. Your changes could not be saved.');
     }
     const patch: Partial<WorkItemInput> = {};
     if ('notes' in data) {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -204,8 +204,8 @@ export class WorkItemEditorPanel {
   <div id="form">
     <div class="field">
       <label for="title">Title</label>
-      <input type="text" id="title" value="${escapeAttr(item.title)}" ${item.providerId ? 'readonly' : ''} />
-${item.providerId ? '      <span class="hint">Title is managed by the provider</span>' : ''}
+      <input type="text" id="title" value="${escapeAttr(item.title)}" ${item.providerId ? 'readonly aria-readonly="true" aria-describedby="readonly-title-hint"' : ''} />
+${item.providerId ? '      <span id="readonly-title-hint" class="hint">Title is managed by the provider</span>' : ''}
     </div>
     <div class="field">
       <label for="notes">Notes</label>
@@ -228,7 +228,8 @@ ${item.providerId ? '      <span class="hint">Title is managed by the provider</
       if (debounceTimer) clearTimeout(debounceTimer);
       debounceTimer = setTimeout(() => {
         const data = getData();
-        if (!data.title) return;
+        const titleEl = document.getElementById('title');
+        if (!data.title && titleEl instanceof HTMLInputElement && !titleEl.readOnly) return;
         vscode.postMessage({ type: 'autosave', data });
       }, 500);
     }

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -57,15 +57,24 @@ export class WorkItemEditorPanel {
   }
 
   private async saveData(data: Record<string, string>): Promise<void> {
-    if (!data.title) {
+    const item = this.workGraph.getItem(this.itemId);
+    if (!item) {
       return;
     }
-    const patch: Partial<WorkItemInput> = { title: data.title };
+    const patch: Partial<WorkItemInput> = {};
     if ('notes' in data) {
       patch.notes = data.notes || undefined;
     }
+
+    if (!item.providerId) {
+      if (!data.title) {
+        return;
+      }
+      patch.title = data.title;
+    }
+
     await this.workGraph.updateItem(this.itemId, patch);
-    if (!this.disposed) {
+    if (!this.disposed && data.title && !item.providerId) {
       this.panel.title = `Edit: ${data.title}`;
     }
   }
@@ -172,6 +181,17 @@ export class WorkItemEditorPanel {
       color: var(--vscode-foreground);
       border: 1px solid var(--input-border);
     }
+    input[readonly] {
+      opacity: 0.7;
+      cursor: not-allowed;
+      border-style: dashed;
+    }
+    .hint {
+      font-size: 0.8em;
+      opacity: 0.6;
+      margin-top: 2px;
+      display: block;
+    }
   </style>
 </head>
 <body>
@@ -179,7 +199,8 @@ export class WorkItemEditorPanel {
   <div id="form">
     <div class="field">
       <label for="title">Title</label>
-      <input type="text" id="title" value="${escapeAttr(item.title)}" />
+      <input type="text" id="title" value="${escapeAttr(item.title)}" ${item.providerId ? 'readonly' : ''} />
+${item.providerId ? '      <span class="hint">Title is managed by the provider</span>' : ''}
     </div>
     <div class="field">
       <label for="notes">Notes</label>
@@ -208,7 +229,10 @@ export class WorkItemEditorPanel {
     }
 
     fields.forEach(f => {
-      document.getElementById(f).addEventListener('input', scheduleAutosave);
+      const el = document.getElementById(f);
+      if (!el.readOnly) {
+        el.addEventListener('input', scheduleAutosave);
+      }
     });
   </script>
 </body>

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -62,15 +62,15 @@ export class WorkItemEditorPanel {
       throw new Error('Work item no longer exists. Your changes could not be saved.');
     }
     const patch: Partial<WorkItemInput> = {};
-    if ('notes' in data) {
-      patch.notes = data.notes || undefined;
-    }
 
     if (!item.providerId) {
       if (!data.title) {
         return;
       }
       patch.title = data.title;
+      if ('notes' in data) {
+        patch.notes = data.notes || undefined;
+      }
     }
 
     await this.workGraph.updateItem(this.itemId, patch);
@@ -181,7 +181,7 @@ export class WorkItemEditorPanel {
       color: var(--vscode-foreground);
       border: 1px solid var(--input-border);
     }
-    input[readonly] {
+    input[readonly], textarea[readonly] {
       opacity: 0.7;
       cursor: not-allowed;
       border-style: dashed;
@@ -204,7 +204,8 @@ ${item.providerId ? '      <span class="hint">Title is managed by the provider</
     </div>
     <div class="field">
       <label for="notes">Notes</label>
-      <textarea id="notes">${escapeHtml(item.notes ?? '')}</textarea>
+      <textarea id="notes" ${item.providerId ? 'readonly' : ''}>${escapeHtml(item.notes ?? '')}</textarea>
+${item.providerId ? '      <span class="hint">Notes are managed by the provider</span>' : ''}
     </div>
   </div>
   <script nonce="${nonce}">


### PR DESCRIPTION
When editing a work item that originated from a provider, the title field is now readonly with visual indication. Only user-owned fields remain editable. The save logic skips title updates for provider items.

Closes #9