### PR TITLE
test: add comprehensive ADO provider tests

### DIFF
--- a/packages/ado/src/test/adoPrReviewProvider.extended.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.extended.test.ts
@@ -1,0 +1,478 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { authentication, window } from 'vscode';
+import { AdoPrReviewProvider } from '../adoPrReviewProvider';
+
+const mockFetch = vi.fn();
+
+function createMockPr(id: number, title: string, project = 'MyProject', repo = 'myrepo') {
+  return {
+    pullRequestId: id,
+    title,
+    description: `Description for PR ${id}`,
+    repository: {
+      name: repo,
+      project: { name: project },
+      webUrl: `https://dev.azure.com/myorg/${project}/_git/${repo}`,
+    },
+  };
+}
+
+function mockConnectionData(userId = 'user-uuid-123') {
+  return {
+    ok: true,
+    json: async () => ({ authenticatedUser: { id: userId } }),
+  };
+}
+
+function mockAuthSession(token = 'test-token', accountId = '1') {
+  vi.mocked(authentication.getSession).mockResolvedValue({
+    accessToken: token,
+    id: 'session-1',
+    scopes: ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+    account: { id: accountId, label: 'testuser' },
+  } as any);
+}
+
+describe('AdoPrReviewProvider — extended', () => {
+  let provider: AdoPrReviewProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+    provider = new AdoPrReviewProvider('myorg', ['MyProject']);
+    mockAuthSession();
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    vi.unstubAllGlobals();
+  });
+
+  describe('getUserId error handling', () => {
+    it('clears cached user ID on network error', async () => {
+      // First refresh with account '1': succeeds, caches userId
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData('user-1'))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [] }),
+        });
+
+      await provider.refresh();
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      mockFetch.mockReset();
+
+      // Switch account to force cache miss, then network error on connection data
+      mockAuthSession('token-2', '2');
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      // getUserId network error → fires empty items via warning path
+      expect(listener).toHaveBeenCalledWith([]);
+      mockFetch.mockReset();
+
+      // Third refresh with same account '2': cache was cleared, should re-fetch
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData('user-1'))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [] }),
+        });
+
+      await provider.refresh();
+      // connection data + PR list = 2 calls (cache was cleared by error)
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears cached user ID on non-ok response', async () => {
+      // First refresh with account '1': succeeds, caches userId
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData('user-1'))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [] }),
+        });
+
+      await provider.refresh();
+      mockFetch.mockReset();
+
+      // Switch account to force cache miss, connection data returns 401
+      mockAuthSession('new-token', '2');
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        text: async () => 'Unauthorized',
+      });
+
+      await provider.refresh();
+      mockFetch.mockReset();
+
+      // Third refresh with same account '2': cache was cleared, should re-fetch
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData('user-1'))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [] }),
+        });
+
+      await provider.refresh();
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('connectiondata'),
+        expect.any(Object),
+      );
+    });
+
+    it('handles malformed JSON from connection data', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => { throw new SyntaxError('Unexpected token'); },
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      // Should fire empty items and show warning
+      expect(listener).toHaveBeenCalledWith([]);
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to determine Azure DevOps user identity'),
+      );
+    });
+
+    it('handles missing authenticatedUser.id in connection data', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ authenticatedUser: {} }),
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      expect(listener).toHaveBeenCalledWith([]);
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to determine Azure DevOps user identity'),
+      );
+    });
+
+    it('handles null authenticatedUser in connection data', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ authenticatedUser: null }),
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      expect(listener).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('PR fetch error handling', () => {
+    it('handles malformed JSON from PR response', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData())
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => { throw new SyntaxError('Bad JSON'); },
+        });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      expect(listener).toHaveBeenCalledWith([]);
+    });
+
+    it('handles fetch throwing on PR call', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData())
+        .mockRejectedValueOnce(new TypeError('Network failure'));
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      // Promise.allSettled catches, fires empty
+      expect(listener).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('multiple projects', () => {
+    it('fetches PRs for each configured project', async () => {
+      provider.dispose();
+      provider = new AdoPrReviewProvider('myorg', ['ProjectA', 'ProjectB']);
+      mockAuthSession();
+
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData('user-1'))
+        // ProjectA PRs
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            value: [createMockPr(1, 'PR in A', 'ProjectA', 'repoA')],
+          }),
+        })
+        // ProjectB PRs
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            value: [createMockPr(2, 'PR in B', 'ProjectB', 'repoB')],
+          }),
+        });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      const items = listener.mock.calls[0][0];
+      expect(items).toHaveLength(2);
+      expect(items[0].group).toBe('ProjectA/repoA');
+      expect(items[1].group).toBe('ProjectB/repoB');
+    });
+
+    it('reports multiple project failures', async () => {
+      provider.dispose();
+      provider = new AdoPrReviewProvider('myorg', ['ProjA', 'ProjB']);
+      mockAuthSession();
+
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData())
+        .mockResolvedValueOnce({ ok: false, status: 403 })
+        .mockResolvedValueOnce({ ok: false, status: 403 });
+
+      await provider.refresh();
+
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('2 projects'),
+      );
+    });
+
+    it('handles mixed success and failure across projects', async () => {
+      provider.dispose();
+      provider = new AdoPrReviewProvider('myorg', ['GoodProj', 'BadProj']);
+      mockAuthSession();
+
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData())
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            value: [createMockPr(1, 'Good PR', 'GoodProj', 'goodrepo')],
+          }),
+        })
+        .mockResolvedValueOnce({ ok: false, status: 500 });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      const items = listener.mock.calls[0][0];
+      expect(items).toHaveLength(1);
+      expect(items[0].group).toBe('GoodProj/goodrepo');
+
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to fetch PR reviews from BadProj'),
+      );
+    });
+  });
+
+  describe('concurrency guard', () => {
+    it('skips concurrent refresh when already refreshing', async () => {
+      let resolveFirst: () => void;
+      const blockingPromise = new Promise<void>(resolve => {
+        resolveFirst = resolve;
+      });
+
+      mockFetch.mockImplementationOnce(async () => {
+        await blockingPromise;
+        return mockConnectionData();
+      }).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ value: [] }),
+      });
+
+      const first = provider.refresh();
+      const second = provider.refresh();
+
+      resolveFirst!();
+      await first;
+      await second;
+
+      // Only one set of fetch calls
+      expect(mockFetch).toHaveBeenCalledTimes(2); // connection data + PR list
+    });
+  });
+
+  describe('URL construction', () => {
+    it('URL-encodes org and project names with special characters', async () => {
+      provider.dispose();
+      provider = new AdoPrReviewProvider('my org', ['My Project']);
+      mockAuthSession();
+
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData())
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [] }),
+        });
+
+      await provider.refresh();
+
+      // Connection data URL
+      const connUrl = mockFetch.mock.calls[0][0] as string;
+      expect(connUrl).toContain('my%20org');
+
+      // PR URL
+      const prUrl = mockFetch.mock.calls[1][0] as string;
+      expect(prUrl).toContain('my%20org');
+      expect(prUrl).toContain('My%20Project');
+    });
+
+    it('includes reviewer ID and active status in PR search URL', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData('reviewer-42'))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [] }),
+        });
+
+      await provider.refresh();
+
+      const prUrl = mockFetch.mock.calls[1][0] as string;
+      expect(prUrl).toContain('searchCriteria.reviewerId=reviewer-42');
+      expect(prUrl).toContain('searchCriteria.status=active');
+    });
+  });
+
+  describe('periodic refresh edge cases', () => {
+    it('clamps intervals below 60 to 60 seconds', () => {
+      vi.useFakeTimers();
+
+      const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
+      provider.startPeriodicRefresh(30);
+
+      vi.advanceTimersByTime(30_000);
+      expect(refreshSpy).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(30_000);
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+
+    it('does not start timer for zero interval', () => {
+      vi.useFakeTimers();
+
+      const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
+      provider.startPeriodicRefresh(0);
+
+      vi.advanceTimersByTime(300_000);
+      expect(refreshSpy).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('does not start timer for negative interval', () => {
+      vi.useFakeTimers();
+
+      const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
+      provider.startPeriodicRefresh(-50);
+
+      vi.advanceTimersByTime(300_000);
+      expect(refreshSpy).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('does not start timer for NaN interval', () => {
+      vi.useFakeTimers();
+
+      const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
+      provider.startPeriodicRefresh(NaN);
+
+      vi.advanceTimersByTime(300_000);
+      expect(refreshSpy).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('replaces existing timer when startPeriodicRefresh called again', () => {
+      vi.useFakeTimers();
+
+      const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
+      provider.startPeriodicRefresh(60);
+      provider.startPeriodicRefresh(120);
+
+      vi.advanceTimersByTime(60_000);
+      expect(refreshSpy).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(60_000);
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('background refresh', () => {
+    it('uses createIfNone: false for background refresh', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData())
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [] }),
+        });
+
+      const refreshBg = (provider as any).refreshInBackground.bind(provider);
+      await refreshBg();
+
+      expect(authentication.getSession).toHaveBeenCalledWith(
+        'microsoft',
+        ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+        { createIfNone: false },
+      );
+    });
+
+    it('uses createIfNone: true for user-triggered refresh', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData())
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [] }),
+        });
+
+      await provider.refresh();
+
+      expect(authentication.getSession).toHaveBeenCalledWith(
+        'microsoft',
+        ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+        { createIfNone: true },
+      );
+    });
+  });
+
+  describe('PR URL construction in results', () => {
+    it('constructs correct PR URL from repository webUrl', async () => {
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData())
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            value: [createMockPr(42, 'My PR', 'TestProj', 'myrepo')],
+          }),
+        });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      const items = listener.mock.calls[0][0];
+      expect(items[0].url).toBe('https://dev.azure.com/myorg/TestProj/_git/myrepo/pullrequest/42');
+    });
+  });
+});

