### PR TITLE
Write README explaining WorkCenter's purpose and value

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,3 +85,22 @@ Tests run outside VS Code via vitest. The `vscode` import is aliased to `src/tes
 
 Items in Inbox and Sources are read live from the provider's in-memory data. The only persisted state is the `inboxState` enum. This keeps data fresh and avoids stale copies.
 
+### PR workflow — use the `create-pr` skill
+
+When creating pull requests, **always invoke the `create-pr` skill** and follow its full multi-phase lifecycle. Do NOT hand-roll a simplified version. The skill enforces:
+
+- **Phase 1 (Local Loop):** Rebase on `dev`, run full test suite, dispatch `superpowers:code-reviewer` agent, fix findings, re-test, and repeat until tests pass AND review is clean.
+- **Phase 2 (Create PR):** Push branch and open PR via `gh pr create --base dev`.
+- **Phase 3 (Remote Loop):** Run Copilot PR review via `copilot-pr-review` skill, fix comments (one commit per comment), verify CI, resolve merge conflicts. Any code change in this phase triggers a re-run of Phase 1.
+
+Key rules:
+- **Never skip or shortcut the process.** Every PR goes through all phases.
+- **Any code change re-triggers the local loop** — whether from code review, Copilot feedback, CI fix, or conflict resolution.
+- **Use `superpowers:code-reviewer` agent** for code review, not a generic code-review agent.
+- When working on multiple issues in parallel, each issue goes through this full cycle independently in its own worktree.
+
+> **Note:** `create-pr`, `copilot-pr-review`, and `superpowers:code-reviewer` are organization- or platform-level skills and are **not defined in this repository**. If they are not available in your environment, follow this equivalent manual process:
+>
+> 1. **Phase 1 (Local Loop):** Rebase on `dev`, run `npm run test`, request code review from a designated reviewer (or any available review tooling), address findings, re-test, and repeat until tests pass and review is clean.
+> 2. **Phase 2 (Create PR):** Push your branch and open a PR against `dev` (e.g., `gh pr create --base dev`).
+> 3. **Phase 3 (Remote Loop):** Monitor CI and PR comments, fix each comment (one commit per comment where practical), re-run local tests, and resolve any merge conflicts. Any code change re-triggers Phase 1.

--- a/README.md
+++ b/README.md
@@ -51,19 +51,19 @@ Newly discovered items from providers that you haven't acted on yet. Each provid
 
 ### Queue
 
-Your curated backlog. Items arrive here when accepted from the Inbox or Sources, or when you create them manually. All Queue items are in the **New** state. From here, move items to Focus to start working, or archive them to skip.
+Your curated backlog. Items arrive here when accepted from the Inbox or Sources, or when you create them manually. From here, move items to Focus when you're ready to start working on them, or archive them to skip.
 
 ### Focus
 
-Your active work. Items here are **InProgress**, **Blocked**, or **WaitingOn**. The Focus view is designed to show only what matters right now. Complete items when done, or mark them as blocked/waiting to signal status at a glance.
+Your active work. Items here are things you're actively working on, blocked on something, or waiting on someone else. The Focus view is designed to show only what matters right now. Mark items complete when you're done, or mark them as blocked or waiting to signal status at a glance.
 
 ### History
 
-Completed and archived items. The History view gives you a record of finished work — useful for standups, status updates, and recalling what you've done. Items here are in the **Done** or **Archived** state.
+Completed and archived items. The History view gives you a record of finished work — useful for standups, status updates, and recalling what you've done.
 
 ### Sources
 
-A browsable library of everything providers know about, organized by provider and sub-group (e.g., repository name). Items show their inbox state — accepted items display a ✓ icon, dismissed items show a label. You can accept items into your Queue directly from Sources at any time.
+A browsable library of everything providers know about, organized by provider and sub-group (e.g., repository name). Items show whether you've already acted on them — accepted items display a ✓ icon, dismissed items show a label. You can accept items into your Queue directly from Sources at any time.
 
 ### Data Flow
 
@@ -75,12 +75,12 @@ Providers (GitHub, etc.)          Manual creation
                                 │                           │
                               Archive                   Block/Wait
                                 │                        ◄──►
-                                │                      InProgress
+                                │                      Working on
                                 │                           │
-                                │                        Complete
+                                │                        Mark complete
                                 ▼                           ▼
                               History ◄──────────────── History
-                          (Archived)                    (Done)
+                          (archived)                    (completed)
 ```
 
 > **Note:** Items in History can be restored — move them back to Queue or Focus to resume work.
