### PR TITLE
fix: resolve no-floating-promises in ado package

### DIFF
--- a/packages/ado/eslint.config.mjs
+++ b/packages/ado/eslint.config.mjs
@@ -9,6 +9,7 @@ export default [
       parserOptions: {
         ecmaVersion: 2022,
         sourceType: 'module',
+        project: ['./tsconfig.json', './tsconfig.test.json'],
       },
     },
     plugins: {
@@ -16,6 +17,7 @@ export default [
     },
     rules: {
       ...tseslint.configs.recommended.rules,
+      '@typescript-eslint/no-floating-promises': 'error',
     },
   },
   {

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -137,7 +137,7 @@ export class AdoPrReviewProvider implements WorkCenterProvider {
     if (!userId) {
       const message = 'Failed to determine Azure DevOps user identity';
       if (isUserTriggered) {
-        vscode.window.showWarningMessage(`WorkCenter ADO: ${message}`);
+        void vscode.window.showWarningMessage(`WorkCenter ADO: ${message}`);
       }
       logger.warn(message);
       this._onDidDiscoverItems.fire([]);
@@ -177,7 +177,7 @@ export class AdoPrReviewProvider implements WorkCenterProvider {
         ? `Failed to fetch PR reviews from ${failures[0]}`
         : `Failed to fetch PR reviews from ${failures.length} projects`;
       if (isUserTriggered) {
-        vscode.window.showWarningMessage(`WorkCenter ADO: ${message}`);
+        void vscode.window.showWarningMessage(`WorkCenter ADO: ${message}`);
       }
       logger.warn(message);
     }

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -168,7 +168,7 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
         ? `Failed to fetch work items from ${failures[0]}`
         : `Failed to fetch work items from ${failures.length} projects`;
       if (isUserTriggered) {
-        vscode.window.showWarningMessage(`WorkCenter ADO: ${message}`);
+        void vscode.window.showWarningMessage(`WorkCenter ADO: ${message}`);
       }
       logger.warn(message);
     }

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -41,7 +41,7 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     logger.error(`Failed to activate core extension — ${message}`);
-    vscode.window.showErrorMessage(`WorkCenter ADO: Failed to activate core extension — ${message}`);
+    void vscode.window.showErrorMessage(`WorkCenter ADO: Failed to activate core extension — ${message}`);
     return;
   }
 

--- a/packages/ado/tsconfig.test.json
+++ b/packages/ado/tsconfig.test.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

Resolves unhandled floating promises in the ADO extension package by adding `void` annotations and enabling the `@typescript-eslint/no-floating-promises` lint rule.

## Changes

- **`packages/ado/eslint.config.mjs`** — Enabled `@typescript-eslint/no-floating-promises` rule as an error. Added `tsconfig.test.json` to `parserOptions.project` for test file coverage.
- **`packages/ado/src/adoPrReviewProvider.ts`** — Added `void` prefix to 2 fire-and-forget `showWarningMessage` calls.
- **`packages/ado/src/adoWorkItemProvider.ts`** — Added `void` prefix to 1 fire-and-forget `showWarningMessage` call.
- **`packages/ado/src/extension.ts`** — Added `void` prefix to 1 fire-and-forget `showErrorMessage` call.
- **`packages/ado/tsconfig.test.json`** — New tsconfig for test files, required by the ESLint parser for type-aware linting.
