### PR TITLE
ux: warn when ADO organization not configured

### DIFF
--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -72,6 +72,7 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
 
     if (!org) {
       logger.info('No organization configured — set workcenterAdo.organization to enable ADO providers');
+      vscode.window.showWarningMessage('Azure DevOps organization not configured. Set workcenterAdo.organization in settings.');
       return;
     }
 

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -54,6 +54,7 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
   let prProvider: AdoPrReviewProvider | undefined;
   let workItemRegistration: vscode.Disposable | undefined;
   let prRegistration: vscode.Disposable | undefined;
+  let orgWarningShown = false;
 
   const configureProviders = () => {
     // Dispose existing providers and registrations before reconfiguring
@@ -72,9 +73,14 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
 
     if (!org) {
       logger.info('No organization configured — set workcenterAdo.organization to enable ADO providers');
-      vscode.window.showWarningMessage('WorkCenter ADO: Azure DevOps organization not configured. Set workcenterAdo.organization in settings.');
+      if (!orgWarningShown) {
+        vscode.window.showWarningMessage('WorkCenter ADO: Azure DevOps organization not configured. Set workcenterAdo.organization in settings.');
+        orgWarningShown = true;
+      }
       return;
     }
+
+    orgWarningShown = false;
 
     logger.debug(`Configuration: org=${org}, projects=[${projects.join(', ')}]`);
 

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -72,7 +72,7 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
 
     if (!org) {
       logger.info('No organization configured — set workcenterAdo.organization to enable ADO providers');
-      vscode.window.showWarningMessage('Azure DevOps organization not configured. Set workcenterAdo.organization in settings.');
+      vscode.window.showWarningMessage('WorkCenter ADO: Azure DevOps organization not configured. Set workcenterAdo.organization in settings.');
       return;
     }
 


### PR DESCRIPTION
When the ADO extension activates without `workcenterAdo.organization` configured, show a VS Code warning message so the user knows to set the setting. Previously, only a log message was emitted which was easy to miss.