@@ -133,8 +133,8 @@ Provider extensions depend on the core extension via `extensionDependencies` and
 
 WorkCenter persists two JSON files in VS Code's `globalStorageUri`:
 
-- **`workitems.json`** — All accepted and manual work items with their full state machine lifecycle, including a snapshot of provider fields (such as `title`, `description`, and `url`) captured at accept time. These snapshots may become stale compared to live data from the provider.
-- **`discovered-state.json`** — A thin index mapping `providerId + externalId` → inbox state (`unseen`, `accepted`, `dismissed`) for discovered items only. This file does not store provider item fields; for inbox items, provider data is read live from the provider.
+- **`workitems.json`** — All accepted and manual work items with their full lifecycle, including a snapshot of provider fields (such as `title`, `description`, and `url`) captured at accept time. These snapshots may become stale compared to live data from the provider.
+- **`discovered-state.json`** — A thin index tracking whether each discovered item has been accepted, dismissed, or not yet seen. This file does not store provider item fields; for inbox items, provider data is read live from the provider.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ WorkCenter is **not** a replacement for GitHub Issues, Jira, or any other system
 3. **Open the WorkCenter sidebar** by clicking the WorkCenter icon in the activity bar.
 4. **Check your Inbox** — newly discovered items from providers appear here. Accept items to add them to your Queue, or dismiss them. Some providers may re-surface dismissed items if they remain relevant.
 5. **Work your Queue** — move items to Focus when you're ready to start, or create manual items with the ➕ button.
-6. **Stay focused** — the Focus view shows only what you're actively working on. Mark items as blocked, waiting, or complete as you go.
+6. **Stay focused** — the Focus view shows only what you're actively working on. Pause items or mark them complete as you go.
 
 ### Configuring the GitHub Provider
 
@@ -39,7 +39,7 @@ After installing WorkCenter GitHub, configure which repositories to watch for is
 
 Leave `repos` empty to fetch all issues assigned to you across all repositories.
 
-> **Note:** The `repos` setting currently scopes **issue discovery only**. PR review requests are always discovered globally (all open PRs where your review is requested across all repositories).
+> **Note:** The `repos` setting scopes both **issue discovery and PR review discovery**. When `repos` is empty, both fall back to global discovery (all issues assigned to you and all PRs where your review is requested, across all repositories).
 
 ## The Five-View Model
 
@@ -55,7 +55,7 @@ Your curated backlog. Items arrive here when accepted from the Inbox or Sources,
 
 ### Focus
 
-Your active work. Items here are things you're actively working on, blocked on something, or waiting on someone else. The Focus view is designed to show only what matters right now. Mark items complete when you're done, or mark them as blocked or waiting to signal status at a glance.
+Your active work. Items here are things you're actively working on or paused. The Focus view is designed to show only what matters right now. Mark items complete when you're done, or pause them to signal status at a glance.
 
 ### History
 
@@ -67,19 +67,15 @@ A browsable library of everything providers know about, organized by provider an
 
 ### Data Flow
 
