### PR TITLE
refactor: extract BaseGitHubProvider to reduce duplication

### DIFF
--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -76,19 +76,20 @@ export abstract class BaseGitHubProvider implements WorkCenterProvider {
     await this.doRefresh(false);
   }
 
-  private async doRefresh(createIfNone: boolean): Promise<void> {
+  private async doRefresh(isUserTriggered: boolean): Promise<void> {
     if (this._isRefreshing) {
       return;
     }
     this._isRefreshing = true;
     try {
+      const createIfNone = isUserTriggered;
       const session = await vscode.authentication.getSession('github', ['repo'], {
         createIfNone,
       }).catch(() => null);
       if (!session) {
         return;
       }
-      await this.fetchAndPublish(session.accessToken, createIfNone);
+      await this.fetchAndPublish(session.accessToken, isUserTriggered);
     } catch (err) {
       logger.error(`Failed to fetch ${this.label}`, err);
     } finally {

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -1,0 +1,125 @@
+import * as vscode from 'vscode';
+import { logger } from './logger';
+
+// Re-declared to match core API contract — separate extension cannot import core types directly
+export interface Disposable {
+  dispose(): void;
+}
+
+// Re-declared to match core API contract — separate extension cannot import core types directly
+export interface Event<T> {
+  (listener: (e: T) => void): Disposable;
+}
+
+export interface DiscoveredItem {
+  externalId: string;
+  title: string;
+  description?: string;
+  url?: string;
+  group?: string;
+}
+
+export interface WorkCenterProvider {
+  readonly id: string;
+  readonly label: string;
+  readonly resurfaceDismissed?: boolean;
+  readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
+  refresh(): Promise<void>;
+}
+
+export interface GitHubIssue {
+  number: number;
+  title: string;
+  body?: string;
+  html_url: string;
+  repository_url: string;
+  pull_request?: unknown;
+}
+
+export abstract class BaseGitHubProvider implements WorkCenterProvider {
+  abstract readonly id: string;
+  abstract readonly label: string;
+  readonly resurfaceDismissed?: boolean;
+
+  protected readonly _onDidDiscoverItems = new vscode.EventEmitter<DiscoveredItem[]>();
+  readonly onDidDiscoverItems = this._onDidDiscoverItems.event;
+
+  private refreshTimer: ReturnType<typeof setInterval> | undefined;
+  private _isRefreshing = false;
+
+  startPeriodicRefresh(intervalSeconds: number): void {
+    this.stopPeriodicRefresh();
+    if (intervalSeconds <= 0) {
+      return;
+    }
+    // Clamp to minimum of 60 seconds
+    const clampedInterval = Math.max(intervalSeconds, 60);
+    this.refreshTimer = setInterval(() => {
+      this.refreshInBackground().catch((err) => {
+        logger.error(`${this.label} refresh failed`, err);
+      });
+    }, clampedInterval * 1000);
+  }
+
+  stopPeriodicRefresh(): void {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = undefined;
+    }
+  }
+
+  async refresh(): Promise<void> {
+    await this.doRefresh(true);
+  }
+
+  private async refreshInBackground(): Promise<void> {
+    await this.doRefresh(false);
+  }
+
+  private async doRefresh(createIfNone: boolean): Promise<void> {
+    if (this._isRefreshing) {
+      return;
+    }
+    this._isRefreshing = true;
+    try {
+      const session = await vscode.authentication.getSession('github', ['repo'], {
+        createIfNone,
+      }).catch(() => null);
+      if (!session) {
+        return;
+      }
+      await this.fetchAndPublish(session.accessToken, createIfNone);
+    } catch (err) {
+      logger.error(`Failed to fetch ${this.label}`, err);
+    } finally {
+      this._isRefreshing = false;
+    }
+  }
+
+  protected abstract fetchAndPublish(accessToken: string, isUserTriggered: boolean): Promise<void>;
+
+  protected parseRepo(issue: GitHubIssue): string {
+    const match = issue.html_url.match(/github\.com\/([^/]+\/[^/]+)/);
+    if (match) {
+      return match[1];
+    }
+
+    // Fallback to parsing from repository_url (API URL)
+    const apiMatch = issue.repository_url.match(/repos\/([^/]+\/[^/]+)/);
+    if (apiMatch) {
+      return apiMatch[1];
+    }
+
+    // Deterministic fallback: hash the repository_url
+    logger.warn(`Could not parse repo from URL: ${issue.html_url}`);
+    const hash = issue.repository_url.split('').reduce((acc, char) => {
+      return ((acc << 5) - acc) + char.charCodeAt(0) | 0;
+    }, 0);
+    return `unknown-repo-${Math.abs(hash).toString(36)}`;
+  }
+
+  dispose(): void {
+    this.stopPeriodicRefresh();
+    this._onDidDiscoverItems.dispose();
+  }
+}

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -1,124 +1,18 @@
 import * as vscode from 'vscode';
 import { logger } from './logger';
-
-// Re-declared to match core API contract — separate extension cannot import core types directly
-interface Disposable {
-  dispose(): void;
-}
-
-// Re-declared to match core API contract — separate extension cannot import core types directly
-interface Event<T> {
-  (listener: (e: T) => void): Disposable;
-}
-
-interface DiscoveredItem {
-  externalId: string;
-  title: string;
-  description?: string;
-  url?: string;
-  group?: string;
-}
-
-interface WorkCenterProvider {
-  readonly id: string;
-  readonly label: string;
-  readonly resurfaceDismissed?: boolean;
-  readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
-  refresh(): Promise<void>;
-}
-
-interface GitHubIssue {
-  number: number;
-  title: string;
-  body?: string;
-  html_url: string;
-  repository_url: string;
-}
+import { BaseGitHubProvider, DiscoveredItem, GitHubIssue } from './baseGithubProvider';
 
 interface GitHubSearchResponse {
   items: GitHubIssue[];
 }
 
-export class GitHubPrReviewProvider implements WorkCenterProvider {
+export class GitHubPrReviewProvider extends BaseGitHubProvider {
   readonly id = 'github-pr-reviews';
   readonly label = 'GitHub PR Reviews';
   readonly resurfaceDismissed = true;
 
-  private readonly _onDidDiscoverItems = new vscode.EventEmitter<DiscoveredItem[]>();
-  readonly onDidDiscoverItems = this._onDidDiscoverItems.event;
-
-  private refreshTimer: ReturnType<typeof setInterval> | undefined;
-  private _isRefreshing = false;
-
-  startPeriodicRefresh(intervalSeconds: number): void {
-    this.stopPeriodicRefresh();
-    if (intervalSeconds <= 0) {
-      return;
-    }
-    // Clamp to minimum of 60 seconds
-    const clampedInterval = Math.max(intervalSeconds, 60);
-    this.refreshTimer = setInterval(() => {
-      this.refreshInBackground().catch((err) => {
-        logger.error('PR review refresh failed', err);
-      });
-    }, clampedInterval * 1000);
-  }
-
-  stopPeriodicRefresh(): void {
-    if (this.refreshTimer) {
-      clearInterval(this.refreshTimer);
-      this.refreshTimer = undefined;
-    }
-  }
-
-  async refresh(): Promise<void> {
-    if (this._isRefreshing) {
-      return;
-    }
-
-    this._isRefreshing = true;
+  protected async fetchAndPublish(accessToken: string, isUserTriggered: boolean): Promise<void> {
     logger.info('Fetching PR review requests...');
-    try {
-      const session = await vscode.authentication.getSession('github', ['repo'], {
-        createIfNone: true,
-      }).catch(() => null);
-
-      if (!session) {
-        return;
-      }
-
-      await this.fetchAndPublishPrs(session.accessToken, true);
-    } catch (err) {
-      logger.error('Failed to fetch PR reviews', err);
-    } finally {
-      this._isRefreshing = false;
-    }
-  }
-
-  private async refreshInBackground(): Promise<void> {
-    if (this._isRefreshing) {
-      return;
-    }
-
-    this._isRefreshing = true;
-    try {
-      const session = await vscode.authentication.getSession('github', ['repo'], {
-        createIfNone: false,
-      }).catch(() => null);
-
-      if (!session) {
-        return;
-      }
-
-      await this.fetchAndPublishPrs(session.accessToken, false);
-    } catch (err) {
-      logger.error('Failed to fetch PR reviews', err);
-    } finally {
-      this._isRefreshing = false;
-    }
-  }
-
-  private async fetchAndPublishPrs(accessToken: string, isUserTriggered: boolean): Promise<void> {
     const response = await fetch(
       'https://api.github.com/search/issues?q=type:pr+state:open+review-requested:@me&per_page=100',
       {
@@ -154,27 +48,5 @@ export class GitHubPrReviewProvider implements WorkCenterProvider {
     });
 
     this._onDidDiscoverItems.fire(items);
-  }
-
-  private parseRepo(pr: GitHubIssue): string {
-    const match = pr.html_url.match(/github\.com\/([^/]+\/[^/]+)/);
-    if (match) {
-      return match[1];
-    }
-
-    // Fallback to parsing from repository_url (API URL)
-    const apiMatch = pr.repository_url.match(/repos\/([^/]+\/[^/]+)/);
-    if (apiMatch) {
-      return apiMatch[1];
-    }
-
-    // Fallback: use repository_url as-is to maintain unique externalId
-    logger.warn(`Could not parse repo from PR URL: ${pr.html_url}`);
-    return pr.repository_url;
-  }
-
-  dispose(): void {
-    this.stopPeriodicRefresh();
-    this._onDidDiscoverItems.dispose();
   }
 }

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -49,4 +49,20 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
 
     this._onDidDiscoverItems.fire(items);
   }
+
+  // Override: use repository_url as-is to maintain unique externalId
+  protected override parseRepo(issue: GitHubIssue): string {
+    const match = issue.html_url.match(/github\.com\/([^/]+\/[^/]+)/);
+    if (match) {
+      return match[1];
+    }
+
+    const apiMatch = issue.repository_url.match(/repos\/([^/]+\/[^/]+)/);
+    if (apiMatch) {
+      return apiMatch[1];
+    }
+
+    logger.warn(`Could not parse repo from PR URL: ${issue.html_url}`);
+    return issue.repository_url;
+  }
 }

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -1,113 +1,13 @@
 import * as vscode from 'vscode';
 import { logger } from './logger';
+import { BaseGitHubProvider, DiscoveredItem, GitHubIssue } from './baseGithubProvider';
 
-// Re-declared to match core API contract — separate extension cannot import core types directly
-interface Disposable {
-  dispose(): void;
-}
-
-// Re-declared to match core API contract — separate extension cannot import core types directly
-interface Event<T> {
-  (listener: (e: T) => void): Disposable;
-}
-
-interface DiscoveredItem {
-  externalId: string;
-  title: string;
-  description?: string;
-  url?: string;
-  group?: string;
-}
-
-interface WorkCenterProvider {
-  readonly id: string;
-  readonly label: string;
-  readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
-  refresh(): Promise<void>;
-}
-
-interface GitHubIssue {
-  number: number;
-  title: string;
-  body?: string;
-  html_url: string;
-  repository_url: string;
-  pull_request?: unknown;
-}
-
-export class GitHubIssueProvider implements WorkCenterProvider {
+export class GitHubIssueProvider extends BaseGitHubProvider {
   readonly id = 'github';
   readonly label = 'GitHub Issues';
 
-  private readonly _onDidDiscoverItems = new vscode.EventEmitter<DiscoveredItem[]>();
-  readonly onDidDiscoverItems = this._onDidDiscoverItems.event;
-
-  private refreshTimer: ReturnType<typeof setInterval> | undefined;
-  private _isRefreshing = false;
-
-  startPeriodicRefresh(intervalSeconds: number): void {
-    this.stopPeriodicRefresh();
-    if (intervalSeconds <= 0) {
-      // Disable periodic refresh if interval is 0 or negative
-      return;
-    }
-    // Clamp to minimum of 60 seconds
-    const clampedInterval = Math.max(intervalSeconds, 60);
-    this.refreshTimer = setInterval(() => {
-      this.refreshInBackground().catch((err) => {
-        logger.error('Refresh failed', err);
-      });
-    }, clampedInterval * 1000);
-  }
-
-  stopPeriodicRefresh(): void {
-    if (this.refreshTimer) {
-      clearInterval(this.refreshTimer);
-      this.refreshTimer = undefined;
-    }
-  }
-
-  async refresh(): Promise<void> {
+  protected async fetchAndPublish(accessToken: string, isUserTriggered: boolean): Promise<void> {
     logger.info('Fetching assigned issues...');
-    try {
-      const session = await vscode.authentication.getSession('github', ['repo'], {
-        createIfNone: true,
-      }).catch(() => null);
-      
-      if (!session) {
-        return;
-      }
-
-      await this.fetchAndPublishIssues(session.accessToken, true);
-    } catch (err) {
-      logger.error('Failed to fetch issues', err);
-    }
-  }
-
-  private async refreshInBackground(): Promise<void> {
-    if (this._isRefreshing) {
-      return;
-    }
-
-    this._isRefreshing = true;
-    try {
-      const session = await vscode.authentication.getSession('github', ['repo'], {
-        createIfNone: false,
-      }).catch(() => null);
-      
-      if (!session) {
-        return;
-      }
-
-      await this.fetchAndPublishIssues(session.accessToken, false);
-    } catch (err) {
-      logger.error('Failed to fetch issues', err);
-    } finally {
-      this._isRefreshing = false;
-    }
-  }
-
-  private async fetchAndPublishIssues(accessToken: string, isUserTriggered: boolean = false): Promise<void> {
     const repos = this.getConfiguredRepos();
     const { issues, failures } = await this.fetchAssignedIssues(accessToken, repos);
 
@@ -140,25 +40,6 @@ export class GitHubIssueProvider implements WorkCenterProvider {
   private getConfiguredRepos(): string[] {
     const config = vscode.workspace.getConfiguration('workcenterGithub');
     return config.get<string[]>('repos', []);
-  }
-
-  private parseRepo(issue: GitHubIssue): string {
-    const match = issue.html_url.match(/github\.com\/([^/]+\/[^/]+)/);
-    if (match) {
-      return match[1];
-    }
-    
-    // Fallback to parsing from repository_url (API URL)
-    const apiMatch = issue.repository_url.match(/repos\/([^/]+\/[^/]+)/);
-    if (apiMatch) {
-      return apiMatch[1];
-    }
-    
-    // Deterministic fallback: hash the repository_url
-    const hash = issue.repository_url.split('').reduce((acc, char) => {
-      return ((acc << 5) - acc) + char.charCodeAt(0) | 0;
-    }, 0);
-    return `unknown-repo-${Math.abs(hash).toString(36)}`;
   }
 
   private async fetchAssignedIssues(
@@ -240,10 +121,5 @@ export class GitHubIssueProvider implements WorkCenterProvider {
     // Filter out pull requests (GitHub /issues endpoint returns both issues and PRs)
     const issues = items.filter(item => !item.pull_request);
     return { issues, failed: false };
-  }
-
-  dispose(): void {
-    this.stopPeriodicRefresh();
-    this._onDidDiscoverItems.dispose();
   }
 }


### PR DESCRIPTION
Separate the concepts of createIfNone (auth behavior) from isUserTriggered
(semantic meaning) to make the code more readable and maintainable.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>