### PR TITLE
ui: add dismiss icon for inbox menu consistency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -238,6 +238,11 @@
         {
           "command": "workcenter.dismissFromInbox",
           "when": "view == workcenter.inbox && viewItem =~ /inboxItem/",
+          "group": "inline"
+        },
+        {
+          "command": "workcenter.dismissFromInbox",
+          "when": "view == workcenter.inbox && viewItem =~ /inboxItem/",
           "group": "1_actions"
         },
         {


### PR DESCRIPTION
## Summary

Adds an inline dismiss icon to inbox items for visual consistency with the existing inline accept icon.

## Changes

- **`packages/core/package.json`** — Added an `inline` menu contribution for the `workcenter.dismissFromInbox` command, so it appears as a hover icon alongside the accept icon in the Inbox tree view.
