### PR TITLE
fix: add error handling to extension event callbacks

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -38,7 +38,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
           const newLevel = vscode.workspace.getConfiguration('workcenter').get<string>('logLevel', 'info');
           setLogLevel(logLevelMap[newLevel] ?? LogLevel.Info);
         }
-      } catch (err) {
+      } catch (err: unknown) {
         logger.error('Error handling configuration change', err);
       }
     }),
@@ -105,7 +105,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
       if (changed) {
         inboxProvider.refresh();
       }
-    } catch (err) {
+    } catch (err: unknown) {
       logger.error('Error handling inbox selection change', err);
     }
   });
@@ -140,7 +140,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   const workGraphSub = workGraph.onDidChange(() => {
     try {
       updateWorkViewMessages();
-    } catch (err) {
+    } catch (err: unknown) {
       logger.error('Error handling work graph change', err);
     }
   });
@@ -162,12 +162,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
     uiUpdateScheduled = true;
     queueMicrotask(() => {
       try {
-        uiUpdateScheduled = false;
         updateViewMessages();
         updateInboxBadge();
-      } catch (err) {
-        uiUpdateScheduled = false;
+      } catch (err: unknown) {
         logger.error('Error during scheduled UI update', err);
+      } finally {
+        uiUpdateScheduled = false;
       }
     });
   };
@@ -175,7 +175,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   updateViewMessages();
   updateInboxBadge();
 
-  const providerRegSub = providerRegistry.onDidRegisterProvider(scheduleUiUpdate);
+  const providerRegSub = providerRegistry.onDidRegisterProvider(() => {
+    try {
+      scheduleUiUpdate();
+    } catch (err: unknown) {
+      logger.error('Error handling provider registration', err);
+    }
+  });
   const discoveredSub = providerRegistry.onDidChangeDiscoveredItems(() => {
     try {
       scheduleUiUpdate();
@@ -187,7 +193,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
         }
         wasLoading = wasLoading || providerRegistry.loading;
       }
-    } catch (err) {
+    } catch (err: unknown) {
       logger.error('Error handling discovered items change', err);
     }
   });
@@ -201,11 +207,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
           `WorkCenter: ${newCount} new item${newCount === 1 ? '' : 's'} in Inbox`
         );
       }
-    } catch (err) {
+    } catch (err: unknown) {
       logger.error('Error handling new unseen items notification', err);
     }
   });
-  const stateStoreSub = stateStore.onDidChange(scheduleUiUpdate);
+  const stateStoreSub = stateStore.onDidChange(() => {
+    try {
+      scheduleUiUpdate();
+    } catch (err: unknown) {
+      logger.error('Error handling state store change', err);
+    }
+  });
 
   context.subscriptions.push(
     inboxTreeView,

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -178,7 +178,7 @@ function wireEvents(
     historyTreeView.message = historyProvider.getChildren().length > 0 ? undefined : 'No history items';
   };
 
-  const workGraphSub = workGraph.onDidChange(updateWorkViewMessages);
+  const workGraphSub = workGraph.onDidChange(safeHandler('Error handling work graph change', updateWorkViewMessages));
   let initialLoadComplete = false;
   let wasLoading = false;
 
@@ -197,12 +197,15 @@ function wireEvents(
     queueMicrotask(() => {
       try {
         updateViewMessages();
+      } catch (err: unknown) {
+        logger.error('Error updating view messages', err);
+      }
+      try {
         updateInboxBadge();
       } catch (err: unknown) {
-        logger.error('Error during scheduled UI update', err);
-      } finally {
-        uiUpdateScheduled = false;
+        logger.error('Error updating inbox badge', err);
       }
+      uiUpdateScheduled = false;
     });
   };
 
@@ -245,7 +248,7 @@ function wireEvents(
     }
   }));
   const stateStoreSub = stateStore.onDidChange(safeHandler('Error handling state store change', scheduleUiUpdate));
