### PR TITLE
fix: add 30s timeout to provider refresh to prevent hanging

### DIFF
--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -23,7 +23,7 @@ interface WorkCenterProvider {
   readonly label: string;
   readonly resurfaceDismissed?: boolean;
   readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
-  refresh(): Promise<void>;
+  refresh(token?: vscode.CancellationToken): Promise<void>;
 }
 
 interface AdoPullRequest {
@@ -84,7 +84,7 @@ export class AdoPrReviewProvider implements WorkCenterProvider {
     }
   }
 
-  async refresh(): Promise<void> {
+  async refresh(token?: vscode.CancellationToken): Promise<void> {
     if (this._isRefreshing) {
       return;
     }
@@ -92,11 +92,15 @@ export class AdoPrReviewProvider implements WorkCenterProvider {
     this._isRefreshing = true;
     try {
       logger.info('Fetching ADO PR reviews...');
+      if (token?.isCancellationRequested) {
+        return;
+      }
+
       const session = await vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], {
         createIfNone: true,
       }).catch(() => null);
 
-      if (!session) {
+      if (!session || token?.isCancellationRequested) {
         return;
       }
 

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -23,7 +23,7 @@ interface WorkCenterProvider {
   readonly label: string;
   readonly resurfaceDismissed?: boolean;
   readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
-  refresh(): Promise<void>;
+  refresh(token?: vscode.CancellationToken): Promise<void>;
 }
 
 // Azure DevOps WIQL query response
@@ -85,7 +85,7 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
     }
   }
 
-  async refresh(): Promise<void> {
+  async refresh(token?: vscode.CancellationToken): Promise<void> {
     if (this._isRefreshing) {
       return;
     }
@@ -93,11 +93,15 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
     this._isRefreshing = true;
     try {
       logger.info('Fetching assigned ADO work items...');
+      if (token?.isCancellationRequested) {
+        return;
+      }
+
       const session = await vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], {
         createIfNone: true,
       }).catch(() => null);
 
-      if (!session) {
+      if (!session || token?.isCancellationRequested) {
         return;
       }
 

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -1,5 +1,5 @@
-import * as vscode from 'vscode';
-import { WorkItem } from '../models/workItem';
+import type * as vscode from 'vscode';
+import type { WorkItem } from '../models/workItem';
 
 export interface Disposable {
   dispose(): void;

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import { WorkItem } from '../models/workItem';
 
 export interface Disposable {
@@ -21,7 +22,7 @@ export interface WorkCenterProvider {
   readonly label: string;
   readonly resurfaceDismissed?: boolean;
   readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
-  refresh(): Promise<void>;
+  refresh(token?: vscode.CancellationToken): Promise<void>;
 }
 
 export interface WorkCenterAction {

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -98,16 +98,18 @@ export class ProviderRegistry {
 
   // Note: the losing promise in Promise.race() continues running — true cancellation
   // would require adding CancellationToken to the provider refresh API.
-  private raceWithTimeout(promise: Promise<void>, providerLabel: string): Promise<void> {
-    let timeoutId: ReturnType<typeof setTimeout>;
+  private raceWithTimeout(promise: Promise<void>, providerId: string): Promise<void> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<void>((resolve) => {
       timeoutId = setTimeout(() => {
-        logger.warn(`Provider "${providerLabel}" refresh timed out after ${ProviderRegistry.REFRESH_TIMEOUT_MS}ms`);
+        logger.warn(`Provider "${providerId}" refresh timed out after ${ProviderRegistry.REFRESH_TIMEOUT_MS}ms`);
         resolve();
       }, ProviderRegistry.REFRESH_TIMEOUT_MS);
     });
     return Promise.race([promise, timeoutPromise]).finally(() => {
-      clearTimeout(timeoutId);
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
     });
   }
 

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -4,7 +4,7 @@ import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import { logger } from './logger';
 
 export class ProviderRegistry {
-  private static readonly REFRESH_TIMEOUT_MS = 30_000;
+  static readonly REFRESH_TIMEOUT_MS = 30_000;
   private readonly providers = new Map<string, WorkCenterProvider>();
   private readonly subscriptions = new Map<string, { dispose(): void }>();
   private readonly discoveredItems = new Map<string, DiscoveredItem[]>();
@@ -15,7 +15,7 @@ export class ProviderRegistry {
   private readonly _onDidAddNewUnseenItems = new vscode.EventEmitter<number>();
   readonly onDidAddNewUnseenItems = this._onDidAddNewUnseenItems.event;
   private readonly _loadingProviders = new Set<string>();
-  private readonly _pendingTimeouts = new Set<ReturnType<typeof setTimeout>>();
+  private readonly _pendingCts = new Set<vscode.CancellationTokenSource>();
 
   get loading(): boolean {
     return this._loadingProviders.size > 0;
@@ -48,11 +48,7 @@ export class ProviderRegistry {
     this._loadingProviders.add(provider.id);
     this._onDidRegisterProvider.fire();
     this._onDidChangeDiscoveredItems.fire();
-    const refreshPromise = provider.refresh()
-      .catch((err: unknown) => {
-        logger.error(`Provider "${provider.id}" refresh failed`, err);
-      });
-    this.raceWithTimeout(refreshPromise, provider.id)
+    this.refreshWithTimeout(provider)
       .finally(() => {
         this._loadingProviders.delete(provider.id);
         this._onDidChangeDiscoveredItems.fire();
@@ -87,36 +83,36 @@ export class ProviderRegistry {
   async refreshAll(): Promise<void> {
     const promises = Array.from(this.providers.values()).map((p) => {
       logger.debug(`Provider ${p.id} refreshing...`);
-
-      const refreshPromise = p.refresh().catch((err: unknown) => {
-        logger.error(`Provider "${p.id}" refresh failed`, err);
-      });
-
-      return this.raceWithTimeout(refreshPromise, p.id);
+      return this.refreshWithTimeout(p);
     });
     await Promise.all(promises);
   }
 
-  // Note: the losing promise in Promise.race() continues running — true cancellation
-  // would require adding CancellationToken to the provider refresh API.
-  private raceWithTimeout(promise: Promise<void>, providerId: string): Promise<void> {
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    const timeoutPromise = new Promise<void>((resolve) => {
-      timeoutId = setTimeout(() => {
-        // Guard against logging for providers that were unregistered before the timeout fired
-        if (this.providers.has(providerId)) {
-          logger.warn(`Provider "${providerId}" refresh timed out after ${ProviderRegistry.REFRESH_TIMEOUT_MS}ms`);
-        }
-        resolve();
-      }, ProviderRegistry.REFRESH_TIMEOUT_MS);
-      this._pendingTimeouts.add(timeoutId);
-    });
-    return Promise.race([promise, timeoutPromise]).finally(() => {
-      if (timeoutId !== undefined) {
-        clearTimeout(timeoutId);
-        this._pendingTimeouts.delete(timeoutId);
+  private refreshWithTimeout(provider: WorkCenterProvider): Promise<void> {
+    const cts = new vscode.CancellationTokenSource();
+    this._pendingCts.add(cts);
+    const timeoutId = setTimeout(() => cts.cancel(), ProviderRegistry.REFRESH_TIMEOUT_MS);
+    cts.token.onCancellationRequested(() => {
+      if (this.providers.has(provider.id)) {
+        logger.warn(`Provider "${provider.id}" refresh timed out after ${ProviderRegistry.REFRESH_TIMEOUT_MS}ms`);
       }
     });
+
+    const refreshPromise = provider.refresh(cts.token)
+      .catch((err: unknown) => {
+        logger.error(`Provider "${provider.id}" refresh failed`, err);
+      });
+
+    const cancelledPromise = new Promise<void>((resolve) => {
+      cts.token.onCancellationRequested(() => resolve());
+    });
+
+    return Promise.race([refreshPromise, cancelledPromise])
+      .finally(() => {
+        clearTimeout(timeoutId);
+        this._pendingCts.delete(cts);
+        cts.dispose();
+      });
   }
 
   private async handleDiscoveredItems(providerId: string, items: DiscoveredItem[]): Promise<void> {
@@ -145,10 +141,10 @@ export class ProviderRegistry {
   }
 
   dispose(): void {
-    for (const id of this._pendingTimeouts) {
-      clearTimeout(id);
+    for (const cts of this._pendingCts) {
+      cts.dispose();
     }
-    this._pendingTimeouts.clear();
+    this._pendingCts.clear();
     for (const sub of this.subscriptions.values()) {
       sub.dispose();
     }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -158,12 +158,16 @@ export class ProviderRegistry {
     if (updates.length > 0) {
       try {
         await this.stateStore.setStates(updates);
-        this._onDidAddNewUnseenItems.fire(updates.length);
+        if (!this._disposed) {
+          this._onDidAddNewUnseenItems.fire(updates.length);
+        }
       } catch (err) {
         logger.error('Failed to persist discovered states', err);
       }
     }
-    this._onDidChangeDiscoveredItems.fire();
+    if (!this._disposed) {
+      this._onDidChangeDiscoveredItems.fire();
+    }
   }
 
   dispose(): void {

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -4,6 +4,7 @@ import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import { logger } from './logger';
 
 export class ProviderRegistry {
+  private static readonly REFRESH_TIMEOUT_MS = 30_000;
   private readonly providers = new Map<string, WorkCenterProvider>();
   private readonly subscriptions = new Map<string, { dispose(): void }>();
   private readonly discoveredItems = new Map<string, DiscoveredItem[]>();
@@ -46,10 +47,17 @@ export class ProviderRegistry {
     this._loadingProviders.add(provider.id);
     this._onDidRegisterProvider.fire();
     this._onDidChangeDiscoveredItems.fire();
-    provider.refresh()
-      .catch((err) => {
+    const refreshPromise = provider.refresh()
+      .catch((err: unknown) => {
         logger.error(`Provider "${provider.id}" refresh failed`, err);
-      })
+      });
+    const timeoutPromise = new Promise<void>((resolve) => {
+      setTimeout(() => {
+        logger.warn(`Provider "${provider.id}" refresh timed out after ${ProviderRegistry.REFRESH_TIMEOUT_MS}ms`);
+        resolve();
+      }, ProviderRegistry.REFRESH_TIMEOUT_MS);
+    });
+    Promise.race([refreshPromise, timeoutPromise])
       .finally(() => {
         this._loadingProviders.delete(provider.id);
         this._onDidChangeDiscoveredItems.fire();
@@ -82,11 +90,22 @@ export class ProviderRegistry {
   }
 
   async refreshAll(): Promise<void> {
+    const timeoutMs = ProviderRegistry.REFRESH_TIMEOUT_MS;
     const promises = Array.from(this.providers.values()).map((p) => {
       logger.debug(`Provider ${p.id} refreshing...`);
-      return p.refresh().catch((err) => {
+
+      const refreshPromise = p.refresh().catch((err: unknown) => {
         logger.error(`Provider "${p.id}" refresh failed`, err);
       });
+
+      const timeoutPromise = new Promise<void>((resolve) => {
+        setTimeout(() => {
+          logger.warn(`Provider "${p.id}" refresh timed out after ${timeoutMs}ms`);
+          resolve();
+        }, timeoutMs);
+      });
+
+      return Promise.race([refreshPromise, timeoutPromise]);
     });
     await Promise.all(promises);
   }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -15,6 +15,7 @@ export class ProviderRegistry {
   private readonly _onDidAddNewUnseenItems = new vscode.EventEmitter<number>();
   readonly onDidAddNewUnseenItems = this._onDidAddNewUnseenItems.event;
   private readonly _loadingProviders = new Set<string>();
+  private readonly _pendingTimeouts = new Set<ReturnType<typeof setTimeout>>();
 
   get loading(): boolean {
     return this._loadingProviders.size > 0;
@@ -108,10 +109,12 @@ export class ProviderRegistry {
         }
         resolve();
       }, ProviderRegistry.REFRESH_TIMEOUT_MS);
+      this._pendingTimeouts.add(timeoutId);
     });
     return Promise.race([promise, timeoutPromise]).finally(() => {
       if (timeoutId !== undefined) {
         clearTimeout(timeoutId);
+        this._pendingTimeouts.delete(timeoutId);
       }
     });
   }
@@ -142,6 +145,10 @@ export class ProviderRegistry {
   }
 
   dispose(): void {
+    for (const id of this._pendingTimeouts) {
+      clearTimeout(id);
+    }
+    this._pendingTimeouts.clear();
     for (const sub of this.subscriptions.values()) {
       sub.dispose();
     }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -102,7 +102,10 @@ export class ProviderRegistry {
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<void>((resolve) => {
       timeoutId = setTimeout(() => {
-        logger.warn(`Provider "${providerId}" refresh timed out after ${ProviderRegistry.REFRESH_TIMEOUT_MS}ms`);
+        // Guard against logging for providers that were unregistered before the timeout fired
+        if (this.providers.has(providerId)) {
+          logger.warn(`Provider "${providerId}" refresh timed out after ${ProviderRegistry.REFRESH_TIMEOUT_MS}ms`);
+        }
         resolve();
       }, ProviderRegistry.REFRESH_TIMEOUT_MS);
     });

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -51,14 +51,16 @@ export class ProviderRegistry {
       .catch((err: unknown) => {
         logger.error(`Provider "${provider.id}" refresh failed`, err);
       });
+    let timeoutId: ReturnType<typeof setTimeout>;
     const timeoutPromise = new Promise<void>((resolve) => {
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         logger.warn(`Provider "${provider.id}" refresh timed out after ${ProviderRegistry.REFRESH_TIMEOUT_MS}ms`);
         resolve();
       }, ProviderRegistry.REFRESH_TIMEOUT_MS);
     });
     Promise.race([refreshPromise, timeoutPromise])
       .finally(() => {
+        clearTimeout(timeoutId);
         this._loadingProviders.delete(provider.id);
         this._onDidChangeDiscoveredItems.fire();
       });
@@ -98,14 +100,17 @@ export class ProviderRegistry {
         logger.error(`Provider "${p.id}" refresh failed`, err);
       });
 
+      let timeoutId: ReturnType<typeof setTimeout>;
       const timeoutPromise = new Promise<void>((resolve) => {
-        setTimeout(() => {
+        timeoutId = setTimeout(() => {
           logger.warn(`Provider "${p.id}" refresh timed out after ${timeoutMs}ms`);
           resolve();
         }, timeoutMs);
       });
 
-      return Promise.race([refreshPromise, timeoutPromise]);
+      return Promise.race([refreshPromise, timeoutPromise]).finally(() => {
+        clearTimeout(timeoutId);
+      });
     });
     await Promise.all(promises);
   }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -52,7 +52,9 @@ export class ProviderRegistry {
     this.refreshWithTimeout(provider)
       .finally(() => {
         this._loadingProviders.delete(provider.id);
-        this._onDidChangeDiscoveredItems.fire();
+        if (!this._disposed) {
+          this._onDidChangeDiscoveredItems.fire();
+        }
       });
 
     return new vscode.Disposable(() => {
@@ -62,7 +64,9 @@ export class ProviderRegistry {
       this.subscriptions.delete(provider.id);
       this.discoveredItems.delete(provider.id);
       this._loadingProviders.delete(provider.id);
-      this._onDidChangeDiscoveredItems.fire();
+      if (!this._disposed) {
+        this._onDidChangeDiscoveredItems.fire();
+      }
     });
   }
 

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -133,7 +133,7 @@ export class ProviderRegistry {
     if (pending) {
       clearTimeout(pending.timeoutId);
       pending.cts.cancel();
-      pending.cts.dispose();
+      // CTS is disposed in refreshWithTimeout's finally block
       this._pendingRefreshes.delete(providerId);
     }
   }
@@ -173,7 +173,7 @@ export class ProviderRegistry {
     for (const { cts, timeoutId } of this._pendingRefreshes.values()) {
       clearTimeout(timeoutId);
       cts.cancel();
-      cts.dispose();
+      // CTS is disposed in refreshWithTimeout's finally block
     }
     this._pendingRefreshes.clear();
     for (const sub of this.subscriptions.values()) {

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -104,7 +104,9 @@ export class ProviderRegistry {
 
     const refreshPromise = provider.refresh(cts.token)
       .catch((err: unknown) => {
-        logger.error(`Provider "${provider.id}" refresh failed`, err);
+        if (!cts.token.isCancellationRequested) {
+          logger.error(`Provider "${provider.id}" refresh failed`, err);
+        }
       });
 
     const cancelledPromise = new Promise<void>((resolve) => {

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -93,13 +93,13 @@ export class ProviderRegistry {
   private refreshWithTimeout(provider: WorkCenterProvider): Promise<void> {
     this.cancelPendingRefresh(provider.id);
     const cts = new vscode.CancellationTokenSource();
-    const timeoutId = setTimeout(() => cts.cancel(), ProviderRegistry.REFRESH_TIMEOUT_MS);
-    this._pendingRefreshes.set(provider.id, { cts, timeoutId });
-    cts.token.onCancellationRequested(() => {
+    const timeoutId = setTimeout(() => {
       if (this.providers.has(provider.id)) {
         logger.warn(`Provider "${provider.id}" refresh timed out after ${ProviderRegistry.REFRESH_TIMEOUT_MS}ms`);
       }
-    });
+      cts.cancel();
+    }, ProviderRegistry.REFRESH_TIMEOUT_MS);
+    this._pendingRefreshes.set(provider.id, { cts, timeoutId });
 
     const refreshPromise = provider.refresh(cts.token)
       .catch((err: unknown) => {

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -99,7 +99,8 @@ export class ProviderRegistry {
       }
       cts.cancel();
     }, ProviderRegistry.REFRESH_TIMEOUT_MS);
-    this._pendingRefreshes.set(provider.id, { cts, timeoutId });
+    const entry = { cts, timeoutId };
+    this._pendingRefreshes.set(provider.id, entry);
 
     const refreshPromise = provider.refresh(cts.token)
       .catch((err: unknown) => {
@@ -113,7 +114,10 @@ export class ProviderRegistry {
     return Promise.race([refreshPromise, cancelledPromise])
       .finally(() => {
         clearTimeout(timeoutId);
-        this._pendingRefreshes.delete(provider.id);
+        // Only clean up if this entry is still the current one for this provider
+        if (this._pendingRefreshes.get(provider.id) === entry) {
+          this._pendingRefreshes.delete(provider.id);
+        }
         cts.dispose();
       });
   }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -15,7 +15,7 @@ export class ProviderRegistry {
   private readonly _onDidAddNewUnseenItems = new vscode.EventEmitter<number>();
   readonly onDidAddNewUnseenItems = this._onDidAddNewUnseenItems.event;
   private readonly _loadingProviders = new Set<string>();
-  private readonly _pendingCts = new Set<vscode.CancellationTokenSource>();
+  private readonly _pendingRefreshes = new Set<{ cts: vscode.CancellationTokenSource; timeoutId: ReturnType<typeof setTimeout> }>();
 
   get loading(): boolean {
     return this._loadingProviders.size > 0;
@@ -90,8 +90,9 @@ export class ProviderRegistry {
 
   private refreshWithTimeout(provider: WorkCenterProvider): Promise<void> {
     const cts = new vscode.CancellationTokenSource();
-    this._pendingCts.add(cts);
     const timeoutId = setTimeout(() => cts.cancel(), ProviderRegistry.REFRESH_TIMEOUT_MS);
+    const entry = { cts, timeoutId };
+    this._pendingRefreshes.add(entry);
     cts.token.onCancellationRequested(() => {
       if (this.providers.has(provider.id)) {
         logger.warn(`Provider "${provider.id}" refresh timed out after ${ProviderRegistry.REFRESH_TIMEOUT_MS}ms`);
@@ -110,7 +111,7 @@ export class ProviderRegistry {
     return Promise.race([refreshPromise, cancelledPromise])
       .finally(() => {
         clearTimeout(timeoutId);
-        this._pendingCts.delete(cts);
+        this._pendingRefreshes.delete(entry);
         cts.dispose();
       });
   }
@@ -141,14 +142,17 @@ export class ProviderRegistry {
   }
 
   dispose(): void {
-    for (const cts of this._pendingCts) {
+    // Clear providers first so cancellation handlers don't log spurious timeout warnings
+    this.providers.clear();
+    for (const { cts, timeoutId } of this._pendingRefreshes) {
+      clearTimeout(timeoutId);
+      cts.cancel();
       cts.dispose();
     }
-    this._pendingCts.clear();
+    this._pendingRefreshes.clear();
     for (const sub of this.subscriptions.values()) {
       sub.dispose();
     }
-    this.providers.clear();
     this.subscriptions.clear();
     this._onDidChangeDiscoveredItems.dispose();
     this._onDidRegisterProvider.dispose();

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -51,16 +51,8 @@ export class ProviderRegistry {
       .catch((err: unknown) => {
         logger.error(`Provider "${provider.id}" refresh failed`, err);
       });
-    let timeoutId: ReturnType<typeof setTimeout>;
-    const timeoutPromise = new Promise<void>((resolve) => {
-      timeoutId = setTimeout(() => {
-        logger.warn(`Provider "${provider.id}" refresh timed out after ${ProviderRegistry.REFRESH_TIMEOUT_MS}ms`);
-        resolve();
-      }, ProviderRegistry.REFRESH_TIMEOUT_MS);
-    });
-    Promise.race([refreshPromise, timeoutPromise])
+    this.raceWithTimeout(refreshPromise, provider.id)
       .finally(() => {
-        clearTimeout(timeoutId);
         this._loadingProviders.delete(provider.id);
         this._onDidChangeDiscoveredItems.fire();
       });
@@ -92,7 +84,6 @@ export class ProviderRegistry {
   }
 
   async refreshAll(): Promise<void> {
-    const timeoutMs = ProviderRegistry.REFRESH_TIMEOUT_MS;
     const promises = Array.from(this.providers.values()).map((p) => {
       logger.debug(`Provider ${p.id} refreshing...`);
 
@@ -100,19 +91,24 @@ export class ProviderRegistry {
         logger.error(`Provider "${p.id}" refresh failed`, err);
       });
 
-      let timeoutId: ReturnType<typeof setTimeout>;
-      const timeoutPromise = new Promise<void>((resolve) => {
-        timeoutId = setTimeout(() => {
-          logger.warn(`Provider "${p.id}" refresh timed out after ${timeoutMs}ms`);
-          resolve();
-        }, timeoutMs);
-      });
-
-      return Promise.race([refreshPromise, timeoutPromise]).finally(() => {
-        clearTimeout(timeoutId);
-      });
+      return this.raceWithTimeout(refreshPromise, p.id);
     });
     await Promise.all(promises);
+  }
+
+  // Note: the losing promise in Promise.race() continues running — true cancellation
+  // would require adding CancellationToken to the provider refresh API.
+  private raceWithTimeout(promise: Promise<void>, providerLabel: string): Promise<void> {
+    let timeoutId: ReturnType<typeof setTimeout>;
+    const timeoutPromise = new Promise<void>((resolve) => {
+      timeoutId = setTimeout(() => {
+        logger.warn(`Provider "${providerLabel}" refresh timed out after ${ProviderRegistry.REFRESH_TIMEOUT_MS}ms`);
+        resolve();
+      }, ProviderRegistry.REFRESH_TIMEOUT_MS);
+    });
+    return Promise.race([promise, timeoutPromise]).finally(() => {
+      clearTimeout(timeoutId);
+    });
   }
 
   private async handleDiscoveredItems(providerId: string, items: DiscoveredItem[]): Promise<void> {

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -15,7 +15,8 @@ export class ProviderRegistry {
   private readonly _onDidAddNewUnseenItems = new vscode.EventEmitter<number>();
   readonly onDidAddNewUnseenItems = this._onDidAddNewUnseenItems.event;
   private readonly _loadingProviders = new Set<string>();
-  private readonly _pendingRefreshes = new Set<{ cts: vscode.CancellationTokenSource; timeoutId: ReturnType<typeof setTimeout> }>();
+  private readonly _pendingRefreshes = new Map<string, { cts: vscode.CancellationTokenSource; timeoutId: ReturnType<typeof setTimeout> }>();
+  private _disposed = false;
 
   get loading(): boolean {
     return this._loadingProviders.size > 0;
@@ -55,6 +56,7 @@ export class ProviderRegistry {
       });
 
     return new vscode.Disposable(() => {
+      this.cancelPendingRefresh(provider.id);
       this.providers.delete(provider.id);
       this.subscriptions.get(provider.id)?.dispose();
       this.subscriptions.delete(provider.id);
@@ -89,10 +91,10 @@ export class ProviderRegistry {
   }
 
   private refreshWithTimeout(provider: WorkCenterProvider): Promise<void> {
+    this.cancelPendingRefresh(provider.id);
     const cts = new vscode.CancellationTokenSource();
     const timeoutId = setTimeout(() => cts.cancel(), ProviderRegistry.REFRESH_TIMEOUT_MS);
-    const entry = { cts, timeoutId };
-    this._pendingRefreshes.add(entry);
+    this._pendingRefreshes.set(provider.id, { cts, timeoutId });
     cts.token.onCancellationRequested(() => {
       if (this.providers.has(provider.id)) {
         logger.warn(`Provider "${provider.id}" refresh timed out after ${ProviderRegistry.REFRESH_TIMEOUT_MS}ms`);
@@ -111,12 +113,25 @@ export class ProviderRegistry {
     return Promise.race([refreshPromise, cancelledPromise])
       .finally(() => {
         clearTimeout(timeoutId);
-        this._pendingRefreshes.delete(entry);
+        this._pendingRefreshes.delete(provider.id);
         cts.dispose();
       });
   }
 
+  private cancelPendingRefresh(providerId: string): void {
+    const pending = this._pendingRefreshes.get(providerId);
+    if (pending) {
+      clearTimeout(pending.timeoutId);
+      pending.cts.cancel();
+      pending.cts.dispose();
+      this._pendingRefreshes.delete(providerId);
+    }
+  }
+
   private async handleDiscoveredItems(providerId: string, items: DiscoveredItem[]): Promise<void> {
+    if (this._disposed) {
+      return;
+    }
     logger.info(`Provider ${providerId} discovered ${items.length} items`);
     this.discoveredItems.set(providerId, items);
     const provider = this.providers.get(providerId);
@@ -142,9 +157,10 @@ export class ProviderRegistry {
   }
 
   dispose(): void {
+    this._disposed = true;
     // Clear providers first so cancellation handlers don't log spurious timeout warnings
     this.providers.clear();
-    for (const { cts, timeoutId } of this._pendingRefreshes) {
+    for (const { cts, timeoutId } of this._pendingRefreshes.values()) {
       clearTimeout(timeoutId);
       cts.cancel();
       cts.dispose();

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -99,7 +99,6 @@ class MockDataTransfer {
 }
 
 class MockCancellationTokenSource {
-  private _isCancellationRequested = false;
   private _listeners: Function[] = [];
   token = {
     isCancellationRequested: false,
@@ -109,7 +108,6 @@ class MockCancellationTokenSource {
     },
   };
   cancel() {
-    this._isCancellationRequested = true;
     this.token.isCancellationRequested = true;
     for (const listener of this._listeners) {
       listener();

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -98,6 +98,28 @@ class MockDataTransfer {
   set(mimeType: string, value: MockDataTransferItem): void { this.items.set(mimeType, value); }
 }
 
+class MockCancellationTokenSource {
+  private _isCancellationRequested = false;
+  private _listeners: Function[] = [];
+  token = {
+    isCancellationRequested: false,
+    onCancellationRequested: (listener: Function) => {
+      this._listeners.push(listener);
+      return { dispose: () => { this._listeners = this._listeners.filter(l => l !== listener); } };
+    },
+  };
+  cancel() {
+    this._isCancellationRequested = true;
+    this.token.isCancellationRequested = true;
+    for (const listener of this._listeners) {
+      listener();
+    }
+  }
+  dispose() {
+    this._listeners = [];
+  }
+}
+
 class MockDisposable {
   private callback: () => void;
   constructor(callback: () => void) { this.callback = callback; }
@@ -118,6 +140,7 @@ export {
   MockTreeItem as TreeItem,
   MockDataTransferItem as DataTransferItem,
   MockDataTransfer as DataTransfer,
+  MockCancellationTokenSource as CancellationTokenSource,
   MockDisposable as Disposable,
   TreeItemCollapsibleState,
   window,

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -103,13 +103,22 @@ class MockCancellationTokenSource {
   token = {
     isCancellationRequested: false,
     onCancellationRequested: (listener: Function) => {
-      this._listeners.push(listener);
+      if (this.token.isCancellationRequested) {
+        listener();
+      } else {
+        this._listeners.push(listener);
+      }
       return { dispose: () => { this._listeners = this._listeners.filter(l => l !== listener); } };
     },
   };
   cancel() {
+    if (this.token.isCancellationRequested) {
+      return;
+    }
     this.token.isCancellationRequested = true;
-    for (const listener of this._listeners) {
+    const listeners = this._listeners.slice();
+    this._listeners = [];
+    for (const listener of listeners) {
       listener();
     }
   }

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -363,7 +363,7 @@ describe('ProviderRegistry', () => {
       registry.register(provider);
       expect(registry.loading).toBe(true);
 
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(ProviderRegistry.REFRESH_TIMEOUT_MS);
       expect(registry.loading).toBe(false);
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Provider "slow" refresh timed out'),
@@ -384,7 +384,7 @@ describe('ProviderRegistry', () => {
       const refreshPromise = registry.refreshAll();
       expect(warnSpy).not.toHaveBeenCalled();
 
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(ProviderRegistry.REFRESH_TIMEOUT_MS);
       await expect(refreshPromise).resolves.toBeUndefined();
       expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(
@@ -400,7 +400,7 @@ describe('ProviderRegistry', () => {
 
       // refresh already resolved (default mock is async () => {})
       // Advance past timeout — no spurious warnings should fire
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(ProviderRegistry.REFRESH_TIMEOUT_MS);
       expect(registry.loading).toBe(false);
       expect(warnSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
@@ -427,7 +427,7 @@ describe('ProviderRegistry', () => {
       expect(receivedToken).toBeDefined();
       expect(receivedToken.isCancellationRequested).toBe(false);
 
-      await vi.advanceTimersByTimeAsync(30_000);
+      await vi.advanceTimersByTimeAsync(ProviderRegistry.REFRESH_TIMEOUT_MS);
       expect(receivedToken.isCancellationRequested).toBe(true);
     });
   });

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -374,15 +374,19 @@ describe('ProviderRegistry', () => {
     it('resolves refreshAll when a provider refresh times out', async () => {
       const warnSpy = vi.spyOn(logger, 'warn');
       const provider = createMockProvider('hanging');
-      vi.mocked(provider.refresh).mockReturnValue(new Promise(() => {}));
+      // Let register-time refresh complete so this test only observes the
+      // timeout behavior from the refreshAll() invocation itself.
       registry.register(provider);
 
-      // Reset for refreshAll call
+      // Make the refresh triggered by refreshAll() hang
       vi.mocked(provider.refresh).mockReturnValue(new Promise(() => {}));
 
       const refreshPromise = registry.refreshAll();
+      expect(warnSpy).not.toHaveBeenCalled();
+
       await vi.advanceTimersByTimeAsync(30_000);
       await expect(refreshPromise).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
       expect(warnSpy).toHaveBeenCalledWith(
         expect.stringContaining('Provider "hanging" refresh timed out'),
       );

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -372,6 +372,7 @@ describe('ProviderRegistry', () => {
     });
 
     it('resolves refreshAll when a provider refresh times out', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn');
       const provider = createMockProvider('hanging');
       vi.mocked(provider.refresh).mockReturnValue(new Promise(() => {}));
       registry.register(provider);
@@ -382,6 +383,10 @@ describe('ProviderRegistry', () => {
       const refreshPromise = registry.refreshAll();
       await vi.advanceTimersByTimeAsync(30_000);
       await expect(refreshPromise).resolves.toBeUndefined();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Provider "hanging" refresh timed out'),
+      );
+      warnSpy.mockRestore();
     });
 
     it('clears timeout when refresh completes quickly', async () => {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'vscode';
 import { WorkCenterProvider, DiscoveredItem } from '../api/types';
 import { WorkGraph } from '../services/workGraph';
@@ -343,6 +343,50 @@ describe('ProviderRegistry', () => {
       expect(registry.getDiscoveredItems('gh')).toHaveLength(1),
     );
     expect(listener).not.toHaveBeenCalled();
+  });
+
+  describe('refresh timeout', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('clears loading state when register refresh times out', async () => {
+      const provider = createMockProvider('slow');
+      vi.mocked(provider.refresh).mockReturnValue(new Promise(() => {}));
+
+      registry.register(provider);
+      expect(registry.loading).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(registry.loading).toBe(false);
+    });
+
+    it('resolves refreshAll when a provider refresh times out', async () => {
+      const provider = createMockProvider('hanging');
+      vi.mocked(provider.refresh).mockReturnValue(new Promise(() => {}));
+      registry.register(provider);
+
+      // Reset for refreshAll call
+      vi.mocked(provider.refresh).mockReturnValue(new Promise(() => {}));
+
+      const refreshPromise = registry.refreshAll();
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(refreshPromise).resolves.toBeUndefined();
+    });
+
+    it('clears timeout when refresh completes quickly', async () => {
+      const provider = createMockProvider('fast');
+      registry.register(provider);
+
+      // refresh already resolved (default mock is async () => {})
+      // Advance past timeout — no spurious warnings should fire
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(registry.loading).toBe(false);
+    });
   });
 
   describe('resurfaceDismissed', () => {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -3,6 +3,7 @@ import { EventEmitter } from 'vscode';
 import { WorkCenterProvider, DiscoveredItem } from '../api/types';
 import { WorkGraph } from '../services/workGraph';
 import { ProviderRegistry } from '../services/providerRegistry';
+import { logger } from '../services/logger';
 import { ITaskStore } from '../storage/taskStore';
 import { WorkItemState } from '../models/workItem';
 
@@ -355,6 +356,7 @@ describe('ProviderRegistry', () => {
     });
 
     it('clears loading state when register refresh times out', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn');
       const provider = createMockProvider('slow');
       vi.mocked(provider.refresh).mockReturnValue(new Promise(() => {}));
 
@@ -363,6 +365,10 @@ describe('ProviderRegistry', () => {
 
       await vi.advanceTimersByTimeAsync(30_000);
       expect(registry.loading).toBe(false);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Provider "slow" refresh timed out'),
+      );
+      warnSpy.mockRestore();
     });
 
     it('resolves refreshAll when a provider refresh times out', async () => {
@@ -379,6 +385,7 @@ describe('ProviderRegistry', () => {
     });
 
     it('clears timeout when refresh completes quickly', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn');
       const provider = createMockProvider('fast');
       registry.register(provider);
 
@@ -386,6 +393,8 @@ describe('ProviderRegistry', () => {
       // Advance past timeout — no spurious warnings should fire
       await vi.advanceTimersByTimeAsync(30_000);
       expect(registry.loading).toBe(false);
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
   });
 

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -401,6 +401,31 @@ describe('ProviderRegistry', () => {
       expect(warnSpy).not.toHaveBeenCalled();
       warnSpy.mockRestore();
     });
+
+    it('passes CancellationToken to provider refresh', async () => {
+      const provider = createMockProvider('tokencheck');
+      registry.register(provider);
+
+      expect(provider.refresh).toHaveBeenCalledWith(
+        expect.objectContaining({ isCancellationRequested: false }),
+      );
+    });
+
+    it('cancels the token when timeout fires', async () => {
+      const provider = createMockProvider('cancel-test');
+      let receivedToken: any;
+      vi.mocked(provider.refresh).mockImplementation(async (token?: any) => {
+        receivedToken = token;
+        return new Promise(() => {});
+      });
+
+      registry.register(provider);
+      expect(receivedToken).toBeDefined();
+      expect(receivedToken.isCancellationRequested).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(receivedToken.isCancellationRequested).toBe(true);
+    });
   });
 
   describe('resurfaceDismissed', () => {

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -24,7 +24,7 @@ interface WorkCenterProvider {
   readonly label: string;
   readonly resurfaceDismissed?: boolean;
   readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
-  refresh(): Promise<void>;
+  refresh(token?: vscode.CancellationToken): Promise<void>;
 }
 
 interface GitHubIssue {
@@ -71,7 +71,7 @@ export class GitHubPrReviewProvider implements WorkCenterProvider {
     }
   }
 
-  async refresh(): Promise<void> {
+  async refresh(token?: vscode.CancellationToken): Promise<void> {
     if (this._isRefreshing) {
       return;
     }
@@ -79,11 +79,15 @@ export class GitHubPrReviewProvider implements WorkCenterProvider {
     this._isRefreshing = true;
     logger.info('Fetching PR review requests...');
     try {
+      if (token?.isCancellationRequested) {
+        return;
+      }
+
       const session = await vscode.authentication.getSession('github', ['repo'], {
         createIfNone: true,
       }).catch(() => null);
 
-      if (!session) {
+      if (!session || token?.isCancellationRequested) {
         return;
       }
 

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -22,6 +22,7 @@ interface DiscoveredItem {
 interface WorkCenterProvider {
   readonly id: string;
   readonly label: string;
+  readonly resurfaceDismissed?: boolean;
   readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
   refresh(token?: vscode.CancellationToken): Promise<void>;
 }

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -23,7 +23,7 @@ interface WorkCenterProvider {
   readonly id: string;
   readonly label: string;
   readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
-  refresh(): Promise<void>;
+  refresh(token?: vscode.CancellationToken): Promise<void>;
 }
 
 interface GitHubIssue {
@@ -67,14 +67,18 @@ export class GitHubIssueProvider implements WorkCenterProvider {
     }
   }
 
-  async refresh(): Promise<void> {
+  async refresh(token?: vscode.CancellationToken): Promise<void> {
     logger.info('Fetching assigned issues...');
     try {
+      if (token?.isCancellationRequested) {
+        return;
+      }
+
       const session = await vscode.authentication.getSession('github', ['repo'], {
         createIfNone: true,
       }).catch(() => null);
       
-      if (!session) {
+      if (!session || token?.isCancellationRequested) {
         return;
       }
 

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -68,6 +68,11 @@ export class GitHubIssueProvider implements WorkCenterProvider {
   }
 
   async refresh(token?: vscode.CancellationToken): Promise<void> {
+    if (this._isRefreshing) {
+      return;
+    }
+
+    this._isRefreshing = true;
     logger.info('Fetching assigned issues...');
     try {
       if (token?.isCancellationRequested) {
@@ -85,6 +90,8 @@ export class GitHubIssueProvider implements WorkCenterProvider {
       await this.fetchAndPublishIssues(session.accessToken, true);
     } catch (err) {
       logger.error('Failed to fetch issues', err);
+    } finally {
+      this._isRefreshing = false;
     }
   }
 


### PR DESCRIPTION
## Summary

Refactor provider refresh timeout to use VS Code's `CancellationTokenSource` pattern instead of `Promise.race` + `setTimeout`. Providers now receive an optional `CancellationToken` and can check `token.isCancellationRequested` to abort work early when timeout fires.

## Changes

- Add optional `CancellationToken` parameter to `WorkCenterProvider.refresh()`
- Replace `raceWithTimeout` / `Promise.race` / `setTimeout` / `_pendingTimeouts` with `CancellationTokenSource`-based timeout in `ProviderRegistry`
- Track pending refreshes per provider for proper cleanup on unregister/dispose
- Add `_disposed` guard to prevent post-dispose event emissions
- Update all 4 provider implementations to accept and check the token
- Add `_isRefreshing` guard to `GitHubIssueProvider.refresh()` for consistency
- Add `CancellationTokenSource` mock to test infrastructure
- Add 5 timeout-related tests (token passing, cancellation, existing behavior)

## Notes

- The `CancellationToken` parameter is optional for backward compatibility
- Timeout warning is only logged from the actual timeout callback, not from manual/cleanup cancellations
- Cancellation-related refresh rejections are silently suppressed (timeout `warn` is the primary signal)