### PR TITLE
refactor: extract generic Registry base class for ActionRegistry

### DIFF
--- a/packages/core/src/services/actionRegistry.ts
+++ b/packages/core/src/services/actionRegistry.ts
@@ -2,33 +2,26 @@ import * as vscode from 'vscode';
 import { WorkCenterAction } from '../api/types';
 import { WorkItem } from '../models/workItem';
 import { logger } from './logger';
+import { Registry } from './registry';
 
 export class ActionRegistry {
-  private readonly actions = new Map<string, WorkCenterAction>();
+  private readonly registry = new Registry<WorkCenterAction>('Action');
 
   register(action: WorkCenterAction): vscode.Disposable {
-    if (this.actions.has(action.id)) {
-      throw new Error(`Action already registered: ${action.id}`);
-    }
-    this.actions.set(action.id, action);
-    logger.info(`Registered action: ${action.id} (${action.label})`);
-
-    return new vscode.Disposable(() => {
-      this.actions.delete(action.id);
-    });
+    return this.registry.register(action);
   }
 
   getActionsFor(item: WorkItem): WorkCenterAction[] {
-    const matching = Array.from(this.actions.values()).filter((a) => a.canRun(item));
+    const matching = this.registry.getAll().filter((a) => a.canRun(item));
     logger.debug(`Found ${matching.length} actions for item ${item.id}`);
     return matching;
   }
 
   getAction(id: string): WorkCenterAction | undefined {
-    return this.actions.get(id);
+    return this.registry.get(id);
   }
 
   dispose(): void {
-    this.actions.clear();
+    this.registry.clear();
   }
 }

--- a/packages/core/src/services/registry.ts
+++ b/packages/core/src/services/registry.ts
@@ -12,7 +12,7 @@ export class Registry<T extends { readonly id: string; readonly label: string }>
       throw new Error(`${this.kind} already registered: ${item.id}`);
     }
     this.items.set(item.id, item);
-    logger.info(`Registered ${this.kind}: ${item.id} (${item.label})`);
+    logger.info(`Registered ${this.kind.toLowerCase()}: ${item.id} (${item.label})`);
     return new vscode.Disposable(() => { this.items.delete(item.id); });
   }
 

--- a/packages/core/src/services/registry.ts
+++ b/packages/core/src/services/registry.ts
@@ -1,0 +1,24 @@
+import * as vscode from 'vscode';
+import { logger } from './logger';
+
+export class Registry<T extends { readonly id: string; readonly label: string }> {
+  private readonly items = new Map<string, T>();
+  private readonly kind: string;
+
+  constructor(kind: string) { this.kind = kind; }
+
+  register(item: T): vscode.Disposable {
+    if (this.items.has(item.id)) {
+      throw new Error(`${this.kind} already registered: ${item.id}`);
+    }
+    this.items.set(item.id, item);
+    logger.info(`Registered ${this.kind}: ${item.id} (${item.label})`);
+    return new vscode.Disposable(() => { this.items.delete(item.id); });
+  }
+
+  get(id: string): T | undefined { return this.items.get(id); }
+  has(id: string): boolean { return this.items.has(id); }
+  getAll(): T[] { return Array.from(this.items.values()); }
+  get size(): number { return this.items.size; }
+  clear(): void { this.items.clear(); }
+}

--- a/packages/core/src/services/registry.ts
+++ b/packages/core/src/services/registry.ts
@@ -13,10 +13,12 @@ export class Registry<T extends { readonly id: string; readonly label: string }>
     }
     this.items.set(item.id, item);
     logger.info(`Registered ${this.kind.toLowerCase()}: ${item.id} (${item.label})`);
+    let disposed = false;
     return new vscode.Disposable(() => {
-      if (this.items.get(item.id) === item) {
+      if (!disposed && this.items.get(item.id) === item) {
         this.items.delete(item.id);
       }
+      disposed = true;
     });
   }
 

--- a/packages/core/src/services/registry.ts
+++ b/packages/core/src/services/registry.ts
@@ -13,7 +13,11 @@ export class Registry<T extends { readonly id: string; readonly label: string }>
     }
     this.items.set(item.id, item);
     logger.info(`Registered ${this.kind.toLowerCase()}: ${item.id} (${item.label})`);
-    return new vscode.Disposable(() => { this.items.delete(item.id); });
+    return new vscode.Disposable(() => {
+      if (this.items.get(item.id) === item) {
+        this.items.delete(item.id);
+      }
+    });
   }
 
   get(id: string): T | undefined { return this.items.get(id); }