-  const markSeenSub = inboxProvider.onDidMarkSeen(scheduleUiUpdate);
+  const markSeenSub = inboxProvider.onDidMarkSeen(safeHandler('Error handling mark seen', scheduleUiUpdate));
 
   return [discoveredSub, newItemsSub, providerRegSub, stateStoreSub, markSeenSub, workGraphSub];
 }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -33,9 +33,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration(e => {
-      if (e.affectsConfiguration('workcenter.logLevel')) {
-        const newLevel = vscode.workspace.getConfiguration('workcenter').get<string>('logLevel', 'info');
-        setLogLevel(logLevelMap[newLevel] ?? LogLevel.Info);
+      try {
+        if (e.affectsConfiguration('workcenter.logLevel')) {
+          const newLevel = vscode.workspace.getConfiguration('workcenter').get<string>('logLevel', 'info');
+          setLogLevel(logLevelMap[newLevel] ?? LogLevel.Info);
+        }
+      } catch (err) {
+        logger.error('Error handling configuration change', err);
       }
     }),
   );
@@ -91,14 +95,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   const sourcesTreeView = vscode.window.createTreeView('workcenter.sources', { treeDataProvider: sourcesProvider });
 
   const inboxSelectionSub = inboxTreeView.onDidChangeSelection((e) => {
-    let changed = false;
-    for (const item of e.selection) {
-      if (item.kind === 'item') {
-        changed = inboxProvider.markSeen(item.providerId, item.externalId) || changed;
+    try {
+      let changed = false;
+      for (const item of e.selection) {
+        if (item.kind === 'item') {
+          changed = inboxProvider.markSeen(item.providerId, item.externalId) || changed;
+        }
       }
-    }
-    if (changed) {
-      inboxProvider.refresh();
+      if (changed) {
+        inboxProvider.refresh();
+      }
+    } catch (err) {
+      logger.error('Error handling inbox selection change', err);
     }
   });
 
@@ -129,7 +137,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
     historyTreeView.message = historyProvider.getChildren().length > 0 ? undefined : 'No history items';
   };
   updateWorkViewMessages();
-  const workGraphSub = workGraph.onDidChange(updateWorkViewMessages);
+  const workGraphSub = workGraph.onDidChange(() => {
+    try {
+      updateWorkViewMessages();
+    } catch (err) {
+      logger.error('Error handling work graph change', err);
+    }
+  });
 
   let initialLoadComplete = false;
   let wasLoading = false;
@@ -147,9 +161,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
     if (uiUpdateScheduled) { return; }
     uiUpdateScheduled = true;
     queueMicrotask(() => {
-      uiUpdateScheduled = false;
-      updateViewMessages();
-      updateInboxBadge();
+      try {
+        uiUpdateScheduled = false;
+        updateViewMessages();
+        updateInboxBadge();
+      } catch (err) {
+        uiUpdateScheduled = false;
+        logger.error('Error during scheduled UI update', err);
+      }
     });
   };
 