--- a/packages/ado/src/test/adoWorkItemProvider.extended.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.extended.test.ts
@@ -1,0 +1,547 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { authentication, window } from 'vscode';
+import { AdoWorkItemProvider } from '../adoWorkItemProvider';
+
+const mockFetch = vi.fn();
+
+function createWiqlResponse(ids: number[]) {
+  return {
+    workItems: ids.map(id => ({ id, url: `https://dev.azure.com/myorg/_apis/wit/workitems/${id}` })),
+  };
+}
+
+function createWorkItemDetail(id: number, title: string, project = 'MyProject', type = 'User Story') {
+  return {
+    id,
+    fields: {
+      'System.Title': title,
+      'System.Description': `<p>Description for ${id}</p>`,
+      'System.TeamProject': project,
+      'System.WorkItemType': type,
+      'System.State': 'Active',
+    },
+    _links: {
+      html: { href: `https://dev.azure.com/myorg/${project}/_workitems/edit/${id}` },
+    },
+  };
+}
+
+function mockAuthSession(token = 'test-token') {
+  vi.mocked(authentication.getSession).mockResolvedValue({
+    accessToken: token,
+    id: 'session-1',
+    scopes: ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+    account: { id: '1', label: 'testuser' },
+  } as any);
+}
+
+describe('AdoWorkItemProvider — extended', () => {
+  let provider: AdoWorkItemProvider;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+    provider = new AdoWorkItemProvider('myorg', ['MyProject']);
+    mockAuthSession();
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    vi.unstubAllGlobals();
+  });
+
+  describe('WIQL query construction', () => {
+    it('sends correct WIQL query body filtering by assignment and state', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => createWiqlResponse([]),
+      });
+
+      await provider.refresh();
+
+      const [, options] = mockFetch.mock.calls[0];
+      const body = JSON.parse(options.body);
+      expect(body.query).toContain('[System.AssignedTo] = @Me');
+      expect(body.query).toContain("[System.State] <> 'Closed'");
+      expect(body.query).toContain("[System.State] <> 'Removed'");
+    });
+
+    it('URL-encodes org and project names with special characters', async () => {
+      provider.dispose();
+      provider = new AdoWorkItemProvider('my org', ['My Project']);
+      mockAuthSession();
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => createWiqlResponse([]),
+      });
+
+      await provider.refresh();
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain('my%20org');
+      expect(url).toContain('My%20Project');
+      expect(url).not.toContain('my org');
+    });
+  });
+
+  describe('batch fetching', () => {
+    it('fetches work item details in batches of 200', async () => {
+      // Generate 450 work item IDs to force 3 batches: 200 + 200 + 50
+      const ids = Array.from({ length: 450 }, (_, i) => i + 1);
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => createWiqlResponse(ids),
+        })
+        // Batch 1: IDs 1-200
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            value: ids.slice(0, 200).map(id => createWorkItemDetail(id, `Item ${id}`)),
+          }),
+        })
+        // Batch 2: IDs 201-400
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            value: ids.slice(200, 400).map(id => createWorkItemDetail(id, `Item ${id}`)),
+          }),
+        })
+        // Batch 3: IDs 401-450
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            value: ids.slice(400).map(id => createWorkItemDetail(id, `Item ${id}`)),
+          }),
+        });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      // 1 WIQL + 3 batch detail calls
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+
+      const items = listener.mock.calls[0][0];
+      expect(items).toHaveLength(450);
+    });
+
+    it('continues fetching remaining batches when one batch fails', async () => {
+      const ids = Array.from({ length: 250 }, (_, i) => i + 1);
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => createWiqlResponse(ids),
+        })
+        // Batch 1 fails
+        .mockResolvedValueOnce({ ok: false, status: 500 })
+        // Batch 2 succeeds
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            value: ids.slice(200).map(id => createWorkItemDetail(id, `Item ${id}`)),
+          }),
+        });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      // Should still return items from successful batch
+      const items = listener.mock.calls[0][0];
+      expect(items).toHaveLength(50);
+    });
+
+    it('reports failure when any batch fails but still returns successful results', async () => {
+      const ids = Array.from({ length: 250 }, (_, i) => i + 1);
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => createWiqlResponse(ids),
+        })
+        .mockResolvedValueOnce({ ok: false, status: 500 })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            value: ids.slice(200).map(id => createWorkItemDetail(id, `Item ${id}`)),
+          }),
+        });
+
+      await provider.refresh();
+
+      // User-triggered refresh should show warning when batches fail
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to fetch work items'),
+      );
+    });
+  });
+
+  describe('malformed response handling', () => {
+    it('handles malformed JSON from WIQL response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => { throw new SyntaxError('Unexpected token'); },
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      expect(listener).toHaveBeenCalledWith([]);
+    });
+
+    it('handles malformed JSON from detail response', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => createWiqlResponse([1, 2]),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => { throw new SyntaxError('Unexpected token'); },
+        });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      // Should fire with empty items since detail parse failed
+      expect(listener).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('network errors', () => {
+    it('handles fetch throwing a network error on WIQL call', async () => {
+      mockFetch.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+
+      // Should not throw
+      await expect(provider.refresh()).resolves.toBeUndefined();
+    });
+
+    it('handles fetch throwing on detail call', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => createWiqlResponse([1]),
+        })
+        .mockRejectedValueOnce(new TypeError('Network timeout'));
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      // Promise.allSettled catches the rejection, so items fire (empty from failure)
+      expect(listener).toHaveBeenCalled();
+    });
+  });
+
+  describe('multiple projects', () => {
+    it('fetches work items for each configured project', async () => {
+      provider.dispose();
+      provider = new AdoWorkItemProvider('myorg', ['ProjectA', 'ProjectB']);
+      mockAuthSession();
+
+      // ProjectA WIQL + detail
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => createWiqlResponse([1]),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => createWiqlResponse([2]),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            value: [createWorkItemDetail(1, 'Item A', 'ProjectA')],
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            value: [createWorkItemDetail(2, 'Item B', 'ProjectB')],
+          }),
+        });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      const items = listener.mock.calls[0][0];
+      expect(items).toHaveLength(2);
+    });
+
+    it('reports multiple project failures', async () => {
+      provider.dispose();
+      provider = new AdoWorkItemProvider('myorg', ['ProjectA', 'ProjectB']);
+      mockAuthSession();
+
+      mockFetch
+        .mockResolvedValueOnce({ ok: false, status: 403 })
+        .mockResolvedValueOnce({ ok: false, status: 403 });
+
+      await provider.refresh();
+
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('2 projects'),
+      );
+    });
+
+    it('handles mix of successful and failed project fetches', async () => {
+      provider.dispose();
+      provider = new AdoWorkItemProvider('myorg', ['GoodProject', 'BadProject']);
+      mockAuthSession();
+
+      // GoodProject: success
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => createWiqlResponse([1]),
+        })
+        // BadProject: fail
+        .mockResolvedValueOnce({ ok: false, status: 404 })
+        // GoodProject detail
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            value: [createWorkItemDetail(1, 'Good item', 'GoodProject')],
+          }),
+        });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      const items = listener.mock.calls[0][0];
+      expect(items).toHaveLength(1);
+      expect(items[0].group).toBe('GoodProject');
+
+      // Should warn about the failed project
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to fetch work items from BadProject'),
+      );
+    });
+  });
+
+  describe('concurrency guard', () => {
+    it('skips concurrent refresh when already refreshing', async () => {
+      let resolveFirstFetch: () => void;
+      const firstFetchPromise = new Promise<void>(resolve => {
+        resolveFirstFetch = resolve;
+      });
+
+      mockFetch.mockImplementationOnce(async () => {
+        await firstFetchPromise;
+        return {
+          ok: true,
+          json: async () => createWiqlResponse([]),
+        };
+      });
+
+      // Start first refresh (will block on fetch)
+      const first = provider.refresh();
+
+      // Start second refresh while first is in progress
+      const second = provider.refresh();
+
+      // Unblock first
+      resolveFirstFetch!();
+      await first;
+      await second;
+
+      // Only one fetch call should have been made
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('work item mapping edge cases', () => {
+    it('handles work item with undefined description', async () => {
+      const item = createWorkItemDetail(1, 'No desc');
+      item.fields['System.Description'] = undefined as any;
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => createWiqlResponse([1]),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [item] }),
+        });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      const items = listener.mock.calls[0][0];
+      expect(items[0].description).toBeUndefined();
+    });
+
+    it('handles work item with empty description', async () => {
+      const item = createWorkItemDetail(1, 'Empty desc');
+      item.fields['System.Description'] = '';
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => createWiqlResponse([1]),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [item] }),
+        });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      const items = listener.mock.calls[0][0];
+      expect(items[0].description).toBe('');
+    });
+  });
+
+  describe('periodic refresh edge cases', () => {
+    it('clamps intervals below 60 to 60 seconds', () => {
+      vi.useFakeTimers();
+
+      const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
+      provider.startPeriodicRefresh(10);
+
+      // At 10 seconds, should NOT have fired (clamped to 60)
+      vi.advanceTimersByTime(10_000);
+      expect(refreshSpy).not.toHaveBeenCalled();
+
+      // At 60 seconds, should fire
+      vi.advanceTimersByTime(50_000);
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+
+    it('does not start timer for zero interval', () => {
+      vi.useFakeTimers();
+
+      const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
+      provider.startPeriodicRefresh(0);
+
+      vi.advanceTimersByTime(300_000);
+      expect(refreshSpy).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('does not start timer for negative interval', () => {
+      vi.useFakeTimers();
+
+      const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
+      provider.startPeriodicRefresh(-100);
+
+      vi.advanceTimersByTime(300_000);
+      expect(refreshSpy).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('does not start timer for NaN interval', () => {
+      vi.useFakeTimers();
+
+      const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
+      provider.startPeriodicRefresh(NaN);
+
+      vi.advanceTimersByTime(300_000);
+      expect(refreshSpy).not.toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+
+    it('replaces existing timer when startPeriodicRefresh is called again', () => {
+      vi.useFakeTimers();
+
+      const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
+
+      // Start with 60s interval
+      provider.startPeriodicRefresh(60);
+      // Replace with 120s interval
+      provider.startPeriodicRefresh(120);
+
+      // At 60s, the old timer would have fired but it was replaced
+      vi.advanceTimersByTime(60_000);
+      expect(refreshSpy).not.toHaveBeenCalled();
+
+      // At 120s, the new timer fires
+      vi.advanceTimersByTime(60_000);
+      expect(refreshSpy).toHaveBeenCalledTimes(1);
+
+      vi.useRealTimers();
+    });
+  });
+
+  describe('background refresh', () => {
+    it('uses createIfNone: false for background refresh', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => createWiqlResponse([]),
+      });
+
+      const refreshBg = (provider as any).refreshInBackground.bind(provider);
+      await refreshBg();
+
+      expect(authentication.getSession).toHaveBeenCalledWith(
+        'microsoft',
+        ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+        { createIfNone: false },
+      );
+    });
+
+    it('uses createIfNone: true for user-triggered refresh', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => createWiqlResponse([]),
+      });
+
+      await provider.refresh();
+
+      expect(authentication.getSession).toHaveBeenCalledWith(
+        'microsoft',
+        ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+        { createIfNone: true },
+      );
+    });
+  });
+
+  describe('detail URL construction', () => {
+    it('constructs correct detail URL with comma-separated IDs', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => createWiqlResponse([10, 20, 30]),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            value: [
+              createWorkItemDetail(10, 'A'),
+              createWorkItemDetail(20, 'B'),
+              createWorkItemDetail(30, 'C'),
+            ],
+          }),
+        });
+
+      await provider.refresh();
+
+      const detailUrl = mockFetch.mock.calls[1][0] as string;
+      expect(detailUrl).toContain('ids=10,20,30');
+      expect(detailUrl).toContain('api-version=7.1');
+      expect(detailUrl).toContain('fields=System.Title,System.Description,System.TeamProject,System.WorkItemType,System.State');
+    });
+  });
+});