-```
-Providers (GitHub, etc.)          Manual creation
-        │                               │
-        ▼                               ▼
-      Inbox  ────Accept────►  Queue  ───Move to Focus──►  Focus
-                                │                           │
-                              Archive                   Block/Wait
-                                │                        ◄──►
-                                │                      Working on
-                                │                           │
-                                │                     Mark complete
-                                ▼                           ▼
-                             History                     History
+```mermaid
+flowchart LR
+    P["Providers\n(GitHub, etc.)"] --> Inbox
+    M["Manual\ncreation"] --> Queue
+    Inbox -- Accept --> Queue
+    Queue -- Move to Focus --> Focus
+    Queue -- Archive --> History
+    Focus -- Pause --> Focus
+    Focus -- Mark complete --> History
 ```
 
 > **Note:** Items in History are a read-only record of completed or archived work. You can open their links (when available), but they can't currently be moved back to Queue or Focus.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ WorkCenter is **not** a replacement for GitHub Issues, Jira, or any other system
 
 After installing WorkCenter GitHub, configure which repositories to watch for issues:
 
-```json
+```jsonc
 // settings.json
 {
   "workcenterGithub.repos": ["owner/repo1", "owner/repo2"],
@@ -111,7 +111,7 @@ An action is an operation that runs on a work item. Actions appear in the **Run 
 
 ### Building Your Own
 
-Provider and action extensions use a simple, well-defined API surface. See the [Extension API documentation](https://github.com/mthalman/workcenter/pull/29) for the full contract, interfaces, and example implementations. *(Added by [PR #29](https://github.com/mthalman/workcenter/pull/29); docs file will be available at `docs/extension-api.md` once merged.)*
+Provider and action extensions use a simple, well-defined API surface. See the [Extension API documentation](docs/extension-api.md) for the full contract, interfaces, and example implementations.
 
 ## Architecture
 
@@ -134,13 +134,13 @@ Provider extensions depend on the core extension via `extensionDependencies` and
 
 WorkCenter persists two JSON files in VS Code's `globalStorageUri`:
 
-- **`workitems.json`** — All accepted and manual work items with their full lifecycle, including a snapshot of provider fields (such as `title`, `description`, and `url`) captured at accept time. These snapshots may become stale compared to live data from the provider.
+- **`workitems.json`** — All accepted and manual work items with their lifecycle state, including the persisted fields WorkCenter stores at creation/accept time, such as the work item `title`, optional `url`, provider provenance (`providerId` and `externalId`), and any `notes`. Provider-derived values captured at accept time may become stale compared to live data from the provider.
 - **`discovered-state.json`** — A thin index tracking whether each discovered item has been accepted, dismissed, or not yet seen. This file does not store provider item fields; for inbox items, provider data is read live from the provider.
 
 ## Documentation
 
 - [UX Guide](https://github.com/mthalman/workcenter/pull/28) — The five views, data flow, work item states, available actions, and the editor panel. *(Added by [PR #28](https://github.com/mthalman/workcenter/pull/28); docs file will be available at `docs/ux-guide.md` once merged.)*
-- [Extension API](https://github.com/mthalman/workcenter/pull/29) — Provider and action contracts, interfaces, and example implementations. *(Added by [PR #29](https://github.com/mthalman/workcenter/pull/29); docs file will be available at `docs/extension-api.md` once merged.)*
+- [Extension API](docs/extension-api.md) — Provider and action contracts, interfaces, and example implementations.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -67,13 +67,18 @@ A browsable library of everything providers know about, organized by provider an
 Providers (GitHub, etc.)          Manual creation
         │                               │
         ▼                               ▼
-      Inbox  ────Accept────►  Queue  ───Move to Focus──►  Focus  ──Complete──►  Done  ──►  Archived
+      Inbox  ────Accept────►  Queue  ───Move to Focus──►  Focus
                                 │                           │
                               Archive                   Block/Wait
                                 │                        ◄──►
-                                ▼                      InProgress
-                             Archived
+                                │                      InProgress
+                                │                           │
+                                │                        Complete
+                                ▼                           ▼
+                          (Archived)                      (Done)
 ```
+
+> **Note:** *Done* and *Archived* are stored states, not browsable views. Completing an item from Focus or archiving from Queue removes it from all visible views.
 
 ## Plugin Ecosystem
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,9 @@ Providers (GitHub, etc.)          Manual creation
                                 │                        ◄──►
                                 │                      Working on
                                 │                           │
-                                │                        Mark complete
+                                │                     Mark complete
                                 ▼                           ▼
