### PR TITLE
security: add input validation for provider URL construction

### DIFF
--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { isValidUrlSegment } from '@workcenter/shared';
 import { logger } from './logger';
 
 // Re-declared to match core API contract — separate extension cannot import core types directly
@@ -133,6 +134,11 @@ export class AdoPrReviewProvider implements WorkCenterProvider {
   }
 
   private async fetchAndPublishPrs(accessToken: string, isUserTriggered: boolean, sessionAccountId: string): Promise<void> {
+    if (!isValidUrlSegment(this.org)) {
+      logger.warn('Skipping PR fetch: invalid ADO organization name', this.org);
+      return;
+    }
+
     const userId = await this.getUserId(accessToken, sessionAccountId);
     if (!userId) {
       const message = 'Failed to determine Azure DevOps user identity';
@@ -144,7 +150,21 @@ export class AdoPrReviewProvider implements WorkCenterProvider {
       return;
     }
 
-    const projectList = this.projects.length > 0 ? this.projects : [''];
+    const validProjects: string[] = [];
+    for (const project of this.projects) {
+      if (project === '' || isValidUrlSegment(project)) {
+        validProjects.push(project);
+      } else {
+        logger.warn('Skipping invalid ADO project name', project);
+      }
+    }
+
+    if (this.projects.length > 0 && validProjects.length === 0) {
+      logger.warn('All configured ADO projects are invalid — skipping PR fetch');
+      return;
+    }
+
+    const projectList = validProjects.length > 0 ? validProjects : [''];
     const results = await Promise.allSettled(
       projectList.map(project => this.fetchPrsForProject(accessToken, project, userId)),
     );

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -136,7 +136,7 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
 
   private async fetchAndPublishWorkItems(accessToken: string, isUserTriggered: boolean): Promise<void> {
     if (!isValidUrlSegment(this.org)) {
-      logger.warn(`Skipping fetch: invalid ADO organization name "${this.org}"`);
+      logger.warn('Skipping fetch: invalid ADO organization name', this.org);
       return;
     }
 
@@ -145,7 +145,7 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
       if (project === '' || isValidUrlSegment(project)) {
         validProjects.push(project);
       } else {
-        logger.warn(`Skipping invalid ADO project name: "${project}"`);
+        logger.warn('Skipping invalid ADO project name', project);
       }
     }
 

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { isValidUrlSegment } from '@workcenter/shared';
 import { logger } from './logger';
 
 // Re-declared to match core API contract — separate extension cannot import core types directly
@@ -62,7 +63,11 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
   constructor(
     private readonly org: string,
     private readonly projects: string[],
-  ) {}
+  ) {
+    if (!isValidUrlSegment(org)) {
+      throw new Error(`Invalid ADO organization name: "${org}"`);
+    }
+  }
 
   startPeriodicRefresh(intervalSeconds: number): void {
     this.stopPeriodicRefresh();
@@ -134,7 +139,17 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
   }
 
   private async fetchAndPublishWorkItems(accessToken: string, isUserTriggered: boolean): Promise<void> {
-    const projectList = this.projects.length > 0 ? this.projects : [''];
+    const validProjects: string[] = [];
+    const invalidProjects: string[] = [];
+    for (const project of this.projects) {
+      if (project === '' || isValidUrlSegment(project)) {
+        validProjects.push(project);
+      } else {
+        logger.warn(`Skipping invalid ADO project name: "${project}"`);
+        invalidProjects.push(project);
+      }
+    }
+    const projectList = validProjects.length > 0 ? validProjects : [''];
     const results = await Promise.allSettled(
       projectList.map(project => this.fetchWorkItemsForProject(accessToken, project)),
     );

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -63,11 +63,7 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
   constructor(
     private readonly org: string,
     private readonly projects: string[],
-  ) {
-    if (!isValidUrlSegment(org)) {
-      throw new Error(`Invalid ADO organization name: "${org}"`);
-    }
-  }
+  ) {}
 
   startPeriodicRefresh(intervalSeconds: number): void {
     this.stopPeriodicRefresh();
@@ -139,16 +135,25 @@ export class AdoWorkItemProvider implements WorkCenterProvider {
   }
 
   private async fetchAndPublishWorkItems(accessToken: string, isUserTriggered: boolean): Promise<void> {
+    if (!isValidUrlSegment(this.org)) {
+      logger.warn(`Skipping fetch: invalid ADO organization name "${this.org}"`);
+      return;
+    }
+
     const validProjects: string[] = [];
-    const invalidProjects: string[] = [];
     for (const project of this.projects) {
       if (project === '' || isValidUrlSegment(project)) {
         validProjects.push(project);
       } else {
         logger.warn(`Skipping invalid ADO project name: "${project}"`);
-        invalidProjects.push(project);
       }
     }
+
+    if (this.projects.length > 0 && validProjects.length === 0) {
+      logger.warn('All configured ADO projects are invalid — skipping fetch');
+      return;
+    }
+
     const projectList = validProjects.length > 0 ? validProjects : [''];
     const results = await Promise.allSettled(
       projectList.map(project => this.fetchWorkItemsForProject(accessToken, project)),

--- a/packages/ado/src/test/adoPrReviewProvider.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.test.ts
@@ -418,4 +418,56 @@ describe('AdoPrReviewProvider', () => {
 
     vi.useRealTimers();
   });
+
+  it('skips fetch when org name is invalid', async () => {
+    provider.dispose();
+    provider = new AdoPrReviewProvider('../evil', ['MyProject']);
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('skips invalid projects and fetches only valid ones', async () => {
+    provider.dispose();
+    provider = new AdoPrReviewProvider('myorg', ['ValidProject', '../bad', 'AlsoValid']);
+
+    // Connection data + 2 valid project PR fetches
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ authenticatedUser: { id: 'user-123' } }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ value: [] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ value: [] }) });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    // 1 connection data + 2 valid project fetches = 3
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('skips fetch when all configured projects are invalid', async () => {
+    provider.dispose();
+    provider = new AdoPrReviewProvider('myorg', ['../bad', '?evil']);
+
+    // Connection data call still happens before project validation
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ authenticatedUser: { id: 'user-123' } }),
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    // Only connection data fetch — no PR fetches
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(listener).not.toHaveBeenCalled();
+  });
 });

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -290,4 +290,51 @@ describe('AdoWorkItemProvider', () => {
       expect.any(Object),
     );
   });
