### PR TITLE
ux: show feedback when Open in Browser has no URL

### DIFF
--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -52,6 +52,8 @@ export function registerCommands(
         vscode.env.openExternal(vscode.Uri.parse(workItem.url));
       } else if (item.url) {
         vscode.env.openExternal(vscode.Uri.parse(item.url));
+      } else {
+        vscode.window.showWarningMessage('This item has no URL to open');
       }
     }),
     vscode.commands.registerCommand('workcenter.runAction', async (item) => {

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -46,14 +46,25 @@ export function registerCommands(
         WorkItemEditorPanel.open(context, workGraph, workItem);
       }
     }),
-    vscode.commands.registerCommand('workcenter.openInBrowser', (item) => {
+    vscode.commands.registerCommand('workcenter.openInBrowser', async (item) => {
+      if (!item?.id) {
+        vscode.window.showWarningMessage('WorkCenter: Select an item to open in the browser.');
+        return;
+      }
       const workItem = workGraph.getItem(item.id);
-      if (workItem?.url) {
-        vscode.env.openExternal(vscode.Uri.parse(workItem.url));
-      } else if (item.url) {
-        vscode.env.openExternal(vscode.Uri.parse(item.url));
-      } else {
-        vscode.window.showWarningMessage('This item has no URL to open');
+      const url = workItem?.url ?? item.url;
+      if (!url) {
+        vscode.window.showWarningMessage('This item has no URL to open.');
+        return;
+      }
+      const uri = vscode.Uri.parse(url);
+      if (uri.scheme !== 'http' && uri.scheme !== 'https') {
+        vscode.window.showWarningMessage(`Cannot open non-web URL: ${url}`);
+        return;
+      }
+      const opened = await vscode.env.openExternal(uri);
+      if (!opened) {
+        vscode.window.showWarningMessage('Failed to open URL in the browser.');
       }
     }),
     vscode.commands.registerCommand('workcenter.runAction', async (item) => {

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -91,7 +91,10 @@ const env = {
 };
 
 const Uri = {
-  parse: vi.fn((s: string) => ({ toString: () => s })),
+  parse: vi.fn((s: string) => {
+    const m = s.match(/^(\w+):/);
+    return { toString: () => s, scheme: m ? m[1] : '' };
+  }),
 };
 
 class MockDataTransferItem {

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -224,45 +224,45 @@ describe('registerCommands', () => {
   // ── openInBrowser ────────────────────────────────────────────────
 
   describe('workcenter.openInBrowser', () => {
-    it('opens workItem url when found', () => {
+    it('opens workItem url when found', async () => {
       const item = createWorkItem({ url: 'https://example.com' });
       workGraph.getItem.mockReturnValue(item);
 
-      invoke('workcenter.openInBrowser', { id: item.id });
+      await invoke('workcenter.openInBrowser', { id: item.id });
 
       expect(vscode.env.openExternal).toHaveBeenCalled();
       expect(vscode.Uri.parse).toHaveBeenCalledWith('https://example.com');
     });
 
-    it('falls back to item.url when workItem has no url', () => {
+    it('falls back to item.url when workItem has no url', async () => {
       workGraph.getItem.mockReturnValue(createWorkItem({ url: undefined }));
 
-      invoke('workcenter.openInBrowser', { id: 'wc-1', url: 'https://fallback.com' });
+      await invoke('workcenter.openInBrowser', { id: 'wc-1', url: 'https://fallback.com' });
 
       expect(vscode.Uri.parse).toHaveBeenCalledWith('https://fallback.com');
       expect(vscode.env.openExternal).toHaveBeenCalled();
     });
 
-    it('does nothing when neither source has a url', () => {
+    it('does nothing when neither source has a url', async () => {
       workGraph.getItem.mockReturnValue(createWorkItem({ url: undefined }));
 
-      invoke('workcenter.openInBrowser', { id: 'wc-1' });
+      await invoke('workcenter.openInBrowser', { id: 'wc-1' });
 
       expect(vscode.env.openExternal).not.toHaveBeenCalled();
     });
 
-    it('does nothing when item not found and tree item has no url', () => {
+    it('does nothing when item not found and tree item has no url', async () => {
       workGraph.getItem.mockReturnValue(undefined);
 
-      invoke('workcenter.openInBrowser', { id: 'wc-gone' });
+      await invoke('workcenter.openInBrowser', { id: 'wc-gone' });
 
       expect(vscode.env.openExternal).not.toHaveBeenCalled();
     });
 
-    it('falls back to tree node url when workItem is not found', () => {
+    it('falls back to tree node url when workItem is not found', async () => {
       workGraph.getItem.mockReturnValue(undefined);
 
-      invoke('workcenter.openInBrowser', { id: 'wc-gone', url: 'https://tree-fallback.com' });
+      await invoke('workcenter.openInBrowser', { id: 'wc-gone', url: 'https://tree-fallback.com' });
 
       expect(vscode.Uri.parse).toHaveBeenCalledWith('https://tree-fallback.com');
       expect(vscode.env.openExternal).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Improves the "Open in Browser" command to show user-friendly feedback instead of silently doing nothing when a URL is missing, invalid, or fails to open.

## Problem

The `workcenter.openInBrowser` command silently failed in several cases: no item selected, item has no URL, non-web URL scheme, or `openExternal` returning false. Users had no way to know why nothing happened.

## Changes

- **`packages/core/src/commands/commands.ts`** — Added guards and feedback to `openInBrowser`:
  - Shows warning when no item is selected
  - Shows warning when the item has no URL
  - Validates URL scheme is `http` or `https` before opening
  - Awaits `openExternal` and shows warning if it returns false
- **`packages/core/src/test/commands.test.ts`** — Updated tests to be async (matching the now-async command handler)
- **`packages/core/src/test/__mocks__/vscode.ts`** — Updated `Uri.parse` mock to extract `scheme` property
