### PR TITLE
fix: add error handling to command handlers

### DIFF
--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -28,6 +28,10 @@ function transitionCommand(
   verb: string,
 ): (item: { id: string }) => Promise<void> {
   return async (item) => {
+    if (!item?.id) {
+      vscode.window.showInformationMessage('WorkCenter: Select a work item first.');
+      return;
+    }
     try {
       await workGraph.transitionState(item.id, targetState);
     } catch (err: unknown) {
@@ -69,6 +73,10 @@ export function registerCommands(
       transitionCommand(workGraph, WorkItemState.WaitingOn, 'mark as waiting'),
     ),
     vscode.commands.registerCommand('workcenter.editItem', (item) => {
+      if (!item?.id) {
+        vscode.window.showInformationMessage('WorkCenter: Select a work item first.');
+        return;
+      }
       try {
         const workItem = workGraph.getItem(item.id);
         if (workItem) {
@@ -79,8 +87,12 @@ export function registerCommands(
       }
     }),
     vscode.commands.registerCommand('workcenter.openInBrowser', (item) => {
+      if (!item?.id && !item?.url) {
+        vscode.window.showInformationMessage('WorkCenter: Select a work item first.');
+        return;
+      }
       try {
-        const workItem = workGraph.getItem(item.id);
+        const workItem = item?.id ? workGraph.getItem(item.id) : undefined;
         if (workItem?.url) {
           vscode.env.openExternal(vscode.Uri.parse(workItem.url));
         } else if (item.url) {
@@ -91,6 +103,10 @@ export function registerCommands(
       }
     }),
     vscode.commands.registerCommand('workcenter.runAction', async (item) => {
+      if (!item?.id) {
+        vscode.window.showInformationMessage('WorkCenter: Select a work item first.');
+        return;
+      }
       // Outer: guards registry/UI lookup errors
       try {
         const workItem = workGraph.getItem(item.id);
@@ -148,12 +164,21 @@ export function registerCommands(
       }
     }),
     vscode.commands.registerCommand('workcenter.acceptFromInbox', async (item: InboxItem) => {
+      if (!item?.providerId || !item?.externalId) {
+        vscode.window.showInformationMessage('WorkCenter: Select an item in the Inbox first.');
+        return;
+      }
       logger.info(`Accepting inbox item: ${item.externalId} from ${item.providerId}`);
       const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
       if (existing) {
         vscode.window.showInformationMessage(
           `WorkCenter: Item already accepted as "${existing.title}"`
         );
+        try {
+          await stateStore.setState(item.providerId, item.externalId, 'accepted');
+        } catch (err: unknown) {
+          handleCommandError('Failed to update state after accepting item', err);
+        }
         return;
       }
       try {
@@ -172,6 +197,10 @@ export function registerCommands(
       }
     }),
     vscode.commands.registerCommand('workcenter.dismissFromInbox', async (item: InboxItem) => {
+      if (!item?.providerId || !item?.externalId) {
+        vscode.window.showInformationMessage('WorkCenter: Select an item in the Inbox first.');
+        return;
+      }
       try {
         logger.info(`Dismissing inbox item: ${item.externalId}`);
         await stateStore.setState(item.providerId, item.externalId, 'dismissed');
@@ -180,6 +209,10 @@ export function registerCommands(
       }
     }),
     vscode.commands.registerCommand('workcenter.acceptFromSources', async (item: SourceItemNode) => {
+      if (!item?.providerId || !item?.externalId) {
+        vscode.window.showInformationMessage('WorkCenter: Select an item in Sources first.');
+        return;
+      }
       logger.info(`Accepting sources item: ${item.externalId}`);
       const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
       if (existing) {

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -18,7 +18,7 @@ function formatItemTitle(item: { group?: string; title: string }): string {
 function handleCommandError(context: string, err: unknown): void {
   logger.error(context, err);
   const detail = err instanceof Error ? err.message : String(err);
-  vscode.window.showErrorMessage(`WorkCenter: ${context} — ${detail}`);
+  void vscode.window.showErrorMessage(`WorkCenter: ${context} — ${detail}`);
 }
 
 /** Wrap a command handler so unhandled errors are logged and shown to the user. */
@@ -200,9 +200,14 @@ async function handleAcceptFromInbox(
       { title: formatItemTitle(item) },
       { providerId: item.providerId, externalId: item.externalId, url: item.url },
     );
-    await stateStore.setState(item.providerId, item.externalId, 'accepted');
   } catch (err: unknown) {
     handleCommandError('Failed to accept inbox item', err);
+    return;
+  }
+  try {
+    await stateStore.setState(item.providerId, item.externalId, 'accepted');
+  } catch (err: unknown) {
+    handleCommandError('Failed to update state after accepting item', err);
   }
 }
 

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -14,6 +14,28 @@ function formatItemTitle(item: { group?: string; title: string }): string {
   return trimmedGroup ? `${trimmedGroup} ${item.title}` : item.title;
 }
 
+/** Log the error and show a user-facing message. */
+function handleCommandError(context: string, err: unknown): void {
+  logger.error(context, err);
+  const detail = err instanceof Error ? err.message : String(err);
+  vscode.window.showErrorMessage(`WorkCenter: ${context} — ${detail}`);
+}
+
+/** Build a command handler that transitions a work item's state. */
+function transitionCommand(
+  workGraph: WorkGraph,
+  targetState: WorkItemState,
+  verb: string,
+): (item: { id: string }) => Promise<void> {
+  return async (item) => {
+    try {
+      await workGraph.transitionState(item.id, targetState);
+    } catch (err: unknown) {
+      handleCommandError(`Failed to ${verb} item`, err);
+    }
+  };
+}
+
 export function registerCommands(
   context: vscode.ExtensionContext,
   workGraph: WorkGraph,
@@ -22,60 +44,30 @@ export function registerCommands(
 ): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('workcenter.createItem', () => createItem(workGraph)),
-    vscode.commands.registerCommand('workcenter.acceptToFocus', async (item) => {
-      try {
-        await workGraph.transitionState(item.id, WorkItemState.InProgress);
-      } catch (err: unknown) {
-        logger.error('Failed to accept item to focus', err);
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to update item — ${message}`);
-      }
-    }),
-    vscode.commands.registerCommand('workcenter.archiveItem', async (item) => {
-      try {
-        await workGraph.transitionState(item.id, WorkItemState.Archived);
-      } catch (err: unknown) {
-        logger.error('Failed to archive item', err);
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to update item — ${message}`);
-      }
-    }),
-    vscode.commands.registerCommand('workcenter.completeItem', async (item) => {
-      try {
-        await workGraph.transitionState(item.id, WorkItemState.Done);
-      } catch (err: unknown) {
-        logger.error('Failed to complete item', err);
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to update item — ${message}`);
-      }
-    }),
-    vscode.commands.registerCommand('workcenter.blockItem', async (item) => {
-      try {
-        await workGraph.transitionState(item.id, WorkItemState.Blocked);
-      } catch (err: unknown) {
-        logger.error('Failed to block item', err);
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to update item — ${message}`);
-      }
-    }),
-    vscode.commands.registerCommand('workcenter.unblockItem', async (item) => {
-      try {
-        await workGraph.transitionState(item.id, WorkItemState.InProgress);
-      } catch (err: unknown) {
-        logger.error('Failed to unblock item', err);
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to update item — ${message}`);
-      }
-    }),
-    vscode.commands.registerCommand('workcenter.markWaitingOn', async (item) => {
-      try {
-        await workGraph.transitionState(item.id, WorkItemState.WaitingOn);
-      } catch (err: unknown) {
-        logger.error('Failed to mark item as waiting', err);
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to update item — ${message}`);
-      }
-    }),
+    vscode.commands.registerCommand(
+      'workcenter.acceptToFocus',
+      transitionCommand(workGraph, WorkItemState.InProgress, 'focus'),
+    ),
+    vscode.commands.registerCommand(
+      'workcenter.archiveItem',
+      transitionCommand(workGraph, WorkItemState.Archived, 'archive'),
+    ),
+    vscode.commands.registerCommand(
+      'workcenter.completeItem',
+      transitionCommand(workGraph, WorkItemState.Done, 'complete'),
+    ),
+    vscode.commands.registerCommand(
+      'workcenter.blockItem',
+      transitionCommand(workGraph, WorkItemState.Blocked, 'block'),
+    ),
+    vscode.commands.registerCommand(
+      'workcenter.unblockItem',
+      transitionCommand(workGraph, WorkItemState.InProgress, 'unblock'),
+    ),
+    vscode.commands.registerCommand(
+      'workcenter.markWaitingOn',
+      transitionCommand(workGraph, WorkItemState.WaitingOn, 'mark as waiting'),
+    ),
     vscode.commands.registerCommand('workcenter.editItem', (item) => {
       try {
         const workItem = workGraph.getItem(item.id);
@@ -83,9 +75,7 @@ export function registerCommands(
           WorkItemEditorPanel.open(context, workGraph, workItem);
         }
       } catch (err: unknown) {
-        logger.error('Failed to open item editor', err);
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to open editor — ${message}`);
+        handleCommandError('Failed to open editor', err);
       }
     }),
     vscode.commands.registerCommand('workcenter.openInBrowser', (item) => {
@@ -97,12 +87,11 @@ export function registerCommands(
           vscode.env.openExternal(vscode.Uri.parse(item.url));
         }
       } catch (err: unknown) {
-        logger.error('Failed to open item in browser', err);
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to open in browser — ${message}`);
+        handleCommandError('Failed to open in browser', err);
       }
     }),
     vscode.commands.registerCommand('workcenter.runAction', async (item) => {
+      // Outer: guards registry/UI lookup errors
       try {
         const workItem = workGraph.getItem(item.id);
         if (!workItem) {
@@ -121,20 +110,19 @@ export function registerCommands(
         if (selected) {
           const action = actionRegistry.getAction(selected.actionId);
           if (action) {
+            // Inner: guards action execution with action-specific error message
             try {
               logger.info(`Running action: ${selected.actionId} on item ${workItem.id}`);
               await action.run(workItem);
             } catch (err: unknown) {
               logger.error('Action failed: ' + selected.label, err);
-              const message = err instanceof Error ? err.message : String(err);
-              vscode.window.showErrorMessage(`WorkCenter: Action "${selected.label}" failed — ${message}`);
+              const detail = err instanceof Error ? err.message : String(err);
+              vscode.window.showErrorMessage(`WorkCenter: Action "${selected.label}" failed — ${detail}`);
             }
           }
         }
       } catch (err: unknown) {
-        logger.error('Failed to run action', err);
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to run action — ${message}`);
+        handleCommandError('Failed to run action', err);
       }
     }),
     vscode.commands.registerCommand('workcenter.moveUp', async (item) => {
@@ -145,9 +133,7 @@ export function registerCommands(
         }
         await workGraph.moveItem(item.id, 'up');
       } catch (err: unknown) {
-        logger.error('Failed to move item up', err);
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to move item — ${message}`);
+        handleCommandError('Failed to move item up', err);
       }
     }),
     vscode.commands.registerCommand('workcenter.moveDown', async (item) => {
@@ -158,30 +144,31 @@ export function registerCommands(
         }
         await workGraph.moveItem(item.id, 'down');
       } catch (err: unknown) {
-        logger.error('Failed to move item down', err);
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to move item — ${message}`);
+        handleCommandError('Failed to move item down', err);
       }
     }),
     vscode.commands.registerCommand('workcenter.acceptFromInbox', async (item: InboxItem) => {
+      logger.info(`Accepting inbox item: ${item.externalId} from ${item.providerId}`);
+      const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
+      if (existing) {
+        vscode.window.showInformationMessage(
+          `WorkCenter: Item already accepted as "${existing.title}"`
+        );
+        return;
+      }
       try {
-        logger.info(`Accepting inbox item: ${item.externalId} from ${item.providerId}`);
-        const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
-        if (existing) {
-          vscode.window.showInformationMessage(
-            `WorkCenter: Item already accepted as "${existing.title}"`
-          );
-          return;
-        }
         await workGraph.createItem(
           { title: formatItemTitle(item) },
           { providerId: item.providerId, externalId: item.externalId, url: item.url },
         );
+      } catch (err: unknown) {
+        handleCommandError('Failed to accept inbox item', err);
+        return;
+      }
+      try {
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {
-        logger.error('Failed to accept inbox item', err);
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to accept item — ${message}`);
+        handleCommandError('Failed to update state after accepting item', err);
       }
     }),
     vscode.commands.registerCommand('workcenter.dismissFromInbox', async (item: InboxItem) => {
@@ -189,31 +176,36 @@ export function registerCommands(
         logger.info(`Dismissing inbox item: ${item.externalId}`);
         await stateStore.setState(item.providerId, item.externalId, 'dismissed');
       } catch (err: unknown) {
-        logger.error('Failed to dismiss inbox item', err);
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to dismiss item — ${message}`);
+        handleCommandError('Failed to dismiss item', err);
       }
     }),
     vscode.commands.registerCommand('workcenter.acceptFromSources', async (item: SourceItemNode) => {
-      try {
-        logger.info(`Accepting sources item: ${item.externalId}`);
-        const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
-        if (existing) {
+      logger.info(`Accepting sources item: ${item.externalId}`);
+      const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
+      if (existing) {
+        try {
           await stateStore.setState(item.providerId, item.externalId, 'accepted');
-          vscode.window.showInformationMessage(
-            `WorkCenter: Item already accepted as "${existing.title}"`
-          );
-          return;
+        } catch (err: unknown) {
+          handleCommandError('Failed to update state for existing item', err);
         }
+        vscode.window.showInformationMessage(
+          `WorkCenter: Item already accepted as "${existing.title}"`
+        );
+        return;
+      }
+      try {
         await workGraph.createItem(
           { title: formatItemTitle(item) },
           { providerId: item.providerId, externalId: item.externalId, url: item.url },
         );
+      } catch (err: unknown) {
+        handleCommandError('Failed to accept sources item', err);
+        return;
+      }
+      try {
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {
-        logger.error('Failed to accept sources item', err);
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to accept item — ${message}`);
+        handleCommandError('Failed to update state after accepting item', err);
       }
     }),
   );
@@ -234,8 +226,6 @@ async function createItem(workGraph: WorkGraph): Promise<void> {
     await workGraph.createItem({ title: title.trim() });
     vscode.window.showInformationMessage(`WorkCenter: Created "${title.trim()}"`);
   } catch (err: unknown) {
-    logger.error('Failed to create work item', err);
-    const message = err instanceof Error ? err.message : String(err);
-    vscode.window.showErrorMessage(`WorkCenter: Failed to create item — ${message}`);
+    handleCommandError('Failed to create item', err);
   }
 }

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -21,99 +21,74 @@ function handleCommandError(context: string, err: unknown): void {
   vscode.window.showErrorMessage(`WorkCenter: ${context} — ${detail}`);
 }
 
+/** Wrap a command handler so unhandled errors are logged and shown to the user. */
+function wrapCommand<T extends unknown[]>(label: string, fn: (...args: T) => Promise<void> | void): (...args: T) => Promise<void> {
+  return async (...args: T) => {
+    try {
+      await fn(...args);
+    } catch (err: unknown) {
+      handleCommandError(label, err);
+    }
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Individual command handlers
 // ---------------------------------------------------------------------------
 
 async function handleCreateItem(workGraph: WorkGraph): Promise<void> {
-  try {
-    const title = await vscode.window.showInputBox({
-      prompt: 'Work item title',
-      placeHolder: 'e.g. Fix login redirect bug',
-      validateInput: (value) => (value.trim() ? undefined : 'Title is required'),
-    });
-    if (!title) {
-      return;
-    }
-
-    logger.info(`Creating new work item: ${title.trim()}`);
-    await workGraph.createItem({ title: title.trim() });
-    void vscode.window.showInformationMessage(`WorkCenter: Created "${title.trim()}"`);
-  } catch (err: unknown) {
-    handleCommandError('Failed to create item', err);
+  const title = await vscode.window.showInputBox({
+    prompt: 'Work item title',
+    placeHolder: 'e.g. Fix login redirect bug',
+    validateInput: (value) => (value.trim() ? undefined : 'Title is required'),
+  });
+  if (!title) {
+    return;
   }
+
+  logger.info(`Creating new work item: ${title.trim()}`);
+  await workGraph.createItem({ title: title.trim() });
+  void vscode.window.showInformationMessage(`WorkCenter: Created "${title.trim()}"`);
 }
 
 async function handleAcceptToFocus(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
   if (!item?.id) { return; }
-  try {
-    await workGraph.transitionState(item.id, WorkItemState.InProgress);
-  } catch (err: unknown) {
-    handleCommandError('Failed to focus item', err);
-  }
+  await workGraph.transitionState(item.id, WorkItemState.InProgress);
 }
 
 async function handleArchiveItem(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
   if (!item?.id) { return; }
-  try {
-    await workGraph.transitionState(item.id, WorkItemState.Archived);
-  } catch (err: unknown) {
-    handleCommandError('Failed to archive item', err);
-  }
+  await workGraph.transitionState(item.id, WorkItemState.Archived);
 }
 
 async function handleCompleteItem(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
   if (!item?.id) { return; }
-  try {
-    await workGraph.transitionState(item.id, WorkItemState.Done);
-  } catch (err: unknown) {
-    handleCommandError('Failed to complete item', err);
-  }
+  await workGraph.transitionState(item.id, WorkItemState.Done);
 }
 
 async function handlePauseItem(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
   if (!item?.id) { return; }
-  try {
-    await workGraph.transitionState(item.id, WorkItemState.Paused);
-  } catch (err: unknown) {
-    handleCommandError('Failed to pause item', err);
-  }
+  await workGraph.transitionState(item.id, WorkItemState.Paused);
 }
 
 async function handleResumeItem(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
   if (!item?.id) { return; }
-  try {
-    await workGraph.transitionState(item.id, WorkItemState.InProgress);
-  } catch (err: unknown) {
-    handleCommandError('Failed to resume item', err);
-  }
+  await workGraph.transitionState(item.id, WorkItemState.InProgress);
 }
 
 async function handleBlockItem(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
   if (!item?.id) { return; }
-  try {
-    await workGraph.transitionState(item.id, WorkItemState.Blocked);
-  } catch (err: unknown) {
-    handleCommandError('Failed to block item', err);
-  }
+  await workGraph.transitionState(item.id, WorkItemState.Blocked);
 }
 
 async function handleUnblockItem(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
   if (!item?.id) { return; }
-  try {
-    await workGraph.transitionState(item.id, WorkItemState.InProgress);
-  } catch (err: unknown) {
-    handleCommandError('Failed to unblock item', err);
-  }
+  await workGraph.transitionState(item.id, WorkItemState.InProgress);
 }
 
 async function handleMarkWaitingOn(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
   if (!item?.id) { return; }
-  try {
-    await workGraph.transitionState(item.id, WorkItemState.WaitingOn);
-  } catch (err: unknown) {
-    handleCommandError('Failed to mark item as waiting', err);
-  }
+  await workGraph.transitionState(item.id, WorkItemState.WaitingOn);
 }
 
 function handleEditItem(
@@ -122,13 +97,9 @@ function handleEditItem(
   item?: { id?: string },
 ): void {
   if (!item?.id) { return; }
-  try {
-    const workItem = workGraph.getItem(item.id);
-    if (workItem) {
-      WorkItemEditorPanel.open(context, workGraph, workItem);
-    }
-  } catch (err: unknown) {
-    handleCommandError('Failed to open editor', err);
+  const workItem = workGraph.getItem(item.id);
+  if (workItem) {
+    WorkItemEditorPanel.open(context, workGraph, workItem);
   }
 }
 
@@ -137,24 +108,20 @@ async function handleOpenInBrowser(workGraph: WorkGraph, item?: { id?: string; u
     vscode.window.showWarningMessage('WorkCenter: Select an item to open in the browser.');
     return;
   }
-  try {
-    const workItem = workGraph.getItem(item.id);
-    const url = workItem?.url ?? item.url;
-    if (!url) {
-      vscode.window.showWarningMessage('This item has no URL to open.');
-      return;
-    }
-    const uri = vscode.Uri.parse(url);
-    if (uri.scheme !== 'http' && uri.scheme !== 'https') {
-      vscode.window.showWarningMessage(`Cannot open non-web URL: ${url}`);
-      return;
-    }
-    const opened = await vscode.env.openExternal(uri);
-    if (!opened) {
-      vscode.window.showWarningMessage('Failed to open URL in the browser.');
-    }
-  } catch (err: unknown) {
-    handleCommandError('Failed to open in browser', err);
+  const workItem = workGraph.getItem(item.id);
+  const url = workItem?.url ?? item.url;
+  if (!url) {
+    vscode.window.showWarningMessage('This item has no URL to open.');
+    return;
+  }
+  const uri = vscode.Uri.parse(url);
+  if (uri.scheme !== 'http' && uri.scheme !== 'https') {
+    vscode.window.showWarningMessage(`Cannot open non-web URL: ${url}`);
+    return;
+  }
+  const opened = await vscode.env.openExternal(uri);
+  if (!opened) {
+    vscode.window.showWarningMessage('Failed to open URL in the browser.');
   }
 }
 
@@ -164,61 +131,49 @@ async function handleRunAction(
   item?: { id?: string },
 ): Promise<void> {
   if (!item?.id) { return; }
-  try {
-    const workItem = workGraph.getItem(item.id);
-    if (!workItem) {
-      return;
-    }
-    const actions = actionRegistry.getActionsFor(workItem);
-    if (actions.length === 0) {
-      logger.warn(`No actions available for item ${workItem.id}`);
-      void vscode.window.showInformationMessage('No actions available for this item.');
-      return;
-    }
-    const picks = actions.map((a) => ({ label: a.label, actionId: a.id }));
-    const selected = await vscode.window.showQuickPick(picks, {
-      placeHolder: 'Select an action',
-    });
-    if (selected) {
-      const action = actionRegistry.getAction(selected.actionId);
-      if (action) {
-        try {
-          logger.info(`Running action: ${selected.actionId} on item ${workItem.id}`);
-          await action.run(workItem);
-        } catch (err: unknown) {
-          logger.error('Action failed: ' + selected.label, err);
-          const detail = err instanceof Error ? err.message : String(err);
-          void vscode.window.showErrorMessage(`WorkCenter: Action "${selected.label}" failed — ${detail}`);
-        }
+  const workItem = workGraph.getItem(item.id);
+  if (!workItem) {
+    return;
+  }
+  const actions = actionRegistry.getActionsFor(workItem);
+  if (actions.length === 0) {
+    logger.warn(`No actions available for item ${workItem.id}`);
+    void vscode.window.showInformationMessage('No actions available for this item.');
+    return;
+  }
+  const picks = actions.map((a) => ({ label: a.label, actionId: a.id }));
+  const selected = await vscode.window.showQuickPick(picks, {
+    placeHolder: 'Select an action',
+  });
+  if (selected) {
+    const action = actionRegistry.getAction(selected.actionId);
+    if (action) {
+      try {
+        logger.info(`Running action: ${selected.actionId} on item ${workItem.id}`);
+        await action.run(workItem);
+      } catch (err: unknown) {
+        logger.error('Action failed: ' + selected.label, err);
+        const detail = err instanceof Error ? err.message : String(err);
+        void vscode.window.showErrorMessage(`WorkCenter: Action "${selected.label}" failed — ${detail}`);
       }
     }
-  } catch (err: unknown) {
-    handleCommandError('Failed to run action', err);
   }
 }
 
 async function handleMoveUp(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
-  try {
-    if (!item?.id) {
-      void vscode.window.showInformationMessage('WorkCenter: Select an item in the Queue to move.');
-      return;
-    }
-    await workGraph.moveItem(item.id, 'up');
-  } catch (err: unknown) {
-    handleCommandError('Failed to move item up', err);
+  if (!item?.id) {
+    void vscode.window.showInformationMessage('WorkCenter: Select an item in the Queue to move.');
+    return;
   }
+  await workGraph.moveItem(item.id, 'up');
 }
 
 async function handleMoveDown(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
-  try {
-    if (!item?.id) {
-      void vscode.window.showInformationMessage('WorkCenter: Select an item in the Queue to move.');
-      return;
-    }
-    await workGraph.moveItem(item.id, 'down');
-  } catch (err: unknown) {
-    handleCommandError('Failed to move item down', err);
+  if (!item?.id) {
+    void vscode.window.showInformationMessage('WorkCenter: Select an item in the Queue to move.');
+    return;
   }
+  await workGraph.moveItem(item.id, 'down');
 }
 
 async function handleAcceptFromInbox(
@@ -245,14 +200,9 @@ async function handleAcceptFromInbox(
       { title: formatItemTitle(item) },
       { providerId: item.providerId, externalId: item.externalId, url: item.url },
     );
-  } catch (err: unknown) {
-    handleCommandError('Failed to accept inbox item', err);
-    return;
-  }
-  try {
     await stateStore.setState(item.providerId, item.externalId, 'accepted');
   } catch (err: unknown) {
-    handleCommandError('Failed to update state after accepting item', err);
+    handleCommandError('Failed to accept inbox item', err);
   }
 }
 
@@ -315,39 +265,39 @@ export function registerCommands(
   stateStore: DiscoveredStateStore,
 ): void {
   context.subscriptions.push(
-    vscode.commands.registerCommand('workcenter.createItem', () =>
-      handleCreateItem(workGraph)),
-    vscode.commands.registerCommand('workcenter.acceptToFocus', (item) =>
-      handleAcceptToFocus(workGraph, item)),
-    vscode.commands.registerCommand('workcenter.archiveItem', (item) =>
-      handleArchiveItem(workGraph, item)),
-    vscode.commands.registerCommand('workcenter.completeItem', (item) =>
-      handleCompleteItem(workGraph, item)),
-    vscode.commands.registerCommand('workcenter.pauseItem', (item) =>
-      handlePauseItem(workGraph, item)),
-    vscode.commands.registerCommand('workcenter.resumeItem', (item) =>
-      handleResumeItem(workGraph, item)),
-    vscode.commands.registerCommand('workcenter.blockItem', (item) =>
-      handleBlockItem(workGraph, item)),
-    vscode.commands.registerCommand('workcenter.unblockItem', (item) =>
-      handleUnblockItem(workGraph, item)),
-    vscode.commands.registerCommand('workcenter.markWaitingOn', (item) =>
-      handleMarkWaitingOn(workGraph, item)),
-    vscode.commands.registerCommand('workcenter.editItem', (item) =>
-      handleEditItem(context, workGraph, item)),
-    vscode.commands.registerCommand('workcenter.openInBrowser', (item) =>
-      handleOpenInBrowser(workGraph, item)),
-    vscode.commands.registerCommand('workcenter.runAction', (item) =>
-      handleRunAction(workGraph, actionRegistry, item)),
-    vscode.commands.registerCommand('workcenter.moveUp', (item) =>
-      handleMoveUp(workGraph, item)),
-    vscode.commands.registerCommand('workcenter.moveDown', (item) =>
-      handleMoveDown(workGraph, item)),
-    vscode.commands.registerCommand('workcenter.acceptFromInbox', (item: InboxItem) =>
-      handleAcceptFromInbox(workGraph, stateStore, item)),
-    vscode.commands.registerCommand('workcenter.dismissFromInbox', (item: InboxItem) =>
-      handleDismissFromInbox(stateStore, item)),
-    vscode.commands.registerCommand('workcenter.acceptFromSources', (item: SourceItemNode) =>
-      handleAcceptFromSources(workGraph, stateStore, item)),
+    vscode.commands.registerCommand('workcenter.createItem',
+      wrapCommand('Failed to create item', () => handleCreateItem(workGraph))),
+    vscode.commands.registerCommand('workcenter.acceptToFocus',
+      wrapCommand('Failed to focus item', (item) => handleAcceptToFocus(workGraph, item))),
+    vscode.commands.registerCommand('workcenter.archiveItem',
+      wrapCommand('Failed to archive item', (item) => handleArchiveItem(workGraph, item))),
+    vscode.commands.registerCommand('workcenter.completeItem',
+      wrapCommand('Failed to complete item', (item) => handleCompleteItem(workGraph, item))),
+    vscode.commands.registerCommand('workcenter.pauseItem',
+      wrapCommand('Failed to pause item', (item) => handlePauseItem(workGraph, item))),
+    vscode.commands.registerCommand('workcenter.resumeItem',
+      wrapCommand('Failed to resume item', (item) => handleResumeItem(workGraph, item))),
+    vscode.commands.registerCommand('workcenter.blockItem',
+      wrapCommand('Failed to block item', (item) => handleBlockItem(workGraph, item))),
+    vscode.commands.registerCommand('workcenter.unblockItem',
+      wrapCommand('Failed to unblock item', (item) => handleUnblockItem(workGraph, item))),
+    vscode.commands.registerCommand('workcenter.markWaitingOn',
+      wrapCommand('Failed to mark item as waiting', (item) => handleMarkWaitingOn(workGraph, item))),
+    vscode.commands.registerCommand('workcenter.editItem',
+      wrapCommand('Failed to open editor', (item) => handleEditItem(context, workGraph, item))),
+    vscode.commands.registerCommand('workcenter.openInBrowser',
+      wrapCommand('Failed to open in browser', (item) => handleOpenInBrowser(workGraph, item))),
+    vscode.commands.registerCommand('workcenter.runAction',
+      wrapCommand('Failed to run action', (item) => handleRunAction(workGraph, actionRegistry, item))),
+    vscode.commands.registerCommand('workcenter.moveUp',
+      wrapCommand('Failed to move item up', (item) => handleMoveUp(workGraph, item))),
+    vscode.commands.registerCommand('workcenter.moveDown',
+      wrapCommand('Failed to move item down', (item) => handleMoveDown(workGraph, item))),
+    vscode.commands.registerCommand('workcenter.acceptFromInbox',
+      wrapCommand('Failed to accept from inbox', (item: InboxItem) => handleAcceptFromInbox(workGraph, stateStore, item))),
+    vscode.commands.registerCommand('workcenter.dismissFromInbox',
+      wrapCommand('Failed to dismiss from inbox', (item: InboxItem) => handleDismissFromInbox(stateStore, item))),
+    vscode.commands.registerCommand('workcenter.acceptFromSources',
+      wrapCommand('Failed to accept from sources', (item: SourceItemNode) => handleAcceptFromSources(workGraph, stateStore, item))),
   );
 }

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -86,7 +86,7 @@ export function registerCommands(
         handleCommandError('Failed to open editor', err);
       }
     }),
-    vscode.commands.registerCommand('workcenter.openInBrowser', (item) => {
+    vscode.commands.registerCommand('workcenter.openInBrowser', async (item) => {
       if (!item?.id && !item?.url) {
         vscode.window.showInformationMessage('WorkCenter: Select a work item first.');
         return;
@@ -94,9 +94,9 @@ export function registerCommands(
       try {
         const workItem = item?.id ? workGraph.getItem(item.id) : undefined;
         if (workItem?.url) {
-          vscode.env.openExternal(vscode.Uri.parse(workItem.url));
+          await vscode.env.openExternal(vscode.Uri.parse(workItem.url));
         } else if (item.url) {
-          vscode.env.openExternal(vscode.Uri.parse(item.url));
+          await vscode.env.openExternal(vscode.Uri.parse(item.url));
         }
       } catch (err: unknown) {
         handleCommandError('Failed to open in browser', err);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -25,8 +25,8 @@ function handleCommandError(context: string, err: unknown): void {
 function transitionCommand(
   workGraph: WorkGraph,
   targetState: WorkItemState,
-  verb: string,
-): (item: { id: string }) => Promise<void> {
+  failureContext: string,
+): (item?: { id?: string }) => Promise<void> {
   return async (item) => {
     if (!item?.id) {
       vscode.window.showInformationMessage('WorkCenter: Select a work item first.');
@@ -35,7 +35,7 @@ function transitionCommand(
     try {
       await workGraph.transitionState(item.id, targetState);
     } catch (err: unknown) {
-      handleCommandError(`Failed to ${verb} item`, err);
+      handleCommandError(failureContext, err);
     }
   };
 }
@@ -50,27 +50,27 @@ export function registerCommands(
     vscode.commands.registerCommand('workcenter.createItem', () => createItem(workGraph)),
     vscode.commands.registerCommand(
       'workcenter.acceptToFocus',
-      transitionCommand(workGraph, WorkItemState.InProgress, 'focus'),
+      transitionCommand(workGraph, WorkItemState.InProgress, 'Failed to focus item'),
     ),
     vscode.commands.registerCommand(
       'workcenter.archiveItem',
-      transitionCommand(workGraph, WorkItemState.Archived, 'archive'),
+      transitionCommand(workGraph, WorkItemState.Archived, 'Failed to archive item'),
     ),
     vscode.commands.registerCommand(
       'workcenter.completeItem',
-      transitionCommand(workGraph, WorkItemState.Done, 'complete'),
+      transitionCommand(workGraph, WorkItemState.Done, 'Failed to complete item'),
     ),
     vscode.commands.registerCommand(
       'workcenter.blockItem',
-      transitionCommand(workGraph, WorkItemState.Blocked, 'block'),
+      transitionCommand(workGraph, WorkItemState.Blocked, 'Failed to block item'),
     ),
     vscode.commands.registerCommand(
       'workcenter.unblockItem',
-      transitionCommand(workGraph, WorkItemState.InProgress, 'unblock'),
+      transitionCommand(workGraph, WorkItemState.InProgress, 'Failed to unblock item'),
     ),
     vscode.commands.registerCommand(
       'workcenter.markWaitingOn',
-      transitionCommand(workGraph, WorkItemState.WaitingOn, 'mark as waiting'),
+      transitionCommand(workGraph, WorkItemState.WaitingOn, 'Failed to mark item as waiting'),
     ),
     vscode.commands.registerCommand('workcenter.editItem', (item) => {
       if (!item?.id) {
@@ -177,7 +177,7 @@ export function registerCommands(
         try {
           await stateStore.setState(item.providerId, item.externalId, 'accepted');
         } catch (err: unknown) {
-          handleCommandError('Failed to update state after accepting item', err);
+          handleCommandError('Failed to update state for existing accepted item', err);
         }
         return;
       }

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -22,132 +22,196 @@ export function registerCommands(
 ): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('workcenter.createItem', () => createItem(workGraph)),
-    vscode.commands.registerCommand('workcenter.acceptToFocus', (item) =>
-      workGraph.transitionState(item.id, WorkItemState.InProgress),
-    ),
-    vscode.commands.registerCommand('workcenter.archiveItem', (item) =>
-      workGraph.transitionState(item.id, WorkItemState.Archived),
-    ),
-    vscode.commands.registerCommand('workcenter.completeItem', (item) =>
-      workGraph.transitionState(item.id, WorkItemState.Done),
-    ),
-    vscode.commands.registerCommand('workcenter.blockItem', (item) =>
-      workGraph.transitionState(item.id, WorkItemState.Blocked),
-    ),
-    vscode.commands.registerCommand('workcenter.unblockItem', (item) =>
-      workGraph.transitionState(item.id, WorkItemState.InProgress),
-    ),
-    vscode.commands.registerCommand('workcenter.markWaitingOn', (item) =>
-      workGraph.transitionState(item.id, WorkItemState.WaitingOn),
-    ),
+    vscode.commands.registerCommand('workcenter.acceptToFocus', async (item) => {
+      try {
+        await workGraph.transitionState(item.id, WorkItemState.InProgress);
+      } catch (err: unknown) {
+        logger.error('Failed to accept item to focus', err);
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`WorkCenter: Failed to update item — ${message}`);
+      }
+    }),
+    vscode.commands.registerCommand('workcenter.archiveItem', async (item) => {
+      try {
+        await workGraph.transitionState(item.id, WorkItemState.Archived);
+      } catch (err: unknown) {
+        logger.error('Failed to archive item', err);
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`WorkCenter: Failed to update item — ${message}`);
+      }
+    }),
+    vscode.commands.registerCommand('workcenter.completeItem', async (item) => {
+      try {
+        await workGraph.transitionState(item.id, WorkItemState.Done);
+      } catch (err: unknown) {
+        logger.error('Failed to complete item', err);
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`WorkCenter: Failed to update item — ${message}`);
+      }
+    }),
+    vscode.commands.registerCommand('workcenter.blockItem', async (item) => {
+      try {
+        await workGraph.transitionState(item.id, WorkItemState.Blocked);
+      } catch (err: unknown) {
+        logger.error('Failed to block item', err);
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`WorkCenter: Failed to update item — ${message}`);
+      }
+    }),
+    vscode.commands.registerCommand('workcenter.unblockItem', async (item) => {
+      try {
+        await workGraph.transitionState(item.id, WorkItemState.InProgress);
+      } catch (err: unknown) {
+        logger.error('Failed to unblock item', err);
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`WorkCenter: Failed to update item — ${message}`);
+      }
+    }),
+    vscode.commands.registerCommand('workcenter.markWaitingOn', async (item) => {
+      try {
+        await workGraph.transitionState(item.id, WorkItemState.WaitingOn);
+      } catch (err: unknown) {
+        logger.error('Failed to mark item as waiting', err);
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`WorkCenter: Failed to update item — ${message}`);
+      }
+    }),
     vscode.commands.registerCommand('workcenter.editItem', (item) => {
-      const workItem = workGraph.getItem(item.id);
-      if (workItem) {
-        WorkItemEditorPanel.open(context, workGraph, workItem);
+      try {
+        const workItem = workGraph.getItem(item.id);
+        if (workItem) {
+          WorkItemEditorPanel.open(context, workGraph, workItem);
+        }
+      } catch (err: unknown) {
+        logger.error('Failed to open item editor', err);
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`WorkCenter: Failed to open editor — ${message}`);
       }
     }),
     vscode.commands.registerCommand('workcenter.openInBrowser', (item) => {
-      const workItem = workGraph.getItem(item.id);
-      if (workItem?.url) {
-        vscode.env.openExternal(vscode.Uri.parse(workItem.url));
-      } else if (item.url) {
-        vscode.env.openExternal(vscode.Uri.parse(item.url));
+      try {
+        const workItem = workGraph.getItem(item.id);
+        if (workItem?.url) {
+          vscode.env.openExternal(vscode.Uri.parse(workItem.url));
+        } else if (item.url) {
+          vscode.env.openExternal(vscode.Uri.parse(item.url));
+        }
+      } catch (err: unknown) {
+        logger.error('Failed to open item in browser', err);
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`WorkCenter: Failed to open in browser — ${message}`);
       }
     }),
     vscode.commands.registerCommand('workcenter.runAction', async (item) => {
-      const workItem = workGraph.getItem(item.id);
-      if (!workItem) {
-        return;
-      }
-      const actions = actionRegistry.getActionsFor(workItem);
-      if (actions.length === 0) {
-        logger.warn(`No actions available for item ${workItem.id}`);
-        vscode.window.showInformationMessage('No actions available for this item.');
-        return;
-      }
-      const picks = actions.map((a) => ({ label: a.label, actionId: a.id }));
-      const selected = await vscode.window.showQuickPick(picks, {
-        placeHolder: 'Select an action',
-      });
-      if (selected) {
-        const action = actionRegistry.getAction(selected.actionId);
-        if (action) {
-          try {
-            logger.info(`Running action: ${selected.actionId} on item ${workItem.id}`);
-            await action.run(workItem);
-          } catch (err: unknown) {
-            logger.error('Action failed: ' + selected.label, err);
-            const message = err instanceof Error ? err.message : String(err);
-            vscode.window.showErrorMessage(`WorkCenter: Action "${selected.label}" failed — ${message}`);
+      try {
+        const workItem = workGraph.getItem(item.id);
+        if (!workItem) {
+          return;
+        }
+        const actions = actionRegistry.getActionsFor(workItem);
+        if (actions.length === 0) {
+          logger.warn(`No actions available for item ${workItem.id}`);
+          vscode.window.showInformationMessage('No actions available for this item.');
+          return;
+        }
+        const picks = actions.map((a) => ({ label: a.label, actionId: a.id }));
+        const selected = await vscode.window.showQuickPick(picks, {
+          placeHolder: 'Select an action',
+        });
+        if (selected) {
+          const action = actionRegistry.getAction(selected.actionId);
+          if (action) {
+            try {
+              logger.info(`Running action: ${selected.actionId} on item ${workItem.id}`);
+              await action.run(workItem);
+            } catch (err: unknown) {
+              logger.error('Action failed: ' + selected.label, err);
+              const message = err instanceof Error ? err.message : String(err);
+              vscode.window.showErrorMessage(`WorkCenter: Action "${selected.label}" failed — ${message}`);
+            }
           }
         }
+      } catch (err: unknown) {
+        logger.error('Failed to run action', err);
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`WorkCenter: Failed to run action — ${message}`);
       }
     }),
-    vscode.commands.registerCommand('workcenter.moveUp', (item) => {
-      if (!item?.id) {
-        vscode.window.showInformationMessage('WorkCenter: Select an item in the Queue to move.');
-        return;
+    vscode.commands.registerCommand('workcenter.moveUp', async (item) => {
+      try {
+        if (!item?.id) {
+          vscode.window.showInformationMessage('WorkCenter: Select an item in the Queue to move.');
+          return;
+        }
+        await workGraph.moveItem(item.id, 'up');
+      } catch (err: unknown) {
+        logger.error('Failed to move item up', err);
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`WorkCenter: Failed to move item — ${message}`);
       }
-      return workGraph.moveItem(item.id, 'up');
     }),
-    vscode.commands.registerCommand('workcenter.moveDown', (item) => {
-      if (!item?.id) {
-        vscode.window.showInformationMessage('WorkCenter: Select an item in the Queue to move.');
-        return;
+    vscode.commands.registerCommand('workcenter.moveDown', async (item) => {
+      try {
+        if (!item?.id) {
+          vscode.window.showInformationMessage('WorkCenter: Select an item in the Queue to move.');
+          return;
+        }
+        await workGraph.moveItem(item.id, 'down');
+      } catch (err: unknown) {
+        logger.error('Failed to move item down', err);
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`WorkCenter: Failed to move item — ${message}`);
       }
-      return workGraph.moveItem(item.id, 'down');
     }),
     vscode.commands.registerCommand('workcenter.acceptFromInbox', async (item: InboxItem) => {
-      logger.info(`Accepting inbox item: ${item.externalId} from ${item.providerId}`);
-      const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
-      if (existing) {
-        vscode.window.showInformationMessage(
-          `WorkCenter: Item already accepted as "${existing.title}"`
-        );
-        return;
-      }
-      await workGraph.createItem(
-        { title: formatItemTitle(item) },
-        { providerId: item.providerId, externalId: item.externalId, url: item.url },
-      );
       try {
-        await stateStore.setState(item.providerId, item.externalId, 'accepted');
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to update state — ${message}`);
-      }
-    }),
-    vscode.commands.registerCommand('workcenter.dismissFromInbox', async (item: InboxItem) => {
-      logger.info(`Dismissing inbox item: ${item.externalId}`);
-      try {
-        await stateStore.setState(item.providerId, item.externalId, 'dismissed');
-      } catch (err: unknown) {
-        const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to dismiss item — ${message}`);
-      }
-    }),
-    vscode.commands.registerCommand('workcenter.acceptFromSources', async (item: SourceItemNode) => {
-      logger.info(`Accepting sources item: ${item.externalId}`);
-      const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
-      if (existing) {
-        try {
-          await stateStore.setState(item.providerId, item.externalId, 'accepted');
-        } catch (err: unknown) {
-          const message = err instanceof Error ? err.message : String(err);
-          vscode.window.showErrorMessage(`WorkCenter: Failed to update state — ${message}`);
+        logger.info(`Accepting inbox item: ${item.externalId} from ${item.providerId}`);
+        const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
+        if (existing) {
+          vscode.window.showInformationMessage(
+            `WorkCenter: Item already accepted as "${existing.title}"`
+          );
+          return;
         }
-        vscode.window.showInformationMessage(
-          `WorkCenter: Item already accepted as "${existing.title}"`
-        );
-        return;
-      }
-      try {
         await workGraph.createItem(
           { title: formatItemTitle(item) },
           { providerId: item.providerId, externalId: item.externalId, url: item.url },
         );
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {
+        logger.error('Failed to accept inbox item', err);
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`WorkCenter: Failed to accept item — ${message}`);
+      }
+    }),
+    vscode.commands.registerCommand('workcenter.dismissFromInbox', async (item: InboxItem) => {
+      try {
+        logger.info(`Dismissing inbox item: ${item.externalId}`);
+        await stateStore.setState(item.providerId, item.externalId, 'dismissed');
+      } catch (err: unknown) {
+        logger.error('Failed to dismiss inbox item', err);
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`WorkCenter: Failed to dismiss item — ${message}`);
+      }
+    }),
+    vscode.commands.registerCommand('workcenter.acceptFromSources', async (item: SourceItemNode) => {
+      try {
+        logger.info(`Accepting sources item: ${item.externalId}`);
+        const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
+        if (existing) {
+          await stateStore.setState(item.providerId, item.externalId, 'accepted');
+          vscode.window.showInformationMessage(
+            `WorkCenter: Item already accepted as "${existing.title}"`
+          );
+          return;
+        }
+        await workGraph.createItem(
+          { title: formatItemTitle(item) },
+          { providerId: item.providerId, externalId: item.externalId, url: item.url },
+        );
+        await stateStore.setState(item.providerId, item.externalId, 'accepted');
+      } catch (err: unknown) {
+        logger.error('Failed to accept sources item', err);
         const message = err instanceof Error ? err.message : String(err);
         vscode.window.showErrorMessage(`WorkCenter: Failed to accept item — ${message}`);
       }
@@ -156,16 +220,22 @@ export function registerCommands(
 }
 
 async function createItem(workGraph: WorkGraph): Promise<void> {
-  const title = await vscode.window.showInputBox({
-    prompt: 'Work item title',
-    placeHolder: 'e.g. Fix login redirect bug',
-    validateInput: (value) => (value.trim() ? undefined : 'Title is required'),
-  });
-  if (!title) {
-    return;
-  }
+  try {
+    const title = await vscode.window.showInputBox({
+      prompt: 'Work item title',
+      placeHolder: 'e.g. Fix login redirect bug',
+      validateInput: (value) => (value.trim() ? undefined : 'Title is required'),
+    });
+    if (!title) {
+      return;
+    }
 
-  logger.info(`Creating new work item: ${title.trim()}`);
-  await workGraph.createItem({ title: title.trim() });
-  vscode.window.showInformationMessage(`WorkCenter: Created "${title.trim()}"`);
+    logger.info(`Creating new work item: ${title.trim()}`);
+    await workGraph.createItem({ title: title.trim() });
+    vscode.window.showInformationMessage(`WorkCenter: Created "${title.trim()}"`);
+  } catch (err: unknown) {
+    logger.error('Failed to create work item', err);
+    const message = err instanceof Error ? err.message : String(err);
+    vscode.window.showErrorMessage(`WorkCenter: Failed to create item — ${message}`);
+  }
 }

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -486,7 +486,7 @@ describe('registerCommands', () => {
       await invoke('workcenter.acceptFromInbox', makeInboxItem());
 
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-        'WorkCenter: Failed to update state after accepting item — disk full',
+        'WorkCenter: Failed to accept inbox item — disk full',
       );
     });
   });

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -594,6 +594,9 @@ describe('registerCommands', () => {
 
       await invoke('workcenter.acceptFromSources', makeSourceItem());
 
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'WorkCenter: Item already accepted as "Existing"',
+      );
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
         'WorkCenter: Failed to update state for existing item — write fail',
       );

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -475,7 +475,7 @@ describe('registerCommands', () => {
       );
     });
 
-    it('shows info message when item already accepted', async () => {
+    it('shows info message and sets state when item already accepted', async () => {
       const existing = createWorkItem({ title: 'Already There' });
       workGraph.findItemByProvenance.mockReturnValue(existing);
 
@@ -485,6 +485,34 @@ describe('registerCommands', () => {
       expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
         'WorkCenter: Item already accepted as "Already There"',
       );
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
+    });
+
+    it('shows error when setState fails for existing accepted item', async () => {
+      const existing = createWorkItem({ title: 'Already There' });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+      stateStore.setState.mockRejectedValue(new Error('write fail'));
+
+      await invoke('workcenter.acceptFromInbox', makeInboxItem());
+
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'WorkCenter: Item already accepted as "Already There"',
+      );
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to update state for existing accepted item — write fail',
+      );
+    });
+
+    it('shows error when createItem fails', async () => {
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem.mockRejectedValue(new Error('store error'));
+
+      await invoke('workcenter.acceptFromInbox', makeInboxItem());
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to accept inbox item — store error',
+      );
+      expect(stateStore.setState).not.toHaveBeenCalled();
     });
 
     it('shows error when setState fails', async () => {

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -197,6 +197,14 @@ describe('registerCommands', () => {
         expect(workGraph.transitionState).toHaveBeenCalledWith('wc-42', expectedState);
       });
     }
+
+    it('shows error when transitionState throws', async () => {
+      workGraph.transitionState.mockRejectedValue(new Error('db crash'));
+      await invoke('workcenter.archiveItem', { id: 'wc-1' });
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to archive item — db crash',
+      );
+    });
   });
 
   // ── editItem ─────────────────────────────────────────────────────
@@ -486,7 +494,7 @@ describe('registerCommands', () => {
       await invoke('workcenter.acceptFromInbox', makeInboxItem());
 
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-        'WorkCenter: Failed to accept inbox item — disk full',
+        'WorkCenter: Failed to update state after accepting item — disk full',
       );
     });
   });


### PR DESCRIPTION
refactor: extract error-handling helpers, restore two-phase accept logic

- Extract handleCommandError() and transitionCommand() helpers to
  eliminate 13x duplicated catch blocks
- Restore two-phase error handling in acceptFromInbox so partial
  failures (createItem succeeds, setState fails) show accurate messages
- Restore original acceptFromSources behavior: 'already exists' path
  always shows info message even if setState fails
