### PR TITLE
fix: remove TOCTOU race in StartWorkAction worktree creation

### DIFF
--- a/packages/github/src/startWorkAction.ts
+++ b/packages/github/src/startWorkAction.ts
@@ -85,15 +85,9 @@ export class StartWorkAction implements WorkCenterAction {
       await execFileAsync('git', ['branch', branchName, baseBranch], { cwd: repoPath });
       logger.info(`Starting work: creating branch ${branchName}`);
 
-      // Create worktree
+      // Create worktree — let git worktree add fail naturally if the directory
+      // already exists, avoiding a TOCTOU race with a pre-check.
       const worktreePath = path.join(path.dirname(repoPath), branchName);
-      
-      // Check if worktree directory already exists
-      if (fs.existsSync(worktreePath)) {
-        await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath });
-        vscode.window.showErrorMessage(`WorkCenter: Directory "${worktreePath}" already exists.`);
-        return;
-      }
 
       try {
         await execFileAsync('git', ['worktree', 'add', worktreePath, branchName], {
@@ -106,6 +100,12 @@ export class StartWorkAction implements WorkCenterAction {
         } catch (rollbackErr) {
           const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
           vscode.window.showWarningMessage(`WorkCenter: Failed to delete branch during rollback — ${rollbackMessage}`);
+        }
+
+        const errMsg = worktreeErr instanceof Error ? worktreeErr.message : String(worktreeErr);
+        if (errMsg.includes('already exists')) {
+          vscode.window.showErrorMessage(`WorkCenter: Directory "${worktreePath}" already exists.`);
+          return;
         }
         throw worktreeErr;
       }

--- a/packages/github/src/startWorkAction.ts
+++ b/packages/github/src/startWorkAction.ts
@@ -103,7 +103,8 @@ export class StartWorkAction implements WorkCenterAction {
         }
 
         const errMsg = worktreeErr instanceof Error ? worktreeErr.message : String(worktreeErr);
-        if (errMsg.includes('already exists')) {
+        const errStderr = (worktreeErr as any)?.stderr ?? '';
+        if (errMsg.includes('already exists') || errStderr.includes('already exists')) {
           vscode.window.showErrorMessage(`WorkCenter: Directory "${worktreePath}" already exists.`);
           return;
         }

--- a/packages/github/src/test/startWorkAction.test.ts
+++ b/packages/github/src/test/startWorkAction.test.ts
@@ -407,16 +407,15 @@ describe('StartWorkAction', () => {
 
     it('handles worktree directory check when branch was already created', async () => {
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-        cb(null, { stdout: '', stderr: '' }, '');
+        // Simulate git worktree add failing because directory already exists
+        if (args[0] === 'worktree' && args[1] === 'add') {
+          const err = new Error("fatal: 'issue-123-fix-bug' already exists");
+          (err as any).stderr = "'issue-123-fix-bug' already exists";
+          cb(err, '', '');
+        } else {
+          cb(null, { stdout: '', stderr: '' }, '');
+        }
       }) as any);
-
-      // existsSync: true for .git, and true for worktree path (simulating existing dir)
-      vi.mocked(fs.existsSync).mockImplementation((p: any) => {
-        const s = p.toString();
-        if (s.endsWith('.git')) return true;
-        if (s.includes('issue-123')) return true;
-        return false;
-      });
 
       const item = createWorkItem({ title: '#123: Fix bug' });
       await action.run(item);

--- a/packages/github/src/test/startWorkAction.test.ts
+++ b/packages/github/src/test/startWorkAction.test.ts
@@ -229,8 +229,14 @@ describe('StartWorkAction', () => {
     });
 
     it('shows error and deletes branch when worktree directory already exists', async () => {
-      // Mock fs.existsSync to return true (directory exists)
-      vi.mocked(fs.existsSync).mockReturnValue(true);
+      // Mock git worktree add to fail because directory already exists
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'worktree') {
+          cb(new Error(`fatal: '${path.join('/mock', 'issue-123-fix-bug')}' already exists`), '', '');
+        } else {
+          cb(null, { stdout: '', stderr: '' }, '');
+        }
+      }) as any);
 
       const item = createWorkItem({ title: '#123: Fix bug' });
       await action.run(item);
@@ -238,7 +244,7 @@ describe('StartWorkAction', () => {
       expect(window.showErrorMessage).toHaveBeenCalledWith(
         `WorkCenter: Directory "${path.join('/mock', 'issue-123-fix-bug')}" already exists.`,
       );
-      // Should delete the branch (I6 rollback fix)
+      // Should delete the branch (rollback)
       expect(execFile).toHaveBeenCalledWith(
         'git',
         ['branch', '-D', 'issue-123-fix-bug'],

--- a/packages/github/src/test/startWorkAction.test.ts
+++ b/packages/github/src/test/startWorkAction.test.ts
@@ -232,7 +232,12 @@ describe('StartWorkAction', () => {
       // Mock git worktree add to fail because directory already exists
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         if (args[0] === 'worktree') {
-          cb(new Error(`fatal: '${path.join('/mock', 'issue-123-fix-bug')}' already exists`), '', '');
+          const stderr = `fatal: '${path.join('/mock', 'issue-123-fix-bug')}' already exists`;
+          const err = new Error(
+            `Command failed: git worktree add ${path.join('/mock', 'issue-123-fix-bug')} issue-123-fix-bug\n${stderr}`
+          );
+          (err as any).stderr = stderr;
+          cb(err, '', '');
         } else {
           cb(null, { stdout: '', stderr: '' }, '');
         }


### PR DESCRIPTION
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

- Also check stderr for 'already exists' to avoid relying solely on
  Node.js error message formatting
- Make test mock produce a realistic execFile error shape with .stderr
  property and 'Command failed:' prefix

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>