### PR TITLE
Fix 'Open in Browser' context menu in Focus view

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -187,17 +187,17 @@
         },
         {
           "command": "workcenter.blockItem",
-          "when": "view == workcenter.focus && viewItem == active",
+          "when": "view == workcenter.focus && viewItem =~ /^active/",
           "group": "1_actions"
         },
         {
           "command": "workcenter.unblockItem",
-          "when": "view == workcenter.focus && viewItem == blocked",
+          "when": "view == workcenter.focus && viewItem =~ /^blocked/",
           "group": "1_actions"
         },
         {
           "command": "workcenter.markWaitingOn",
-          "when": "view == workcenter.focus && viewItem == active",
+          "when": "view == workcenter.focus && viewItem =~ /^active/",
           "group": "1_actions"
         },
         {

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventEmitter } from 'vscode';
+import { WorkItem, WorkItemState } from '../models/workItem';
+import { FocusTreeProvider } from '../views/focusTreeProvider';
+
+function createMockWorkGraph() {
+  const emitter = new EventEmitter<void>();
+  return {
+    onDidChange: emitter.event,
+    getItemsByState: vi.fn((..._states: WorkItemState[]) => [] as WorkItem[]),
+    _fire: () => emitter.fire(),
+  };
+}
+
+function makeItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 'item-1',
+    title: 'Test item',
+    state: WorkItemState.InProgress,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('FocusTreeProvider', () => {
+  let workGraph: ReturnType<typeof createMockWorkGraph>;
+  let provider: FocusTreeProvider;
+
+  beforeEach(() => {
+    workGraph = createMockWorkGraph();
+    provider = new FocusTreeProvider(workGraph as any);
+  });
+
+  describe('getTreeItem contextValue', () => {
+    it('should set contextValue to "active" for InProgress item without url', () => {
+      const item = makeItem({ state: WorkItemState.InProgress });
+      expect(provider.getTreeItem(item).contextValue).toBe('active');
+    });
+
+    it('should set contextValue to "active.hasUrl" for InProgress item with url', () => {
+      const item = makeItem({ state: WorkItemState.InProgress, url: 'https://example.com' });
+      expect(provider.getTreeItem(item).contextValue).toBe('active.hasUrl');
+    });
+
+    it('should set contextValue to "blocked" for Blocked item without url', () => {
+      const item = makeItem({ state: WorkItemState.Blocked });
+      expect(provider.getTreeItem(item).contextValue).toBe('blocked');
+    });
+
+    it('should set contextValue to "blocked.hasUrl" for Blocked item with url', () => {
+      const item = makeItem({ state: WorkItemState.Blocked, url: 'https://example.com' });
+      expect(provider.getTreeItem(item).contextValue).toBe('blocked.hasUrl');
+    });
+
+    it('should set contextValue to "blocked.hasUrl" for WaitingOn item with url', () => {
+      const item = makeItem({ state: WorkItemState.WaitingOn, url: 'https://example.com' });
+      expect(provider.getTreeItem(item).contextValue).toBe('blocked.hasUrl');
+    });
+
+    it('should set contextValue to "blocked" for WaitingOn item without url', () => {
+      const item = makeItem({ state: WorkItemState.WaitingOn });
+      expect(provider.getTreeItem(item).contextValue).toBe('blocked');
+    });
+  });
+
+  describe('getChildren', () => {
+    it('should return items sorted by title', () => {
+      const items = [
+        makeItem({ id: '2', title: 'Zebra', state: WorkItemState.InProgress }),
+        makeItem({ id: '1', title: 'Alpha', state: WorkItemState.Blocked }),
+      ];
+      workGraph.getItemsByState.mockReturnValue(items);
+
+      const children = provider.getChildren();
+      expect(children.map(c => c.title)).toEqual(['Alpha', 'Zebra']);
+    });
+  });
+
+  describe('events', () => {
+    it('should refresh when workGraph fires change event', () => {
+      const listener = vi.fn();
+      provider.onDidChangeTreeData(listener);
+      workGraph._fire();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -25,9 +25,9 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<WorkItem> {
 
     // contextValue controls which context menu items appear
     if (item.state === WorkItemState.Blocked || item.state === WorkItemState.WaitingOn) {
-      treeItem.contextValue = 'blocked';
+      treeItem.contextValue = item.url ? 'blocked.hasUrl' : 'blocked';
     } else {
-      treeItem.contextValue = 'active';
+      treeItem.contextValue = item.url ? 'active.hasUrl' : 'active';
     }
 
     return treeItem;


### PR DESCRIPTION
Add .hasUrl suffix to Focus tree item contextValue when the work item has a URL, matching the pattern used by Queue, Inbox, and Sources views. Update package.json menu conditions to use regex matching for active/blocked states.

Closes #13