-                              History ◄──────────────── History
-                          (archived)                    (completed)
+                             History                     History
 ```
 
 > **Note:** Items in History can be restored — move them back to Queue or Focus to resume work.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ An action is an operation that runs on a work item. Actions appear in the **Run 
 
 ### Building Your Own
 
-Provider and action extensions use a simple, well-defined API surface. See the [Extension API documentation](docs/extension-api.md) for the full contract, interfaces, and example implementations.
+Provider and action extensions use a simple, well-defined API surface. See the [Extension API documentation](docs/extension-api.md) for the full contract, interfaces, and example implementations. *(Added by [PR #29](https://github.com/mthalman/workcenter/pull/29).)*
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **A unified work hub inside VS Code.**
 
-WorkCenter is a VS Code extension that brings all of your work items — GitHub issues, PR review requests, investigations, follow-ups, and ad-hoc tasks — into a single, organized sidebar. Instead of juggling browser tabs, notification emails, and sticky notes, you manage everything from where you already write code.
+WorkCenter is a VS Code extension that brings all of your work items — GitHub issues, Azure DevOps work items, PR review requests, investigations, follow-ups, and ad-hoc tasks — into a single, organized sidebar. Instead of juggling browser tabs, notification emails, and sticky notes, you manage everything from where you already write code.
 
 ## The Problem
 
@@ -12,7 +12,7 @@ Developers constantly context-switch between tools. Issues live in GitHub, tasks
 
 WorkCenter is **not** a replacement for GitHub Issues, Jira, or any other system of record. It is an **aggregation layer** that sits inside VS Code and gives you a personal, unified view of your work:
 
-- **Providers** discover items from external sources (GitHub issues, PR reviews, and more in the future) and surface them automatically.
+- **Providers** discover items from external sources (GitHub issues, Azure DevOps work items, PR reviews, and more in the future) and surface them automatically.
 - **You** decide what to accept, what to dismiss, and what to work on next.
 - **Actions** let provider extensions automate workflows — like creating a branch and worktree for a GitHub issue with one click.
 
@@ -88,22 +88,25 @@ WorkCenter is built around an extensible plugin model with two extension points:
 
 A provider discovers work items from an external source and reports them to WorkCenter. The core extension handles all UI — providers just emit data.
 
-**Built-in providers** (via WorkCenter GitHub):
+**Built-in providers:**
 
 | Provider | What It Discovers |
 |----------|-------------------|
 | **GitHub Issues** | Issues assigned to you in configured repositories |
 | **GitHub PR Reviews** | Pull requests where your review is requested |
+| **ADO Work Items** | Azure DevOps work items assigned to you |
+| **ADO PR Reviews** | Azure DevOps pull requests where your review is requested |
 
 ### Actions
 
 An action is an operation that runs on a work item. Actions appear in the **Run Action…** menu on Queue and Focus items.
 
-**Built-in actions** (via WorkCenter GitHub):
+**Built-in actions:**
 
 | Action | Description |
 |--------|-------------|
 | **Start Work (Branch + Worktree)** | Creates a git branch and worktree for a GitHub issue, then opens a new VS Code window |
+| **AI Code Review** | Analyzes the current diff using an AI model and posts review comments |
 
 ### Building Your Own
 
@@ -111,20 +114,24 @@ Provider and action extensions use a simple, well-defined API surface. See the [
 
 ## Architecture
 
-WorkCenter is a monorepo with two VS Code extensions and a shared library:
+WorkCenter is a monorepo with four VS Code extensions and a shared library:
 
 ```
 packages/
-├── core/       # WorkCenter — the hub extension (UI, lifecycle, plugin API)
-├── github/     # WorkCenter GitHub — provider for issues and PR reviews
-└── shared/     # Shared library used by both extensions
+├── core/          # WorkCenter — the hub extension (UI, lifecycle, plugin API)
+├── github/        # WorkCenter GitHub — provider for GitHub issues and PR reviews
+├── ado/           # WorkCenter ADO — provider for Azure DevOps work items and PR reviews
+├── ai-reviewer/   # AI code review action extension
+└── shared/        # Shared library (BaseProvider, URL validation, logger, refresh interval)
 ```
 
 - **`packages/core`** owns the five views, work item persistence, the editor panel, and the extension API (`WorkCenterApi`).
 - **`packages/github`** is a provider extension that discovers GitHub issues and PR reviews, and offers a "Start Work" action.
-- **`packages/shared`** contains common utilities and types shared across both extensions.
+- **`packages/ado`** is a provider extension that discovers Azure DevOps work items and PR reviews.
+- **`packages/ai-reviewer`** is an action extension that analyzes diffs using an AI model and posts review comments.
+- **`packages/shared`** contains the `BaseProvider` base class for consistent provider lifecycle management (periodic refresh, concurrency guards, disposal), URL validation helpers, a logger service, and refresh interval validation.
 
-Provider extensions depend on the core extension via `extensionDependencies` and acquire the API at activation time. They do not import code from the core package directly — interfaces are re-declared to keep the extensions decoupled.
+Provider extensions extend `BaseProvider` from `@workcenter/shared` and depend on the core extension via `extensionDependencies`, acquiring the API at activation time. They do not import code from the core package directly — interfaces are re-declared to keep the extensions decoupled.
 
 ### Data Storage
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ WorkCenter persists two JSON files in VS Code's `globalStorageUri`:
 
 ## Documentation
 
-- [UX Guide](https://github.com/mthalman/workcenter/pull/28) — The five views, data flow, work item states, available actions, and the editor panel. *(Added by [PR #28](https://github.com/mthalman/workcenter/pull/28); docs file will be available at `docs/ux-guide.md` once merged.)*
+- [UX Guide](docs/ux-guide.md) — The five views, data flow, work item states, available actions, and the editor panel.
 - [Extension API](docs/extension-api.md) — Provider and action contracts, interfaces, and example implementations.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Leave `repos` empty to fetch all issues assigned to you across all repositories.
 
 > **Note:** The `repos` setting currently scopes **issue discovery only**. PR review requests are always discovered globally (all open PRs where your review is requested across all repositories).
 
-## The Four-View Model
+## The Five-View Model
 
-WorkCenter organizes work across four views in the sidebar:
+WorkCenter organizes work across five views in the sidebar:
 
 ### Inbox
 
@@ -56,6 +56,10 @@ Your curated backlog. Items arrive here when accepted from the Inbox or Sources,
 ### Focus
 
 Your active work. Items here are **InProgress**, **Blocked**, or **WaitingOn**. The Focus view is designed to show only what matters right now. Complete items when done, or mark them as blocked/waiting to signal status at a glance.
+
+### History
+
+Completed and archived items. The History view gives you a record of finished work — useful for standups, status updates, and recalling what you've done. Items here are in the **Done** or **Archived** state.
 
 ### Sources
 
@@ -75,10 +79,11 @@ Providers (GitHub, etc.)          Manual creation
                                 │                           │
                                 │                        Complete
                                 ▼                           ▼
-                          (Archived)                      (Done)
+                              History ◄──────────────── History
+                          (Archived)                    (Done)
 ```
 
