### PR TITLE
lint: add no-floating-promises and prefer-const ESLint rules

### DIFF
--- a/packages/ado/eslint.config.mjs
+++ b/packages/ado/eslint.config.mjs
@@ -9,6 +9,7 @@ export default [
       parserOptions: {
         ecmaVersion: 2022,
         sourceType: 'module',
+        project: true,
       },
     },
     plugins: {
@@ -16,9 +17,11 @@ export default [
     },
     rules: {
       ...tseslint.configs.recommended.rules,
+      '@typescript-eslint/no-floating-promises': 'warn',
+      'prefer-const': 'warn',
     },
   },
   {
-    ignores: ['dist/**', 'node_modules/**'],
+    ignores: ['dist/**', 'node_modules/**', 'src/test/**'],
   },
 ];

--- a/packages/core/eslint.config.mjs
+++ b/packages/core/eslint.config.mjs
@@ -9,6 +9,7 @@ export default [
       parserOptions: {
         ecmaVersion: 2022,
         sourceType: 'module',
+        project: true,
       },
     },
     plugins: {
@@ -16,9 +17,11 @@ export default [
     },
     rules: {
       ...tseslint.configs.recommended.rules,
+      '@typescript-eslint/no-floating-promises': 'warn',
+      'prefer-const': 'warn',
     },
   },
   {
-    ignores: ['dist/**', 'node_modules/**'],
+    ignores: ['dist/**', 'node_modules/**', 'src/test/**'],
   },
 ];

--- a/packages/github/eslint.config.mjs
+++ b/packages/github/eslint.config.mjs
@@ -9,6 +9,7 @@ export default [
       parserOptions: {
         ecmaVersion: 2022,
         sourceType: 'module',
+        project: true,
       },
     },
     plugins: {
@@ -16,9 +17,11 @@ export default [
     },
     rules: {
       ...tseslint.configs.recommended.rules,
+      '@typescript-eslint/no-floating-promises': 'warn',
+      'prefer-const': 'warn',
     },
   },
   {
-    ignores: ['dist/**', 'node_modules/**'],
+    ignores: ['dist/**', 'node_modules/**', 'src/test/**'],
   },
 ];


### PR DESCRIPTION
- Add @typescript-eslint/no-floating-promises as warn (30 existing violations)
- Add prefer-const as warn (0 existing violations)
- Enable type-aware linting with project: true in parserOptions
- Exclude test files from lint (not covered by tsconfig project)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

