### PR TITLE
fix: update inbox badge count when items are read

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -135,7 +135,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   let wasLoading = false;
 
   const updateInboxBadge = () => {
-    const count = getInboxUnseenCount(providerRegistry, stateStore);
+    const count = getInboxUnseenCount(providerRegistry, stateStore, inboxProvider.readItems);
     inboxTreeView.badge = count > 0 ? { value: count, tooltip: `${count} unseen item${count === 1 ? '' : 's'}` } : undefined;
   };
 
@@ -179,6 +179,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
     }
   });
   const stateStoreSub = stateStore.onDidChange(scheduleUiUpdate);
+  const markSeenSub = inboxProvider.onDidMarkSeen(scheduleUiUpdate);
 
   context.subscriptions.push(
     inboxTreeView,
@@ -191,6 +192,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
     newItemsSub,
     providerRegSub,
     stateStoreSub,
+    markSeenSub,
     workGraphSub,
     { dispose: () => workGraph.dispose() },
     { dispose: () => stateStore.dispose() },

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -135,7 +135,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   let wasLoading = false;
 
   const updateInboxBadge = () => {
-    const count = getInboxUnseenCount(providerRegistry, stateStore, inboxProvider.readItems);
+    const count = getInboxUnseenCount(providerRegistry, stateStore, inboxProvider.sessionSeenItems);
     inboxTreeView.badge = count > 0 ? { value: count, tooltip: `${count} unseen item${count === 1 ? '' : 's'}` } : undefined;
   };
 

--- a/packages/core/src/services/inboxBadge.ts
+++ b/packages/core/src/services/inboxBadge.ts
@@ -4,14 +4,14 @@ import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 export function getInboxUnseenCount(
   providerRegistry: ProviderRegistry,
   stateStore: DiscoveredStateStore,
-  readItems?: ReadonlySet<string>,
+  seenItems?: ReadonlySet<string>,
 ): number {
   let count = 0;
   for (const [providerId, items] of providerRegistry.getAllDiscoveredItems()) {
     for (const item of items) {
       const state = stateStore.getState(providerId, item.externalId);
       if (state === undefined || state === 'unseen') {
-        if (!readItems?.has(`${providerId}::${item.externalId}`)) {
+        if (!seenItems?.has(`${providerId}::${item.externalId}`)) {
           count++;
         }
       }

--- a/packages/core/src/services/inboxBadge.ts
+++ b/packages/core/src/services/inboxBadge.ts
@@ -1,13 +1,19 @@
 import { ProviderRegistry } from './providerRegistry';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 
-export function getInboxUnseenCount(providerRegistry: ProviderRegistry, stateStore: DiscoveredStateStore): number {
+export function getInboxUnseenCount(
+  providerRegistry: ProviderRegistry,
+  stateStore: DiscoveredStateStore,
+  readItems?: ReadonlySet<string>,
+): number {
   let count = 0;
   for (const [providerId, items] of providerRegistry.getAllDiscoveredItems()) {
     for (const item of items) {
       const state = stateStore.getState(providerId, item.externalId);
       if (state === undefined || state === 'unseen') {
-        count++;
+        if (!readItems?.has(`${providerId}::${item.externalId}`)) {
+          count++;
+        }
       }
     }
   }

--- a/packages/core/src/test/getInboxUnseenCount.test.ts
+++ b/packages/core/src/test/getInboxUnseenCount.test.ts
@@ -111,4 +111,64 @@ describe('getInboxUnseenCount', () => {
 
     expect(getInboxUnseenCount(registry, stateStore as any)).toBe(1);
   });
+
+  it('excludes items present in seenItems set', () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+    provider.fireItems([
+      { externalId: '1', title: 'Issue 1' },
+      { externalId: '2', title: 'Issue 2' },
+    ]);
+
+    const seen = new Set(['gh::1']);
+    expect(getInboxUnseenCount(registry, stateStore as any, seen)).toBe(1);
+  });
+
+  it('still counts unseen items not in seenItems set', () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+    provider.fireItems([
+      { externalId: '1', title: 'Issue 1' },
+      { externalId: '2', title: 'Issue 2' },
+      { externalId: '3', title: 'Issue 3' },
+    ]);
+
+    const seen = new Set(['gh::2']);
+    expect(getInboxUnseenCount(registry, stateStore as any, seen)).toBe(2);
+  });
+
+  it('returns full count when seenItems is undefined', () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+    provider.fireItems([
+      { externalId: '1', title: 'Issue 1' },
+      { externalId: '2', title: 'Issue 2' },
+    ]);
+
+    expect(getInboxUnseenCount(registry, stateStore as any, undefined)).toBe(2);
+  });
+
+  it('returns full count when seenItems is empty', () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+    provider.fireItems([
+      { externalId: '1', title: 'Issue 1' },
+      { externalId: '2', title: 'Issue 2' },
+    ]);
+
+    expect(getInboxUnseenCount(registry, stateStore as any, new Set())).toBe(2);
+  });
+
+  it('does not double-exclude items that are both seen and accepted', () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+    provider.fireItems([
+      { externalId: '1', title: 'Issue 1' },
+      { externalId: '2', title: 'Issue 2' },
+    ]);
+    stateStore._set('gh', '1', 'accepted');
+
+    const seen = new Set(['gh::1', 'gh::2']);
+    expect(getInboxUnseenCount(registry, stateStore as any, seen)).toBe(0);
+  });
 });

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -315,11 +315,11 @@ describe('InboxTreeProvider', () => {
       expect(listener).not.toHaveBeenCalled();
     });
 