+
+  it('skips fetch when org name is invalid', async () => {
+    provider.dispose();
+    provider = new AdoWorkItemProvider('../evil', ['MyProject']);
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('skips invalid projects and fetches only valid ones', async () => {
+    provider.dispose();
+    provider = new AdoWorkItemProvider('myorg', ['ValidProject', '../bad', 'AlsoValid']);
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => createWiqlResponse([]) })
+      .mockResolvedValueOnce({ ok: true, json: async () => createWiqlResponse([]) });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://dev.azure.com/myorg/ValidProject/_apis/wit/wiql?api-version=7.1',
+      expect.any(Object),
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://dev.azure.com/myorg/AlsoValid/_apis/wit/wiql?api-version=7.1',
+      expect.any(Object),
+    );
+  });
+
+  it('skips fetch when all configured projects are invalid', async () => {
+    provider.dispose();
+    provider = new AdoWorkItemProvider('myorg', ['../bad', '?evil']);
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
+  });
 });

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { isValidGitHubRepo } from '@workcenter/shared';
 import { logger } from './logger';
 
 // Re-declared to match core API contract — separate extension cannot import core types directly
@@ -166,22 +167,32 @@ export class GitHubIssueProvider implements WorkCenterProvider {
     repos: string[],
   ): Promise<{ issues: GitHubIssue[]; failures: string[] }> {
     if (repos.length > 0) {
+      const validRepos: string[] = [];
+      const failures: string[] = [];
+      for (const repo of repos) {
+        if (isValidGitHubRepo(repo)) {
+          validRepos.push(repo);
+        } else {
+          logger.warn(`Skipping invalid repo identifier: "${repo}"`);
+          failures.push(repo);
+        }
+      }
+
       const results = await Promise.allSettled(
-        repos.map(repo => this.fetchRepoIssues(token, repo))
+        validRepos.map(repo => this.fetchRepoIssues(token, repo))
       );
 
       const allIssues: GitHubIssue[] = [];
-      const failures: string[] = [];
 
       results.forEach((result, index) => {
         if (result.status === 'fulfilled') {
           const { issues, failed } = result.value;
           allIssues.push(...issues);
           if (failed) {
-            failures.push(repos[index]);
+            failures.push(validRepos[index]);
           }
         } else {
-          failures.push(repos[index]);
+          failures.push(validRepos[index]);
         }
       });
 

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -168,15 +168,15 @@ export class GitHubIssueProvider implements WorkCenterProvider {
   ): Promise<{ issues: GitHubIssue[]; failures: string[] }> {
     if (repos.length > 0) {
       const validRepos: string[] = [];
-      const failures: string[] = [];
       for (const repo of repos) {
         if (isValidGitHubRepo(repo)) {
           validRepos.push(repo);
         } else {
           logger.warn(`Skipping invalid repo identifier: "${repo}"`);
-          failures.push(repo);
         }
       }
+
+      const failures: string[] = [];
 
       const results = await Promise.allSettled(
         validRepos.map(repo => this.fetchRepoIssues(token, repo))

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -172,7 +172,7 @@ export class GitHubIssueProvider implements WorkCenterProvider {
         if (isValidGitHubRepo(repo)) {
           validRepos.push(repo);
         } else {
-          logger.warn(`Skipping invalid repo identifier: "${repo}"`);
+          logger.warn('Skipping invalid repo identifier', repo);
         }
       }
 

--- a/packages/github/src/test/githubProvider.test.ts
+++ b/packages/github/src/test/githubProvider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { authentication, workspace } from 'vscode';
+import { authentication, workspace, window } from 'vscode';
 import { GitHubIssueProvider } from '../githubProvider';
 
 // Mock global fetch
@@ -238,6 +238,8 @@ describe('GitHubIssueProvider', () => {
     expect(listener).toHaveBeenCalledTimes(1);
     const items = listener.mock.calls[0][0];
     expect(items).toHaveLength(2);
+    // Invalid repo should not surface as a fetch failure warning
+    expect(window.showWarningMessage).not.toHaveBeenCalled();
   });
 
   it('stopPeriodicRefresh clears the timer', () => {

--- a/packages/github/src/test/githubProvider.test.ts
+++ b/packages/github/src/test/githubProvider.test.ts
@@ -211,6 +211,35 @@ describe('GitHubIssueProvider', () => {
     vi.useRealTimers();
   });
 
+  it('skips invalid repo identifiers without treating them as fetch failures', async () => {
+    vi.mocked(workspace.getConfiguration).mockReturnValue({
+      get: vi.fn((key: string, defaultValue?: any) => {
+        if (key === 'repos') { return ['owner/valid', '../traversal', 'good/repo']; }
+        return defaultValue;
+      }),
+    } as any);
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [createMockIssue(1, 'Issue A', 'owner/valid')],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [createMockIssue(2, 'Issue B', 'good/repo')],
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    // Only 2 fetch calls — invalid repo is skipped
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenCalledTimes(1);
+    const items = listener.mock.calls[0][0];
+    expect(items).toHaveLength(2);
+  });
+
   it('stopPeriodicRefresh clears the timer', () => {
     vi.useFakeTimers();
 

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,5 +8,8 @@
     "build": "echo No build needed",
     "test": "vitest run",
     "lint": "echo No lint needed"
+  },
+  "devDependencies": {
+    "vitest": "^1.2.0"
   }
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,7 +6,7 @@
   "types": "src/index.ts",
   "scripts": {
     "build": "echo No build needed",
-    "test": "echo No tests yet",
+    "test": "vitest run",
     "lint": "echo No lint needed"
   }
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,3 @@
 export { createLoggerService, LogLevel, serializeArg } from './logger';
 export type { Logger, LogOutput, LoggerService } from './logger';
+export { isValidUrlSegment, isValidGitHubRepo } from './urlValidation';

--- a/packages/shared/src/test/urlValidation.test.ts
+++ b/packages/shared/src/test/urlValidation.test.ts
@@ -48,6 +48,7 @@ describe('isValidUrlSegment', () => {
   describe('rejects query and fragment characters', () => {
     it.each([
       'org?malicious=param',
+      'org?param',
       'org#fragment',
     ])('rejects "%s"', (input) => {
       expect(isValidUrlSegment(input)).toBe(false);
@@ -81,15 +82,6 @@ describe('isValidUrlSegment', () => {
       '_underscore',
     ])('accepts "%s"', (input) => {
       expect(isValidUrlSegment(input)).toBe(true);
-    });
-  });
-
-  describe('rejects special characters used in URL injection', () => {
-    it.each([
-      'org?param',
-      'org#fragment',
-    ])('rejects "%s"', (input) => {
-      expect(isValidUrlSegment(input)).toBe(false);
     });
   });
 

--- a/packages/shared/src/test/urlValidation.test.ts
+++ b/packages/shared/src/test/urlValidation.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { isValidUrlSegment, isValidGitHubRepo } from '../urlValidation';
+
+describe('isValidUrlSegment', () => {
+  describe('accepts valid segments', () => {
+    it.each([
+      'my-org',
+      'my_org',
+      'my.org',
+      'org123',
+      'A',
+      '9starts-with-number',
+      'MixedCase',
+      'a.b.c',
+      'a-b_c.d',
+    ])('accepts "%s"', (input) => {
+      expect(isValidUrlSegment(input)).toBe(true);
+    });
+  });
+
+  describe('rejects path traversal attempts', () => {
+    it.each([
+      '..',
+      '../etc',
+      'a..b',
+      '...',
+    ])('rejects "%s"', (input) => {
+      expect(isValidUrlSegment(input)).toBe(false);
+    });
+  });
+
+  describe('rejects slashes and backslashes', () => {
+    it.each([
+      'org/subpath',
+      'org\\subpath',
+      'a//b',
+    ])('rejects "%s"', (input) => {
+      expect(isValidUrlSegment(input)).toBe(false);
+    });
+  });
+
+  describe('rejects query and fragment characters', () => {
+    it.each([
+      'org?malicious=param',
+      'org#fragment',
+    ])('rejects "%s"', (input) => {
+      expect(isValidUrlSegment(input)).toBe(false);
+    });
+  });
+
+  describe('rejects empty and non-string values', () => {
+    it('rejects empty string', () => {
+      expect(isValidUrlSegment('')).toBe(false);
+    });
+
+    it('rejects null', () => {
+      expect(isValidUrlSegment(null as unknown as string)).toBe(false);
+    });
+
+    it('rejects undefined', () => {
+      expect(isValidUrlSegment(undefined as unknown as string)).toBe(false);
+    });
+  });
+
+  describe('rejects segments starting with non-alphanumeric', () => {
+    it.each([
+      '.hidden',
+      '-dash',
+      '_underscore',
+    ])('rejects "%s"', (input) => {
+      expect(isValidUrlSegment(input)).toBe(false);
+    });
+  });
+
+  describe('rejects special characters', () => {
+    it.each([
+      'org name',
+      'org@host',
+      'org:port',
+      'org;semi',
+    ])('rejects "%s"', (input) => {
+      expect(isValidUrlSegment(input)).toBe(false);
+    });
+  });
+});
+
+describe('isValidGitHubRepo', () => {
+  describe('accepts valid owner/repo identifiers', () => {
+    it.each([
+      'owner/repo',
+      'my-org/my-repo',
+      'user123/project_v2',
+      'Org/Repo.js',
+    ])('accepts "%s"', (input) => {
+      expect(isValidGitHubRepo(input)).toBe(true);
+    });
+  });
+
+  describe('rejects invalid formats', () => {
+    it('rejects single segment', () => {
+      expect(isValidGitHubRepo('owner')).toBe(false);
+    });
+
+    it('rejects three segments', () => {
+      expect(isValidGitHubRepo('owner/repo/extra')).toBe(false);
+    });
+
+    it('rejects traversal in owner', () => {
+      expect(isValidGitHubRepo('../repo')).toBe(false);
+    });
+
+    it('rejects traversal in repo', () => {
+      expect(isValidGitHubRepo('owner/..')).toBe(false);
+    });
+
+    it('rejects empty string', () => {
+      expect(isValidGitHubRepo('')).toBe(false);
+    });
+
+    it('rejects null', () => {
+      expect(isValidGitHubRepo(null as unknown as string)).toBe(false);
+    });
+  });
+});

--- a/packages/shared/src/test/urlValidation.test.ts
+++ b/packages/shared/src/test/urlValidation.test.ts
@@ -21,11 +21,19 @@ describe('isValidUrlSegment', () => {
   describe('rejects path traversal attempts', () => {
     it.each([
       '..',
-      '../etc',
-      'a..b',
-      '...',
+      '.',
     ])('rejects "%s"', (input) => {
       expect(isValidUrlSegment(input)).toBe(false);
+    });
+
+    it.each([
+      'a..b',
+    ])('accepts "%s" (not traversal)', (input) => {
+      expect(isValidUrlSegment(input)).toBe(true);
+    });
+
+    it('rejects "..." (starts with non-alphanumeric)', () => {
+      expect(isValidUrlSegment('...')).toBe(false);
     });
   });
 

--- a/packages/shared/src/test/urlValidation.test.ts
+++ b/packages/shared/src/test/urlValidation.test.ts
@@ -28,12 +28,10 @@ describe('isValidUrlSegment', () => {
 
     it.each([
       'a..b',
+      '...',
+      '.github',
     ])('accepts "%s" (not traversal)', (input) => {
       expect(isValidUrlSegment(input)).toBe(true);
-    });
-
-    it('rejects "..." (starts with non-alphanumeric)', () => {
-      expect(isValidUrlSegment('...')).toBe(false);
     });
   });
 
@@ -70,13 +68,21 @@ describe('isValidUrlSegment', () => {
     });
   });
 
-  describe('rejects segments starting with non-alphanumeric', () => {
+  describe('rejects segments starting with non-safe characters', () => {
+    it.each([
+      ' leading-space',
+    ])('rejects "%s"', (input) => {
+      expect(isValidUrlSegment(input)).toBe(false);
+    });
+  });
+
+  describe('accepts segments starting with dot/dash/underscore', () => {
     it.each([
       '.hidden',
       '-dash',
       '_underscore',
-    ])('rejects "%s"', (input) => {
-      expect(isValidUrlSegment(input)).toBe(false);
+    ])('accepts "%s"', (input) => {
+      expect(isValidUrlSegment(input)).toBe(true);
     });
   });
 
@@ -119,6 +125,10 @@ describe('isValidGitHubRepo', () => {
 
     it('rejects traversal in repo', () => {
       expect(isValidGitHubRepo('owner/..')).toBe(false);
+    });
+
+    it('accepts .github repo names', () => {
+      expect(isValidGitHubRepo('owner/.github')).toBe(true);
     });
 
     it('rejects empty string', () => {

--- a/packages/shared/src/test/urlValidation.test.ts
+++ b/packages/shared/src/test/urlValidation.test.ts
@@ -69,10 +69,8 @@ describe('isValidUrlSegment', () => {
   });
 
   describe('rejects segments starting with non-safe characters', () => {
-    it.each([
-      ' leading-space',
-    ])('rejects "%s"', (input) => {
-      expect(isValidUrlSegment(input)).toBe(false);
+    it('rejects whitespace-only strings', () => {
+      expect(isValidUrlSegment('   ')).toBe(false);
     });
   });
 
@@ -86,14 +84,23 @@ describe('isValidUrlSegment', () => {
     });
   });
 
-  describe('rejects special characters', () => {
+  describe('rejects special characters used in URL injection', () => {
+    it.each([
+      'org?param',
+      'org#fragment',
+    ])('rejects "%s"', (input) => {
+      expect(isValidUrlSegment(input)).toBe(false);
+    });
+  });
+
+  describe('accepts segments with other special characters', () => {
     it.each([
       'org name',
       'org@host',
       'org:port',
       'org;semi',
-    ])('rejects "%s"', (input) => {
-      expect(isValidUrlSegment(input)).toBe(false);
+    ])('accepts "%s" (encoded by provider)', (input) => {
+      expect(isValidUrlSegment(input)).toBe(true);
     });
   });
 });

--- a/packages/shared/src/urlValidation.ts
+++ b/packages/shared/src/urlValidation.ts
@@ -1,13 +1,14 @@
-// Pattern for a single URL path segment: one or more alphanumeric/hyphens/underscores/dots
-const SAFE_SEGMENT = /^[a-zA-Z0-9._-]+$/;
-
 /**
  * Validates a single URL path segment (org name, project name, repo name).
- * Rejects empty strings, path traversal sequences, query/fragment characters,
- * slashes, and anything that doesn't match the safe character set.
+ * Blocks path traversal (`.` / `..`), path separators (`/` / `\`),
+ * and query/fragment injection (`?` / `#`). Allows other characters
+ * since providers already apply encodeURIComponent when building URLs.
  */
 export function isValidUrlSegment(value: string): boolean {
   if (!value || typeof value !== 'string') {
+    return false;
+  }
+  if (!value.trim()) {
     return false;
   }
   if (value === '.' || value === '..') {
@@ -19,7 +20,7 @@ export function isValidUrlSegment(value: string): boolean {
   if (value.includes('/') || value.includes('\\')) {
     return false;
   }
-  return SAFE_SEGMENT.test(value);
+  return true;
 }
 
 /**

--- a/packages/shared/src/urlValidation.ts
+++ b/packages/shared/src/urlValidation.ts
@@ -10,7 +10,7 @@ export function isValidUrlSegment(value: string): boolean {
   if (!value || typeof value !== 'string') {
     return false;
   }
-  if (value.includes('..') || value.includes('//')) {
+  if (value === '.' || value === '..') {
     return false;
   }
   if (value.includes('?') || value.includes('#')) {

--- a/packages/shared/src/urlValidation.ts
+++ b/packages/shared/src/urlValidation.ts
@@ -1,0 +1,38 @@
+// Pattern for a single URL path segment: alphanumeric start, then alphanumeric/hyphens/underscores/dots
+const SAFE_SEGMENT = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
+/**
+ * Validates a single URL path segment (org name, project name, repo name).
+ * Rejects empty strings, path traversal sequences, query/fragment characters,
+ * slashes, and anything that doesn't match the safe character set.
+ */
+export function isValidUrlSegment(value: string): boolean {
+  if (!value || typeof value !== 'string') {
+    return false;
+  }
+  if (value.includes('..') || value.includes('//')) {
+    return false;
+  }
+  if (value.includes('?') || value.includes('#')) {
+    return false;
+  }
+  if (value.includes('/') || value.includes('\\')) {
+    return false;
+  }
+  return SAFE_SEGMENT.test(value);
+}
+
+/**
+ * Validates a GitHub repo identifier in "owner/repo" format.
+ * Both owner and repo segments must individually pass segment validation.
+ */
+export function isValidGitHubRepo(repo: string): boolean {
+  if (!repo || typeof repo !== 'string') {
+    return false;
+  }
+  const parts = repo.split('/');
+  if (parts.length !== 2) {
+    return false;
+  }
+  return isValidUrlSegment(parts[0]) && isValidUrlSegment(parts[1]);
+}

--- a/packages/shared/src/urlValidation.ts
+++ b/packages/shared/src/urlValidation.ts
@@ -23,9 +23,13 @@ export function isValidUrlSegment(value: string): boolean {
   return true;
 }
 
+// GitHub owner/repo names: alphanumeric, hyphens, dots, underscores
+const GITHUB_SEGMENT = /^[a-zA-Z0-9._-]+$/;
+
 /**
  * Validates a GitHub repo identifier in "owner/repo" format.
- * Both owner and repo segments must individually pass segment validation.
+ * Uses a strict character set since GitHub URLs interpolate the value
+ * directly without encodeURIComponent.
  */
 export function isValidGitHubRepo(repo: string): boolean {
   if (!repo || typeof repo !== 'string') {
@@ -35,5 +39,9 @@ export function isValidGitHubRepo(repo: string): boolean {
   if (parts.length !== 2) {
     return false;
   }
-  return isValidUrlSegment(parts[0]) && isValidUrlSegment(parts[1]);
+  const [owner, name] = parts;
+  if (owner === '.' || owner === '..' || name === '.' || name === '..') {
+    return false;
+  }
+  return GITHUB_SEGMENT.test(owner) && GITHUB_SEGMENT.test(name);
 }

--- a/packages/shared/src/urlValidation.ts
+++ b/packages/shared/src/urlValidation.ts
@@ -1,5 +1,5 @@
-// Pattern for a single URL path segment: alphanumeric start, then alphanumeric/hyphens/underscores/dots
-const SAFE_SEGMENT = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+// Pattern for a single URL path segment: one or more alphanumeric/hyphens/underscores/dots
+const SAFE_SEGMENT = /^[a-zA-Z0-9._-]+$/;
 
 /**
  * Validates a single URL path segment (org name, project name, repo name).

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/test/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

Add input validation for provider URL construction to prevent path traversal, query injection, and other URL manipulation attacks.

## Changes

- **packages/shared/src/urlValidation.ts** (new): Shared validation utilities
  - isValidUrlSegment() — validates a single URL path segment (org, project, repo names)
  - isValidGitHubRepo() — validates owner/repo format with segment-level checks
- **packages/github/src/githubProvider.ts**: Validate repo identifiers before constructing API URLs; skip invalid repos with a warning
- **packages/ado/src/adoWorkItemProvider.ts**: Validate org and project names at fetch time; skip invalid entries with warnings; avoid silent org-wide fallback when all configured projects are invalid
- **packages/shared/src/test/urlValidation.test.ts** (new): Test cases covering path traversal, query injection, slashes, edge cases, and valid inputs
- **packages/shared/vitest.config.ts** (new): Test infrastructure for shared package
- **packages/ado/src/test/adoWorkItemProvider.test.ts**: Tests for invalid org/project validation
- **packages/github/src/test/githubProvider.test.ts**: Test for invalid repo skipping

## Motivation

Provider-supplied org/project/repo names flow directly into URL construction. Without validation, a misconfigured or malicious input could alter API request paths. This adds defense-in-depth validation alongside existing ncodeURIComponent encoding.
