### PR TITLE
feat: persist inbox read/unread state across restarts

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -95,16 +95,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   const inboxTreeView = vscode.window.createTreeView('workcenter.inbox', { treeDataProvider: inboxProvider });
   const sourcesTreeView = vscode.window.createTreeView('workcenter.sources', { treeDataProvider: sourcesProvider });
 
-  const inboxSelectionSub = inboxTreeView.onDidChangeSelection(async (e) => {
-    let changed = false;
-    for (const item of e.selection) {
-      if (item.kind === 'item') {
-        changed = await inboxProvider.markSeen(item.providerId, item.externalId) || changed;
+  const inboxSelectionSub = inboxTreeView.onDidChangeSelection((e) => {
+    void (async () => {
+      let changed = false;
+      for (const item of e.selection) {
+        if (item.kind === 'item') {
+          changed = await inboxProvider.markSeen(item.providerId, item.externalId) || changed;
+        }
       }
-    }
-    if (changed) {
-      inboxProvider.refresh();
-    }
+      if (changed) {
+        inboxProvider.refresh();
+      }
+    })().catch(err => logger.error('Failed to mark inbox item as seen', err));
   });
 
   // View message state: empty by default, loading when providers are fetching

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -3,6 +3,7 @@ import { WorkCenterApi } from './api/types';
 import { WorkCenterApiImpl } from './api/workCenterApi';
 import { JsonTaskStore } from './storage/jsonTaskStore';
 import { DiscoveredStateStore } from './storage/discoveredStateStore';
+import { ReadStateStore } from './storage/readStateStore';
 import { WorkGraph } from './services/workGraph';
 import { ProviderRegistry } from './services/providerRegistry';
 import { ActionRegistry } from './services/actionRegistry';
@@ -52,6 +53,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   await stateStore.load();
   logger.debug('Loaded discovered state');
 
+  const readStateStore = new ReadStateStore(storagePath);
+  await readStateStore.load();
+  logger.debug('Loaded read state');
+
   // Migration: mark existing provider-backed items as accepted
   const itemsToMigrate: Array<{ providerId: string; externalId: string; state: 'accepted' }> = [];
   
@@ -81,7 +86,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   const actionRegistry = new ActionRegistry();
   const api = new WorkCenterApiImpl(providerRegistry, actionRegistry);
 
-  const inboxProvider = new InboxTreeProvider(providerRegistry, stateStore);
+  const inboxProvider = new InboxTreeProvider(providerRegistry, stateStore, readStateStore);
   const queueProvider = new QueueTreeProvider(workGraph);
   const focusProvider = new FocusTreeProvider(workGraph);
   const sourcesProvider = new SourcesTreeProvider(providerRegistry, stateStore);

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -95,11 +95,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   const inboxTreeView = vscode.window.createTreeView('workcenter.inbox', { treeDataProvider: inboxProvider });
   const sourcesTreeView = vscode.window.createTreeView('workcenter.sources', { treeDataProvider: sourcesProvider });
 
-  const inboxSelectionSub = inboxTreeView.onDidChangeSelection((e) => {
+  const inboxSelectionSub = inboxTreeView.onDidChangeSelection(async (e) => {
     let changed = false;
     for (const item of e.selection) {
       if (item.kind === 'item') {
-        changed = inboxProvider.markSeen(item.providerId, item.externalId) || changed;
+        changed = await inboxProvider.markSeen(item.providerId, item.externalId) || changed;
       }
     }
     if (changed) {

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -26,21 +26,20 @@ export class ReadStateStore {
   /** Returns true only when the key is newly added. Persists automatically. */
   async add(key: string): Promise<boolean> {
     if (!this.loaded) { await this.load(); }
-    if (this.items.has(key)) { return false; }
+    let added = false;
     await this.enqueue(async () => {
+      if (this.items.has(key)) { return; }
       this.items.add(key);
+      added = true;
       try {
         await this.writeFile();
       } catch (err) {
         this.items.delete(key);
+        added = false;
         throw err;
       }
     });
-    return true;
-  }
-
-  delete(key: string): boolean {
-    return this.items.delete(key);
+    return added;
   }
 
   keys(): IterableIterator<string> {
@@ -48,15 +47,22 @@ export class ReadStateStore {
   }
 
   /**
-   * Persist current state to disk with rollback on failure.
-   * If the write fails, previously-deleted keys are restored.
+   * Atomically delete keys and persist, with rollback on write failure.
+   * Both deletes and write are serialized through the writeQueue.
    */
-  saveWithRollback(deletedKeys: string[]): void {
+  deleteMany(keys: string[]): void {
     this.enqueue(async () => {
+      const actuallyDeleted: string[] = [];
+      for (const key of keys) {
+        if (this.items.delete(key)) {
+          actuallyDeleted.push(key);
+        }
+      }
+      if (actuallyDeleted.length === 0) { return; }
       try {
         await this.writeFile();
       } catch (err) {
-        for (const key of deletedKeys) {
+        for (const key of actuallyDeleted) {
           this.items.add(key);
         }
         logger.error('Failed to save read state, rolled back deletions', err);

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -47,12 +47,22 @@ export class ReadStateStore {
     return this.items.values();
   }
 
-  /** Persist current state to disk (call after batch deletions). */
-  save(): void {
+  /**
+   * Persist current state to disk with rollback on failure.
+   * If the write fails, previously-deleted keys are restored.
+   */
+  saveWithRollback(deletedKeys: string[]): void {
     this.enqueue(async () => {
-      await this.writeFile();
-    }).catch((err) => {
-      logger.error('Failed to save read state', err);
+      try {
+        await this.writeFile();
+      } catch (err) {
+        for (const key of deletedKeys) {
+          this.items.add(key);
+        }
+        logger.error('Failed to save read state, rolled back deletions', err);
+      }
+    }).catch(() => {
+      // Error already handled inside enqueue with rollback
     });
   }
 

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -1,0 +1,94 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { logger } from '../services/logger';
+
+/**
+ * Persists the set of inbox item IDs that the user has viewed ("read")
+ * so read/unread state survives across VS Code restarts.
+ *
+ * Stored as a JSON array of composite keys ("providerId::externalId")
+ * in read-state.json alongside the other stores.
+ */
+export class ReadStateStore {
+  private readonly filePath: string;
+  private readonly items = new Set<string>();
+  private writeQueue: Promise<void> = Promise.resolve();
+  private loaded = false;
+
+  constructor(storagePath: string) {
+    this.filePath = path.join(storagePath, 'read-state.json');
+  }
+
+  has(key: string): boolean {
+    return this.items.has(key);
+  }
+
+  /** Returns true only when the key is newly added. Persists automatically. */
+  add(key: string): boolean {
+    if (this.items.has(key)) { return false; }
+    this.items.add(key);
+    this.enqueueSave();
+    return true;
+  }
+
+  delete(key: string): boolean {
+    return this.items.delete(key);
+  }
+
+  keys(): IterableIterator<string> {
+    return this.items.values();
+  }
+
+  /** Persist current state to disk (call after batch deletions). */
+  save(): void {
+    this.enqueueSave();
+  }
+
+  /** Returns a promise that resolves when all queued writes complete. */
+  flush(): Promise<void> {
+    return this.writeQueue;
+  }
+
+  async load(): Promise<void> {
+    if (this.loaded) { return; }
+    try {
+      const data = await fs.readFile(this.filePath, 'utf-8');
+      const arr = JSON.parse(data) as string[];
+      this.items.clear();
+      for (const key of arr) {
+        this.items.add(key);
+      }
+      logger.debug(`Loaded read state: ${this.items.size} entries`);
+      this.loaded = true;
+    } catch (err: unknown) {
+      if (isNodeError(err) && err.code === 'ENOENT') {
+        this.items.clear();
+        this.loaded = true;
+        return;
+      }
+      throw err;
+    }
+  }
+
+  private enqueueSave(): void {
+    this.enqueue(async () => {
+      await this.writeFile();
+    });
+  }
+
+  private async writeFile(): Promise<void> {
+    const dir = path.dirname(this.filePath);
+    await fs.mkdir(dir, { recursive: true });
+    const data = JSON.stringify([...this.items], null, 2);
+    await fs.writeFile(this.filePath, data, 'utf-8');
+  }
+
+  private enqueue(op: () => Promise<void>): Promise<void> {
+    this.writeQueue = this.writeQueue.then(op, op);
+    return this.writeQueue;
+  }
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return err instanceof Error && 'code' in err;
+}

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -24,10 +24,16 @@ export class ReadStateStore {
   }
 
   /** Returns true only when the key is newly added. Persists automatically. */
-  add(key: string): boolean {
+  async add(key: string): Promise<boolean> {
+    if (!this.loaded) { await this.load(); }
     if (this.items.has(key)) { return false; }
-    this.items.add(key);
-    this.enqueueSave();
+    await this.enqueue(() => {
+      this.items.add(key);
+      return this.writeFile().catch((err) => {
+        this.items.delete(key);
+        throw err;
+      });
+    });
     return true;
   }
 

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -27,12 +27,14 @@ export class ReadStateStore {
   async add(key: string): Promise<boolean> {
     if (!this.loaded) { await this.load(); }
     if (this.items.has(key)) { return false; }
-    await this.enqueue(() => {
+    await this.enqueue(async () => {
       this.items.add(key);
-      return this.writeFile().catch((err) => {
+      try {
+        await this.writeFile();
+      } catch (err) {
         this.items.delete(key);
         throw err;
-      });
+      }
     });
     return true;
   }
@@ -47,7 +49,11 @@ export class ReadStateStore {
 
   /** Persist current state to disk (call after batch deletions). */
   save(): void {
-    this.enqueueSave();
+    this.enqueue(async () => {
+      await this.writeFile();
+    }).catch((err) => {
+      logger.error('Failed to save read state', err);
+    });
   }
 
   /** Returns a promise that resolves when all queued writes complete. */
@@ -74,12 +80,6 @@ export class ReadStateStore {
       }
       throw err;
     }
-  }
-
-  private enqueueSave(): void {
-    this.enqueue(async () => {
-      await this.writeFile();
-    });
   }
 
   private async writeFile(): Promise<void> {

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -43,15 +43,33 @@ function createMockProviderRegistry() {
   };
 }
 
+function createMockReadStateStore() {
+  const items = new Set<string>();
+  return {
+    has: vi.fn((key: string) => items.has(key)),
+    add: vi.fn((key: string) => {
+      if (items.has(key)) { return false; }
+      items.add(key);
+      return true;
+    }),
+    delete: vi.fn((key: string) => items.delete(key)),
+    keys: vi.fn(() => items.values()),
+    save: vi.fn(),
+    load: vi.fn(async () => {}),
+  };
+}
+
 describe('InboxTreeProvider', () => {
   let stateStore: ReturnType<typeof createMockStateStore>;
+  let readStateStore: ReturnType<typeof createMockReadStateStore>;
   let registry: ReturnType<typeof createMockProviderRegistry>;
   let provider: InboxTreeProvider;
 
   beforeEach(() => {
     stateStore = createMockStateStore();
+    readStateStore = createMockReadStateStore();
     registry = createMockProviderRegistry();
-    provider = new InboxTreeProvider(registry as any, stateStore as any);
+    provider = new InboxTreeProvider(registry as any, stateStore as any, readStateStore as any);
   });
 
   function providerNode(providerId: string): InboxProviderNode {

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -57,7 +57,7 @@ function createMockReadStateStore() {
     }),
     delete: vi.fn((key: string) => items.delete(key)),
     keys: vi.fn(() => items.values()),
-    save: vi.fn(),
+    saveWithRollback: vi.fn(),
     load: vi.fn(async () => {}),
   };
 }

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -47,7 +47,7 @@ function createMockReadStateStore() {
   const items = new Set<string>();
   return {
     has: vi.fn((key: string) => items.has(key)),
-    add: vi.fn((key: string) => {
+    add: vi.fn(async (key: string) => {
       if (items.has(key)) { return false; }
       items.add(key);
       return true;
@@ -273,9 +273,9 @@ describe('InboxTreeProvider', () => {
       expect((treeItem.iconPath as any).id).toBe('circle-filled');
     });
 
-    it('should render seen inbox item with circle-outline icon', () => {
+    it('should render seen inbox item with circle-outline icon', async () => {
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
-      provider.markSeen('gh', '1');
+      await provider.markSeen('gh', '1');
       const treeItem = provider.getTreeItem(item);
 
       expect(treeItem.label).toBe('Bug');
@@ -309,13 +309,13 @@ describe('InboxTreeProvider', () => {
   });
 
   describe('markSeen', () => {
-    it('should return true for a newly seen item', () => {
-      expect(provider.markSeen('gh', '1')).toBe(true);
+    it('should return true for a newly seen item', async () => {
+      expect(await provider.markSeen('gh', '1')).toBe(true);
     });
 
-    it('should return false if item is already seen', () => {
-      provider.markSeen('gh', '1');
-      expect(provider.markSeen('gh', '1')).toBe(false);
+    it('should return false if item is already seen', async () => {
+      await provider.markSeen('gh', '1');
+      expect(await provider.markSeen('gh', '1')).toBe(false);
     });
   });
 
@@ -367,10 +367,10 @@ describe('InboxTreeProvider', () => {
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
-    it('should retain seenItems for items still in inbox after provider refresh', () => {
+    it('should retain seenItems for items still in inbox after provider refresh', async () => {
       registry._setItems('gh', [{ externalId: '1', title: 'Bug' }]);
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
-      provider.markSeen('gh', '1');
+      await provider.markSeen('gh', '1');
 
       // Before refresh, item should be seen (circle-outline icon)
       expect(provider.getTreeItem(item).label).toBe('Bug');
@@ -384,9 +384,9 @@ describe('InboxTreeProvider', () => {
       expect((provider.getTreeItem(item).iconPath as any).id).toBe('circle-outline');
     });
 
-    it('should prune seenItems for items no longer in inbox after provider refresh', () => {
+    it('should prune seenItems for items no longer in inbox after provider refresh', async () => {
       registry._setItems('gh', [{ externalId: '1', title: 'Bug' }]);
-      provider.markSeen('gh', '1');
+      await provider.markSeen('gh', '1');
 
       // Remove item from provider
       registry._setItems('gh', []);

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -388,15 +388,21 @@ describe('InboxTreeProvider', () => {
     });
 
     it('should prune seenItems for items no longer in inbox after provider refresh', async () => {
-      registry._setItems('gh', [{ externalId: '1', title: 'Bug' }]);
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Bug' },
+        { externalId: '2', title: 'Feature' },
+      ]);
       await provider.markSeen('gh', '1');
 
-      // Remove item from provider
-      registry._setItems('gh', []);
+      // Replace items — item '1' is gone, item '2' remains
+      registry._setItems('gh', [{ externalId: '2', title: 'Feature' }]);
       registry._fire();
 
-      // Re-add item — should appear as unseen (circle-filled icon)
-      registry._setItems('gh', [{ externalId: '1', title: 'Bug' }]);
+      // Re-add item '1' — should appear as unseen since it was pruned
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Bug' },
+        { externalId: '2', title: 'Feature' },
+      ]);
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
       expect(provider.getTreeItem(item).label).toBe('Bug');
       expect((provider.getTreeItem(item).iconPath as any).id).toBe('circle-filled');

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -28,7 +28,9 @@ function createMockProviderRegistry() {
   const items = new Map<string, DiscoveredItem[]>();
   const labels = new Map<string, string>();
   const emitter = new EventEmitter<void>();
+  let _loading = false;
   return {
+    get loading() { return _loading; },
     getAllDiscoveredItems: vi.fn(() => items),
     getDiscoveredItems: vi.fn((id: string) => items.get(id) ?? []),
     getProviderLabel: vi.fn((id: string) => labels.get(id) ?? id),
@@ -39,6 +41,7 @@ function createMockProviderRegistry() {
     _setLabel: (providerId: string, label: string) => {
       labels.set(providerId, label);
     },
+    _setLoading: (val: boolean) => { _loading = val; },
     _fire: () => emitter.fire(),
   };
 }
@@ -404,6 +407,25 @@ describe('InboxTreeProvider', () => {
       provider.onDidChangeTreeData(listener);
       stateStore._fire();
       expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should skip pruning seenItems while providers are loading', async () => {
+      registry._setItems('gh', [{ externalId: '1', title: 'Bug' }]);
+      await provider.markSeen('gh', '1');
+
+      // Simulate provider re-registration: items temporarily empty, loading=true
+      registry._setItems('gh', []);
+      registry._setLoading(true);
+      registry._fire();
+
+      // After loading completes, items come back
+      registry._setItems('gh', [{ externalId: '1', title: 'Bug' }]);
+      registry._setLoading(false);
+      registry._fire();
+
+      // Item should still be seen because pruning was skipped while loading
+      const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
+      expect((provider.getTreeItem(item).iconPath as any).id).toBe('circle-outline');
     });
   });
 });

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -55,9 +55,10 @@ function createMockReadStateStore() {
       items.add(key);
       return true;
     }),
-    delete: vi.fn((key: string) => items.delete(key)),
+    deleteMany: vi.fn((keys: string[]) => {
+      for (const key of keys) { items.delete(key); }
+    }),
     keys: vi.fn(() => items.values()),
-    saveWithRollback: vi.fn(),
     load: vi.fn(async () => {}),
   };
 }

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -46,16 +46,30 @@ describe('ReadStateStore', () => {
     expect(store.has('gh::1')).toBe(true);
   });
 
-  it('should delete a key', async () => {
+  it('should deleteMany keys and persist', async () => {
     await store.load();
     await store.add('gh::1');
-    expect(store.delete('gh::1')).toBe(true);
+    await store.add('gh::2');
+    await store.add('gh::3');
+    store.deleteMany(['gh::1', 'gh::3']);
+    await store.flush();
+
     expect(store.has('gh::1')).toBe(false);
+    expect(store.has('gh::2')).toBe(true);
+    expect(store.has('gh::3')).toBe(false);
+
+    const filePath = path.join(tmpDir, 'read-state.json');
+    const raw = await fs.readFile(filePath, 'utf-8');
+    expect(JSON.parse(raw)).toEqual(['gh::2']);
   });
 
-  it('should return false when deleting a non-existent key', async () => {
+  it('should ignore non-existent keys in deleteMany', async () => {
     await store.load();
-    expect(store.delete('gh::nonexistent')).toBe(false);
+    await store.add('gh::1');
+    store.deleteMany(['gh::nonexistent']);
+    await store.flush();
+
+    expect(store.has('gh::1')).toBe(true);
   });
 
   it('should iterate keys', async () => {
@@ -64,19 +78,6 @@ describe('ReadStateStore', () => {
     await store.add('gh::2');
     const keys = [...store.keys()];
     expect(keys.sort()).toEqual(['gh::1', 'gh::2']);
-  });
-
-  it('should persist after saveWithRollback()', async () => {
-    await store.load();
-    await store.add('gh::1');
-    await store.add('gh::2');
-    store.delete('gh::1');
-    store.saveWithRollback(['gh::1']);
-    await store.flush();
-
-    const filePath = path.join(tmpDir, 'read-state.json');
-    const raw = await fs.readFile(filePath, 'utf-8');
-    expect(JSON.parse(raw)).toEqual(['gh::2']);
   });
 
   it('should load persisted state from a fresh instance', async () => {

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -66,12 +66,12 @@ describe('ReadStateStore', () => {
     expect(keys.sort()).toEqual(['gh::1', 'gh::2']);
   });
 
-  it('should persist after save()', async () => {
+  it('should persist after saveWithRollback()', async () => {
     await store.load();
     await store.add('gh::1');
     await store.add('gh::2');
     store.delete('gh::1');
-    store.save();
+    store.saveWithRollback(['gh::1']);
     await store.flush();
 
     const filePath = path.join(tmpDir, 'read-state.json');

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
@@ -119,5 +119,33 @@ describe('ReadStateStore', () => {
     // Second load should be a no-op
     await store.load();
     expect(store.has('gh::1')).toBe(true);
+  });
+
+  it('should rollback in-memory state when write fails', async () => {
+    await store.load();
+
+    // Point the store at an invalid path to trigger a write error.
+    const originalPath = (store as any).filePath;
+    (store as any).filePath = path.join(tmpDir, '\0invalid');
+
+    await expect(store.add('gh::fail')).rejects.toThrow();
+    expect(store.has('gh::fail')).toBe(false);
+
+    // Restore path and reset write queue so afterEach cleanup succeeds
+    (store as any).filePath = originalPath;
+    (store as any).writeQueue = Promise.resolve();
+  });
+
+  it('should auto-load when add() is called before load()', async () => {
+    // Write existing state to disk first
+    const filePath = path.join(tmpDir, 'read-state.json');
+    await fs.writeFile(filePath, JSON.stringify(['gh::existing']), 'utf-8');
+
+    const freshStore = new ReadStateStore(tmpDir);
+    // Call add() without calling load() first
+    await freshStore.add('gh::new');
+
+    expect(freshStore.has('gh::existing')).toBe(true);
+    expect(freshStore.has('gh::new')).toBe(true);
   });
 });

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -25,7 +25,7 @@ describe('ReadStateStore', () => {
 
   it('should add a key and persist to disk', async () => {
     await store.load();
-    expect(store.add('gh::issue-1')).toBe(true);
+    expect(await store.add('gh::issue-1')).toBe(true);
     await store.flush();
 
     const filePath = path.join(tmpDir, 'read-state.json');
@@ -35,20 +35,20 @@ describe('ReadStateStore', () => {
 
   it('should return false when adding a duplicate key', async () => {
     await store.load();
-    expect(store.add('gh::1')).toBe(true);
-    expect(store.add('gh::1')).toBe(false);
+    expect(await store.add('gh::1')).toBe(true);
+    expect(await store.add('gh::1')).toBe(false);
   });
 
   it('should report has() correctly after add', async () => {
     await store.load();
     expect(store.has('gh::1')).toBe(false);
-    store.add('gh::1');
+    await store.add('gh::1');
     expect(store.has('gh::1')).toBe(true);
   });
 
   it('should delete a key', async () => {
     await store.load();
-    store.add('gh::1');
+    await store.add('gh::1');
     expect(store.delete('gh::1')).toBe(true);
     expect(store.has('gh::1')).toBe(false);
   });
@@ -60,16 +60,16 @@ describe('ReadStateStore', () => {
 
   it('should iterate keys', async () => {
     await store.load();
-    store.add('gh::1');
-    store.add('gh::2');
+    await store.add('gh::1');
+    await store.add('gh::2');
     const keys = [...store.keys()];
     expect(keys.sort()).toEqual(['gh::1', 'gh::2']);
   });
 
   it('should persist after save()', async () => {
     await store.load();
-    store.add('gh::1');
-    store.add('gh::2');
+    await store.add('gh::1');
+    await store.add('gh::2');
     store.delete('gh::1');
     store.save();
     await store.flush();
@@ -81,8 +81,8 @@ describe('ReadStateStore', () => {
 
   it('should load persisted state from a fresh instance', async () => {
     await store.load();
-    store.add('gh::1');
-    store.add('jira::2');
+    await store.add('gh::1');
+    await store.add('jira::2');
     await store.flush();
 
     const store2 = new ReadStateStore(tmpDir);
@@ -103,7 +103,7 @@ describe('ReadStateStore', () => {
     const nestedDir = path.join(tmpDir, 'nested', 'path');
     const nestedStore = new ReadStateStore(nestedDir);
     await nestedStore.load();
-    nestedStore.add('gh::1');
+    await nestedStore.add('gh::1');
     await nestedStore.flush();
 
     const filePath = path.join(nestedDir, 'read-state.json');
@@ -113,7 +113,7 @@ describe('ReadStateStore', () => {
 
   it('should only load once (idempotent)', async () => {
     await store.load();
-    store.add('gh::1');
+    await store.add('gh::1');
     await store.flush();
 
     // Second load should be a no-op

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { ReadStateStore } from '../storage/readStateStore';
+
+describe('ReadStateStore', () => {
+  let tmpDir: string;
+  let store: ReadStateStore;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workcenter-readstate-test-'));
+    store = new ReadStateStore(tmpDir);
+  });
+
+  afterEach(async () => {
+    await store.flush();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('should return false for has() when file is missing on load', async () => {
+    await store.load();
+    expect(store.has('gh::1')).toBe(false);
+  });
+
+  it('should add a key and persist to disk', async () => {
+    await store.load();
+    expect(store.add('gh::issue-1')).toBe(true);
+    await store.flush();
+
+    const filePath = path.join(tmpDir, 'read-state.json');
+    const raw = await fs.readFile(filePath, 'utf-8');
+    expect(JSON.parse(raw)).toEqual(['gh::issue-1']);
+  });
+
+  it('should return false when adding a duplicate key', async () => {
+    await store.load();
+    expect(store.add('gh::1')).toBe(true);
+    expect(store.add('gh::1')).toBe(false);
+  });
+
+  it('should report has() correctly after add', async () => {
+    await store.load();
+    expect(store.has('gh::1')).toBe(false);
+    store.add('gh::1');
+    expect(store.has('gh::1')).toBe(true);
+  });
+
+  it('should delete a key', async () => {
+    await store.load();
+    store.add('gh::1');
+    expect(store.delete('gh::1')).toBe(true);
+    expect(store.has('gh::1')).toBe(false);
+  });
+
+  it('should return false when deleting a non-existent key', async () => {
+    await store.load();
+    expect(store.delete('gh::nonexistent')).toBe(false);
+  });
+
+  it('should iterate keys', async () => {
+    await store.load();
+    store.add('gh::1');
+    store.add('gh::2');
+    const keys = [...store.keys()];
+    expect(keys.sort()).toEqual(['gh::1', 'gh::2']);
+  });
+
+  it('should persist after save()', async () => {
+    await store.load();
+    store.add('gh::1');
+    store.add('gh::2');
+    store.delete('gh::1');
+    store.save();
+    await store.flush();
+
+    const filePath = path.join(tmpDir, 'read-state.json');
+    const raw = await fs.readFile(filePath, 'utf-8');
+    expect(JSON.parse(raw)).toEqual(['gh::2']);
+  });
+
+  it('should load persisted state from a fresh instance', async () => {
+    await store.load();
+    store.add('gh::1');
+    store.add('jira::2');
+    await store.flush();
+
+    const store2 = new ReadStateStore(tmpDir);
+    await store2.load();
+    expect(store2.has('gh::1')).toBe(true);
+    expect(store2.has('jira::2')).toBe(true);
+    expect(store2.has('gh::3')).toBe(false);
+  });
+
+  it('should handle corrupted JSON by throwing', async () => {
+    const filePath = path.join(tmpDir, 'read-state.json');
+    await fs.writeFile(filePath, 'not valid json', 'utf-8');
+
+    await expect(store.load()).rejects.toThrow();
+  });
+
+  it('should create storage directory if it does not exist', async () => {
+    const nestedDir = path.join(tmpDir, 'nested', 'path');
+    const nestedStore = new ReadStateStore(nestedDir);
+    await nestedStore.load();
+    nestedStore.add('gh::1');
+    await nestedStore.flush();
+
+    const filePath = path.join(nestedDir, 'read-state.json');
+    const raw = await fs.readFile(filePath, 'utf-8');
+    expect(JSON.parse(raw)).toEqual(['gh::1']);
+  });
+
+  it('should only load once (idempotent)', async () => {
+    await store.load();
+    store.add('gh::1');
+    await store.flush();
+
+    // Second load should be a no-op
+    await store.load();
+    expect(store.has('gh::1')).toBe(true);
+  });
+});

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -52,6 +52,10 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   }
 
   private pruneSeenItems(): void {
+    // Skip pruning while providers are still loading to avoid
+    // wiping persisted read-state before discovery completes.
+    if (this.providerRegistry.loading) { return; }
+
     const currentKeys = new Set<string>();
     for (const [providerId, items] of this.providerRegistry.getAllDiscoveredItems()) {
       for (const item of items) {

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -58,6 +58,14 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     const discoveredItems = this.providerRegistry.getAllDiscoveredItems();
     if (discoveredItems.size === 0) { return; }
 
+    // Skip pruning if no provider has any discovered items yet (e.g.
+    // all initial refreshes failed), so transient failures don't wipe state.
+    let totalItems = 0;
+    for (const [, items] of discoveredItems) {
+      totalItems += items.length;
+    }
+    if (totalItems === 0) { return; }
+
     const currentKeys = new Set<string>();
     for (const [providerId, items] of discoveredItems) {
       for (const item of items) {

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { DiscoveredItem } from '../api/types';
 import { ProviderRegistry } from '../services/providerRegistry';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
+import { ReadStateStore } from '../storage/readStateStore';
 
 export interface InboxProviderNode {
   kind: 'provider';
@@ -32,11 +33,11 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private readonly disposables: vscode.Disposable[] = [];
-  private readonly seenItems = new Set<string>();
 
   constructor(
     private readonly providerRegistry: ProviderRegistry,
     private readonly stateStore: DiscoveredStateStore,
+    private readonly readStateStore: ReadStateStore,
   ) {
     this.disposables.push(
       providerRegistry.onDidChangeDiscoveredItems(() => {
@@ -60,10 +61,15 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
         }
       }
     }
-    for (const key of this.seenItems) {
+    let changed = false;
+    for (const key of this.readStateStore.keys()) {
       if (!currentKeys.has(key)) {
-        this.seenItems.delete(key);
+        this.readStateStore.delete(key);
+        changed = true;
       }
+    }
+    if (changed) {
+      this.readStateStore.save();
     }
   }
 
@@ -71,11 +77,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   markSeen(providerId: string, externalId: string): boolean {
     const key = `${providerId}::${externalId}`;
-    if (!this.seenItems.has(key)) {
-      this.seenItems.add(key);
-      return true;
-    }
-    return false;
+    return this.readStateStore.add(key);
   }
 
   getTreeItem(element: InboxElement): vscode.TreeItem {
@@ -99,7 +101,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     }
 
     const key = `${element.providerId}::${element.externalId}`;
-    const isSeen = this.seenItems.has(key);
+    const isSeen = this.readStateStore.has(key);
 
     const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = `inbox::item::${element.providerId}::${element.externalId}`;

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -52,12 +52,14 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   }
 
   private pruneSeenItems(): void {
-    // Skip pruning while providers are still loading to avoid
-    // wiping persisted read-state before discovery completes.
+    // Skip pruning while providers are still loading or temporarily
+    // unregistered to avoid wiping persisted read-state.
     if (this.providerRegistry.loading) { return; }
+    const discoveredItems = this.providerRegistry.getAllDiscoveredItems();
+    if (discoveredItems.size === 0) { return; }
 
     const currentKeys = new Set<string>();
-    for (const [providerId, items] of this.providerRegistry.getAllDiscoveredItems()) {
+    for (const [providerId, items] of discoveredItems) {
       for (const item of items) {
         const state = this.stateStore.getState(providerId, item.externalId);
         if (state === undefined || state === 'unseen') {
@@ -65,15 +67,17 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
         }
       }
     }
-    let changed = false;
+    const deletedKeys: string[] = [];
     for (const key of this.readStateStore.keys()) {
       if (!currentKeys.has(key)) {
-        this.readStateStore.delete(key);
-        changed = true;
+        deletedKeys.push(key);
       }
     }
-    if (changed) {
-      this.readStateStore.save();
+    if (deletedKeys.length > 0) {
+      for (const key of deletedKeys) {
+        this.readStateStore.delete(key);
+      }
+      this.readStateStore.saveWithRollback(deletedKeys);
     }
   }
 

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -75,7 +75,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   refresh(): void { this._onDidChangeTreeData.fire(); }
 
-  markSeen(providerId: string, externalId: string): boolean {
+  async markSeen(providerId: string, externalId: string): Promise<boolean> {
     const key = `${providerId}::${externalId}`;
     return this.readStateStore.add(key);
   }

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -58,16 +58,14 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     const discoveredItems = this.providerRegistry.getAllDiscoveredItems();
     if (discoveredItems.size === 0) { return; }
 
-    // Skip pruning if no provider has any discovered items yet (e.g.
-    // all initial refreshes failed), so transient failures don't wipe state.
-    let totalItems = 0;
-    for (const [, items] of discoveredItems) {
-      totalItems += items.length;
-    }
-    if (totalItems === 0) { return; }
-
+    // Build current inbox keys, scoped to providers that have items.
+    // Providers with empty item arrays (e.g. failed refresh) are excluded
+    // so their read-state keys are preserved.
     const currentKeys = new Set<string>();
+    const activeProviderIds = new Set<string>();
     for (const [providerId, items] of discoveredItems) {
+      if (items.length === 0) { continue; }
+      activeProviderIds.add(providerId);
       for (const item of items) {
         const state = this.stateStore.getState(providerId, item.externalId);
         if (state === undefined || state === 'unseen') {
@@ -75,17 +73,18 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
         }
       }
     }
-    const deletedKeys: string[] = [];
+    if (activeProviderIds.size === 0) { return; }
+
+    const keysToDelete: string[] = [];
     for (const key of this.readStateStore.keys()) {
-      if (!currentKeys.has(key)) {
-        deletedKeys.push(key);
+      const providerId = key.split('::')[0];
+      // Only prune keys belonging to providers that have active items
+      if (activeProviderIds.has(providerId) && !currentKeys.has(key)) {
+        keysToDelete.push(key);
       }
     }
-    if (deletedKeys.length > 0) {
-      for (const key of deletedKeys) {
-        this.readStateStore.delete(key);
-      }
-      this.readStateStore.saveWithRollback(deletedKeys);
+    if (keysToDelete.length > 0) {
+      this.readStateStore.deleteMany(keysToDelete);
     }
   }
 


### PR DESCRIPTION
fix: add auto-load guard and write-failure rollback to ReadStateStore.add()

Match DiscoveredStateStore.setState() patterns:
- add() is now async with auto-load guard (if !this.loaded)
- Write failure rolls back in-memory state
- Update callers (markSeen, extension.ts) for async
- Update all tests to await async add()

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Merge remote-tracking branch 'origin/dev' into swarm/swarm-20260405-1513/persist-read-unread-state


feat: persist inbox read/unread state across restarts [swarm]

Closes #35

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