-    it('should expose seen items via readItems', () => {
-      expect(provider.readItems.size).toBe(0);
+    it('should expose seen items via sessionSeenItems', () => {
+      expect(provider.sessionSeenItems.size).toBe(0);
       provider.markSeen('gh', '1');
-      expect(provider.readItems.has('gh::1')).toBe(true);
-      expect(provider.readItems.size).toBe(1);
+      expect(provider.sessionSeenItems.has('gh::1')).toBe(true);
+      expect(provider.sessionSeenItems.size).toBe(1);
     });
   });
 

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -299,6 +299,28 @@ describe('InboxTreeProvider', () => {
       provider.markSeen('gh', '1');
       expect(provider.markSeen('gh', '1')).toBe(false);
     });
+
+    it('should fire onDidMarkSeen when a new item is marked seen', () => {
+      const listener = vi.fn();
+      provider.onDidMarkSeen(listener);
+      provider.markSeen('gh', '1');
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not fire onDidMarkSeen when item is already seen', () => {
+      provider.markSeen('gh', '1');
+      const listener = vi.fn();
+      provider.onDidMarkSeen(listener);
+      provider.markSeen('gh', '1');
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should expose seen items via readItems', () => {
+      expect(provider.readItems.size).toBe(0);
+      provider.markSeen('gh', '1');
+      expect(provider.readItems.has('gh::1')).toBe(true);
+      expect(provider.readItems.size).toBe(1);
+    });
   });
 
   describe('getParent', () => {

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -69,7 +69,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     }
   }
 
-  get readItems(): ReadonlySet<string> { return this.seenItems; }
+  get sessionSeenItems(): ReadonlySet<string> { return this.seenItems; }
 
   refresh(): void { this._onDidChangeTreeData.fire(); }
 

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -33,6 +33,8 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private readonly disposables: vscode.Disposable[] = [];
   private readonly seenItems = new Set<string>();
+  private readonly _onDidMarkSeen = new vscode.EventEmitter<void>();
+  readonly onDidMarkSeen = this._onDidMarkSeen.event;
 
   constructor(
     private readonly providerRegistry: ProviderRegistry,
@@ -67,12 +69,15 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     }
   }
 
+  get readItems(): ReadonlySet<string> { return this.seenItems; }
+
   refresh(): void { this._onDidChangeTreeData.fire(); }
 
   markSeen(providerId: string, externalId: string): boolean {
     const key = `${providerId}::${externalId}`;
     if (!this.seenItems.has(key)) {
       this.seenItems.add(key);
+      this._onDidMarkSeen.fire();
       return true;
     }
     return false;
@@ -248,6 +253,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   dispose(): void {
     this._onDidChangeTreeData.dispose();
+    this._onDidMarkSeen.dispose();
     this.disposables.forEach(d => d.dispose());
   }
 }


### PR DESCRIPTION
## Summary

The inbox badge count was not updating when a user viewed (expanded) items in the inbox tree. Items marked as "seen" in the current session were still counted as unseen in the badge.

## Changes

- **InboxTreeProvider**: Added `onDidMarkSeen` event emitter that fires when an item is newly marked seen. Added `sessionSeenItems` getter exposing the in-memory seen set.
- **getInboxUnseenCount**: Accepts an optional `seenItems` set to exclude session-seen items from the unseen count.
- **extension.ts**: Wires the `onDidMarkSeen` event to trigger a badge update, and passes `sessionSeenItems` to the count function.
- **Tests**: Added 5 tests for `seenItems` filtering in `getInboxUnseenCount`, and 3 tests for the new event/getter in `InboxTreeProvider`.

Fixes https://github.com/mthalman/workcenter/issues/36