### PR TITLE
build: add minified production builds with sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "scripts": {
     "build": "npm run build --workspaces",
+    "build:prod": "npm run build:prod --workspaces",
     "test": "npm run test --workspaces",
     "lint": "npm run lint --workspaces"
   }

--- a/packages/ado/package.json
+++ b/packages/ado/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "vscode:prepublish": "npm run build:prod",
     "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
-    "build:prod": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify",
+    "build:prod": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify --sourcemap",
     "watch": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap --watch",
     "lint": "eslint src",
     "test": "vitest run"

--- a/packages/ado/package.json
+++ b/packages/ado/package.json
@@ -44,8 +44,9 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "npm run build",
+    "vscode:prepublish": "npm run build:prod",
     "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
+    "build:prod": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify",
     "watch": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap --watch",
     "lint": "eslint src",
     "test": "vitest run"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -249,8 +249,9 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "npm run build",
+    "vscode:prepublish": "npm run build:prod",
     "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
+    "build:prod": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify",
     "watch": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap --watch",
     "lint": "eslint src",
     "test": "vitest run",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -251,7 +251,7 @@
   "scripts": {
     "vscode:prepublish": "npm run build:prod",
     "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
-    "build:prod": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify",
+    "build:prod": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify --sourcemap",
     "watch": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap --watch",
     "lint": "eslint src",
     "test": "vitest run",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "vscode:prepublish": "npm run build:prod",
     "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
-    "build:prod": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify",
+    "build:prod": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify --sourcemap",
     "watch": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap --watch",
     "lint": "eslint src",
     "test": "vitest run"

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -39,8 +39,9 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "npm run build",
+    "vscode:prepublish": "npm run build:prod",
     "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
+    "build:prod": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify",
     "watch": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap --watch",
     "lint": "eslint src",
     "test": "vitest run"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,6 +6,7 @@
   "types": "src/index.ts",
   "scripts": {
     "build": "echo No build needed",
+    "build:prod": "echo No build needed",
     "test": "echo No tests yet",
     "lint": "echo No lint needed"
   }


### PR DESCRIPTION
## Summary

Adds a `build:prod` script to all extension packages that enables esbuild `--minify` for production builds while keeping sourcemaps for debuggability. The `vscode:prepublish` hook is updated to use `build:prod` so published extensions are minified.

## Changes

- **Root `package.json`:** Add `build:prod` workspace script to run production builds across all packages
- **core, github, ado:** Add `build:prod` esbuild command with `--minify --sourcemap` flags
- **core, github, ado:** Update `vscode:prepublish` to use `build:prod` instead of `build`
- **shared:** Add no-op `build:prod` for workspace script compatibility

## Motivation

Development builds (`npm run build`) remain fast and unminified for easier debugging. Production builds (`npm run build:prod` / `vscode:prepublish`) now produce smaller bundles for published extensions while retaining sourcemaps so stack traces remain useful.