-> **Note:** *Done* and *Archived* are stored states, not browsable views. Completing an item from Focus or archiving from Queue removes it from all visible views.
+> **Note:** Items in History can be restored — move them back to Queue or Focus to resume work.
 
 ## Plugin Ecosystem
 
@@ -119,7 +124,7 @@ packages/
 └── github/     # WorkCenter GitHub — provider for issues and PR reviews
 ```
 
-- **`packages/core`** owns the four views, work item persistence, the editor panel, and the extension API (`WorkCenterApi`).
+- **`packages/core`** owns the five views, work item persistence, the editor panel, and the extension API (`WorkCenterApi`).
 - **`packages/github`** is a provider extension that discovers GitHub issues and PR reviews, and offers a "Start Work" action.
 
 Provider extensions depend on the core extension via `extensionDependencies` and acquire the API at activation time. They do not import code from the core package directly — interfaces are re-declared to keep the extensions decoupled.
@@ -133,7 +138,7 @@ WorkCenter persists two JSON files in VS Code's `globalStorageUri`:
 
 ## Documentation
 
-- [UX Guide](https://github.com/mthalman/workcenter/pull/28) — The four views, data flow, work item states, available actions, and the editor panel. *(Added by [PR #28](https://github.com/mthalman/workcenter/pull/28); link will point to `docs/ux-guide.md` once merged.)*
+- [UX Guide](https://github.com/mthalman/workcenter/pull/28) — The five views, data flow, work item states, available actions, and the editor panel. *(Added by [PR #28](https://github.com/mthalman/workcenter/pull/28); link will point to `docs/ux-guide.md` once merged.)*
 - [Extension API](https://github.com/mthalman/workcenter/pull/29) — Provider and action contracts, interfaces, and example implementations. *(Added by [PR #29](https://github.com/mthalman/workcenter/pull/29); link will point to `docs/extension-api.md` once merged.)*
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ An action is an operation that runs on a work item. Actions appear in the **Run 
 
 ### Building Your Own
 
-Provider and action extensions use a simple, well-defined API surface. See the [Extension API documentation](https://github.com/mthalman/workcenter/pull/29) for the full contract, interfaces, and example implementations. *(Added by [PR #29](https://github.com/mthalman/workcenter/pull/29); link will point to `docs/extension-api.md` once merged.)*
+Provider and action extensions use a simple, well-defined API surface. See the [Extension API documentation](https://github.com/mthalman/workcenter/pull/29) for the full contract, interfaces, and example implementations. *(Added by [PR #29](https://github.com/mthalman/workcenter/pull/29); docs file will be available at `docs/extension-api.md` once merged.)*
 
 ## Architecture
 
@@ -139,8 +139,8 @@ WorkCenter persists two JSON files in VS Code's `globalStorageUri`:
 
 ## Documentation
 
-- [UX Guide](https://github.com/mthalman/workcenter/pull/28) — The five views, data flow, work item states, available actions, and the editor panel. *(Added by [PR #28](https://github.com/mthalman/workcenter/pull/28); link will point to `docs/ux-guide.md` once merged.)*
-- [Extension API](https://github.com/mthalman/workcenter/pull/29) — Provider and action contracts, interfaces, and example implementations. *(Added by [PR #29](https://github.com/mthalman/workcenter/pull/29); link will point to `docs/extension-api.md` once merged.)*
+- [UX Guide](https://github.com/mthalman/workcenter/pull/28) — The five views, data flow, work item states, available actions, and the editor panel. *(Added by [PR #28](https://github.com/mthalman/workcenter/pull/28); docs file will be available at `docs/ux-guide.md` once merged.)*
+- [Extension API](https://github.com/mthalman/workcenter/pull/29) — Provider and action contracts, interfaces, and example implementations. *(Added by [PR #29](https://github.com/mthalman/workcenter/pull/29); docs file will be available at `docs/extension-api.md` once merged.)*
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Provider extensions depend on the core extension via `extensionDependencies` and
 
 WorkCenter persists two JSON files in VS Code's `globalStorageUri`:
 
-- **`workitems.json`** — All work items with their full state machine lifecycle.
-- **`discovered-state.json`** — A thin index mapping `providerId + externalId` → inbox state (`unseen`, `accepted`, `dismissed`). Provider item data (title, description, URL) is never persisted — it is always read live from the provider.
+- **`workitems.json`** — All accepted and manual work items with their full state machine lifecycle, including a snapshot of provider fields (such as `title`, `description`, and `url`) captured at accept time. These snapshots may become stale compared to live data from the provider.
+- **`discovered-state.json`** — A thin index mapping `providerId + externalId` → inbox state (`unseen`, `accepted`, `dismissed`) for discovered items only. This file does not store provider item fields; for inbox items, provider data is read live from the provider.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ An action is an operation that runs on a work item. Actions appear in the **Run 
 
 ### Building Your Own
 
-Provider and action extensions use a simple, well-defined API surface. See the [Extension API documentation](docs/extension-api.md) for the full contract, interfaces, and example implementations. *(Added by [PR #29](https://github.com/mthalman/workcenter/pull/29).)*
+Provider and action extensions use a simple, well-defined API surface. See the [Extension API documentation](https://github.com/mthalman/workcenter/pull/29) for the full contract, interfaces, and example implementations. *(Added by [PR #29](https://github.com/mthalman/workcenter/pull/29); link will point to `docs/extension-api.md` once merged.)*
 
 ## Architecture
 
@@ -128,8 +128,8 @@ WorkCenter persists two JSON files in VS Code's `globalStorageUri`:
 
 ## Documentation
 
-- [UX Guide](docs/ux-guide.md) — The four views, data flow, work item states, available actions, and the editor panel. *(Added by [PR #28](https://github.com/mthalman/workcenter/pull/28).)*
-- [Extension API](docs/extension-api.md) — Provider and action contracts, interfaces, and example implementations. *(Added by [PR #29](https://github.com/mthalman/workcenter/pull/29).)*
+- [UX Guide](https://github.com/mthalman/workcenter/pull/28) — The four views, data flow, work item states, available actions, and the editor panel. *(Added by [PR #28](https://github.com/mthalman/workcenter/pull/28); link will point to `docs/ux-guide.md` once merged.)*
+- [Extension API](https://github.com/mthalman/workcenter/pull/29) — Provider and action contracts, interfaces, and example implementations. *(Added by [PR #29](https://github.com/mthalman/workcenter/pull/29); link will point to `docs/extension-api.md` once merged.)*
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ WorkCenter persists two JSON files in VS Code's `globalStorageUri`:
 
 ## Documentation
 
-- [UX Guide](docs/ux-guide.md) — The four views, data flow, work item states, available actions, and the editor panel.
-- [Extension API](docs/extension-api.md) — Provider and action contracts, interfaces, and example implementations.
+- [UX Guide](docs/ux-guide.md) — The four views, data flow, work item states, available actions, and the editor panel. *(Added by [PR #28](https://github.com/mthalman/workcenter/pull/28).)*
+- [Extension API](docs/extension-api.md) — Provider and action contracts, interfaces, and example implementations. *(Added by [PR #29](https://github.com/mthalman/workcenter/pull/29).)*
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ WorkCenter is **not** a replacement for GitHub Issues, Jira, or any other system
 1. **Install WorkCenter** from the VS Code marketplace (`mthalman.workcenter`).
 2. **Install a provider** — for example, WorkCenter GitHub (`mthalman.workcenter-github`) to discover GitHub issues and PR review requests.
 3. **Open the WorkCenter sidebar** by clicking the WorkCenter icon in the activity bar.
-4. **Check your Inbox** — newly discovered items from providers appear here. Accept items to add them to your Queue, or dismiss them.
+4. **Check your Inbox** — newly discovered items from providers appear here. Accept items to add them to your Queue, or dismiss them. Some providers may re-surface dismissed items if they remain relevant.
 5. **Work your Queue** — move items to Focus when you're ready to start, or create manual items with the ➕ button.
 6. **Stay focused** — the Focus view shows only what you're actively working on. Mark items as blocked, waiting, or complete as you go.
 
@@ -47,7 +47,7 @@ WorkCenter organizes work across five views in the sidebar:
 
 ### Inbox
 
-Newly discovered items from providers that you haven't acted on yet. Each provider's items are grouped under the provider name. Accept items to move them to your Queue, or dismiss them to hide them from the Inbox.
+Newly discovered items from providers that you haven't acted on yet. Each provider's items are grouped under the provider name. Accept items to move them to your Queue, or dismiss them to hide them from the Inbox; depending on the provider, dismissed items may later reappear if they are resurfaced.
 
 ### Queue
 
@@ -82,7 +82,7 @@ Providers (GitHub, etc.)          Manual creation
                              History                     History
 ```
 
