### PR TITLE
test: expand SourcesTreeProvider test coverage

### DIFF
--- a/packages/core/src/test/sourcesTreeProvider.test.ts
+++ b/packages/core/src/test/sourcesTreeProvider.test.ts
@@ -288,6 +288,93 @@ describe('SourcesTreeProvider', () => {
     });
   });
 
+  describe('getTreeItem tooltip', () => {
+    it('should include title and description in tooltip when item has description', () => {
+      const node: SourceItemNode = {
+        kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug Report',
+        description: 'App crashes on startup',
+      };
+      const treeItem = provider.getTreeItem(node);
+      expect(treeItem.tooltip.value).toContain('Bug Report');
+      expect(treeItem.tooltip.value).toContain('App crashes on startup');
+      expect(treeItem.tooltip.value).toContain('**Description:**');
+    });
+
+    it('should include only title in tooltip when item has no description', () => {
+      const node: SourceItemNode = {
+        kind: 'item', providerId: 'gh', externalId: '1', title: 'Simple Item',
+      };
+      const treeItem = provider.getTreeItem(node);
+      expect(treeItem.tooltip.value).toContain('Simple Item');
+      expect(treeItem.tooltip.value).not.toContain('**Description:**');
+    });
+  });
+
+  describe('sorting', () => {
+    it('should sort provider nodes alphabetically by label', () => {
+      registry._setLabel('zz', 'Zeta Provider');
+      registry._setLabel('aa', 'Alpha Provider');
+      registry._setLabel('mm', 'Mid Provider');
+      registry._setItems('zz', [{ externalId: '1', title: 'Z' }]);
+      registry._setItems('aa', [{ externalId: '2', title: 'A' }]);
+      registry._setItems('mm', [{ externalId: '3', title: 'M' }]);
+
+      const children = provider.getChildren();
+      const labels = children.map((c) => (c as SourceProviderNode).label);
+      expect(labels).toEqual(['Alpha Provider', 'Mid Provider', 'Zeta Provider']);
+    });
+
+    it('should sort group children alphabetically by title', () => {
+      registry._setItems('gh', [
+        { externalId: '3', title: 'Zebra', group: 'Animals' },
+        { externalId: '1', title: 'Aardvark', group: 'Animals' },
+        { externalId: '2', title: 'Meerkat', group: 'Animals' },
+      ]);
+
+      const groupNode: SourceGroupNode = { kind: 'group', providerId: 'gh', groupName: 'Animals' };
+      const children = provider.getChildren(groupNode);
+      const titles = children.map((c) => (c as SourceItemNode).title);
+      expect(titles).toEqual(['Aardvark', 'Meerkat', 'Zebra']);
+    });
+  });
+
+  describe('dispose', () => {
+    it('should stop firing tree data changes after dispose', () => {
+      const listener = vi.fn();
+      provider.onDidChangeTreeData(listener);
+
+      registry._fire();
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      provider.dispose();
+
+      registry._fire();
+      stateStore._fire();
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return empty children for a group with no matching items', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'PR #1', group: 'Pull Requests' },
+      ]);
+
+      const groupNode: SourceGroupNode = { kind: 'group', providerId: 'gh', groupName: 'Nonexistent Group' };
+      const children = provider.getChildren(groupNode);
+      expect(children).toEqual([]);
+    });
+
+    it('should return empty array for item element with all fields set', () => {
+      const itemNode: SourceItemNode = {
+        kind: 'item', providerId: 'gh', externalId: '99', title: 'Full Item',
+        description: 'A description', url: 'https://example.com', group: 'SomeGroup',
+      };
+      const children = provider.getChildren(itemNode);
+      expect(children).toEqual([]);
+    });
+  });
+
   describe('refresh', () => {
     it('should refresh when providerRegistry fires change event', () => {
       const listener = vi.fn();

--- a/packages/core/src/test/sourcesTreeProvider.test.ts
+++ b/packages/core/src/test/sourcesTreeProvider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { EventEmitter, TreeItemCollapsibleState, ThemeIcon } from 'vscode';
+import { EventEmitter, MarkdownString, TreeItemCollapsibleState, ThemeIcon } from 'vscode';
 import { DiscoveredItem } from '../api/types';
 import { SourcesTreeProvider, SourceProviderNode, SourceGroupNode, SourceItemNode } from '../views/sourcesTreeProvider';
 
@@ -295,9 +295,10 @@ describe('SourcesTreeProvider', () => {
         description: 'App crashes on startup',
       };
       const treeItem = provider.getTreeItem(node);
-      expect(treeItem.tooltip.value).toContain('Bug Report');
-      expect(treeItem.tooltip.value).toContain('App crashes on startup');
-      expect(treeItem.tooltip.value).toContain('**Description:**');
+      const tooltip = treeItem.tooltip as MarkdownString;
+      expect(tooltip.value).toContain('Bug Report');
+      expect(tooltip.value).toContain('App crashes on startup');
+      expect(tooltip.value).toContain('**Description:**');
     });
 
     it('should include only title in tooltip when item has no description', () => {
@@ -305,8 +306,9 @@ describe('SourcesTreeProvider', () => {
         kind: 'item', providerId: 'gh', externalId: '1', title: 'Simple Item',
       };
       const treeItem = provider.getTreeItem(node);
-      expect(treeItem.tooltip.value).toContain('Simple Item');
-      expect(treeItem.tooltip.value).not.toContain('**Description:**');
+      const tooltip = treeItem.tooltip as MarkdownString;
+      expect(tooltip.value).toContain('Simple Item');
+      expect(tooltip.value).not.toContain('**Description:**');
     });
   });
 
@@ -336,6 +338,19 @@ describe('SourcesTreeProvider', () => {
       const titles = children.map((c) => (c as SourceItemNode).title);
       expect(titles).toEqual(['Aardvark', 'Meerkat', 'Zebra']);
     });
+
+    it('should sort group nodes alphabetically by group name', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'X', group: 'Zulu' },
+        { externalId: '2', title: 'Y', group: 'Alpha' },
+        { externalId: '3', title: 'Z', group: 'Mike' },
+      ]);
+
+      const providerNode: SourceProviderNode = { kind: 'provider', providerId: 'gh', label: 'GH' };
+      const children = provider.getChildren(providerNode);
+      const groupNames = children.map((c) => (c as SourceGroupNode).groupName);
+      expect(groupNames).toEqual(['Alpha', 'Mike', 'Zulu']);
+    });
   });
 
   describe('dispose', () => {
@@ -362,15 +377,6 @@ describe('SourcesTreeProvider', () => {
 
       const groupNode: SourceGroupNode = { kind: 'group', providerId: 'gh', groupName: 'Nonexistent Group' };
       const children = provider.getChildren(groupNode);
-      expect(children).toEqual([]);
-    });
-
-    it('should return empty array for item element with all fields set', () => {
-      const itemNode: SourceItemNode = {
-        kind: 'item', providerId: 'gh', externalId: '99', title: 'Full Item',
-        description: 'A description', url: 'https://example.com', group: 'SomeGroup',
-      };
-      const children = provider.getChildren(itemNode);
       expect(children).toEqual([]);
     });
   });


### PR DESCRIPTION
Adds test coverage for SourcesTreeProvider including:
- Tooltip content verification (with/without description)
- Alphabetical sorting of provider nodes, group nodes, and items within groups
- Dispose behavior (events stop firing)
- Edge case: empty children for non-matching group