### PR TITLE
cleanup: add readonly modifiers to immutable class properties

### DIFF
--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -4,7 +4,7 @@ import { ITaskStore } from '../storage/taskStore';
 import { logger } from './logger';
 
 export class WorkGraph {
-  private items: Map<string, WorkItem> = new Map();
+  private readonly items: Map<string, WorkItem> = new Map();
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   readonly onDidChange = this._onDidChange.event;
 

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -93,7 +93,7 @@ class MockDataTransferItem {
 }
 
 class MockDataTransfer {
-  private items = new Map<string, MockDataTransferItem>();
+  private readonly items = new Map<string, MockDataTransferItem>();
   get(mimeType: string): MockDataTransferItem | undefined { return this.items.get(mimeType); }
   set(mimeType: string, value: MockDataTransferItem): void { this.items.set(mimeType, value); }
 }


### PR DESCRIPTION
Add \eadonly\ modifiers to class properties that are initialized inline and never reassigned, enforcing immutability at compile time.

## Changes
- \WorkGraph.items\: Map property used only via \.set()\/\.get()\/\.clear()\/\.delete()\ — never reassigned
- \MockDataTransfer.items\: Test mock Map property used only via \.get()\/\.set()\ — never reassigned

This brings these properties in line with the existing \eadonly\ pattern used elsewhere in the codebase (e.g., \_onDidChange\, \store\).