@@ -158,24 +177,32 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
 
   const providerRegSub = providerRegistry.onDidRegisterProvider(scheduleUiUpdate);
   const discoveredSub = providerRegistry.onDidChangeDiscoveredItems(() => {
-    scheduleUiUpdate();
+    try {
+      scheduleUiUpdate();
 
-    // Mark initial load complete when loading transitions from true to false
-    if (!initialLoadComplete) {
-      if (wasLoading && !providerRegistry.loading) {
-        initialLoadComplete = true;
+      // Mark initial load complete when loading transitions from true to false
+      if (!initialLoadComplete) {
+        if (wasLoading && !providerRegistry.loading) {
+          initialLoadComplete = true;
+        }
+        wasLoading = wasLoading || providerRegistry.loading;
       }
-      wasLoading = wasLoading || providerRegistry.loading;
+    } catch (err) {
+      logger.error('Error handling discovered items change', err);
     }
   });
   const newItemsSub = providerRegistry.onDidAddNewUnseenItems((newCount) => {
-    if (!initialLoadComplete) { return; }
-    const config = vscode.workspace.getConfiguration('workcenter');
-    const showNotifications = config.get<boolean>('showInboxNotifications', true);
-    if (showNotifications && newCount > 0) {
-      vscode.window.showInformationMessage(
-        `WorkCenter: ${newCount} new item${newCount === 1 ? '' : 's'} in Inbox`
-      );
+    try {
+      if (!initialLoadComplete) { return; }
+      const config = vscode.workspace.getConfiguration('workcenter');
+      const showNotifications = config.get<boolean>('showInboxNotifications', true);
+      if (showNotifications && newCount > 0) {
+        vscode.window.showInformationMessage(
+          `WorkCenter: ${newCount} new item${newCount === 1 ? '' : 's'} in Inbox`
+        );
+      }
+    } catch (err) {
+      logger.error('Error handling new unseen items notification', err);
     }
   });
   const stateStoreSub = stateStore.onDidChange(scheduleUiUpdate);

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -20,14 +20,14 @@ import { performance } from 'perf_hooks';
 export type { WorkCenterApi, WorkCenterProvider, WorkCenterAction, DiscoveredItem, Disposable } from './api/types';
 export { logger } from './services/logger';
 
-/** Wrap an event callback so unhandled errors are logged instead of crashing. */
-function safeHandler<T extends unknown[]>(label: string, fn: (...args: T) => void): (...args: T) => void {
+/** Wrap an event callback so unhandled errors (sync or async) are logged instead of crashing. */
+function safeHandler<T extends unknown[]>(label: string, fn: (...args: T) => void | Promise<void>): (...args: T) => void {
   return (...args: T) => {
-    try {
-      fn(...args);
-    } catch (err: unknown) {
-      logger.error(label, err);
-    }
+    void Promise.resolve()
+      .then(() => fn(...args))
+      .catch((err: unknown) => {
+        logger.error(label, err);
+      });
   };
 }
 
@@ -196,16 +196,19 @@ function wireEvents(
     uiUpdateScheduled = true;
     queueMicrotask(() => {
       try {
-        updateViewMessages();
-      } catch (err: unknown) {
-        logger.error('Error updating view messages', err);
+        try {
+          updateViewMessages();
+        } catch (err: unknown) {
+          logger.error('Error updating view messages', err);
+        }
+        try {
+          updateInboxBadge();
+        } catch (err: unknown) {
+          logger.error('Error updating inbox badge', err);
+        }
+      } finally {
+        uiUpdateScheduled = false;
       }
-      try {
-        updateInboxBadge();
-      } catch (err: unknown) {
-        logger.error('Error updating inbox badge', err);
-      }
-      uiUpdateScheduled = false;
     });
   };
 

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -20,6 +20,17 @@ import { performance } from 'perf_hooks';
 export type { WorkCenterApi, WorkCenterProvider, WorkCenterAction, DiscoveredItem, Disposable } from './api/types';
 export { logger } from './services/logger';
 
+/** Wrap an event callback so unhandled errors are logged instead of crashing. */
+function safeHandler<T extends unknown[]>(label: string, fn: (...args: T) => void): (...args: T) => void {
+  return (...args: T) => {
+    try {
+      fn(...args);
+    } catch (err: unknown) {
+      logger.error(label, err);
+    }
+  };
+}
+
 function initializeLogging(context: vscode.ExtensionContext): void {
   const outputChannel = vscode.window.createOutputChannel('WorkCenter');
   context.subscriptions.push(outputChannel);
@@ -28,16 +39,12 @@ function initializeLogging(context: vscode.ExtensionContext): void {
   initLogger(outputChannel, resolveLogLevel(logLevelConfig));
 
   context.subscriptions.push(
-    vscode.workspace.onDidChangeConfiguration(e => {
-      try {
-        if (e.affectsConfiguration('workcenter.logLevel')) {
-          const newLevel = vscode.workspace.getConfiguration('workcenter').get<string>('logLevel', 'info');
-          setLogLevel(resolveLogLevel(newLevel));
-        }
-      } catch (err: unknown) {
-        logger.error('Error handling configuration change', err);
+    vscode.workspace.onDidChangeConfiguration(safeHandler('Error handling configuration change', (e) => {
+      if (e.affectsConfiguration('workcenter.logLevel')) {
+        const newLevel = vscode.workspace.getConfiguration('workcenter').get<string>('logLevel', 'info');
+        setLogLevel(resolveLogLevel(newLevel));
       }
-    }),
+    })),
   );
 }
 
@@ -191,60 +198,40 @@ function wireEvents(
   updateViewMessages();
   updateInboxBadge();
 
-  const providerRegSub = providerRegistry.onDidRegisterProvider(() => {
-    try {
-      scheduleUiUpdate();
-    } catch (err: unknown) {
-      logger.error('Error handling provider registration', err);
-    }
-  });
-  const discoveredSub = providerRegistry.onDidChangeDiscoveredItems(() => {
-    try {
-      scheduleUiUpdate();
+  const providerRegSub = providerRegistry.onDidRegisterProvider(safeHandler('Error handling provider registration', scheduleUiUpdate));
+  const discoveredSub = providerRegistry.onDidChangeDiscoveredItems(safeHandler('Error handling discovered items change', () => {
+    scheduleUiUpdate();
 
-      // Mark initial load complete when loading transitions from true to false
-      if (!initialLoadComplete) {
-        if (wasLoading && !providerRegistry.loading) {
-          initialLoadComplete = true;
-        }
-        wasLoading = wasLoading || providerRegistry.loading;
+    // Mark initial load complete when loading transitions from true to false
+    if (!initialLoadComplete) {
+      if (wasLoading && !providerRegistry.loading) {
+        initialLoadComplete = true;
       }
-    } catch (err: unknown) {
-      logger.error('Error handling discovered items change', err);
+      wasLoading = wasLoading || providerRegistry.loading;
     }
-  });
-  const newItemsSub = providerRegistry.onDidAddNewUnseenItems((newCount) => {
-    try {
-      if (!initialLoadComplete) { return; }
-      const config = vscode.workspace.getConfiguration('workcenter');
-      const showNotifications = config.get<boolean>('showInboxNotifications', true);
-      if (showNotifications && newCount > 0) {
-        void vscode.window.showInformationMessage(
-          `WorkCenter: ${newCount} new item${newCount === 1 ? '' : 's'} in Inbox`,
-          'Show Inbox'
-        ).then(
-          action => {
-            if (action === 'Show Inbox') {
-              vscode.commands.executeCommand('workcenter.inbox.focus').then(
-                undefined,
-                () => { /* view focus is best-effort */ }
-              );
-            }
-          },
-          () => { /* notification is best-effort */ }
-        );
-      }
-    } catch (err: unknown) {
-      logger.error('Error handling new unseen items notification', err);
+  }));
+  const newItemsSub = providerRegistry.onDidAddNewUnseenItems(safeHandler('Error handling new unseen items notification', (newCount) => {
+    if (!initialLoadComplete) { return; }
+    const config = vscode.workspace.getConfiguration('workcenter');
+    const showNotifications = config.get<boolean>('showInboxNotifications', true);
+    if (showNotifications && newCount > 0) {
+      void vscode.window.showInformationMessage(
+        `WorkCenter: ${newCount} new item${newCount === 1 ? '' : 's'} in Inbox`,
+        'Show Inbox'
+      ).then(
+        action => {
+          if (action === 'Show Inbox') {
+            vscode.commands.executeCommand('workcenter.inbox.focus').then(
+              undefined,
+              () => { /* view focus is best-effort */ }
+            );
+          }
+        },
+        () => { /* notification is best-effort */ }
+      );
     }
-  });
-  const stateStoreSub = stateStore.onDidChange(() => {
-    try {
-      scheduleUiUpdate();
-    } catch (err: unknown) {
-      logger.error('Error handling state store change', err);
-    }
-  });
+  }));
+  const stateStoreSub = stateStore.onDidChange(safeHandler('Error handling state store change', scheduleUiUpdate));
   const markSeenSub = inboxProvider.onDidMarkSeen(scheduleUiUpdate);
 
   return [discoveredSub, newItemsSub, providerRegSub, stateStoreSub, markSeenSub, workGraphSub];

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import * as vscode from 'vscode';
-import { activate, deactivate } from '../extension';
+import { activate, deactivate, logger } from '../extension';
 
 // Stub fs so stores never touch disk
 vi.mock('fs/promises', () => ({
@@ -301,47 +301,33 @@ describe('activate()', () => {
   });
 
   // ------------------------------------------------------------------
-  // 15. Error handling: safeHandler catches sync errors in callbacks
+  // 15. Error handling: safeHandler catches sync throw in event callback
   // ------------------------------------------------------------------
-  it('continues activation when a wrapped event callback throws synchronously', async () => {
-    const api = await activate(context);
+  it('logs error and continues when a safeHandler-wrapped callback throws', async () => {
+    await activate(context);
     await flushMicrotasks();
 
-    const itemEmitter = new (vscode.EventEmitter as any)();
-    const provider = {
-      id: 'err-sync',
-      label: 'ErrSync',
-      onDidDiscoverItems: itemEmitter.event,
-      refresh: vi.fn().mockResolvedValue(undefined),
-    };
-    api.registerProvider(provider as any);
+    const errorSpy = vi.spyOn(logger, 'error');
+
+    // The onDidChangeConfiguration listener is wrapped with safeHandler.
+    // Force its inner code to throw by making getConfiguration throw.
+    const onDidChangeCfg = vscode.workspace.onDidChangeConfiguration as ReturnType<typeof vi.fn>;
+    const configListener = onDidChangeCfg.mock.calls[0][0];
+
+    (vscode.workspace.getConfiguration as ReturnType<typeof vi.fn>)
+      .mockImplementationOnce(() => { throw new Error('Config read failure'); });
+
+    // Call the safeHandler-wrapped listener — should not throw
+    configListener({ affectsConfiguration: () => true });
     await flushMicrotasks();
 
-    // Fire an event that triggers a callback which will exercise safeHandler.
-    // Even if the internal UI update path encountered an error, the extension
-    // should remain functional — subsequent events still trigger UI updates.
-    const createTreeView = vscode.window.createTreeView as ReturnType<typeof vi.fn>;
-    const inboxIdx = createTreeView.mock.calls.findIndex((c: any[]) => c[0] === 'workcenter.inbox');
-    const inboxView = createTreeView.mock.results[inboxIdx].value;
+    // Verify the error was logged via safeHandler's catch
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Error handling configuration change',
+      expect.any(Error),
+    );
 
-    let messageSetCount = 0;
-    let currentMessage: string | undefined = inboxView.message;
-    Object.defineProperty(inboxView, 'message', {
-      get: () => currentMessage,
-      set: (v: string | undefined) => { currentMessage = v; messageSetCount++; },
-      configurable: true,
-    });
-
-    // Fire a discovered items event, then verify the UI still updates
-    itemEmitter.fire([]);
-    await flushMicrotasks();
-    expect(messageSetCount).toBeGreaterThan(0);
-
-    // Fire again — should still work (coalescing flag was properly reset)
-    messageSetCount = 0;
-    itemEmitter.fire([]);
-    await flushMicrotasks();
-    expect(messageSetCount).toBeGreaterThan(0);
+    errorSpy.mockRestore();
   });
 
   // ------------------------------------------------------------------
@@ -355,7 +341,9 @@ describe('activate()', () => {
     const sourcesIdx = createTreeView.mock.calls.findIndex((c: any[]) => c[0] === 'workcenter.sources');
     const sourcesView = createTreeView.mock.results[sourcesIdx].value;
 
-    // Make the sources view message setter throw to simulate a microtask error
+    // Make the sources view message setter throw to trigger the inner catch
+    // inside the microtask's updateViewMessages() path.
+    const errorSpy = vi.spyOn(logger, 'error');
     Object.defineProperty(sourcesView, 'message', {
       get: () => undefined,
       set: () => { throw new Error('Simulated view message error'); },
@@ -371,6 +359,12 @@ describe('activate()', () => {
     };
     api.registerProvider(provider as any);
     await flushMicrotasks();
+
+    // Verify the error was caught and logged inside the microtask
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Error updating view messages',
+      expect.any(Error),
+    );
 
     // Remove the throwing setter so next update succeeds
     Object.defineProperty(sourcesView, 'message', {
@@ -395,6 +389,8 @@ describe('activate()', () => {
     itemEmitter.fire([]);
     await flushMicrotasks();
     expect(messageSetCount).toBeGreaterThan(0);
+
+    errorSpy.mockRestore();
   });
 
   // ------------------------------------------------------------------
@@ -404,29 +400,45 @@ describe('activate()', () => {
     const api = await activate(context);
     await flushMicrotasks();
 
-    // Register a provider whose refresh rejects — safeHandler should
-    // catch the rejection without surfacing an unhandled promise rejection.
-    const itemEmitter = new (vscode.EventEmitter as any)();
-    const provider = {
-      id: 'err-async',
-      label: 'ErrAsync',
-      onDidDiscoverItems: itemEmitter.event,
-      refresh: vi.fn().mockRejectedValue(new Error('Async refresh failure')),
-    };
+    const errorSpy = vi.spyOn(logger, 'error');
+    const onUnhandledRejection = vi.fn();
+    process.on('unhandledRejection', onUnhandledRejection);
 
-    // registerProvider should not throw despite refresh rejection
-    expect(() => api.registerProvider(provider as any)).not.toThrow();
-    await flushMicrotasks();
+    try {
+      // The onDidChangeConfiguration listener is wrapped with safeHandler
+      // which supports async handlers via Promise.resolve().then().catch().
+      // Make getConfiguration return an object whose get() rejects.
+      const onDidChangeCfg = vscode.workspace.onDidChangeConfiguration as ReturnType<typeof vi.fn>;
+      const configListener = onDidChangeCfg.mock.calls[0][0];
 
-    // Extension should still be functional — can register more providers
-    const provider2 = {
-      id: 'err-async-2',
-      label: 'ErrAsync2',
-      onDidDiscoverItems: new (vscode.EventEmitter as any)().event,
-      refresh: vi.fn().mockResolvedValue(undefined),
-    };
-    expect(() => api.registerProvider(provider2 as any)).not.toThrow();
-    await flushMicrotasks();
+      // Simulate an async throw by making the wrapped function throw after
+      // a resolved promise tick — safeHandler's .catch() should capture it.
+      (vscode.workspace.getConfiguration as ReturnType<typeof vi.fn>)
+        .mockImplementationOnce(() => { throw new Error('Async config failure'); });
+
+      configListener({ affectsConfiguration: () => true });
+      await flushMicrotasks();
+
+      // Error should have been caught by safeHandler, not surfaced as unhandled
+      expect(errorSpy).toHaveBeenCalledWith(
+        'Error handling configuration change',
+        expect.any(Error),
+      );
+      expect(onUnhandledRejection).not.toHaveBeenCalled();
+
+      // Extension should still be functional — register a provider
+      const provider = {
+        id: 'err-async-ok',
+        label: 'ErrAsyncOk',
+        onDidDiscoverItems: new (vscode.EventEmitter as any)().event,
+        refresh: vi.fn().mockResolvedValue(undefined),
+      };
+      expect(() => api.registerProvider(provider as any)).not.toThrow();
+      await flushMicrotasks();
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+      errorSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -299,6 +299,135 @@ describe('activate()', () => {
     const historyView = createTreeView.mock.results[historyIdx].value;
     expect(historyView.message).toBe('No history items');
   });
+
+  // ------------------------------------------------------------------
+  // 15. Error handling: safeHandler catches sync errors in callbacks
+  // ------------------------------------------------------------------
+  it('continues activation when a wrapped event callback throws synchronously', async () => {
+    const api = await activate(context);
+    await flushMicrotasks();
+
+    const itemEmitter = new (vscode.EventEmitter as any)();
+    const provider = {
+      id: 'err-sync',
+      label: 'ErrSync',
+      onDidDiscoverItems: itemEmitter.event,
+      refresh: vi.fn().mockResolvedValue(undefined),
+    };
+    api.registerProvider(provider as any);
+    await flushMicrotasks();
+
+    // Fire an event that triggers a callback which will exercise safeHandler.
+    // Even if the internal UI update path encountered an error, the extension
+    // should remain functional — subsequent events still trigger UI updates.
+    const createTreeView = vscode.window.createTreeView as ReturnType<typeof vi.fn>;
+    const inboxIdx = createTreeView.mock.calls.findIndex((c: any[]) => c[0] === 'workcenter.inbox');
+    const inboxView = createTreeView.mock.results[inboxIdx].value;
+
+    let messageSetCount = 0;
+    let currentMessage: string | undefined = inboxView.message;
+    Object.defineProperty(inboxView, 'message', {
+      get: () => currentMessage,
+      set: (v: string | undefined) => { currentMessage = v; messageSetCount++; },
+      configurable: true,
+    });
+
+    // Fire a discovered items event, then verify the UI still updates
+    itemEmitter.fire([]);
+    await flushMicrotasks();
+    expect(messageSetCount).toBeGreaterThan(0);
+
+    // Fire again — should still work (coalescing flag was properly reset)
+    messageSetCount = 0;
+    itemEmitter.fire([]);
+    await flushMicrotasks();
+    expect(messageSetCount).toBeGreaterThan(0);
+  });
+
+  // ------------------------------------------------------------------
+  // 16. Error handling: uiUpdateScheduled resets even when microtask throws
+  // ------------------------------------------------------------------
+  it('resets uiUpdateScheduled flag after microtask errors via finally', async () => {
+    const api = await activate(context);
+    await flushMicrotasks();
+
+    const createTreeView = vscode.window.createTreeView as ReturnType<typeof vi.fn>;
+    const sourcesIdx = createTreeView.mock.calls.findIndex((c: any[]) => c[0] === 'workcenter.sources');
+    const sourcesView = createTreeView.mock.results[sourcesIdx].value;
+
+    // Make the sources view message setter throw to simulate a microtask error
+    Object.defineProperty(sourcesView, 'message', {
+      get: () => undefined,
+      set: () => { throw new Error('Simulated view message error'); },
+      configurable: true,
+    });
+
+    const itemEmitter = new (vscode.EventEmitter as any)();
+    const provider = {
+      id: 'err-finally',
+      label: 'ErrFinally',
+      onDidDiscoverItems: itemEmitter.event,
+      refresh: vi.fn().mockResolvedValue(undefined),
+    };
+    api.registerProvider(provider as any);
+    await flushMicrotasks();
+
+    // Remove the throwing setter so next update succeeds
+    Object.defineProperty(sourcesView, 'message', {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+
+    // The coalescing flag should have been reset by `finally`, so
+    // a subsequent event should still trigger a UI update.
+    const inboxIdx = createTreeView.mock.calls.findIndex((c: any[]) => c[0] === 'workcenter.inbox');
+    const inboxView = createTreeView.mock.results[inboxIdx].value;
+
+    let messageSetCount = 0;
+    let currentMessage: string | undefined = inboxView.message;
+    Object.defineProperty(inboxView, 'message', {
+      get: () => currentMessage,
+      set: (v: string | undefined) => { currentMessage = v; messageSetCount++; },
+      configurable: true,
+    });
+
+    itemEmitter.fire([]);
+    await flushMicrotasks();
+    expect(messageSetCount).toBeGreaterThan(0);
+  });
+
+  // ------------------------------------------------------------------
+  // 17. Error handling: safeHandler catches async rejection in callbacks
+  // ------------------------------------------------------------------
+  it('catches async rejections in safeHandler-wrapped callbacks', async () => {
+    const api = await activate(context);
+    await flushMicrotasks();
+
+    // Register a provider whose refresh rejects — safeHandler should
+    // catch the rejection without surfacing an unhandled promise rejection.
+    const itemEmitter = new (vscode.EventEmitter as any)();
+    const provider = {
+      id: 'err-async',
+      label: 'ErrAsync',
+      onDidDiscoverItems: itemEmitter.event,
+      refresh: vi.fn().mockRejectedValue(new Error('Async refresh failure')),
+    };
+
+    // registerProvider should not throw despite refresh rejection
+    expect(() => api.registerProvider(provider as any)).not.toThrow();
+    await flushMicrotasks();
+
+    // Extension should still be functional — can register more providers
+    const provider2 = {
+      id: 'err-async-2',
+      label: 'ErrAsync2',
+      onDidDiscoverItems: new (vscode.EventEmitter as any)().event,
+      refresh: vi.fn().mockResolvedValue(undefined),
+    };
+    expect(() => api.registerProvider(provider2 as any)).not.toThrow();
+    await flushMicrotasks();
+  });
 });
 
 describe('deactivate()', () => {

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -331,9 +331,10 @@ describe('activate()', () => {
   });
 
   // ------------------------------------------------------------------
-  // 16. Error handling: uiUpdateScheduled resets even when microtask throws
+  // 16. Error handling: microtask catches view setter errors and
+  //     continues processing subsequent UI updates
   // ------------------------------------------------------------------
-  it('resets uiUpdateScheduled flag after microtask errors via finally', async () => {
+  it('catches view setter errors in microtask and continues processing UI updates', async () => {
     const api = await activate(context);
     await flushMicrotasks();
 
@@ -373,8 +374,8 @@ describe('activate()', () => {
       configurable: true,
     });
 
-    // The coalescing flag should have been reset by `finally`, so
-    // a subsequent event should still trigger a UI update.
+    // The coalescing flag should have been reset (by the finally block),
+    // so a subsequent event should still trigger a UI update.
     const inboxIdx = createTreeView.mock.calls.findIndex((c: any[]) => c[0] === 'workcenter.inbox');
     const inboxView = createTreeView.mock.results[inboxIdx].value;
 
@@ -394,9 +395,9 @@ describe('activate()', () => {
   });
 
   // ------------------------------------------------------------------
-  // 17. Error handling: safeHandler catches async rejection in callbacks
+  // 17. Error handling: safeHandler catches sync throws via promise chain
   // ------------------------------------------------------------------
-  it('catches async rejections in safeHandler-wrapped callbacks', async () => {
+  it('catches sync throws via promise chain without unhandled rejections', async () => {
     const api = await activate(context);
     await flushMicrotasks();
 
@@ -406,15 +407,15 @@ describe('activate()', () => {
 
     try {
       // The onDidChangeConfiguration listener is wrapped with safeHandler
-      // which supports async handlers via Promise.resolve().then().catch().
-      // Make getConfiguration return an object whose get() rejects.
+      // which runs callbacks via Promise.resolve().then().catch(). A sync
+      // throw inside .then() becomes a rejected promise caught by .catch().
       const onDidChangeCfg = vscode.workspace.onDidChangeConfiguration as ReturnType<typeof vi.fn>;
       const configListener = onDidChangeCfg.mock.calls[0][0];
 
-      // Simulate an async throw by making the wrapped function throw after
-      // a resolved promise tick — safeHandler's .catch() should capture it.
+      // Make the wrapped function throw synchronously — safeHandler's
+      // promise chain converts this to a caught rejection.
       (vscode.workspace.getConfiguration as ReturnType<typeof vi.fn>)
-        .mockImplementationOnce(() => { throw new Error('Async config failure'); });
+        .mockImplementationOnce(() => { throw new Error('Config failure'); });
 
       configListener({ affectsConfiguration: () => true });
       await flushMicrotasks();


### PR DESCRIPTION
## Summary

Adds defensive try/catch error handling to all VS Code extension event callbacks in packages/core/src/extension.ts.

## Changes

- Wrap all event handler callbacks in try/catch blocks
- Use catch (err: unknown) per codebase convention with strict mode
- Log errors via logger.error() with descriptive context strings
- Use finally block in queueMicrotask to ensure uiUpdateScheduled flag is always reset
- Wrap previously unwrapped onDidRegisterProvider and stateStore.onDidChange callbacks

## Why

Unhandled exceptions in event handlers can silently break extension features or cause cascading failures. This hardening ensures that individual callback errors are caught, logged, and do not propagate.