-> **Note:** Items in History can be restored — move them back to Queue or Focus to resume work.
+> **Note:** Items in History are a read-only record of completed or archived work. You can open their links (when available), but they can't currently be moved back to Queue or Focus.
 
 ## Plugin Ecosystem
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ WorkCenter is **not** a replacement for GitHub Issues, Jira, or any other system
 
 ### Configuring the GitHub Provider
 
-After installing WorkCenter GitHub, configure which repositories to watch:
+After installing WorkCenter GitHub, configure which repositories to watch for issues:
 
 ```json
 // settings.json
@@ -38,6 +38,8 @@ After installing WorkCenter GitHub, configure which repositories to watch:
 ```
 
 Leave `repos` empty to fetch all issues assigned to you across all repositories.
+
+> **Note:** The `repos` setting currently scopes **issue discovery only**. PR review requests are always discovered globally (all open PRs where your review is requested across all repositories).
 
 ## The Four-View Model
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,144 @@
-# workcenter
+# WorkCenter
+
+**A unified work hub inside VS Code.**
+
+WorkCenter is a VS Code extension that brings all of your work items — GitHub issues, PR review requests, investigations, follow-ups, and ad-hoc tasks — into a single, organized sidebar. Instead of juggling browser tabs, notification emails, and sticky notes, you manage everything from where you already write code.
+
+## The Problem
+
+Developers constantly context-switch between tools. Issues live in GitHub, tasks live in Jira, review requests arrive by email, and ad-hoc follow-ups exist only in your head. Each tool has its own UI, its own notification model, and its own idea of "what's next." The result: work falls through the cracks, and you waste time just figuring out what to do.
+
+## How WorkCenter Helps
+
+WorkCenter is **not** a replacement for GitHub Issues, Jira, or any other system of record. It is an **aggregation layer** that sits inside VS Code and gives you a personal, unified view of your work:
+
+- **Providers** discover items from external sources (GitHub issues, PR reviews, and more in the future) and surface them automatically.
+- **You** decide what to accept, what to dismiss, and what to work on next.
+- **Actions** let provider extensions automate workflows — like creating a branch and worktree for a GitHub issue with one click.
+
+## Quick Start
+
+1. **Install WorkCenter** from the VS Code marketplace (`mthalman.workcenter`).
+2. **Install a provider** — for example, WorkCenter GitHub (`mthalman.workcenter-github`) to discover GitHub issues and PR review requests.
+3. **Open the WorkCenter sidebar** by clicking the WorkCenter icon in the activity bar.
+4. **Check your Inbox** — newly discovered items from providers appear here. Accept items to add them to your Queue, or dismiss them.
+5. **Work your Queue** — move items to Focus when you're ready to start, or create manual items with the ➕ button.
+6. **Stay focused** — the Focus view shows only what you're actively working on. Mark items as blocked, waiting, or complete as you go.
+
+### Configuring the GitHub Provider
+
+After installing WorkCenter GitHub, configure which repositories to watch:
+
+```json
+// settings.json
+{
+  "workcenterGithub.repos": ["owner/repo1", "owner/repo2"],
+  "workcenterGithub.refreshIntervalSeconds": 300
+}
+```
+
+Leave `repos` empty to fetch all issues assigned to you across all repositories.
+
+## The Four-View Model
+
+WorkCenter organizes work across four views in the sidebar:
+
+### Inbox
+
+Newly discovered items from providers that you haven't acted on yet. Each provider's items are grouped under the provider name. Accept items to move them to your Queue, or dismiss them to hide them from the Inbox.
+
+### Queue
+
+Your curated backlog. Items arrive here when accepted from the Inbox or Sources, or when you create them manually. All Queue items are in the **New** state. From here, move items to Focus to start working, or archive them to skip.
+
+### Focus
+
+Your active work. Items here are **InProgress**, **Blocked**, or **WaitingOn**. The Focus view is designed to show only what matters right now. Complete items when done, or mark them as blocked/waiting to signal status at a glance.
+
+### Sources
+
+A browsable library of everything providers know about, organized by provider and sub-group (e.g., repository name). Items show their inbox state — accepted items display a ✓ icon, dismissed items show a label. You can accept items into your Queue directly from Sources at any time.
+
+### Data Flow
+
+```
+Providers (GitHub, etc.)          Manual creation
+        │                               │
+        ▼                               ▼
+      Inbox  ────Accept────►  Queue  ───Move to Focus──►  Focus  ──Complete──►  Done  ──►  Archived
+                                │                           │
+                              Archive                   Block/Wait
+                                │                        ◄──►
+                                ▼                      InProgress
+                             Archived
+```
+
+## Plugin Ecosystem
+
+WorkCenter is built around an extensible plugin model with two extension points:
+
+### Providers
+
+A provider discovers work items from an external source and reports them to WorkCenter. The core extension handles all UI — providers just emit data.
+
+**Built-in providers** (via WorkCenter GitHub):
+
+| Provider | What It Discovers |
+|----------|-------------------|
+| **GitHub Issues** | Issues assigned to you in configured repositories |
+| **GitHub PR Reviews** | Pull requests where your review is requested |
+
+### Actions
+
+An action is an operation that runs on a work item. Actions appear in the **Run Action…** menu on Queue and Focus items.
+
+**Built-in actions** (via WorkCenter GitHub):
+
+| Action | Description |
+|--------|-------------|
+| **Start Work (Branch + Worktree)** | Creates a git branch and worktree for a GitHub issue, then opens a new VS Code window |
+
+### Building Your Own
+
+Provider and action extensions use a simple, well-defined API surface. See the [Extension API documentation](docs/extension-api.md) for the full contract, interfaces, and example implementations.
+
+## Architecture
+
+WorkCenter is a monorepo with two VS Code extensions:
+
+```
+packages/
+├── core/       # WorkCenter — the hub extension (UI, lifecycle, plugin API)
+└── github/     # WorkCenter GitHub — provider for issues and PR reviews
+```
+
+- **`packages/core`** owns the four views, work item persistence, the editor panel, and the extension API (`WorkCenterApi`).
+- **`packages/github`** is a provider extension that discovers GitHub issues and PR reviews, and offers a "Start Work" action.
+
+Provider extensions depend on the core extension via `extensionDependencies` and acquire the API at activation time. They do not import code from the core package directly — interfaces are re-declared to keep the extensions decoupled.
+
+### Data Storage
+
+WorkCenter persists two JSON files in VS Code's `globalStorageUri`:
+
+- **`workitems.json`** — All work items with their full state machine lifecycle.
+- **`discovered-state.json`** — A thin index mapping `providerId + externalId` → inbox state (`unseen`, `accepted`, `dismissed`). Provider item data (title, description, URL) is never persisted — it is always read live from the provider.
+
+## Documentation
+
+- [UX Guide](docs/ux-guide.md) — The four views, data flow, work item states, available actions, and the editor panel.
+- [Extension API](docs/extension-api.md) — Provider and action contracts, interfaces, and example implementations.
+
+## Contributing
+
+1. Fork the repository and create a branch from `dev`.
+2. Install dependencies: `npm install`
+3. Build all packages: `npm run build`
+4. Run tests: `npm run test`
+5. Open a pull request targeting the `dev` branch.
+
+The default branch is **`dev`** — all work should be based from and merged back to `dev`.
+
+## License
+
+[MIT](LICENSE) © Matt Thalman

