### PR TITLE
docs: add JSDoc comments to core API types and WorkGraph

### DIFF
--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -40,8 +40,8 @@ export interface WorkCenterProvider {
   /** Human-readable name shown in the UI. */
   readonly label: string;
   /**
-   * When `true`, previously dismissed items will reappear in the Inbox on
-   * the next refresh. Defaults to `false`.
+   * When `true`, previously dismissed items are reset to unseen on the next
+   * refresh, allowing them to reappear in the Inbox. Defaults to `false`.
    */
   readonly resurfaceDismissed?: boolean;
   /** Fires when the provider has a new or updated set of discovered items. */

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -1,37 +1,81 @@
 import { WorkItem } from '../models/workItem';
 
+/** A handle that releases a resource when disposed. */
 export interface Disposable {
   dispose(): void;
 }
 
+/** A typed event that listeners can subscribe to. */
 export interface Event<T> {
   (listener: (e: T) => void): Disposable;
 }
 
+/**
+ * An item discovered by a {@link WorkCenterProvider}.
+ * Provider data is kept in memory and read live — only the inbox state is persisted.
+ */
 export interface DiscoveredItem {
+  /** Provider-scoped unique identifier (e.g. GitHub issue number). */
   externalId: string;
+  /** Short display title shown in Inbox and Sources views. */
   title: string;
+  /** Optional longer description of the item. */
   description?: string;
+  /** Optional URL linking back to the item in its source system. */
   url?: string;
+  /** Optional grouping key used to organize items in the Sources view. */
   group?: string;
 }
 
+/**
+ * A provider that discovers work items from an external source (e.g. GitHub Issues).
+ *
+ * Providers are registered via {@link WorkCenterApi.registerProvider} and emit
+ * {@link DiscoveredItem}s through the {@link onDidDiscoverItems} event. The core
+ * extension reads items live from the provider — it never persists provider data.
+ */
 export interface WorkCenterProvider {
+  /** Stable unique identifier for this provider (e.g. `"github"`). */
   readonly id: string;
+  /** Human-readable name shown in the UI. */
   readonly label: string;
+  /**
+   * When `true`, previously dismissed items will reappear in the Inbox on
+   * the next refresh. Defaults to `false`.
+   */
   readonly resurfaceDismissed?: boolean;
+  /** Fires when the provider has a new or updated set of discovered items. */
   readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
+  /** Re-fetch items from the external source. */
   refresh(): Promise<void>;
 }
 
+/**
+ * A context-menu action that can be run against a {@link WorkItem}.
+ *
+ * Actions are registered via {@link WorkCenterApi.registerAction} and surfaced
+ * dynamically — {@link canRun} is called to determine visibility.
+ */
 export interface WorkCenterAction {
+  /** Stable unique identifier for this action. */
   readonly id: string;
+  /** Label shown in the context menu. */
   readonly label: string;
+  /** Return `true` if this action is applicable to the given item. */
   canRun(item: WorkItem): boolean;
+  /** Execute the action for the given item. */
   run(item: WorkItem): Promise<void>;
 }
 
+/**
+ * Main entry point for provider extensions.
+ *
+ * Acquired via `vscode.extensions.getExtension('mthalman.workcenter')` and
+ * returned from the core extension's `activate()`.
+ */
 export interface WorkCenterApi {
+  /** Register a provider that discovers work items from an external source. */
   registerProvider(provider: WorkCenterProvider): Disposable;
+  /** Register a context-menu action that operates on work items. */
   registerAction(action: WorkCenterAction): Disposable;
 }

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -71,8 +71,10 @@ export interface WorkCenterAction {
 /**
  * Main entry point for provider extensions.
  *
- * Acquired via `vscode.extensions.getExtension('mthalman.workcenter')` and
- * returned from the core extension's `activate()`.
+ * Obtain this API from the core extension by first getting its extension
+ * wrapper via `vscode.extensions.getExtension('mthalman.workcenter')`, then
+ * activating it with `await extension.activate()` (or reading `extension.exports`
+ * after activation). The core extension's `activate()` returns this API.
  */
 export interface WorkCenterApi {
   /** Register a provider that discovers work items from an external source. */

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -23,7 +23,7 @@ export interface DiscoveredItem {
   description?: string;
   /** Optional URL linking back to the item in its source system. */
   url?: string;
-  /** Optional grouping key used to organize items in the Sources view. */
+  /** Optional grouping key used to organize items in the UI (for example, in the Inbox and Sources views). */
   group?: string;
 }
 

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -32,7 +32,8 @@ export interface DiscoveredItem {
  *
  * Providers are registered via {@link WorkCenterApi.registerProvider} and emit
  * {@link DiscoveredItem}s through the {@link onDidDiscoverItems} event. The core
- * extension reads items live from the provider — it never persists provider data.
+ * extension reads discovered item metadata live from the provider and does not
+ * persist that metadata; only inbox state associated with provider items is persisted.
  */
 export interface WorkCenterProvider {
   /** Stable unique identifier for this provider (e.g. `"github"`). */

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -1,27 +1,54 @@
+/**
+ * Lifecycle states for a {@link WorkItem}.
+ *
+ * Typical flow: `New` → `Triaged` → `InProgress` → `Done` → `Archived`.
+ * Items may also move to `Blocked` or `WaitingOn` while in progress.
+ */
 export enum WorkItemState {
+  /** Freshly created or accepted from the Inbox; sits in the Queue. */
   New = 'New',
+  /** Reviewed and prioritized but not yet started. */
   Triaged = 'Triaged',
+  /** Actively being worked on; shown in the Focus view. */
   InProgress = 'InProgress',
+  /** Work is stalled on an impediment; shown in the Focus view. */
   Blocked = 'Blocked',
+  /** Waiting on an external party; shown in the Focus view. */
   WaitingOn = 'WaitingOn',
+  /** Work is complete; shown in History. */
   Done = 'Done',
+  /** Removed from active views; retained in History for reference. */
   Archived = 'Archived',
 }
 
+/** A persisted work item managed by the WorkGraph. */
 export interface WorkItem {
+  /** Unique identifier (auto-generated on creation). */
   id: string;
+  /** Short display title. */
   title: string;
+  /** Optional free-form notes or description. */
   notes?: string;
+  /** Current lifecycle state. */
   state: WorkItemState;
+  /** ID of the provider that discovered this item, if any. */
   providerId?: string;
+  /** Provider-scoped external identifier linking back to the source item. */
   externalId?: string;
+  /** URL to the item in its source system. */
   url?: string;
+  /** Ordering key within items of the same state. Lower values sort first. */
   sortOrder?: number;
+  /** Epoch timestamp (ms) when the item was created. */
   createdAt: number;
+  /** Epoch timestamp (ms) of the last modification. */
   updatedAt: number;
 }
 
+/** Input required to create or update a work item. */
 export interface WorkItemInput {
+  /** Short display title. */
   title: string;
+  /** Optional free-form notes or description. */
   notes?: string;
 }

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -1,13 +1,14 @@
 /**
  * Lifecycle states for a {@link WorkItem}.
  *
- * Typical flow: `New` → `Triaged` → `InProgress` → `Done` → `Archived`.
- * Items may also move to `Blocked` or `WaitingOn` while in progress.
+ * Typical flow in the current UI: `New` → `InProgress` → `Done` → `Archived`.
+ * Items may also move from active work to `Blocked` or `WaitingOn`.
+ * `Triaged` is reserved for future use and is not currently used in the UI flow.
  */
 export enum WorkItemState {
   /** Freshly created or accepted from the Inbox; sits in the Queue. */
   New = 'New',
-  /** Reviewed and prioritized but not yet started. */
+  /** Reserved for future use; not currently used in the UI flow. */
   Triaged = 'Triaged',
   /** Actively being worked on; shown in the Focus view. */
   InProgress = 'InProgress',

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -10,7 +10,11 @@ import { logger } from './logger';
 export class WorkGraph {
   private items: Map<string, WorkItem> = new Map();
   private readonly _onDidChange = new vscode.EventEmitter<void>();
-  /** Fires whenever items are created, updated, reordered, state-transitioned, or deleted. */
+  /**
+   * Fires when this graph changes through public mutation operations exposed by {@link WorkGraph}.
+   * Internal maintenance performed during load (for example, sort-order backfilling) may update items
+   * without emitting this event.
+   */
   readonly onDidChange = this._onDidChange.event;
 
   constructor(private readonly store: ITaskStore) {}

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -3,13 +3,19 @@ import { WorkItem, WorkItemInput, WorkItemState } from '../models/workItem';
 import { ITaskStore } from '../storage/taskStore';
 import { logger } from './logger';
 
+/**
+ * In-memory graph of {@link WorkItem}s backed by a persistent {@link ITaskStore}.
+ * Provides CRUD operations, state transitions, and ordering.
+ */
 export class WorkGraph {
   private items: Map<string, WorkItem> = new Map();
   private readonly _onDidChange = new vscode.EventEmitter<void>();
+  /** Fires whenever items are created, updated, reordered, or deleted. */
   readonly onDidChange = this._onDidChange.event;
 
   constructor(private readonly store: ITaskStore) {}
 
+  /** Load all work items from the backing store into memory. */
   async load(): Promise<void> {
     const items = await this.store.loadAll();
     this.items.clear();
@@ -48,24 +54,29 @@ export class WorkGraph {
     }
   }
 
+  /** Return all work items. */
   getAll(): WorkItem[] {
     return Array.from(this.items.values());
   }
 
+  /** Return all work items matching any of the given states. */
   getItemsByState(...states: WorkItemState[]): WorkItem[] {
     return this.getAll().filter((item) => states.includes(item.state));
   }
 
+  /** Return a single work item by ID, or `undefined` if not found. */
   getItem(id: string): WorkItem | undefined {
     return this.items.get(id);
   }
 
+  /** Find a work item by its provider-scoped provenance (provider ID + external ID). */
   findItemByProvenance(providerId: string, externalId: string): WorkItem | undefined {
     return this.getAll().find(
       (item) => item.providerId === providerId && item.externalId === externalId
     );
   }
 
+  /** Create a new work item, optionally linking it to a provider-discovered source. */
   async createItem(
     input: WorkItemInput,
     provenance?: { providerId: string; externalId: string; url?: string },
@@ -95,6 +106,7 @@ export class WorkGraph {
     return item;
   }
 
+  /** Apply a partial update (title and/or notes) to an existing work item. */
   async updateItem(id: string, patch: Partial<WorkItemInput>): Promise<void> {
     const item = this.items.get(id);
     if (!item) {
@@ -107,6 +119,7 @@ export class WorkGraph {
     logger.info(`Updated work item: ${id}`);
   }
 
+  /** Transition a work item to a new lifecycle state. */
   async transitionState(id: string, newState: WorkItemState): Promise<void> {
     const item = this.items.get(id);
     if (!item) {
@@ -119,6 +132,7 @@ export class WorkGraph {
     logger.info(`Transitioned work item ${id} to ${newState}`);
   }
 
+  /** Swap a work item one position up or down among siblings in the same state. */
   async moveItem(id: string, direction: 'up' | 'down'): Promise<void> {
     const item = this.items.get(id);
     if (!item) {
@@ -166,6 +180,7 @@ export class WorkGraph {
     this._onDidChange.fire();
   }
 
+  /** Move a work item to the position of a target item (drag-and-drop reorder). */
   async reorderItem(draggedId: string, targetId: string): Promise<void> {
     const dragged = this.items.get(draggedId);
     const target = this.items.get(targetId);
@@ -204,6 +219,7 @@ export class WorkGraph {
     }
   }
 
+  /** Move a work item to the last position among siblings in the same state. */
   async moveToEnd(id: string): Promise<void> {
     const item = this.items.get(id);
     if (!item) { return; }
@@ -237,6 +253,7 @@ export class WorkGraph {
     }
   }
 
+  /** Permanently delete a work item from the store. */
   async deleteItem(id: string): Promise<void> {
     await this.store.delete(id);
     this.items.delete(id);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -11,9 +11,10 @@ export class WorkGraph {
   private items: Map<string, WorkItem> = new Map();
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   /**
-   * Fires when this graph changes through public mutation operations exposed by {@link WorkGraph}.
-   * Internal maintenance performed during load (for example, sort-order backfilling) may update items
-   * without emitting this event.
+   * Fires when this graph changes through public mutation operations exposed by {@link WorkGraph},
+   * except for internal maintenance or normalization work that may update items without emitting
+   * this event. This includes maintenance performed during load (for example, sort-order backfilling)
+   * and normalization triggered as part of a public operation when no user-visible mutation occurs.
    */
   readonly onDidChange = this._onDidChange.event;
 

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -10,7 +10,7 @@ import { logger } from './logger';
 export class WorkGraph {
   private items: Map<string, WorkItem> = new Map();
   private readonly _onDidChange = new vscode.EventEmitter<void>();
-  /** Fires whenever items are created, updated, reordered, or deleted. */
+  /** Fires whenever items are created, updated, reordered, state-transitioned, or deleted. */
   readonly onDidChange = this._onDidChange.event;
 
   constructor(private readonly store: ITaskStore) {}
@@ -180,7 +180,7 @@ export class WorkGraph {
     this._onDidChange.fire();
   }
 
-  /** Move a work item to the position of a target item (drag-and-drop reorder). */
+  /** Insert a work item before or after a target item (drag-and-drop reorder). */
   async reorderItem(draggedId: string, targetId: string): Promise<void> {
     const dragged = this.items.get(draggedId);
     const target = this.items.get(targetId);


### PR DESCRIPTION
Adds comprehensive JSDoc documentation to the core public API surfaces:

- **\packages/core/src/api/types.ts\** — All interfaces (\Disposable\, \Event\, \DiscoveredItem\, \WorkCenterProvider\, \WorkCenterAction\, \WorkCenterApi\) and their members
- **\packages/core/src/models/workItem.ts\** — \WorkItemState\ enum values, \WorkItem\ interface, and \WorkItemInput\ interface
- **\packages/core/src/services/workGraph.ts\** — Class-level docs and all public methods

Uses `@link` cross-references to connect related types. No functional changes.