### PR TITLE
security: add schema validation for JSON task store loading

### DIFF
--- a/packages/core/src/storage/discoveredStateStore.ts
+++ b/packages/core/src/storage/discoveredStateStore.ts
@@ -118,7 +118,8 @@ export class DiscoveredStateStore {
       try {
         parsed = JSON.parse(data);
       } catch {
-        logger.warn('Failed to parse discovered state file — resetting to empty');
+        logger.warn('Failed to parse discovered state file — backing up and resetting to empty');
+        await this.backupCorruptedFile();
         this.cache.clear();
         this.loaded = true;
         return;
@@ -162,6 +163,16 @@ export class DiscoveredStateStore {
   private enqueue(op: () => Promise<void>): Promise<void> {
     this.writeQueue = this.writeQueue.then(op, op);
     return this.writeQueue;
+  }
+
+  private async backupCorruptedFile(): Promise<void> {
+    try {
+      const backupPath = `${this.filePath}.corrupt.${Date.now()}`;
+      await fs.rename(this.filePath, backupPath);
+      logger.warn(`Backed up corrupted file to ${backupPath}`);
+    } catch {
+      logger.warn('Failed to back up corrupted discovered state file');
+    }
   }
 
   dispose(): void {

--- a/packages/core/src/storage/discoveredStateStore.ts
+++ b/packages/core/src/storage/discoveredStateStore.ts
@@ -3,9 +3,11 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { logger } from '../services/logger';
 
-export type InboxState = 'unseen' | 'accepted' | 'dismissed';
+const inboxStates = ['unseen', 'accepted', 'dismissed'] as const;
 
-const validInboxStates = new Set<string>(['unseen', 'accepted', 'dismissed']);
+export type InboxState = (typeof inboxStates)[number];
+
+const validInboxStates = new Set<string>(inboxStates);
 
 export interface DiscoveredStateRecord {
   providerId: string;

--- a/packages/core/src/storage/discoveredStateStore.ts
+++ b/packages/core/src/storage/discoveredStateStore.ts
@@ -125,7 +125,8 @@ export class DiscoveredStateStore {
         return;
       }
       if (!Array.isArray(parsed)) {
-        logger.warn('Discovered state file does not contain an array — resetting to empty');
+        logger.warn('Discovered state file does not contain an array — backing up and resetting to empty');
+        await this.backupCorruptedFile();
         this.cache.clear();
         this.loaded = true;
         return;

--- a/packages/core/src/storage/discoveredStateStore.ts
+++ b/packages/core/src/storage/discoveredStateStore.ts
@@ -5,10 +5,33 @@ import { logger } from '../services/logger';
 
 export type InboxState = 'unseen' | 'accepted' | 'dismissed';
 
+const validInboxStates = new Set<string>(['unseen', 'accepted', 'dismissed']);
+
 export interface DiscoveredStateRecord {
   providerId: string;
   externalId: string;
   inboxState: InboxState;
+}
+
+/**
+ * Validates that a parsed JSON value has the required shape of a DiscoveredStateRecord.
+ * Returns a descriptive error string if invalid, or undefined if valid.
+ */
+function validateDiscoveredStateRecord(value: unknown, index: number): string | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return `Record at index ${index} is not an object`;
+  }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.providerId !== 'string' || obj.providerId.length === 0) {
+    return `Record at index ${index} is missing a valid "providerId" (string)`;
+  }
+  if (typeof obj.externalId !== 'string' || obj.externalId.length === 0) {
+    return `Record at index ${index} is missing a valid "externalId" (string)`;
+  }
+  if (typeof obj.inboxState !== 'string' || !validInboxStates.has(obj.inboxState)) {
+    return `Record at index ${index} has invalid "inboxState": ${JSON.stringify(obj.inboxState)}`;
+  }
+  return undefined;
 }
 
 export class DiscoveredStateStore {
@@ -89,9 +112,29 @@ export class DiscoveredStateStore {
     }
     try {
       const data = await fs.readFile(this.filePath, 'utf-8');
-      const records = JSON.parse(data) as DiscoveredStateRecord[];
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(data);
+      } catch {
+        logger.warn('Failed to parse discovered state file — resetting to empty');
+        this.cache.clear();
+        this.loaded = true;
+        return;
+      }
+      if (!Array.isArray(parsed)) {
+        logger.warn('Discovered state file does not contain an array — resetting to empty');
+        this.cache.clear();
+        this.loaded = true;
+        return;
+      }
       this.cache.clear();
-      for (const record of records) {
+      for (let i = 0; i < parsed.length; i++) {
+        const error = validateDiscoveredStateRecord(parsed[i], i);
+        if (error) {
+          logger.warn(`Skipping invalid discovered state record: ${error}`);
+          continue;
+        }
+        const record = parsed[i] as DiscoveredStateRecord;
         this.cache.set(this.key(record.providerId, record.externalId), record);
       }
       logger.debug(`Loaded discovered state: ${this.cache.size} entries`);

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -32,6 +32,21 @@ function validateWorkItem(value: unknown, index: number): string | undefined {
   if (typeof obj.updatedAt !== 'number' || !Number.isFinite(obj.updatedAt)) {
     return `Item "${obj.id}" at index ${index} is missing a valid "updatedAt" (finite number)`;
   }
+  if (obj.url !== undefined && typeof obj.url !== 'string') {
+    return `Item "${obj.id}" at index ${index} has invalid "url" (string expected)`;
+  }
+  if (obj.providerId !== undefined && typeof obj.providerId !== 'string') {
+    return `Item "${obj.id}" at index ${index} has invalid "providerId" (string expected)`;
+  }
+  if (obj.externalId !== undefined && typeof obj.externalId !== 'string') {
+    return `Item "${obj.id}" at index ${index} has invalid "externalId" (string expected)`;
+  }
+  if (obj.notes !== undefined && typeof obj.notes !== 'string') {
+    return `Item "${obj.id}" at index ${index} has invalid "notes" (string expected)`;
+  }
+  if (obj.sortOrder !== undefined && (typeof obj.sortOrder !== 'number' || !Number.isFinite(obj.sortOrder))) {
+    return `Item "${obj.id}" at index ${index} has invalid "sortOrder" (finite number expected)`;
+  }
   return undefined;
 }
 

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -41,6 +41,9 @@ function validateWorkItem(value: unknown, index: number): string | undefined {
   if (obj.externalId !== undefined && typeof obj.externalId !== 'string') {
     return `Item "${obj.id}" at index ${index} has invalid "externalId" (string expected)`;
   }
+  if (obj.description !== undefined && typeof obj.description !== 'string') {
+    return `Item "${obj.id}" at index ${index} has invalid legacy "description" (string expected)`;
+  }
   if (obj.notes !== undefined && typeof obj.notes !== 'string') {
     return `Item "${obj.id}" at index ${index} has invalid "notes" (string expected)`;
   }

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -62,7 +62,8 @@ export class JsonTaskStore implements ITaskStore {
       try {
         parsed = JSON.parse(data);
       } catch {
-        logger.warn('Failed to parse work items file — resetting to empty');
+        logger.warn('Failed to parse work items file — backing up and resetting to empty');
+        await this.backupCorruptedFile();
         this.cache = new Map();
         return [];
       }
@@ -190,6 +191,16 @@ export class JsonTaskStore implements ITaskStore {
   private enqueue(op: () => Promise<void>): Promise<void> {
     this.writeQueue = this.writeQueue.then(op, op);
     return this.writeQueue;
+  }
+
+  private async backupCorruptedFile(): Promise<void> {
+    try {
+      const backupPath = `${this.filePath}.corrupt.${Date.now()}`;
+      await fs.rename(this.filePath, backupPath);
+      logger.warn(`Backed up corrupted file to ${backupPath}`);
+    } catch {
+      logger.warn('Failed to back up corrupted work items file');
+    }
   }
 }
 

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -24,6 +24,12 @@ function validateWorkItem(value: unknown, index: number): string | undefined {
   if (typeof obj.state !== 'string' || !validWorkItemStates.has(obj.state)) {
     return `Item "${obj.id}" at index ${index} has invalid "state": ${JSON.stringify(obj.state)}`;
   }
+  if (typeof obj.createdAt !== 'number' || !Number.isFinite(obj.createdAt)) {
+    return `Item "${obj.id}" at index ${index} is missing a valid "createdAt" (finite number)`;
+  }
+  if (typeof obj.updatedAt !== 'number' || !Number.isFinite(obj.updatedAt)) {
+    return `Item "${obj.id}" at index ${index} is missing a valid "updatedAt" (finite number)`;
+  }
   return undefined;
 }
 
@@ -56,8 +62,9 @@ export class JsonTaskStore implements ITaskStore {
       try {
         parsed = JSON.parse(data);
       } catch {
-        logger.warn('Failed to parse work items file');
-        throw new Error('Failed to parse work items file');
+        logger.warn('Failed to parse work items file — resetting to empty');
+        this.cache = new Map();
+        return [];
       }
       if (!Array.isArray(parsed)) {
         logger.warn('Work items file does not contain an array — resetting to empty');

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -68,8 +68,10 @@ export class JsonTaskStore implements ITaskStore {
         return [];
       }
       if (!Array.isArray(parsed)) {
-        logger.warn('Work items file does not contain an array — resetting to empty');
-        parsed = [];
+        logger.warn('Work items file does not contain an array — backing up and resetting to empty');
+        await this.backupCorruptedFile();
+        this.cache = new Map();
+        return [];
       }
       // Validate each item and discard invalid entries
       const items: WorkItem[] = [];

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -1,8 +1,31 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
-import { WorkItem } from '../models/workItem';
+import { WorkItem, WorkItemState } from '../models/workItem';
 import { ITaskStore } from './taskStore';
 import { logger } from '../services/logger';
+
+const validWorkItemStates = new Set<string>(Object.values(WorkItemState));
+
+/**
+ * Validates that a parsed JSON value has the required shape of a WorkItem.
+ * Returns a descriptive error string if invalid, or undefined if valid.
+ */
+function validateWorkItem(value: unknown, index: number): string | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return `Item at index ${index} is not an object`;
+  }
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.id !== 'string' || obj.id.length === 0) {
+    return `Item at index ${index} is missing a valid "id" (string)`;
+  }
+  if (typeof obj.title !== 'string' || obj.title.length === 0) {
+    return `Item "${obj.id}" at index ${index} is missing a valid "title" (string)`;
+  }
+  if (typeof obj.state !== 'string' || !validWorkItemStates.has(obj.state)) {
+    return `Item "${obj.id}" at index ${index} has invalid "state": ${JSON.stringify(obj.state)}`;
+  }
+  return undefined;
+}
 
 export class JsonTaskStore implements ITaskStore {
   private readonly filePath: string;
@@ -29,12 +52,26 @@ export class JsonTaskStore implements ITaskStore {
     logger.debug(`Loading work items from ${this.filePath}`);
     try {
       const data = await fs.readFile(this.filePath, 'utf-8');
-      let items: WorkItem[];
+      let parsed: unknown;
       try {
-        items = JSON.parse(data) as WorkItem[];
+        parsed = JSON.parse(data);
       } catch {
         logger.warn('Failed to parse work items file');
         throw new Error('Failed to parse work items file');
+      }
+      if (!Array.isArray(parsed)) {
+        logger.warn('Work items file does not contain an array — resetting to empty');
+        parsed = [];
+      }
+      // Validate each item and discard invalid entries
+      const items: WorkItem[] = [];
+      for (let i = 0; i < (parsed as unknown[]).length; i++) {
+        const error = validateWorkItem((parsed as unknown[])[i], i);
+        if (error) {
+          logger.warn(`Skipping invalid work item: ${error}`);
+        } else {
+          items.push((parsed as unknown[])[i] as WorkItem);
+        }
       }
       // Migrate legacy 'description' field to 'notes'
       let needsMigration = false;

--- a/packages/core/src/test/discoveredStateStore.test.ts
+++ b/packages/core/src/test/discoveredStateStore.test.ts
@@ -170,12 +170,16 @@ describe('DiscoveredStateStore', () => {
       expect(records[0].externalId).toBe('issue-2');
     });
 
-    it('should return empty for non-array JSON', async () => {
+    it('should return empty for non-array JSON and back up', async () => {
       const filePath = path.join(tmpDir, 'discovered-state.json');
       await fs.writeFile(filePath, JSON.stringify({ not: 'an array' }), 'utf-8');
 
       const records = await store.loadAll();
       expect(records).toEqual([]);
+
+      const files = await fs.readdir(tmpDir);
+      const backupFiles = files.filter(f => f.startsWith('discovered-state.json.corrupt.'));
+      expect(backupFiles).toHaveLength(1);
     });
 
     it('should skip non-object entries', async () => {

--- a/packages/core/src/test/discoveredStateStore.test.ts
+++ b/packages/core/src/test/discoveredStateStore.test.ts
@@ -104,11 +104,13 @@ describe('DiscoveredStateStore', () => {
     store2.dispose();
   });
 
-  it('should handle corrupted JSON by throwing', async () => {
+  it('should handle corrupted JSON gracefully by loading empty', async () => {
     const filePath = path.join(tmpDir, 'discovered-state.json');
     await fs.writeFile(filePath, 'not valid json', 'utf-8');
 
-    await expect(store.load()).rejects.toThrow();
+    await store.load();
+    const records = await store.loadAll();
+    expect(records).toEqual([]);
   });
 
   it('should create storage directory if it does not exist', async () => {
@@ -121,5 +123,54 @@ describe('DiscoveredStateStore', () => {
     const raw = await fs.readFile(filePath, 'utf-8');
     expect(JSON.parse(raw)).toHaveLength(1);
     nestedStore.dispose();
+  });
+
+  describe('schema validation', () => {
+    it('should skip records missing providerId', async () => {
+      const filePath = path.join(tmpDir, 'discovered-state.json');
+      const data = [
+        { externalId: 'issue-1', inboxState: 'unseen' },
+        { providerId: 'gh', externalId: 'issue-2', inboxState: 'accepted' },
+      ];
+      await fs.writeFile(filePath, JSON.stringify(data), 'utf-8');
+
+      const records = await store.loadAll();
+      expect(records).toHaveLength(1);
+      expect(records[0].externalId).toBe('issue-2');
+    });
+
+    it('should skip records missing externalId', async () => {
+      const filePath = path.join(tmpDir, 'discovered-state.json');
+      const data = [
+        { providerId: 'gh', inboxState: 'unseen' },
+        { providerId: 'gh', externalId: 'issue-2', inboxState: 'accepted' },
+      ];
+      await fs.writeFile(filePath, JSON.stringify(data), 'utf-8');
+
+      const records = await store.loadAll();
+      expect(records).toHaveLength(1);
+      expect(records[0].externalId).toBe('issue-2');
+    });
+
+    it('should skip records with invalid inboxState', async () => {
+      const filePath = path.join(tmpDir, 'discovered-state.json');
+      const data = [
+        { providerId: 'gh', externalId: 'issue-1', inboxState: 'bogus' },
+        { providerId: 'gh', externalId: 'issue-2', inboxState: 'accepted' },
+      ];
+      await fs.writeFile(filePath, JSON.stringify(data), 'utf-8');
+
+      const records = await store.loadAll();
+      expect(records).toHaveLength(1);
+      expect(records[0].externalId).toBe('issue-2');
+    });
+
+    it('should return empty for non-array JSON', async () => {
+      const filePath = path.join(tmpDir, 'discovered-state.json');
+      await fs.writeFile(filePath, JSON.stringify({ not: 'an array' }), 'utf-8');
+
+      const records = await store.loadAll();
+      expect(records).toEqual([]);
+    });
   });
 });

--- a/packages/core/src/test/discoveredStateStore.test.ts
+++ b/packages/core/src/test/discoveredStateStore.test.ts
@@ -104,13 +104,18 @@ describe('DiscoveredStateStore', () => {
     store2.dispose();
   });
 
-  it('should handle corrupted JSON gracefully by loading empty', async () => {
+  it('should handle corrupted JSON gracefully by loading empty and backing up', async () => {
     const filePath = path.join(tmpDir, 'discovered-state.json');
     await fs.writeFile(filePath, 'not valid json', 'utf-8');
 
     await store.load();
     const records = await store.loadAll();
     expect(records).toEqual([]);
+
+    // Verify the corrupted file was backed up
+    const files = await fs.readdir(tmpDir);
+    const backupFiles = files.filter(f => f.startsWith('discovered-state.json.corrupt.'));
+    expect(backupFiles).toHaveLength(1);
   });
 
   it('should create storage directory if it does not exist', async () => {
@@ -171,6 +176,21 @@ describe('DiscoveredStateStore', () => {
 
       const records = await store.loadAll();
       expect(records).toEqual([]);
+    });
+
+    it('should skip non-object entries', async () => {
+      const filePath = path.join(tmpDir, 'discovered-state.json');
+      const data = [
+        'a string',
+        42,
+        null,
+        { providerId: 'gh', externalId: 'issue-1', inboxState: 'accepted' },
+      ];
+      await fs.writeFile(filePath, JSON.stringify(data), 'utf-8');
+
+      const records = await store.loadAll();
+      expect(records).toHaveLength(1);
+      expect(records[0].externalId).toBe('issue-1');
     });
   });
 });

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -260,11 +260,11 @@ describe('activate()', () => {
   // ------------------------------------------------------------------
   // 12. Error handling: corrupt workitems.json
   // ------------------------------------------------------------------
-  it('throws when workitems.json contains invalid JSON', async () => {
+  it('recovers gracefully when workitems.json contains invalid JSON', async () => {
     const fs = await import('fs/promises');
     (fs.readFile as ReturnType<typeof vi.fn>).mockResolvedValueOnce('NOT VALID JSON');
 
-    await expect(activate(context)).rejects.toThrow();
+    await expect(activate(context)).resolves.toBeDefined();
   });
 
   // ------------------------------------------------------------------

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -257,5 +257,57 @@ describe('JsonTaskStore', () => {
       const items = await store.loadAll();
       expect(items).toEqual([]);
     });
+
+    it('skips items missing createdAt', async () => {
+      const filePath = path.join(tmpDir, 'workitems.json');
+      const data = [
+        { id: 'no-created', title: 'Missing ts', state: 'New', updatedAt: 1000 },
+        makeItem({ id: 'valid' }),
+      ];
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(filePath, JSON.stringify(data), 'utf-8');
+
+      const items = await store.loadAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('valid');
+    });
+
+    it('skips items missing updatedAt', async () => {
+      const filePath = path.join(tmpDir, 'workitems.json');
+      const data = [
+        { id: 'no-updated', title: 'Missing ts', state: 'New', createdAt: 1000 },
+        makeItem({ id: 'valid' }),
+      ];
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(filePath, JSON.stringify(data), 'utf-8');
+
+      const items = await store.loadAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('valid');
+    });
+
+    it('skips items with non-finite timestamps', async () => {
+      const filePath = path.join(tmpDir, 'workitems.json');
+      const data = [
+        { id: 'inf-ts', title: 'Bad ts', state: 'New', createdAt: Infinity, updatedAt: 1000 },
+        makeItem({ id: 'valid' }),
+      ];
+      await fs.mkdir(tmpDir, { recursive: true });
+      // Infinity serializes to null in JSON
+      await fs.writeFile(filePath, JSON.stringify(data), 'utf-8');
+
+      const items = await store.loadAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('valid');
+    });
+
+    it('handles corrupted JSON gracefully by loading empty', async () => {
+      const filePath = path.join(tmpDir, 'workitems.json');
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(filePath, 'not valid json', 'utf-8');
+
+      const items = await store.loadAll();
+      expect(items).toEqual([]);
+    });
   });
 });

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -318,6 +318,25 @@ describe('JsonTaskStore', () => {
       const backupFiles = files.filter(f => f.startsWith('workitems.json.corrupt.'));
       expect(backupFiles).toHaveLength(1);
     });
+
+    it('skips items with invalid optional fields', async () => {
+      const filePath = path.join(tmpDir, 'workitems.json');
+      const data = [
+        { ...makeItem({ id: 'bad-url' }), url: 123 },
+        { ...makeItem({ id: 'bad-provider' }), providerId: 42 },
+        { ...makeItem({ id: 'bad-external' }), externalId: true },
+        { ...makeItem({ id: 'bad-notes' }), notes: 999 },
+        { ...makeItem({ id: 'bad-sort' }), sortOrder: 'abc' },
+        { ...makeItem({ id: 'inf-sort' }), sortOrder: Infinity },
+        makeItem({ id: 'valid' }),
+      ];
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(filePath, JSON.stringify(data), 'utf-8');
+
+      const items = await store.loadAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('valid');
+    });
   });
 
   it('migrates legacy Blocked state to Paused on load', async () => {

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -325,6 +325,7 @@ describe('JsonTaskStore', () => {
         { ...makeItem({ id: 'bad-url' }), url: 123 },
         { ...makeItem({ id: 'bad-provider' }), providerId: 42 },
         { ...makeItem({ id: 'bad-external' }), externalId: true },
+        { ...makeItem({ id: 'bad-desc' }), description: 42 },
         { ...makeItem({ id: 'bad-notes' }), notes: 999 },
         { ...makeItem({ id: 'bad-sort' }), sortOrder: 'abc' },
         { ...makeItem({ id: 'inf-sort' }), sortOrder: Infinity },

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -194,4 +194,68 @@ describe('JsonTaskStore', () => {
     expect(persisted[0].notes).toBe('Legacy description');
     expect(persisted[0].description).toBeUndefined();
   });
+
+  describe('schema validation', () => {
+    it('skips items missing an id', async () => {
+      const filePath = path.join(tmpDir, 'workitems.json');
+      const data = [
+        { title: 'No ID', state: 'New', createdAt: 1000, updatedAt: 1000 },
+        makeItem({ id: 'valid' }),
+      ];
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(filePath, JSON.stringify(data), 'utf-8');
+
+      const items = await store.loadAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('valid');
+    });
+
+    it('skips items missing a title', async () => {
+      const filePath = path.join(tmpDir, 'workitems.json');
+      const data = [
+        { id: 'no-title', state: 'New', createdAt: 1000, updatedAt: 1000 },
+        makeItem({ id: 'valid' }),
+      ];
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(filePath, JSON.stringify(data), 'utf-8');
+
+      const items = await store.loadAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('valid');
+    });
+
+    it('skips items with an invalid state', async () => {
+      const filePath = path.join(tmpDir, 'workitems.json');
+      const data = [
+        { id: 'bad-state', title: 'Bad', state: 'InvalidState', createdAt: 1000, updatedAt: 1000 },
+        makeItem({ id: 'valid' }),
+      ];
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(filePath, JSON.stringify(data), 'utf-8');
+
+      const items = await store.loadAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('valid');
+    });
+
+    it('skips non-object entries', async () => {
+      const filePath = path.join(tmpDir, 'workitems.json');
+      const data = ['a string', 42, null, makeItem({ id: 'valid' })];
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(filePath, JSON.stringify(data), 'utf-8');
+
+      const items = await store.loadAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('valid');
+    });
+
+    it('returns empty when file contains a non-array JSON value', async () => {
+      const filePath = path.join(tmpDir, 'workitems.json');
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(filePath, JSON.stringify({ not: 'an array' }), 'utf-8');
+
+      const items = await store.loadAll();
+      expect(items).toEqual([]);
+    });
+  });
 });

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -288,13 +288,13 @@ describe('JsonTaskStore', () => {
 
     it('skips items with non-finite timestamps', async () => {
       const filePath = path.join(tmpDir, 'workitems.json');
-      const data = [
-        { id: 'inf-ts', title: 'Bad ts', state: 'New', createdAt: Infinity, updatedAt: 1000 },
-        makeItem({ id: 'valid' }),
-      ];
+      // Use raw JSON so 1e309 parses as a number but fails Number.isFinite(...)
+      const data = `[
+        {"id":"inf-ts","title":"Bad ts","state":"New","createdAt":1e309,"updatedAt":1000},
+        ${JSON.stringify(makeItem({ id: 'valid' }))}
+      ]`;
       await fs.mkdir(tmpDir, { recursive: true });
-      // Infinity serializes to null in JSON
-      await fs.writeFile(filePath, JSON.stringify(data), 'utf-8');
+      await fs.writeFile(filePath, data, 'utf-8');
 
       const items = await store.loadAll();
       expect(items).toHaveLength(1);

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -249,13 +249,17 @@ describe('JsonTaskStore', () => {
       expect(items[0].id).toBe('valid');
     });
 
-    it('returns empty when file contains a non-array JSON value', async () => {
+    it('returns empty when file contains a non-array JSON value and backs up', async () => {
       const filePath = path.join(tmpDir, 'workitems.json');
       await fs.mkdir(tmpDir, { recursive: true });
       await fs.writeFile(filePath, JSON.stringify({ not: 'an array' }), 'utf-8');
 
       const items = await store.loadAll();
       expect(items).toEqual([]);
+
+      const files = await fs.readdir(tmpDir);
+      const backupFiles = files.filter(f => f.startsWith('workitems.json.corrupt.'));
+      expect(backupFiles).toHaveLength(1);
     });
 
     it('skips items missing createdAt', async () => {

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -301,13 +301,18 @@ describe('JsonTaskStore', () => {
       expect(items[0].id).toBe('valid');
     });
 
-    it('handles corrupted JSON gracefully by loading empty', async () => {
+    it('handles corrupted JSON gracefully by loading empty and backing up', async () => {
       const filePath = path.join(tmpDir, 'workitems.json');
       await fs.mkdir(tmpDir, { recursive: true });
       await fs.writeFile(filePath, 'not valid json', 'utf-8');
 
       const items = await store.loadAll();
       expect(items).toEqual([]);
+
+      // Verify the corrupted file was backed up
+      const files = await fs.readdir(tmpDir);
+      const backupFiles = files.filter(f => f.startsWith('workitems.json.corrupt.'));
+      expect(backupFiles).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
## Summary

Add schema validation for JSON data loaded from both JsonTaskStore and DiscoveredStateStore. Previously, the stores blindly cast parsed JSON to their respective types, which could lead to runtime errors or silent data corruption if a file was manually edited, corrupted, or contained unexpected values.

## Changes

### jsonTaskStore.ts
- Added alidateWorkItem() function that checks each item has a valid id (string), 	itle (string), and state (member of WorkItemState enum)
- Non-array JSON values are now handled gracefully (reset to empty) instead of crashing
- Invalid items are skipped with a warning log rather than crashing the entire load

### discoveredStateStore.ts
- Added alidateDiscoveredStateRecord() function that checks each record has a valid providerId, xternalId, and inboxState
- Corrupted JSON is now handled gracefully (reset to empty) instead of throwing
- Non-array JSON values are handled gracefully
- Invalid records are skipped with a warning log

### Tests
- Added schema validation test suites for both stores covering: missing fields, invalid enum values, non-object entries, and non-array JSON
- Updated corrupted-JSON test to verify graceful recovery instead of expecting a throw