--- a/README.md
+++ b/README.md
@@ -115,16 +115,18 @@ Provider and action extensions use a simple, well-defined API surface. See the [
 
 ## Architecture
 
-WorkCenter is a monorepo with two VS Code extensions:
+WorkCenter is a monorepo with two VS Code extensions and a shared library:
 
 ```
 packages/
 ├── core/       # WorkCenter — the hub extension (UI, lifecycle, plugin API)
-└── github/     # WorkCenter GitHub — provider for issues and PR reviews
+├── github/     # WorkCenter GitHub — provider for issues and PR reviews
+└── shared/     # Shared library used by both extensions
 ```
 
 - **`packages/core`** owns the five views, work item persistence, the editor panel, and the extension API (`WorkCenterApi`).
 - **`packages/github`** is a provider extension that discovers GitHub issues and PR reviews, and offers a "Start Work" action.
+- **`packages/shared`** contains common utilities and types shared across both extensions.
 
 Provider extensions depend on the core extension via `extensionDependencies` and acquire the API at activation time. They do not import code from the core package directly — interfaces are re-declared to keep the extensions decoupled.
 


### PR DESCRIPTION
Replace the stub README with comprehensive documentation covering WorkCenter's purpose, value proposition, quick start guide, plugin ecosystem overview, and links to detailed docs.

Closes #16