--- a/packages/ado/src/test/extension.test.ts
+++ b/packages/ado/src/test/extension.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { workspace, extensions, window } from 'vscode';
+import { activate, deactivate } from '../extension';
+
+// Stub fetch globally to prevent real network calls from provider.refresh()
+const mockFetch = vi.fn();
+
+describe('extension activation', () => {
+  let mockContext: any;
+  let mockApi: any;
+  let disposables: any[];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+    vi.stubGlobal('fetch', mockFetch);
+
+    // Add createOutputChannel to window mock (not in default vscode mock)
+    (window as any).createOutputChannel = vi.fn(() => ({
+      appendLine: vi.fn(),
+      dispose: vi.fn(),
+    }));
+
+    disposables = [];
+    mockContext = {
+      subscriptions: {
+        push: (...items: any[]) => disposables.push(...items),
+      },
+    };
+
+    mockApi = {
+      registerProvider: vi.fn(() => ({ dispose: vi.fn() })),
+    };
+
+    // Default: core extension found and active with valid API
+    vi.mocked(extensions.getExtension).mockReturnValue({
+      isActive: true,
+      exports: mockApi,
+      activate: vi.fn(),
+    } as any);
+
+    // Default: organization configured
+    vi.mocked(workspace.getConfiguration).mockImplementation((section?: string) => {
+      if (section === 'workcenterAdo') {
+        return {
+          get: vi.fn((key: string, defaultValue?: any) => {
+            if (key === 'organization') return 'myorg';
+            if (key === 'projects') return ['ProjectA'];
+            if (key === 'refreshIntervalSeconds') return 300;
+            return defaultValue;
+          }),
+        } as any;
+      }
+      // workcenter config for log level
+      return {
+        get: vi.fn((_key: string, defaultValue?: any) => defaultValue),
+      } as any;
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns early when core extension is not found', async () => {
+    vi.mocked(extensions.getExtension).mockReturnValue(undefined as any);
+
+    await activate(mockContext);
+
+    expect(mockApi.registerProvider).not.toHaveBeenCalled();
+  });
+
+  it('shows error and returns when core extension fails to activate', async () => {
+    vi.mocked(extensions.getExtension).mockReturnValue({
+      isActive: false,
+      exports: undefined,
+      activate: vi.fn().mockRejectedValue(new Error('Activation failed')),
+    } as any);
+
+    await activate(mockContext);
+
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to activate core extension'),
+    );
+    expect(mockApi.registerProvider).not.toHaveBeenCalled();
+  });
+
+  it('returns when core extension API is missing registerProvider', async () => {
+    vi.mocked(extensions.getExtension).mockReturnValue({
+      isActive: true,
+      exports: {},
+      activate: vi.fn(),
+    } as any);
+
+    await activate(mockContext);
+
+    expect(mockApi.registerProvider).not.toHaveBeenCalled();
+  });
+
+  it('returns when core extension API is null', async () => {
+    vi.mocked(extensions.getExtension).mockReturnValue({
+      isActive: true,
+      exports: null,
+      activate: vi.fn(),
+    } as any);
+
+    await activate(mockContext);
+
+    expect(mockApi.registerProvider).not.toHaveBeenCalled();
+  });
+
+  it('activates core extension when not yet active', async () => {
+    const mockActivate = vi.fn().mockResolvedValue(mockApi);
+    vi.mocked(extensions.getExtension).mockReturnValue({
+      isActive: false,
+      exports: undefined,
+      activate: mockActivate,
+    } as any);
+
+    await activate(mockContext);
+
+    expect(mockActivate).toHaveBeenCalled();
+    expect(mockApi.registerProvider).toHaveBeenCalledTimes(2);
+  });
+
+  it('registers two providers when organization is configured', async () => {
+    await activate(mockContext);
+
+    expect(mockApi.registerProvider).toHaveBeenCalledTimes(2);
+
+    // Verify provider objects passed
+    const firstProvider = mockApi.registerProvider.mock.calls[0][0];
+    const secondProvider = mockApi.registerProvider.mock.calls[1][0];
+    expect(firstProvider.id).toBe('ado-work-items');
+    expect(secondProvider.id).toBe('ado-pr-reviews');
+  });
+
+  it('does not register providers when no organization is configured', async () => {
+    vi.mocked(workspace.getConfiguration).mockImplementation((section?: string) => {
+      if (section === 'workcenterAdo') {
+        return {
+          get: vi.fn((key: string, defaultValue?: any) => {
+            if (key === 'organization') return '';
+            if (key === 'projects') return [];
+            if (key === 'refreshIntervalSeconds') return 300;
+            return defaultValue;
+          }),
+        } as any;
+      }
+      return {
+        get: vi.fn((_key: string, defaultValue?: any) => defaultValue),
+      } as any;
+    });
+
+    await activate(mockContext);
+
+    expect(mockApi.registerProvider).not.toHaveBeenCalled();
+  });
+
+  it('creates an output channel', async () => {
+    await activate(mockContext);
+
+    // Output channel is pushed to subscriptions (first subscription)
+    expect(disposables.length).toBeGreaterThan(0);
+  });
+
+  it('registers configuration change listener', async () => {
+    await activate(mockContext);
+
+    expect(workspace.onDidChangeConfiguration).toHaveBeenCalled();
+  });
+
+  it('deactivate is a no-op', () => {
+    // Just ensure it doesn't throw
+    expect(() => deactivate()).not.toThrow();
+  });
+});

