### PR TITLE
feat: add Show Inbox button to new items notification

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -178,7 +178,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
         'Show Inbox'
       ).then(action => {
         if (action === 'Show Inbox') {
-          vscode.commands.executeCommand('workcenter.inbox.focus');
+          vscode.commands.executeCommand('workcenter.inbox.focus').then(
+            undefined,
+            () => { /* view focus is best-effort */ }
+          );
         }
       });
     }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -176,14 +176,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
       vscode.window.showInformationMessage(
         `WorkCenter: ${newCount} new item${newCount === 1 ? '' : 's'} in Inbox`,
         'Show Inbox'
-      ).then(action => {
-        if (action === 'Show Inbox') {
-          vscode.commands.executeCommand('workcenter.inbox.focus').then(
-            undefined,
-            () => { /* view focus is best-effort */ }
-          );
-        }
-      });
+      ).then(
+        action => {
+          if (action === 'Show Inbox') {
+            vscode.commands.executeCommand('workcenter.inbox.focus').then(
+              undefined,
+              () => { /* view focus is best-effort */ }
+            );
+          }
+        },
+        () => { /* notification is best-effort */ }
+      );
     }
   });
   const stateStoreSub = stateStore.onDidChange(scheduleUiUpdate);

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -174,8 +174,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
     const showNotifications = config.get<boolean>('showInboxNotifications', true);
     if (showNotifications && newCount > 0) {
       vscode.window.showInformationMessage(
-        `WorkCenter: ${newCount} new item${newCount === 1 ? '' : 's'} in Inbox`
-      );
+        `WorkCenter: ${newCount} new item${newCount === 1 ? '' : 's'} in Inbox`,
+        'Show Inbox'
+      ).then(action => {
+        if (action === 'Show Inbox') {
+          vscode.commands.executeCommand('workcenter.inbox.focus');
+        }
+      });
     }
   });
   const stateStoreSub = stateStore.onDidChange(scheduleUiUpdate);

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -48,7 +48,7 @@ class MockTreeItem {
 
 const window = {
   showInputBox: vi.fn(),
-  showInformationMessage: vi.fn(),
+  showInformationMessage: vi.fn().mockResolvedValue(undefined),
   showWarningMessage: vi.fn(),
   showErrorMessage: vi.fn(),
   showQuickPick: vi.fn(),

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -78,6 +78,7 @@ const window = {
 
 const commands = {
   registerCommand: vi.fn(() => ({ dispose: vi.fn() })),
+  executeCommand: vi.fn().mockResolvedValue(undefined),
 };
 
 const env = {


### PR DESCRIPTION
Add a "Show Inbox" quick action button to the inbox notification that appears when new unseen items arrive.

When clicked, the button focuses the Inbox view via `workcenter.inbox.focus`.

Also addresses:
- Unhandled promise rejection on `executeCommand` (best-effort error suppression)
- `showInformationMessage` mock now returns a resolved promise to match real VS Code API
