### PR TITLE
docs: add JSDoc to remaining public API exports [swarm]

### DIFF
--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -45,6 +45,15 @@ interface ConnectionData {
 // Azure DevOps REST API scope for authentication
 const ADO_AUTH_SCOPE = '499b84ac-1321-427f-aa17-267ca6975798/.default';
 
+/**
+ * WorkCenter provider that discovers Azure DevOps pull requests where the
+ * current user is listed as a reviewer.
+ *
+ * Uses the ADO Git Pull Requests API filtered by `reviewerId`. The user's
+ * ADO identity is resolved from the connection data endpoint and cached for
+ * subsequent refreshes. Sets {@link WorkCenterProvider.resurfaceDismissed}
+ * to `true` so dismissed reviews reappear if still active.
+ */
 export class AdoPrReviewProvider implements WorkCenterProvider {
   readonly id = 'ado-pr-reviews';
   readonly label = 'Azure DevOps PR Reviews';
@@ -58,11 +67,20 @@ export class AdoPrReviewProvider implements WorkCenterProvider {
   private _cachedUserId: string | undefined;
   private _cachedSessionAccountId: string | undefined;
 
+  /**
+   * @param org      - The Azure DevOps organisation name.
+   * @param projects - Project names to query. An empty array queries the whole org.
+   */
   constructor(
     private readonly org: string,
     private readonly projects: string[],
   ) {}
 
+  /**
+   * Starts a repeating timer that refreshes PR review requests in the background.
+   * The interval is clamped to a minimum of 60 seconds.
+   * @param intervalSeconds - Desired refresh interval in seconds (≤ 0 disables).
+   */
   startPeriodicRefresh(intervalSeconds: number): void {
     this.stopPeriodicRefresh();
     const interval = Number(intervalSeconds);
@@ -77,6 +95,7 @@ export class AdoPrReviewProvider implements WorkCenterProvider {
     }, clampedInterval * 1000);
   }
 
+  /** Stops the periodic background refresh timer, if running. */
   stopPeriodicRefresh(): void {
     if (this.refreshTimer) {
       clearInterval(this.refreshTimer);
@@ -84,6 +103,10 @@ export class AdoPrReviewProvider implements WorkCenterProvider {
     }
   }
 
+  /**
+   * Performs a user-triggered refresh of PR review requests.
+   * Prompts for authentication if no session exists.
+   */
   async refresh(): Promise<void> {
     if (this._isRefreshing) {
       return;
@@ -276,6 +299,7 @@ export class AdoPrReviewProvider implements WorkCenterProvider {
     return { items, failed: false };
   }
 
+  /** Cleans up the refresh timer and event emitter. */
   dispose(): void {
     this.stopPeriodicRefresh();
     this._onDidDiscoverItems.dispose();

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -49,6 +49,15 @@ interface AdoWorkItem {
 // Azure DevOps REST API scope for authentication
 const ADO_AUTH_SCOPE = '499b84ac-1321-427f-aa17-267ca6975798/.default';
 
+/**
+ * WorkCenter provider that discovers Azure DevOps work items assigned to the
+ * current user.
+ *
+ * Uses the ADO REST API with WIQL queries and Microsoft authentication.
+ * When projects are specified, only those projects are queried; otherwise
+ * the entire organisation is searched. Work items in `Closed` or `Removed`
+ * states are excluded.
+ */
 export class AdoWorkItemProvider implements WorkCenterProvider {
   readonly id = 'ado-work-items';
   readonly label = 'Azure DevOps Work Items';
@@ -59,11 +68,20 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
   private refreshTimer: ReturnType<typeof setInterval> | undefined;
   private _isRefreshing = false;
 
+  /**
+   * @param org      - The Azure DevOps organisation name.
+   * @param projects - Project names to query. An empty array queries the whole org.
+   */
   constructor(
     private readonly org: string,
     private readonly projects: string[],
   ) {}
 
+  /**
+   * Starts a repeating timer that refreshes work items in the background.
+   * The interval is clamped to a minimum of 60 seconds.
+   * @param intervalSeconds - Desired refresh interval in seconds (≤ 0 disables).
+   */
   startPeriodicRefresh(intervalSeconds: number): void {
     this.stopPeriodicRefresh();
     const interval = Number(intervalSeconds);
@@ -78,6 +96,7 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
     }, clampedInterval * 1000);
   }
 
+  /** Stops the periodic background refresh timer, if running. */
   stopPeriodicRefresh(): void {
     if (this.refreshTimer) {
       clearInterval(this.refreshTimer);
@@ -85,6 +104,10 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
     }
   }
 
+  /**
+   * Performs a user-triggered refresh of assigned ADO work items.
+   * Prompts for authentication if no session exists.
+   */
   async refresh(): Promise<void> {
     if (this._isRefreshing) {
       return;
@@ -260,6 +283,7 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
     return { items, failed: batchFailed };
   }
 
+  /** Cleans up the refresh timer and event emitter. */
   dispose(): void {
     this.stopPeriodicRefresh();
     this._onDidDiscoverItems.dispose();

--- a/packages/core/src/storage/discoveredStateStore.ts
+++ b/packages/core/src/storage/discoveredStateStore.ts
@@ -79,7 +79,7 @@ export class DiscoveredStateStore {
   }
 
   /**
-   * Sets the inbox state for multiple discovered items in a single atomic write.
+   * Sets the inbox state for multiple discovered items in a single serialized write.
    * @param items - Array of items with their new states.
    * @throws If the write to disk fails (cache is rolled back on error).
    */

--- a/packages/core/src/storage/discoveredStateStore.ts
+++ b/packages/core/src/storage/discoveredStateStore.ts
@@ -3,14 +3,24 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { logger } from '../services/logger';
 
+/** Possible states for a provider-discovered item in the inbox workflow. */
 export type InboxState = 'unseen' | 'accepted' | 'dismissed';
 
+/** Persisted mapping of a provider item to its inbox state. */
 export interface DiscoveredStateRecord {
   providerId: string;
   externalId: string;
   inboxState: InboxState;
 }
 
+/**
+ * Persists inbox-state records (`unseen | accepted | dismissed`) for
+ * provider-discovered items as a JSON file on disk.
+ *
+ * Only the state enum is stored — item data (title, description, url) is
+ * always read live from the provider. All writes are serialized through an
+ * internal queue to prevent concurrent file corruption.
+ */
 export class DiscoveredStateStore {
   private readonly filePath: string;
   private readonly cache = new Map<string, DiscoveredStateRecord>();
@@ -19,6 +29,9 @@ export class DiscoveredStateStore {
   private writeQueue: Promise<void> = Promise.resolve();
   private loaded = false;
 
+  /**
+   * @param storagePath - Directory where `discovered-state.json` will be stored.
+   */
   constructor(storagePath: string) {
     this.filePath = path.join(storagePath, 'discovered-state.json');
   }
@@ -27,10 +40,22 @@ export class DiscoveredStateStore {
     return `${providerId}::${externalId}`;
   }
 
+  /**
+   * Returns the current inbox state for a discovered item, or `undefined` if unknown.
+   * @param providerId - The provider that discovered the item.
+   * @param externalId - The provider-scoped item identifier.
+   */
   getState(providerId: string, externalId: string): InboxState | undefined {
     return this.cache.get(this.key(providerId, externalId))?.inboxState;
   }
 
+  /**
+   * Sets the inbox state for a single discovered item and persists to disk.
+   * @param providerId - The provider that discovered the item.
+   * @param externalId - The provider-scoped item identifier.
+   * @param state      - The new inbox state.
+   * @throws If the write to disk fails (cache is rolled back on error).
+   */
   async setState(providerId: string, externalId: string, state: InboxState): Promise<void> {
     logger.debug(`Setting state for ${providerId}/${externalId} to ${state}`);
     if (!this.loaded) {
@@ -53,6 +78,11 @@ export class DiscoveredStateStore {
     this._onDidChange.fire();
   }
 
+  /**
+   * Sets the inbox state for multiple discovered items in a single atomic write.
+   * @param items - Array of items with their new states.
+   * @throws If the write to disk fails (cache is rolled back on error).
+   */
   async setStates(items: Array<{ providerId: string; externalId: string; state: InboxState }>): Promise<void> {
     if (!this.loaded) {
       await this.load();
@@ -78,11 +108,19 @@ export class DiscoveredStateStore {
     this._onDidChange.fire();
   }
 
+  /**
+   * Returns all persisted state records, loading from disk on first call.
+   * @returns All discovered-state records.
+   */
   async loadAll(): Promise<DiscoveredStateRecord[]> {
     await this.load();
     return Array.from(this.cache.values());
   }
 
+  /**
+   * Loads state records from disk into the cache. No-ops if already loaded.
+   * @throws If the file exists but cannot be parsed.
+   */
   async load(): Promise<void> {
     if (this.loaded) {
       return;
@@ -119,6 +157,7 @@ export class DiscoveredStateStore {
     return this.writeQueue;
   }
 
+  /** Disposes the change event emitter. */
   dispose(): void {
     this._onDidChange.dispose();
   }

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -4,16 +4,32 @@ import { WorkItem } from '../models/workItem';
 import { ITaskStore } from './taskStore';
 import { logger } from '../services/logger';
 
+/**
+ * Persists {@link WorkItem} objects as a JSON array on disk.
+ *
+ * All write operations are serialized through an internal queue to prevent
+ * concurrent file corruption. An in-memory cache is populated on first load
+ * and kept in sync with every mutation.
+ */
 export class JsonTaskStore implements ITaskStore {
   private readonly filePath: string;
   private writeQueue: Promise<void> = Promise.resolve();
   private cache: Map<string, WorkItem> | null = null;
   private loadPromise: Promise<WorkItem[]> | null = null;
 
+  /**
+   * @param storagePath - Directory where `workitems.json` will be stored.
+   */
   constructor(storagePath: string) {
     this.filePath = path.join(storagePath, 'workitems.json');
   }
 
+  /**
+   * Returns all persisted work items, loading from disk on first call.
+   * Subsequent calls return the cached data.
+   * @returns All stored work items.
+   * @throws If the JSON file exists but cannot be parsed.
+   */
   async loadAll(): Promise<WorkItem[]> {
     if (this.cache !== null) {
       return Array.from(this.cache.values());
@@ -67,6 +83,11 @@ export class JsonTaskStore implements ITaskStore {
     }
   }
 
+  /**
+   * Persists a single work item, inserting or replacing by `id`.
+   * @param item - The work item to save.
+   * @throws If the write to disk fails (cache is rolled back on error).
+   */
   async save(item: WorkItem): Promise<void> {
     logger.debug(`Saving work item: ${item.id}`);
     if (this.cache === null) {
@@ -90,6 +111,11 @@ export class JsonTaskStore implements ITaskStore {
     });
   }
 
+  /**
+   * Persists multiple work items in a single atomic write.
+   * @param items - The work items to save (inserted or replaced by `id`).
+   * @throws If the write to disk fails (cache is rolled back on error).
+   */
   async saveAll(items: WorkItem[]): Promise<void> {
     return this.enqueue(async () => {
       if (this.cache === null) {
@@ -117,6 +143,11 @@ export class JsonTaskStore implements ITaskStore {
     });
   }
 
+  /**
+   * Removes a work item by its ID.
+   * @param id - The ID of the work item to delete.
+   * @throws If the write to disk fails (cache is rolled back on error).
+   */
   async delete(id: string): Promise<void> {
     if (this.cache === null) {
       await this.loadAll();

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -112,7 +112,7 @@ export class JsonTaskStore implements ITaskStore {
   }
 
   /**
-   * Persists multiple work items in a single atomic write.
+   * Persists multiple work items in a single serialized write.
    * @param items - The work items to save (inserted or replaced by `id`).
    * @throws If the write to disk fails (cache is rolled back on error).
    */

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -61,7 +61,7 @@ export class GitHubPrReviewProvider implements WorkCenterProvider {
   /**
    * Starts a repeating timer that refreshes PR review requests in the background.
    * The interval is clamped to a minimum of 60 seconds.
-   * @param intervalSeconds - Desired refresh interval in seconds (≤ 0 disables).
+   * @param intervalSeconds - Desired refresh interval in seconds; must be a finite number (≤ 0 disables).
    */
   startPeriodicRefresh(intervalSeconds: number): void {
     this.stopPeriodicRefresh();

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -65,7 +65,7 @@ export class GitHubPrReviewProvider implements WorkCenterProvider {
    */
   startPeriodicRefresh(intervalSeconds: number): void {
     this.stopPeriodicRefresh();
-    if (intervalSeconds <= 0) {
+    if (!Number.isFinite(intervalSeconds) || intervalSeconds <= 0) {
       return;
     }
     // Clamp to minimum of 60 seconds

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -39,6 +39,14 @@ interface GitHubSearchResponse {
   items: GitHubIssue[];
 }
 
+/**
+ * WorkCenter provider that discovers GitHub pull requests where the current
+ * user has been requested as a reviewer.
+ *
+ * Uses the GitHub Search API (`review-requested:@me`) to find open PRs.
+ * Sets {@link WorkCenterProvider.resurfaceDismissed} to `true` so that
+ * previously dismissed review requests reappear if still active.
+ */
 export class GitHubPrReviewProvider implements WorkCenterProvider {
   readonly id = 'github-pr-reviews';
   readonly label = 'GitHub PR Reviews';
@@ -50,6 +58,11 @@ export class GitHubPrReviewProvider implements WorkCenterProvider {
   private refreshTimer: ReturnType<typeof setInterval> | undefined;
   private _isRefreshing = false;
 
+  /**
+   * Starts a repeating timer that refreshes PR review requests in the background.
+   * The interval is clamped to a minimum of 60 seconds.
+   * @param intervalSeconds - Desired refresh interval in seconds (≤ 0 disables).
+   */
   startPeriodicRefresh(intervalSeconds: number): void {
     this.stopPeriodicRefresh();
     if (intervalSeconds <= 0) {
@@ -64,6 +77,7 @@ export class GitHubPrReviewProvider implements WorkCenterProvider {
     }, clampedInterval * 1000);
   }
 
+  /** Stops the periodic background refresh timer, if running. */
   stopPeriodicRefresh(): void {
     if (this.refreshTimer) {
       clearInterval(this.refreshTimer);
@@ -71,6 +85,10 @@ export class GitHubPrReviewProvider implements WorkCenterProvider {
     }
   }
 
+  /**
+   * Performs a user-triggered refresh of PR review requests.
+   * Prompts for authentication if no session exists.
+   */
   async refresh(): Promise<void> {
     if (this._isRefreshing) {
       return;
@@ -173,6 +191,7 @@ export class GitHubPrReviewProvider implements WorkCenterProvider {
     return pr.repository_url;
   }
 
+  /** Cleans up the refresh timer and event emitter. */
   dispose(): void {
     this.stopPeriodicRefresh();
     this._onDidDiscoverItems.dispose();

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -35,6 +35,16 @@ interface GitHubIssue {
   pull_request?: unknown;
 }
 
+/**
+ * WorkCenter provider that discovers GitHub issues assigned to the current user.
+ *
+ * Issues are fetched via the GitHub REST API using VS Code's built-in GitHub
+ * authentication. When configured repos are specified, only those repos are
+ * queried; otherwise all assigned issues across GitHub are returned.
+ *
+ * Supports periodic background refresh and emits discovered items through
+ * the {@link WorkCenterProvider.onDidDiscoverItems} event.
+ */
 export class GitHubIssueProvider implements WorkCenterProvider {
   readonly id = 'github';
   readonly label = 'GitHub Issues';
@@ -45,6 +55,12 @@ export class GitHubIssueProvider implements WorkCenterProvider {
   private refreshTimer: ReturnType<typeof setInterval> | undefined;
   private _isRefreshing = false;
 
+  /**
+   * Starts a repeating timer that refreshes issues in the background.
+   * The interval is clamped to a minimum of 60 seconds. A value of 0 or
+   * negative disables periodic refresh.
+   * @param intervalSeconds - Desired refresh interval in seconds.
+   */
   startPeriodicRefresh(intervalSeconds: number): void {
     this.stopPeriodicRefresh();
     if (intervalSeconds <= 0) {
@@ -60,6 +76,7 @@ export class GitHubIssueProvider implements WorkCenterProvider {
     }, clampedInterval * 1000);
   }
 
+  /** Stops the periodic background refresh timer, if running. */
   stopPeriodicRefresh(): void {
     if (this.refreshTimer) {
       clearInterval(this.refreshTimer);
@@ -67,6 +84,10 @@ export class GitHubIssueProvider implements WorkCenterProvider {
     }
   }
 
+  /**
+   * Performs a user-triggered refresh of assigned GitHub issues.
+   * Prompts for authentication if no session exists.
+   */
   async refresh(): Promise<void> {
     logger.info('Fetching assigned issues...');
     try {
@@ -242,6 +263,7 @@ export class GitHubIssueProvider implements WorkCenterProvider {
     return { issues, failed: false };
   }
 
+  /** Cleans up the refresh timer and event emitter. */
   dispose(): void {
     this.stopPeriodicRefresh();
     this._onDidDiscoverItems.dispose();

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -63,8 +63,7 @@ export class GitHubIssueProvider implements WorkCenterProvider {
    */
   startPeriodicRefresh(intervalSeconds: number): void {
     this.stopPeriodicRefresh();
-    if (intervalSeconds <= 0) {
-      // Disable periodic refresh if interval is 0 or negative
+    if (!Number.isFinite(intervalSeconds) || intervalSeconds <= 0) {
       return;
     }
     // Clamp to minimum of 60 seconds

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -59,7 +59,7 @@ export class GitHubIssueProvider implements WorkCenterProvider {
    * Starts a repeating timer that refreshes issues in the background.
    * The interval is clamped to a minimum of 60 seconds. A value of 0 or
    * negative disables periodic refresh.
-   * @param intervalSeconds - Desired refresh interval in seconds.
+   * @param intervalSeconds - Desired refresh interval in seconds (must be a finite number).
    */
   startPeriodicRefresh(intervalSeconds: number): void {
     this.stopPeriodicRefresh();

--- a/packages/github/src/startWorkAction.ts
+++ b/packages/github/src/startWorkAction.ts
@@ -28,14 +28,34 @@ interface WorkCenterAction {
   run(item: WorkItem): Promise<void>;
 }
 
+/**
+ * WorkCenter action that bootstraps a development environment for a GitHub issue.
+ *
+ * When executed on a work item originating from the GitHub provider, it:
+ * 1. Creates a feature branch from `origin/dev` (falling back to `origin/main` or `HEAD`).
+ * 2. Creates a git worktree at a sibling directory of the repository.
+ * 3. Opens the worktree in a new VS Code window.
+ *
+ * Only available for items in the `New` state from the `github` provider.
+ */
 export class StartWorkAction implements WorkCenterAction {
   readonly id = 'github.startWork';
   readonly label = 'Start Work (Branch + Worktree)';
 
+  /**
+   * Returns `true` when the item is a new GitHub issue that can be started.
+   * @param item - The work item to evaluate.
+   * @returns Whether the action is applicable.
+   */
   canRun(item: WorkItem): boolean {
     return item.providerId === 'github' && item.state === 'New';
   }
 
+  /**
+   * Creates a branch and worktree for the given work item, then opens it in a new window.
+   * @param item - The work item to start working on.
+   * @throws Displays a VS Code error message on failure (does not throw to caller).
+   */
   async run(item: WorkItem): Promise<void> {
     const issueNumber = this.extractIssueNumber(item.externalId);
     if (!issueNumber) {

--- a/packages/github/src/startWorkAction.ts
+++ b/packages/github/src/startWorkAction.ts
@@ -53,8 +53,8 @@ export class StartWorkAction implements WorkCenterAction {
 
   /**
    * Creates a branch and worktree for the given work item, then opens it in a new window.
+   * Errors are reported via VS Code notification messages rather than thrown.
    * @param item - The work item to start working on.
-   * @throws Displays a VS Code error message on failure (does not throw to caller).
    */
   async run(item: WorkItem): Promise<void> {
     const issueNumber = this.extractIssueNumber(item.externalId);

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -242,6 +242,22 @@ describe('GitHubPrReviewProvider', () => {
     vi.useRealTimers();
   });
 
+  it('startPeriodicRefresh does not schedule a timer for NaN or Infinity', () => {
+    vi.useFakeTimers();
+
+    const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
+
+    provider.startPeriodicRefresh(NaN);
+    vi.advanceTimersByTime(120_000);
+    expect(refreshSpy).not.toHaveBeenCalled();
+
+    provider.startPeriodicRefresh(Infinity);
+    vi.advanceTimersByTime(120_000);
+    expect(refreshSpy).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
   it('stopPeriodicRefresh clears the timer', () => {
     vi.useFakeTimers();
 

--- a/packages/github/src/test/githubProvider.test.ts
+++ b/packages/github/src/test/githubProvider.test.ts
@@ -211,6 +211,22 @@ describe('GitHubIssueProvider', () => {
     vi.useRealTimers();
   });
 
+  it('startPeriodicRefresh does not schedule a timer for NaN or Infinity', () => {
+    vi.useFakeTimers();
+
+    const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue();
+
+    provider.startPeriodicRefresh(NaN);
+    vi.advanceTimersByTime(120_000);
+    expect(refreshSpy).not.toHaveBeenCalled();
+
+    provider.startPeriodicRefresh(Infinity);
+    vi.advanceTimersByTime(120_000);
+    expect(refreshSpy).not.toHaveBeenCalled();
+
+    vi.useRealTimers();
+  });
+
   it('stopPeriodicRefresh clears the timer', () => {
     vi.useFakeTimers();
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,6 @@
-/** @module workcenter-shared — shared logging utilities used across all WorkCenter packages. */
+/**
+ * Shared logging utilities used across all WorkCenter packages.
+ * @module workcenter-shared
+ */
 export { createLoggerService, LogLevel, serializeArg } from './logger';
 export type { Logger, LogOutput, LoggerService } from './logger';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * Shared logging utilities used across all WorkCenter packages.
- * @module workcenter-shared
+ * @module @workcenter/shared
  */
 export { createLoggerService, LogLevel, serializeArg } from './logger';
 export type { Logger, LogOutput, LoggerService } from './logger';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
+/** @module workcenter-shared — shared logging utilities used across all WorkCenter packages. */
 export { createLoggerService, LogLevel, serializeArg } from './logger';
 export type { Logger, LogOutput, LoggerService } from './logger';

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -1,3 +1,7 @@
+/**
+ * Severity levels for log messages, ordered from least to most severe.
+ * Messages below the current threshold are suppressed.
+ */
 export enum LogLevel {
   Debug = 0,
   Info = 1,
@@ -5,10 +9,20 @@ export enum LogLevel {
   Error = 3,
 }
 
+/**
+ * Minimal output sink for log messages.
+ * Compatible with VS Code's `OutputChannel`.
+ */
 export interface LogOutput {
   appendLine(value: string): void;
 }
 
+/**
+ * Converts an arbitrary value to a human-readable string for log output.
+ * Errors are serialized with their stack trace; other values use JSON.
+ * @param arg - The value to serialize.
+ * @returns A string representation of the argument.
+ */
 export function serializeArg(arg: unknown): string {
   if (arg instanceof Error) {
     return arg.stack || `${arg.name}: ${arg.message}`;
@@ -21,19 +35,44 @@ export function serializeArg(arg: unknown): string {
   }
 }
 
+/**
+ * Structured logger with levelled convenience methods.
+ */
 export interface Logger {
+  /** Logs a debug-level message. Suppressed unless log level is {@link LogLevel.Debug}. */
   debug(msg: string, ...args: unknown[]): void;
+  /** Logs an informational message. */
   info(msg: string, ...args: unknown[]): void;
+  /** Logs a warning message. */
   warn(msg: string, ...args: unknown[]): void;
+  /** Logs an error message. */
   error(msg: string, ...args: unknown[]): void;
 }
 
+/**
+ * Manages a {@link Logger} instance and its output configuration.
+ */
 export interface LoggerService {
+  /** The logger instance used to emit messages. */
   logger: Logger;
+  /**
+   * Initialises the logger with an output sink and an optional starting level.
+   * @param output - The sink that receives formatted log lines.
+   * @param level  - Initial log level (defaults to {@link LogLevel.Info}).
+   */
   initLogger(output: LogOutput, level?: LogLevel): void;
+  /**
+   * Changes the minimum severity level at runtime.
+   * @param level - The new log level threshold.
+   */
   setLogLevel(level: LogLevel): void;
 }
 
+/**
+ * Creates a new {@link LoggerService} with its own output channel and log level.
+ * Call {@link LoggerService.initLogger} before emitting messages.
+ * @returns A fresh logger service instance.
+ */
 export function createLoggerService(): LoggerService {
   let outputChannel: LogOutput | undefined;
   let currentLevel: LogLevel = LogLevel.Info;

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -69,8 +69,8 @@ export interface LoggerService {
 }
 
 /**
- * Creates a new {@link LoggerService} with its own output channel and log level.
- * Call {@link LoggerService.initLogger} before emitting messages.
+ * Creates a new {@link LoggerService} that starts unconfigured.
+ * Call {@link LoggerService.initLogger} to attach an output sink before emitting messages.
  * @returns A fresh logger service instance.
  */
 export function createLoggerService(): LoggerService {

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -19,7 +19,9 @@ export interface LogOutput {
 
 /**
  * Converts an arbitrary value to a human-readable string for log output.
- * Errors are serialized with their stack trace; other values use JSON.
+ * Errors are serialized with their stack trace when available, otherwise `name: message`.
+ * Other values use `JSON.stringify` when possible and fall back to `String(arg)`
+ * if JSON serialization returns `undefined` or throws.
  * @param arg - The value to serialize.
  * @returns A string representation of the argument.
  */


### PR DESCRIPTION
Adds JSDoc comments to remaining public API exports across the monorepo.

Also includes a defensive fix: adds \Number.isFinite()\ guards to \startPeriodicRefresh()\ in the GitHub issue and PR review providers to prevent NaN/Infinity from creating a tight refresh loop.