### PR TITLE
test focus history providers

### DIFF
--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -17,8 +17,8 @@ function makeItem(overrides: Partial<WorkItem> = {}): WorkItem {
     id: 'item-1',
     title: 'Test item',
     state: WorkItemState.InProgress,
-    createdAt: Date.now(),
-    updatedAt: Date.now(),
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
     ...overrides,
   };
 }
@@ -124,11 +124,11 @@ describe('FocusTreeProvider', () => {
     });
 
     it('should include created timestamp in tooltip', () => {
-      const now = Date.now();
-      const item = makeItem({ createdAt: now });
+      const ts = 1700000000000;
+      const item = makeItem({ createdAt: ts });
       const tooltip = (provider.getTreeItem(item).tooltip as any).value;
       expect(tooltip).toContain('**Created:**');
-      expect(tooltip).toContain(new Date(now).toLocaleString());
+      expect(tooltip).toContain(new Date(ts).toLocaleString());
     });
   });
 

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -64,6 +64,74 @@ describe('FocusTreeProvider', () => {
     });
   });
 
+  describe('getTreeItem description', () => {
+    it('should show "in progress" for InProgress items', () => {
+      const item = makeItem({ state: WorkItemState.InProgress });
+      expect(provider.getTreeItem(item).description).toBe('in progress');
+    });
+
+    it('should show "⛔ blocked" for Blocked items', () => {
+      const item = makeItem({ state: WorkItemState.Blocked });
+      expect(provider.getTreeItem(item).description).toBe('⛔ blocked');
+    });
+
+    it('should show "⏳ waiting" for WaitingOn items', () => {
+      const item = makeItem({ state: WorkItemState.WaitingOn });
+      expect(provider.getTreeItem(item).description).toBe('⏳ waiting');
+    });
+  });
+
+  describe('getTreeItem icon', () => {
+    it('should show play-circle icon for InProgress items', () => {
+      const item = makeItem({ state: WorkItemState.InProgress });
+      expect((provider.getTreeItem(item).iconPath as any).id).toBe('play-circle');
+    });
+
+    it('should show circle-slash icon for Blocked items', () => {
+      const item = makeItem({ state: WorkItemState.Blocked });
+      expect((provider.getTreeItem(item).iconPath as any).id).toBe('circle-slash');
+    });
+
+    it('should show clock icon for WaitingOn items', () => {
+      const item = makeItem({ state: WorkItemState.WaitingOn });
+      expect((provider.getTreeItem(item).iconPath as any).id).toBe('clock');
+    });
+  });
+
+  describe('getTreeItem tooltip', () => {
+    it('should include title in tooltip', () => {
+      const item = makeItem({ title: 'My Task' });
+      const tooltip = (provider.getTreeItem(item).tooltip as any).value;
+      expect(tooltip).toContain('My Task');
+    });
+
+    it('should include notes in tooltip when present', () => {
+      const item = makeItem({ notes: 'Some details' });
+      const tooltip = (provider.getTreeItem(item).tooltip as any).value;
+      expect(tooltip).toContain('Some details');
+    });
+
+    it('should not include notes section when notes are absent', () => {
+      const item = makeItem();
+      const tooltip = (provider.getTreeItem(item).tooltip as any).value;
+      expect(tooltip).not.toContain('**Notes:**');
+    });
+
+    it('should include state in tooltip', () => {
+      const item = makeItem({ state: WorkItemState.Blocked });
+      const tooltip = (provider.getTreeItem(item).tooltip as any).value;
+      expect(tooltip).toContain(WorkItemState.Blocked);
+    });
+
+    it('should include created timestamp in tooltip', () => {
+      const now = Date.now();
+      const item = makeItem({ createdAt: now });
+      const tooltip = (provider.getTreeItem(item).tooltip as any).value;
+      expect(tooltip).toContain('**Created:**');
+      expect(tooltip).toContain(new Date(now).toLocaleString());
+    });
+  });
+
   describe('getChildren', () => {
     it('should return items sorted by title', () => {
       const items = [
@@ -75,6 +143,21 @@ describe('FocusTreeProvider', () => {
       const children = provider.getChildren();
       expect(children.map(c => c.title)).toEqual(['Alpha', 'Zebra']);
     });
+
+    it('should request InProgress, Blocked, and WaitingOn states', () => {
+      workGraph.getItemsByState.mockReturnValue([]);
+      provider.getChildren();
+      expect(workGraph.getItemsByState).toHaveBeenCalledWith(
+        WorkItemState.InProgress,
+        WorkItemState.Blocked,
+        WorkItemState.WaitingOn,
+      );
+    });
+
+    it('should return empty array when no focus items exist', () => {
+      workGraph.getItemsByState.mockReturnValue([]);
+      expect(provider.getChildren()).toEqual([]);
+    });
   });
 
   describe('events', () => {
@@ -83,6 +166,16 @@ describe('FocusTreeProvider', () => {
       provider.onDidChangeTreeData(listener);
       workGraph._fire();
       expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('dispose', () => {
+    it('should stop firing events after dispose', () => {
+      const listener = vi.fn();
+      provider.onDidChangeTreeData(listener);
+      provider.dispose();
+      workGraph._fire();
+      expect(listener).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/test/historyTreeProvider.test.ts
+++ b/packages/core/src/test/historyTreeProvider.test.ts
@@ -108,6 +108,40 @@ describe('HistoryTreeProvider', () => {
       const treeItem = provider.getTreeItem(item);
       expect((treeItem.tooltip as any).value).toContain('Details here');
     });
+
+    it('should include title in tooltip', () => {
+      const item = makeItem({ id: '1', title: 'My History Item' });
+      const tooltip = (provider.getTreeItem(item).tooltip as any).value;
+      expect(tooltip).toContain('My History Item');
+    });
+
+    it('should not include notes section when notes are absent', () => {
+      const item = makeItem({ id: '1', title: 'X' });
+      const tooltip = (provider.getTreeItem(item).tooltip as any).value;
+      expect(tooltip).not.toContain('**Notes:**');
+    });
+
+    it('should include state in tooltip', () => {
+      const item = makeItem({ id: '1', title: 'X', state: WorkItemState.Archived });
+      const tooltip = (provider.getTreeItem(item).tooltip as any).value;
+      expect(tooltip).toContain(WorkItemState.Archived);
+    });
+
+    it('should show "Completed at" timestamp label for Done items', () => {
+      const ts = 1700000000000;
+      const item = makeItem({ id: '1', title: 'X', state: WorkItemState.Done, updatedAt: ts });
+      const tooltip = (provider.getTreeItem(item).tooltip as any).value;
+      expect(tooltip).toContain('**Completed at:**');
+      expect(tooltip).toContain(new Date(ts).toLocaleString());
+    });
+
+    it('should show "Archived at" timestamp label for Archived items', () => {
+      const ts = 1700000000000;
+      const item = makeItem({ id: '1', title: 'X', state: WorkItemState.Archived, updatedAt: ts });
+      const tooltip = (provider.getTreeItem(item).tooltip as any).value;
+      expect(tooltip).toContain('**Archived at:**');
+      expect(tooltip).toContain(new Date(ts).toLocaleString());
+    });
   });
 
   describe('events', () => {
@@ -122,6 +156,14 @@ describe('HistoryTreeProvider', () => {
   describe('dispose', () => {
     it('should not throw on dispose', () => {
       expect(() => provider.dispose()).not.toThrow();
+    });
+
+    it('should stop firing events after dispose', () => {
+      const listener = vi.fn();
+      provider.onDidChangeTreeData(listener);
+      provider.dispose();
+      workGraph._fire();
+      expect(listener).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
- **test: expand FocusTreeProvider and HistoryTreeProvider tests [swarm]**
- **fix: use fixed timestamps in focus test makeItem to avoid flakiness**
