### PR TITLE
ui: change Accept to Queue icon to right-arrow

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -146,7 +146,7 @@
         "command": "workcenter.acceptFromInbox",
         "title": "Accept to Queue",
         "category": "WorkCenter",
-        "icon": "$(arrow-down)"
+        "icon": "$(arrow-right)"
       },
       {
         "command": "workcenter.dismissFromInbox",
@@ -158,7 +158,7 @@
         "command": "workcenter.acceptFromSources",
         "title": "Accept to Queue",
         "category": "WorkCenter",
-        "icon": "$(arrow-down)"
+        "icon": "$(arrow-right)"
       }
     ],
     "menus": {


### PR DESCRIPTION
## Summary

Changes the "Accept to Queue" icon from a down-arrow to a right-arrow, better conveying the idea of moving an item forward into the queue rather than downloading it.

## Changes

- **`packages/core/package.json`** — Changed the icon for `acceptFromInbox` and `acceptFromSources` commands from `$(arrow-down)` to `$(arrow-right)`.

Fixes https://github.com/mthalman/workcenter/issues/31
