### PR TITLE
fix: enforce no-floating-promises lint rule in github package

### DIFF
--- a/packages/github/eslint.config.mjs
+++ b/packages/github/eslint.config.mjs
@@ -4,6 +4,25 @@ import tsparser from '@typescript-eslint/parser';
 export default [
   {
     files: ['**/*.ts'],
+    ignores: ['src/test/**'],
+    languageOptions: {
+      parser: tsparser,
+      parserOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+        project: './tsconfig.json',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+    },
+    rules: {
+      ...tseslint.configs.recommended.rules,
+      '@typescript-eslint/no-floating-promises': 'error',
+    },
+  },
+  {
+    files: ['src/test/**/*.ts'],
     languageOptions: {
       parser: tsparser,
       parserOptions: {

--- a/packages/github/eslint.config.mjs
+++ b/packages/github/eslint.config.mjs
@@ -3,7 +3,7 @@ import tsparser from '@typescript-eslint/parser';
 
 export default [
   {
-    files: ['**/*.ts'],
+    files: ['src/**/*.ts'],
     ignores: ['src/test/**'],
     languageOptions: {
       parser: tsparser,

--- a/packages/github/src/extension.ts
+++ b/packages/github/src/extension.ts
@@ -43,7 +43,7 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     logger.error(`Failed to activate core extension — ${message}`);
-    vscode.window.showErrorMessage(`WorkCenter GitHub: Failed to activate core extension — ${message}`);
+    void vscode.window.showErrorMessage(`WorkCenter GitHub: Failed to activate core extension — ${message}`);
     return;
   }
 

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -133,7 +133,7 @@ export class GitHubPrReviewProvider implements WorkCenterProvider {
     if (!response.ok) {
       const message = 'Failed to fetch PR review requests';
       if (isUserTriggered) {
-        vscode.window.showWarningMessage(`WorkCenter GitHub: ${message}`);
+        void vscode.window.showWarningMessage(`WorkCenter GitHub: ${message}`);
       } else {
         logger.warn(`${message}: ${response.status}`);
       }

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -130,7 +130,7 @@ export class GitHubIssueProvider implements WorkCenterProvider {
         ? `Failed to fetch issues from ${failures[0]}`
         : `Failed to fetch issues from ${failures.length} repositories`;
       if (isUserTriggered) {
-        vscode.window.showWarningMessage(`WorkCenter GitHub: ${message}`);
+        void vscode.window.showWarningMessage(`WorkCenter GitHub: ${message}`);
       } else {
         logger.warn(message);
       }

--- a/packages/github/src/startWorkAction.ts
+++ b/packages/github/src/startWorkAction.ts
@@ -39,7 +39,7 @@ export class StartWorkAction implements WorkCenterAction {
   async run(item: WorkItem): Promise<void> {
     const issueNumber = this.extractIssueNumber(item.externalId);
     if (!issueNumber) {
-      vscode.window.showErrorMessage('Could not determine issue number.');
+      void vscode.window.showErrorMessage('Could not determine issue number.');
       return;
     }
 
@@ -47,7 +47,7 @@ export class StartWorkAction implements WorkCenterAction {
 
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (!workspaceFolders || workspaceFolders.length === 0) {
-      vscode.window.showErrorMessage('WorkCenter: No workspace folder open. Open a repository first.');
+      void vscode.window.showErrorMessage('WorkCenter: No workspace folder open. Open a repository first.');
       return;
     }
 
@@ -56,7 +56,7 @@ export class StartWorkAction implements WorkCenterAction {
       repoPath = await this.selectRepository(workspaceFolders);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
-      vscode.window.showErrorMessage(`WorkCenter: ${message}`);
+      void vscode.window.showErrorMessage(`WorkCenter: ${message}`);
       return;
     }
 
@@ -64,7 +64,7 @@ export class StartWorkAction implements WorkCenterAction {
       // Check if branch already exists
       const { stdout: branchList } = await execFileAsync('git', ['branch', '--list', branchName], { cwd: repoPath });
       if (branchList.trim()) {
-        vscode.window.showErrorMessage(`WorkCenter: Branch "${branchName}" already exists.`);
+        void vscode.window.showErrorMessage(`WorkCenter: Branch "${branchName}" already exists.`);
         return;
       }
 
@@ -91,7 +91,7 @@ export class StartWorkAction implements WorkCenterAction {
       // Check if worktree directory already exists
       if (fs.existsSync(worktreePath)) {
         await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath });
-        vscode.window.showErrorMessage(`WorkCenter: Directory "${worktreePath}" already exists.`);
+        void vscode.window.showErrorMessage(`WorkCenter: Directory "${worktreePath}" already exists.`);
         return;
       }
 
@@ -105,7 +105,7 @@ export class StartWorkAction implements WorkCenterAction {
           await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath });
         } catch (rollbackErr) {
           const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
-          vscode.window.showWarningMessage(`WorkCenter: Failed to delete branch during rollback — ${rollbackMessage}`);
+          void vscode.window.showWarningMessage(`WorkCenter: Failed to delete branch during rollback — ${rollbackMessage}`);
         }
         throw worktreeErr;
       }
@@ -118,13 +118,13 @@ export class StartWorkAction implements WorkCenterAction {
         forceNewWindow: true,
       });
 
-      vscode.window.showInformationMessage(
+      void vscode.window.showInformationMessage(
         `WorkCenter: Created worktree for ${branchName}`,
       );
     } catch (err: unknown) {
       logger.error('Failed to start work', err);
       const message = err instanceof Error ? err.message : String(err);
-      vscode.window.showErrorMessage(`WorkCenter: Failed to start work — ${message}`);
+      void vscode.window.showErrorMessage(`WorkCenter: Failed to start work — ${message}`);
     }
   }
 


### PR DESCRIPTION
## Summary

Adds the `@typescript-eslint/no-floating-promises` lint rule to `packages/github` and fixes all existing violations. Unhandled promise rejections from fire-and-forget `vscode.window.show*Message()` calls are now explicitly voided, preventing silent failures.

## Changes

### ESLint configuration (`packages/github/eslint.config.mjs`)
- Split the config into two blocks: production code (`src/**/*.ts`) and test files (`src/test/**/*.ts`).
- Enabled typed linting (`project: './tsconfig.json'`) for production code.
- Added `@typescript-eslint/no-floating-promises: 'error'` to production rules.

### Floating-promise fixes
- **`extension.ts`** — `void` the `showErrorMessage` call in the activation error path.
- **`githubProvider.ts`** — `void` the `showWarningMessage` call for fetch failures.
- **`startWorkAction.ts`** — `void` all eight `showErrorMessage` / `showWarningMessage` / `showInformationMessage` calls that were fire-and-forget.

## Testing

All existing tests continue to pass (142 github, 133 shared). No behavioral changes — `void` simply tells the linter the unawaited promise is intentional.

Closes #81
