### PR TITLE
docs: add JSDoc to core models and public API

### DIFF
--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -53,6 +53,7 @@ export interface DiscoveredItem {
  *
  * @example
  * ```ts
+ * const emitter = new vscode.EventEmitter<DiscoveredItem[]>();
  * const provider: WorkCenterProvider = {
  *   id: 'github',
  *   label: 'GitHub Issues',
@@ -131,7 +132,7 @@ export interface WorkCenterAction {
  * @example
  * ```ts
  * const ext = vscode.extensions.getExtension<WorkCenterApi>('mthalman.workcenter');
- * const api = ext?.exports;
+ * const api = await ext?.activate();
  * if (api) {
  *   api.registerProvider(myProvider);
  *   api.registerAction(myAction);

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -1,37 +1,160 @@
 import { WorkItem } from '../models/workItem';
 
+/**
+ * A resource that can be released to free underlying handles or subscriptions.
+ */
 export interface Disposable {
+  /** Release any resources held by this object. */
   dispose(): void;
 }
 
+/**
+ * A typed event that listeners can subscribe to.
+ *
+ * @typeParam T - The payload type delivered to each listener.
+ */
 export interface Event<T> {
+  /**
+   * Subscribe to this event.
+   *
+   * @param listener - Callback invoked each time the event fires.
+   * @returns A {@link Disposable} that removes the listener when disposed.
+   */
   (listener: (e: T) => void): Disposable;
 }
 
+/**
+ * An item discovered by a {@link WorkCenterProvider}.
+ *
+ * Discovered items are ephemeral references held in memory by the provider.
+ * Only the inbox state (`unseen` | `accepted` | `dismissed`) is persisted;
+ * the item's data is always read live from the provider.
+ */
 export interface DiscoveredItem {
+  /** Provider-scoped unique identifier (e.g. a GitHub issue number). */
   externalId: string;
+  /** Human-readable title displayed in the Inbox and Sources views. */
   title: string;
+  /** Optional longer description of the item. */
   description?: string;
+  /** URL linking to the external resource. */
   url?: string;
+  /** Optional grouping label used to organize items in the Sources tree view. */
   group?: string;
 }
 
+/**
+ * A provider that discovers work items from an external source.
+ *
+ * Providers are registered via {@link WorkCenterApi.registerProvider} and emit
+ * {@link DiscoveredItem} arrays when new items are found. The core extension
+ * tracks inbox state for each discovered item.
+ *
+ * @example
+ * ```ts
+ * const provider: WorkCenterProvider = {
+ *   id: 'github',
+ *   label: 'GitHub Issues',
+ *   onDidDiscoverItems: emitter.event,
+ *   async refresh() {
+ *     const issues = await fetchIssues();
+ *     emitter.fire(issues);
+ *   },
+ * };
+ * api.registerProvider(provider);
+ * ```
+ */
 export interface WorkCenterProvider {
+  /** Unique identifier for this provider (e.g. `'github'`). */
   readonly id: string;
+  /** Human-readable display name shown in the UI. */
   readonly label: string;
+  /**
+   * When `true`, previously dismissed items are resurfaced as `unseen`
+   * if the provider rediscovers them. Defaults to `false`.
+   */
   readonly resurfaceDismissed?: boolean;
+  /** Event fired when the provider discovers or refreshes its item list. */
   readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
+  /**
+   * Fetch the latest items from the external source.
+   * Implementations should fire {@link onDidDiscoverItems} with the results.
+   */
   refresh(): Promise<void>;
 }
 
+/**
+ * An action that can be performed on a {@link WorkItem}.
+ *
+ * Actions are registered via {@link WorkCenterApi.registerAction} and appear
+ * dynamically in context menus for work items where {@link canRun} returns `true`.
+ *
+ * @example
+ * ```ts
+ * const action: WorkCenterAction = {
+ *   id: 'start-work',
+ *   label: 'Start Work',
+ *   canRun: (item) => !!item.providerId,
+ *   run: async (item) => { await createBranch(item); },
+ * };
+ * api.registerAction(action);
+ * ```
+ */
 export interface WorkCenterAction {
+  /** Unique identifier for this action (e.g. `'start-work'`). */
   readonly id: string;
+  /** Human-readable label displayed in context menus. */
   readonly label: string;
+  /**
+   * Determine whether this action is applicable to the given work item.
+   *
+   * @param item - The work item to test.
+   * @returns `true` if the action should be offered for this item.
+   */
   canRun(item: WorkItem): boolean;
+  /**
+   * Execute the action against the given work item.
+   *
+   * @param item - The work item to act on.
+   */
   run(item: WorkItem): Promise<void>;
 }
 
+/**
+ * Public API surface of the WorkCenter extension.
+ *
+ * Returned by {@link activate} and consumed by provider extensions via
+ * `vscode.extensions.getExtension('mthalman.workcenter')`.
+ *
+ * @example
+ * ```ts
+ * const ext = vscode.extensions.getExtension<WorkCenterApi>('mthalman.workcenter');
+ * const api = ext?.exports;
+ * if (api) {
+ *   api.registerProvider(myProvider);
+ *   api.registerAction(myAction);
+ * }
+ * ```
+ */
 export interface WorkCenterApi {
+  /**
+   * Register a work-item provider.
+   *
+   * The provider will be immediately refreshed and its discovered items will
+   * appear in the Inbox and Sources views.
+   *
+   * @param provider - The provider to register.
+   * @returns A {@link Disposable} that unregisters the provider when disposed.
+   */
   registerProvider(provider: WorkCenterProvider): Disposable;
+  /**
+   * Register a contextual action for work items.
+   *
+   * The action's {@link WorkCenterAction.canRun} method is evaluated per item
+   * to determine whether it appears in context menus.
+   *
+   * @param action - The action to register.
+   * @returns A {@link Disposable} that unregisters the action when disposed.
+   */
   registerAction(action: WorkCenterAction): Disposable;
 }

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -44,7 +44,7 @@ export interface DiscoveredItem {
 }
 
 /**
- * A provider that discoverswork items from an external source.
+ * A provider that discovers work items from an external source.
  *
  * Providers are registered via {@link WorkCenterApi.registerProvider} and emit
  * {@link DiscoveredItem} arrays when new items are found. The core extension
@@ -85,7 +85,7 @@ export interface WorkCenterProvider {
 }
 
 /**
- * A context-menu actionthat can be run against a {@link WorkItem}.
+ * A context-menu action that can be run against a {@link WorkItem}.
  *
  * Actions are registered via {@link WorkCenterApi.registerAction} and surfaced
  * dynamically — {@link canRun} is called to determine visibility.
@@ -122,7 +122,7 @@ export interface WorkCenterAction {
 }
 
 /**
- * Public API surfaceof the WorkCenter extension.
+ * Public API surface of the WorkCenter extension.
  *
  * Obtain this API from the core extension by getting its extension wrapper via
  * `vscode.extensions.getExtension('mthalman.workcenter')`, then activating it
@@ -142,8 +142,9 @@ export interface WorkCenterApi {
   /**
    * Register a work-item provider.
    *
-   * The provider will be immediately refreshed and its discovered items will
-   * appear in the Inbox and Sources views.
+   * The provider's initial refresh is triggered automatically after
+   * registration (asynchronously), and its discovered items will appear
+   * in the Inbox and Sources views.
    *
    * @param provider - The provider to register.
    * @returns A {@link Disposable} that unregisters the provider when disposed.

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -18,6 +18,16 @@ import { getInboxUnseenCount } from './services/inboxBadge';
 export type { WorkCenterApi, WorkCenterProvider, WorkCenterAction, DiscoveredItem, Disposable } from './api/types';
 export { logger } from './services/logger';
 
+/**
+ * Activate the WorkCenter extension.
+ *
+ * Initialises storage, loads persisted work items and discovered-item state,
+ * registers all tree views (Inbox, Queue, Focus, History, Sources), and
+ * returns the public {@link WorkCenterApi} for provider extensions to consume.
+ *
+ * @param context - The VS Code extension context provided at activation.
+ * @returns The public API used by provider extensions to register providers and actions.
+ */
 export async function activate(context: vscode.ExtensionContext): Promise<WorkCenterApi> {
   const outputChannel = vscode.window.createOutputChannel('WorkCenter');
   context.subscriptions.push(outputChannel);
@@ -209,6 +219,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   return api;
 }
 
+/**
+ * Deactivate the WorkCenter extension.
+ *
+ * All resources are disposed automatically via `context.subscriptions`,
+ * so this function is intentionally a no-op.
+ */
 export function deactivate(): void {
   // Resources disposed via subscriptions
 }

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -4,7 +4,7 @@
  * Items move through these states following the work-item state machine:
  *
  * ```
- * New → Triaged (future) → InProgress → Done → Archived
+ * New → InProgress → Done → Archived
  *                            ↕    ↕
  *                        Blocked  WaitingOn
  * ```

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -1,12 +1,12 @@
 /**
  * Lifecycle states for a {@link WorkItem}.
  *
- * Items move throughthese states following the work-item state machine:
+ * Items move through these states following the work-item state machine:
  *
  * ```
- * New → Triaged → InProgress → Done → Archived
- *                   ↕    ↕
- *               Blocked  WaitingOn
+ * New → Triaged (future) → InProgress → Done → Archived
+ *                            ↕    ↕
+ *                        Blocked  WaitingOn
  * ```
  *
  * `Triaged` is reserved for future use and is not currently used in the UI flow.
@@ -59,7 +59,8 @@ export interface WorkItem {
 }
 
 /**
- * Input payload for creating a new work item manually (without a provider).
+ * Editable fields of a work item, used as input for creation and
+ * (via `Partial<WorkItemInput>`) for updates.
  *
  * @example
  * ```ts

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -29,7 +29,7 @@ export enum WorkItemState {
 }
 
 /**
- * A persisted work item managed by WorkCenter.
+ * A persisted work item managed by the WorkGraph.
  *
  * Work items may originate from a provider (e.g. a GitHub issue) or be created
  * manually by the user. Provider-backed items carry {@link providerId} and
@@ -46,7 +46,7 @@ export interface WorkItem {
   state: WorkItemState;
   /** ID of the provider that originally discovered this item, if any. */
   providerId?: string;
-  /** Provider-scoped identifier used to correlate with {@link DiscoveredItem.externalId}. */
+  /** Provider-scoped identifier used to correlate with the provider's discovered item. */
   externalId?: string;
   /** URL to the item in its source system (e.g. GitHub issue page). */
   url?: string;
@@ -71,7 +71,7 @@ export interface WorkItem {
  * ```
  */
 export interface WorkItemInput {
-  /** Short human-readable title for the new work item. */
+  /** Short human-readable title of the work item. */
   title: string;
   /** Optional free-form notes or description. */
   notes?: string;

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -1,27 +1,75 @@
+/**
+ * Lifecycle states for a {@link WorkItem}.
+ *
+ * Items move through these states following the work-item state machine:
+ *
+ * ```
+ * New → Triaged → InProgress → Done → Archived
+ *                   ↕    ↕
+ *               Blocked  WaitingOn
+ * ```
+ */
 export enum WorkItemState {
+  /** Freshly created item that has not yet been triaged. */
   New = 'New',
+  /** Item has been reviewed and accepted into the queue. */
   Triaged = 'Triaged',
+  /** Item is actively being worked on (appears in Focus view). */
   InProgress = 'InProgress',
+  /** Work is blocked by an impediment (appears in Focus view). */
   Blocked = 'Blocked',
+  /** Waiting on an external party or event (appears in Focus view). */
   WaitingOn = 'WaitingOn',
+  /** Work is complete (appears in History view). */
   Done = 'Done',
+  /** Item has been archived and hidden from the default History view. */
   Archived = 'Archived',
 }
 
+/**
+ * A persisted work item managed by WorkCenter.
+ *
+ * Work items may originate from a provider (e.g. a GitHub issue) or be created
+ * manually by the user. Provider-backed items carry {@link providerId} and
+ * {@link externalId} so they can be correlated with the live provider data.
+ */
 export interface WorkItem {
+  /** Unique identifier (UUID) for this work item. */
   id: string;
+  /** Short human-readable title displayed in tree views. */
   title: string;
+  /** Optional free-form notes or description entered by the user. */
   notes?: string;
+  /** Current lifecycle state of the work item. */
   state: WorkItemState;
+  /** Identifier of the provider that originally discovered this item, if any. */
   providerId?: string;
+  /** Provider-scoped identifier used to correlate with {@link DiscoveredItem.externalId}. */
   externalId?: string;
+  /** URL linking to the external resource (e.g. GitHub issue page). */
   url?: string;
+  /** Position within the queue for manual ordering. Lower values appear first. */
   sortOrder?: number;
+  /** Unix epoch timestamp (ms) of when the item was created. */
   createdAt: number;
+  /** Unix epoch timestamp (ms) of the last state or content change. */
   updatedAt: number;
 }
 
+/**
+ * Input payload for creating a new work item manually (without a provider).
+ *
+ * @example
+ * ```ts
+ * const input: WorkItemInput = {
+ *   title: 'Fix login bug',
+ *   notes: 'Users report intermittent 401 errors on the /auth endpoint.',
+ * };
+ * ```
+ */
 export interface WorkItemInput {
+  /** Short human-readable title for the new work item. */
   title: string;
+  /** Optional free-form notes or description. */
   notes?: string;
 }

--- a/packages/core/src/services/actionRegistry.ts
+++ b/packages/core/src/services/actionRegistry.ts
@@ -3,9 +3,23 @@ import { WorkCenterAction } from '../api/types';
 import { WorkItem } from '../models/workItem';
 import { logger } from './logger';
 
+/**
+ * Central registry for {@link WorkCenterAction} instances.
+ *
+ * Actions are contributed by provider extensions and appear as contextual
+ * commands on work items whose {@link WorkCenterAction.canRun} predicate
+ * returns `true`.
+ */
 export class ActionRegistry {
   private readonly actions = new Map<string, WorkCenterAction>();
 
+  /**
+   * Register an action and make it available in work-item context menus.
+   *
+   * @param action - The action to register.
+   * @returns A {@link vscode.Disposable} that unregisters the action when disposed.
+   * @throws If an action with the same {@link WorkCenterAction.id} is already registered.
+   */
   register(action: WorkCenterAction): vscode.Disposable {
     if (this.actions.has(action.id)) {
       throw new Error(`Action already registered: ${action.id}`);
@@ -18,16 +32,32 @@ export class ActionRegistry {
     });
   }
 
+  /**
+   * Find all actions applicable to a given work item.
+   *
+   * Each registered action's {@link WorkCenterAction.canRun} is evaluated
+   * and only matching actions are returned.
+   *
+   * @param item - The work item to match actions against.
+   * @returns An array of actions that can be run on the item.
+   */
   getActionsFor(item: WorkItem): WorkCenterAction[] {
     const matching = Array.from(this.actions.values()).filter((a) => a.canRun(item));
     logger.debug(`Found ${matching.length} actions for item ${item.id}`);
     return matching;
   }
 
+  /**
+   * Look up a registered action by its unique identifier.
+   *
+   * @param id - The action identifier to search for.
+   * @returns The matching action, or `undefined` if not registered.
+   */
   getAction(id: string): WorkCenterAction | undefined {
     return this.actions.get(id);
   }
 
+  /** Release all registered actions. */
   dispose(): void {
     this.actions.clear();
   }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -3,22 +3,34 @@ import { WorkCenterProvider, DiscoveredItem } from '../api/types';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import { logger } from './logger';
 
+/**
+ * Central registry for {@link WorkCenterProvider} instances.
+ *
+ * Manages provider lifecycle, tracks discovered items from each provider,
+ * and coordinates inbox state persistence through the {@link DiscoveredStateStore}.
+ * Fires events when providers are registered or when their discovered items change.
+ */
 export class ProviderRegistry {
   private readonly providers = new Map<string, WorkCenterProvider>();
   private readonly subscriptions = new Map<string, { dispose(): void }>();
   private readonly discoveredItems = new Map<string, DiscoveredItem[]>();
   private readonly _onDidChangeDiscoveredItems = new vscode.EventEmitter<void>();
+  /** Fired whenever any provider's discovered items change. */
   readonly onDidChangeDiscoveredItems = this._onDidChangeDiscoveredItems.event;
   private readonly _onDidRegisterProvider = new vscode.EventEmitter<void>();
+  /** Fired when a new provider is registered. */
   readonly onDidRegisterProvider = this._onDidRegisterProvider.event;
   private readonly _onDidAddNewUnseenItems = new vscode.EventEmitter<number>();
+  /** Fired when new unseen items are added to the inbox, with the count of new items. */
   readonly onDidAddNewUnseenItems = this._onDidAddNewUnseenItems.event;
   private readonly _loadingProviders = new Set<string>();
 
+  /** Whether any provider is currently performing its initial refresh. */
   get loading(): boolean {
     return this._loadingProviders.size > 0;
   }
 
+  /** Whether at least one provider has been registered. */
   get hasProviders(): boolean {
     return this.providers.size > 0;
   }
@@ -27,6 +39,16 @@ export class ProviderRegistry {
     private readonly stateStore: DiscoveredStateStore,
   ) {}
 
+  /**
+   * Register a provider and trigger its initial refresh.
+   *
+   * The provider's {@link WorkCenterProvider.onDidDiscoverItems} event is
+   * subscribed to so that future discoveries are automatically tracked.
+   *
+   * @param provider - The provider to register.
+   * @returns A {@link vscode.Disposable} that unregisters the provider when disposed.
+   * @throws If a provider with the same {@link WorkCenterProvider.id} is already registered.
+   */
   register(provider: WorkCenterProvider): vscode.Disposable {
     if (this.providers.has(provider.id)) {
       throw new Error(`Provider already registered: ${provider.id}`);
@@ -65,22 +87,51 @@ export class ProviderRegistry {
     });
   }
 
+  /**
+   * Look up a registered provider by its unique identifier.
+   *
+   * @param id - The provider identifier to search for.
+   * @returns The matching provider, or `undefined` if not registered.
+   */
   getProvider(id: string): WorkCenterProvider | undefined {
     return this.providers.get(id);
   }
 
+  /**
+   * Get the human-readable label for a provider.
+   *
+   * @param providerId - The provider identifier.
+   * @returns The provider's label, or the raw `providerId` if the provider is not registered.
+   */
   getProviderLabel(providerId: string): string {
     return this.providers.get(providerId)?.label ?? providerId;
   }
 
+  /**
+   * Get the discovered items for a specific provider.
+   *
+   * @param providerId - The provider identifier.
+   * @returns The array of discovered items, or an empty array if the provider has none.
+   */
   getDiscoveredItems(providerId: string): DiscoveredItem[] {
     return this.discoveredItems.get(providerId) ?? [];
   }
 
+  /**
+   * Get all discovered items across every registered provider.
+   *
+   * @returns A map keyed by provider ID, with each value being the provider's discovered items.
+   */
   getAllDiscoveredItems(): Map<string, DiscoveredItem[]> {
     return this.discoveredItems;
   }
 
+  /**
+   * Refresh all registered providers concurrently.
+   *
+   * Errors from individual providers are logged but do not reject the
+   * returned promise, so one failing provider does not block others.
+   */
   async refreshAll(): Promise<void> {
     const promises = Array.from(this.providers.values()).map((p) => {
       logger.debug(`Provider ${p.id} refreshing...`);
@@ -116,6 +167,7 @@ export class ProviderRegistry {
     this._onDidChangeDiscoveredItems.fire();
   }
 
+  /** Release all subscriptions and clear internal state. */
   dispose(): void {
     for (const sub of this.subscriptions.values()) {
       sub.dispose();


### PR DESCRIPTION
- Fix 4 typos (missing spaces in compound words)
- Correct WorkItemInput doc: used for both creation and updates
- Fix registerProvider doc: refresh is async, not immediate
- Mark Triaged as (future) in state machine diagram

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