--- a/packages/core/src/test/registry.test.ts
+++ b/packages/core/src/test/registry.test.ts
@@ -88,6 +88,18 @@ describe('Registry', () => {
     expect(registry.size).toBe(1);
   });
 
+  it('dispose-reregister same instance-dispose does not remove re-registered entry', () => {
+    const item = createItem('idem');
+    const disposable1 = registry.register(item);
+    disposable1.dispose();
+
+    registry.register(item);
+    disposable1.dispose();
+
+    expect(registry.get('idem')).toBe(item);
+    expect(registry.size).toBe(1);
+  });
+
   it('clear() removes all items', () => {
     registry.register(createItem('a'));
     registry.register(createItem('b'));

--- a/packages/core/src/test/registry.test.ts
+++ b/packages/core/src/test/registry.test.ts
@@ -72,6 +72,22 @@ describe('Registry', () => {
     expect(registry.get('reuse')).toBe(item2);
   });
 
+  it('disposing the first registration after re-registering the same id does not remove the new item', () => {
+    const item1 = createItem('reuse', 'Original');
+    const disposable1 = registry.register(item1);
+
+    disposable1.dispose();
+
+    const item2 = createItem('reuse', 'Reused');
+    registry.register(item2);
+
+    disposable1.dispose();
+
+    expect(registry.get('reuse')).toBe(item2);
+    expect(registry.has('reuse')).toBe(true);
+    expect(registry.size).toBe(1);
+  });
+
   it('clear() removes all items', () => {
     registry.register(createItem('a'));
     registry.register(createItem('b'));

--- a/packages/core/src/test/registry.test.ts
+++ b/packages/core/src/test/registry.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Registry } from '../services/registry';
+
+interface TestItem {
+  readonly id: string;
+  readonly label: string;
+}
+
+function createItem(id: string, label = `Item ${id}`): TestItem {
+  return { id, label };
+}
+
+describe('Registry', () => {
+  let registry: Registry<TestItem>;
+
+  beforeEach(() => {
+    registry = new Registry<TestItem>('Test');
+  });
+
+  it('registers an item and retrieves it by id', () => {
+    const item = createItem('a');
+    registry.register(item);
+    expect(registry.get('a')).toBe(item);
+  });
+
+  it('returns undefined for unknown id', () => {
+    expect(registry.get('missing')).toBeUndefined();
+  });
+
+  it('has() returns true for registered and false for missing', () => {
+    registry.register(createItem('x'));
+    expect(registry.has('x')).toBe(true);
+    expect(registry.has('y')).toBe(false);
+  });
+
+  it('getAll() returns all registered items', () => {
+    const a = createItem('a');
+    const b = createItem('b');
+    registry.register(a);
+    registry.register(b);
+    expect(registry.getAll()).toEqual(expect.arrayContaining([a, b]));
+    expect(registry.getAll()).toHaveLength(2);
+  });
+
+  it('size reflects the number of registered items', () => {
+    expect(registry.size).toBe(0);
+    registry.register(createItem('a'));
+    expect(registry.size).toBe(1);
+    registry.register(createItem('b'));
+    expect(registry.size).toBe(2);
+  });
+
+  it('throws on duplicate id', () => {
+    registry.register(createItem('dup'));
+    expect(() => registry.register(createItem('dup'))).toThrow('Test already registered: dup');
+  });
+
+  it('disposing the returned Disposable removes the item', () => {
+    const disposable = registry.register(createItem('removable'));
+    expect(registry.has('removable')).toBe(true);
+    disposable.dispose();
+    expect(registry.has('removable')).toBe(false);
+    expect(registry.get('removable')).toBeUndefined();
+    expect(registry.size).toBe(0);
+  });
+
+  it('allows re-registration after disposal', () => {
+    const disposable = registry.register(createItem('reuse'));
+    disposable.dispose();
+    const item2 = createItem('reuse', 'Reused');
+    registry.register(item2);
+    expect(registry.get('reuse')).toBe(item2);
+  });
+
+  it('clear() removes all items', () => {
+    registry.register(createItem('a'));
+    registry.register(createItem('b'));
+    registry.clear();
+    expect(registry.size).toBe(0);
+    expect(registry.getAll()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
- Disposal callback now runs at most once via a captured disposed flag
- Prevents stale Disposable from removing a re-registered same-instance entry
- Add test for dispose-reregister-same-instance-dispose edge case

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>