### PR TITLE
fix: add void to floating promises in core package

### DIFF
--- a/packages/core/eslint.config.mjs
+++ b/packages/core/eslint.config.mjs
@@ -4,6 +4,25 @@ import tsparser from '@typescript-eslint/parser';
 export default [
   {
     files: ['**/*.ts'],
+    ignores: ['src/test/**'],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+        project: './tsconfig.json',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+    },
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      '@typescript-eslint/no-floating-promises': 'warn',
+    },
+  },
+  {
+    files: ['src/test/**/*.ts'],
     languageOptions: {
       parser: tsparser,
       parserOptions: {

--- a/packages/core/eslint.config.mjs
+++ b/packages/core/eslint.config.mjs
@@ -3,7 +3,7 @@ import tsparser from '@typescript-eslint/parser';
 
 export default [
   {
-    files: ['**/*.ts'],
+    files: ['src/**/*.ts'],
     ignores: ['src/test/**'],
     languageOptions: {
       parser: tsparser,

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -49,9 +49,9 @@ export function registerCommands(
     vscode.commands.registerCommand('workcenter.openInBrowser', (item) => {
       const workItem = workGraph.getItem(item.id);
       if (workItem?.url) {
-        vscode.env.openExternal(vscode.Uri.parse(workItem.url));
+        void vscode.env.openExternal(vscode.Uri.parse(workItem.url));
       } else if (item.url) {
-        vscode.env.openExternal(vscode.Uri.parse(item.url));
+        void vscode.env.openExternal(vscode.Uri.parse(item.url));
       }
     }),
     vscode.commands.registerCommand('workcenter.runAction', async (item) => {
@@ -62,7 +62,7 @@ export function registerCommands(
       const actions = actionRegistry.getActionsFor(workItem);
       if (actions.length === 0) {
         logger.warn(`No actions available for item ${workItem.id}`);
-        vscode.window.showInformationMessage('No actions available for this item.');
+        void vscode.window.showInformationMessage('No actions available for this item.');
         return;
       }
       const picks = actions.map((a) => ({ label: a.label, actionId: a.id }));
@@ -78,21 +78,21 @@ export function registerCommands(
           } catch (err: unknown) {
             logger.error('Action failed: ' + selected.label, err);
             const message = err instanceof Error ? err.message : String(err);
-            vscode.window.showErrorMessage(`WorkCenter: Action "${selected.label}" failed — ${message}`);
+            void vscode.window.showErrorMessage(`WorkCenter: Action "${selected.label}" failed — ${message}`);
           }
         }
       }
     }),
     vscode.commands.registerCommand('workcenter.moveUp', (item) => {
       if (!item?.id) {
-        vscode.window.showInformationMessage('WorkCenter: Select an item in the Queue to move.');
+        void vscode.window.showInformationMessage('WorkCenter: Select an item in the Queue to move.');
         return;
       }
       return workGraph.moveItem(item.id, 'up');
     }),
     vscode.commands.registerCommand('workcenter.moveDown', (item) => {
       if (!item?.id) {
-        vscode.window.showInformationMessage('WorkCenter: Select an item in the Queue to move.');
+        void vscode.window.showInformationMessage('WorkCenter: Select an item in the Queue to move.');
         return;
       }
       return workGraph.moveItem(item.id, 'down');
@@ -101,7 +101,7 @@ export function registerCommands(
       logger.info(`Accepting inbox item: ${item.externalId} from ${item.providerId}`);
       const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
       if (existing) {
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
           `WorkCenter: Item already accepted as "${existing.title}"`
         );
         return;
@@ -114,7 +114,7 @@ export function registerCommands(
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to update state — ${message}`);
+        void vscode.window.showErrorMessage(`WorkCenter: Failed to update state — ${message}`);
       }
     }),
     vscode.commands.registerCommand('workcenter.dismissFromInbox', async (item: InboxItem) => {
@@ -123,7 +123,7 @@ export function registerCommands(
         await stateStore.setState(item.providerId, item.externalId, 'dismissed');
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to dismiss item — ${message}`);
+        void vscode.window.showErrorMessage(`WorkCenter: Failed to dismiss item — ${message}`);
       }
     }),
     vscode.commands.registerCommand('workcenter.acceptFromSources', async (item: SourceItemNode) => {
@@ -134,9 +134,9 @@ export function registerCommands(
           await stateStore.setState(item.providerId, item.externalId, 'accepted');
         } catch (err: unknown) {
           const message = err instanceof Error ? err.message : String(err);
-          vscode.window.showErrorMessage(`WorkCenter: Failed to update state — ${message}`);
+          void vscode.window.showErrorMessage(`WorkCenter: Failed to update state — ${message}`);
         }
-        vscode.window.showInformationMessage(
+        void vscode.window.showInformationMessage(
           `WorkCenter: Item already accepted as "${existing.title}"`
         );
         return;
@@ -149,7 +149,7 @@ export function registerCommands(
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`WorkCenter: Failed to accept item — ${message}`);
+        void vscode.window.showErrorMessage(`WorkCenter: Failed to accept item — ${message}`);
       }
     }),
   );
@@ -167,5 +167,5 @@ async function createItem(workGraph: WorkGraph): Promise<void> {
 
   logger.info(`Creating new work item: ${title.trim()}`);
   await workGraph.createItem({ title: title.trim() });
-  vscode.window.showInformationMessage(`WorkCenter: Created "${title.trim()}"`);
+  void vscode.window.showInformationMessage(`WorkCenter: Created "${title.trim()}"`);
 }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -173,7 +173,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
     const config = vscode.workspace.getConfiguration('workcenter');
     const showNotifications = config.get<boolean>('showInboxNotifications', true);
     if (showNotifications && newCount > 0) {
-      vscode.window.showInformationMessage(
+      void vscode.window.showInformationMessage(
         `WorkCenter: ${newCount} new item${newCount === 1 ? '' : 's'} in Inbox`
       );
     }

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -44,7 +44,7 @@ export class WorkItemEditorPanel {
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        vscode.window.showErrorMessage(`Failed to save work item: ${message}`);
+        void vscode.window.showErrorMessage(`Failed to save work item: ${message}`);
       }
     });
 


### PR DESCRIPTION
## Summary

Fix floating promise warnings in `packages/core` by adding `void` prefixes to all fire-and-forget `Thenable` calls (`showInformationMessage`, `showErrorMessage`, `openExternal`) and enabling the `@typescript-eslint/no-floating-promises` lint rule to prevent regressions.

## Changes

### ESLint configuration (`packages/core/eslint.config.mjs`)
- Split ESLint config into separate blocks for source and test files
- Enable `@typescript-eslint/no-floating-promises: "warn"` for production source files (not tests)
- Wire up `project: './tsconfig.json'` so the rule has type information

### Floating promise fixes
- **`commands.ts`** — Add `void` prefix to 11 fire-and-forget calls across all command handlers (`showInformationMessage`, `showErrorMessage`)
- **`extension.ts`** — Add `void` to the inbox notification `showInformationMessage`
- **`workItemEditorPanel.ts`** — Add `void` to the save-error `showErrorMessage`

## Why `void` instead of `await`?

These are notification toasts where the caller intentionally does not wait for user dismissal. The `void` operator explicitly signals this intent to both the linter and future readers, without changing runtime behavior.

## Testing

- All 43 command tests pass
- Build succeeds across all packages
