### PR TITLE
fix: add error handling to ADO provider fetch methods

### DIFF
--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -201,7 +201,7 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
 
     if (!wiqlResponse.ok) {
       logger.warn(`Failed to fetch work items for project: ${project || this.org}`);
-      logger.error(`WIQL query failed for project "${project}": ${wiqlResponse.status}`);
+      logger.error(`WIQL query failed for project "${project || this.org}": ${wiqlResponse.status}`);
       return { items: [], failed: true };
     }
 
@@ -235,7 +235,10 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
           },
         });
       } catch (err) {
-        logger.error(`Network error fetching work item details (batch at index ${i}):`, err);
+        logger.error(
+          `Network error fetching work item details for ${project || this.org} (batch at index ${i}, ids ${batchIds[0]}-${batchIds[batchIds.length - 1]}):`,
+          err,
+        );
         batchFailed = true;
         continue;
       }

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -184,14 +184,20 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
 
     const wiqlQuery = `SELECT [System.Id] FROM WorkItems WHERE [System.AssignedTo] = @Me AND [System.State] <> 'Closed' AND [System.State] <> 'Removed'`;
 
-    const wiqlResponse = await fetch(wiqlUrl, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${token}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ query: wiqlQuery }),
-    });
+    let wiqlResponse: Response;
+    try {
+      wiqlResponse = await fetch(wiqlUrl, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ query: wiqlQuery }),
+      });
+    } catch (err) {
+      logger.error(`Network error querying work items for project "${project || this.org}":`, err);
+      return { items: [], failed: true };
+    }
 
     if (!wiqlResponse.ok) {
       logger.warn(`Failed to fetch work items for project: ${project || this.org}`);
@@ -221,11 +227,18 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
       const batchIds = ids.slice(i, i + batchSize);
       const detailUrl = `https://dev.azure.com/${encodeURIComponent(this.org)}/_apis/wit/workitems?ids=${batchIds.join(',')}&fields=System.Title,System.Description,System.TeamProject,System.WorkItemType,System.State&$expand=links&api-version=7.1`;
 
-      const detailResponse = await fetch(detailUrl, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      let detailResponse: Response;
+      try {
+        detailResponse = await fetch(detailUrl, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        });
+      } catch (err) {
+        logger.error(`Network error fetching work item details (batch at index ${i}):`, err);
+        batchFailed = true;
+        continue;
+      }
 
       if (!detailResponse.ok) {
         logger.error(`Failed to fetch work item details: ${detailResponse.status}`);

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -286,20 +286,31 @@ describe('AdoWorkItemProvider', () => {
   });
 
   it('handles detail batch network error with partial results', async () => {
-    // WIQL returns 2 items, but the detail fetch throws a network error
+    // WIQL returns 201 items to trigger two batches (batch size is 200)
+    const ids = Array.from({ length: 201 }, (_, i) => i + 1);
     mockFetch
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => createWiqlResponse([1, 2]),
+        json: async () => createWiqlResponse(ids),
       })
+      // First batch (items 1-200) succeeds with one item for simplicity
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          value: [createWorkItemDetail(1, 'Survived')],
+        }),
+      })
+      // Second batch (item 201) fails with network error
       .mockRejectedValueOnce(new Error('Network error'));
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
     await provider.refresh();
 
-    // Items fire but empty since the only batch failed
-    expect(listener).toHaveBeenCalledWith([]);
+    // Partial results from the first batch are preserved
+    const items = listener.mock.calls[0][0];
+    expect(items).toHaveLength(1);
+    expect(items[0].title).toContain('Survived');
     expect(window.showWarningMessage).toHaveBeenCalledWith(
       expect.stringContaining('Failed to fetch work items'),
     );

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -272,6 +272,39 @@ describe('AdoWorkItemProvider', () => {
     vi.useRealTimers();
   });
 
+  it('handles WIQL network error gracefully', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).toHaveBeenCalledWith([]);
+    expect(window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to fetch work items'),
+    );
+  });
+
+  it('handles detail batch network error with partial results', async () => {
+    // WIQL returns 2 items, but the detail fetch throws a network error
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => createWiqlResponse([1, 2]),
+      })
+      .mockRejectedValueOnce(new Error('Network error'));
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    // Items fire but empty since the only batch failed
+    expect(listener).toHaveBeenCalledWith([]);
+    expect(window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to fetch work items'),
+    );
+  });
+
   it('uses org-level WIQL when no projects are configured', async () => {
     provider.dispose();
     provider = new AdoWorkItemProvider('myorg', []);


### PR DESCRIPTION
## Summary

Add try/catch error handling around `fetch()` calls in `AdoWorkItemProvider` to gracefully handle network errors.

## Changes

- **WIQL query fetch**: On network error, logs the error and returns `{ items: [], failed: true }` so the caller can report the failure
- **Detail batch fetch**: On network error, logs the error, sets `batchFailed = true`, and continues to the next batch so partial results are preserved
- **Tests**: Added two new test cases covering both network error paths

## Testing

All 272 tests pass (34 ADO + 196 core + 42 GitHub).