--- a/packages/ado/src/test/extension.test.ts
+++ b/packages/ado/src/test/extension.test.ts
@@ -46,7 +46,7 @@ describe('extension activation', () => {
           get: vi.fn((key: string, defaultValue?: any) => {
             if (key === 'organization') return 'myorg';
             if (key === 'projects') return ['ProjectA'];
-            if (key === 'refreshIntervalSeconds') return 300;
+            if (key === 'refreshIntervalSeconds') return 0;
             return defaultValue;
           }),
         } as any;
@@ -59,6 +59,11 @@ describe('extension activation', () => {
   });
 
   afterEach(() => {
+    for (const d of disposables) {
+      if (d && typeof d.dispose === 'function') {
+        d.dispose();
+      }
+    }
     vi.unstubAllGlobals();
   });
 
@@ -142,7 +147,7 @@ describe('extension activation', () => {
           get: vi.fn((key: string, defaultValue?: any) => {
             if (key === 'organization') return '';
             if (key === 'projects') return [];
-            if (key === 'refreshIntervalSeconds') return 300;
+            if (key === 'refreshIntervalSeconds') return 0;
             return defaultValue;
           }),
         } as any;


### PR DESCRIPTION
## test: add comprehensive ADO provider tests

Adds thorough test coverage for the ADO provider extension (`packages/ado`):

- **`extension.test.ts`** — Tests extension activation lifecycle: core extension discovery, activation failures, API validation, provider registration, configuration change listeners, and deactivate.
- **`adoWorkItemProvider.extended.test.ts`** — Tests WIQL query construction, batch fetching (200-item batches), partial batch failure handling, malformed JSON responses, network errors, multi-project support, concurrency guard, edge cases for descriptions, periodic refresh clamping, background vs user-triggered auth, and detail URL construction.
- **`adoPrReviewProvider.extended.test.ts`** — Tests getUserId caching/error handling, PR fetch error handling, multi-project support, concurrency guard, URL encoding, periodic refresh edge cases, background vs user-triggered auth, and PR URL construction.

All 86 ADO tests pass. No production code changes.
