### PR TITLE
test: add provider registration race condition tests

### DIFF
--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -132,9 +132,8 @@ describe('registerCommands', () => {
       'workcenter.acceptToFocus',
       'workcenter.archiveItem',
       'workcenter.completeItem',
-      'workcenter.blockItem',
-      'workcenter.unblockItem',
-      'workcenter.markWaitingOn',
+      'workcenter.pauseItem',
+      'workcenter.resumeItem',
       'workcenter.editItem',
       'workcenter.openInBrowser',
       'workcenter.runAction',
@@ -188,9 +187,8 @@ describe('registerCommands', () => {
       ['workcenter.acceptToFocus', WorkItemState.InProgress],
       ['workcenter.archiveItem', WorkItemState.Archived],
       ['workcenter.completeItem', WorkItemState.Done],
-      ['workcenter.blockItem', WorkItemState.Blocked],
-      ['workcenter.unblockItem', WorkItemState.InProgress],
-      ['workcenter.markWaitingOn', WorkItemState.WaitingOn],
+      ['workcenter.pauseItem', WorkItemState.Paused],
+      ['workcenter.resumeItem', WorkItemState.InProgress],
     ];
 
     for (const [cmd, expectedState] of transitions) {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -346,7 +346,7 @@ describe('ProviderRegistry', () => {
   });
 
   describe('loading state and registration race conditions', () => {
-    // Yields to the event loop so pending promise chains (.then/.finally) settle
+    // Yields a macrotask so pending promise chains (.then/.finally) settle
     function nextTick(): Promise<void> {
       return new Promise(resolve => setTimeout(resolve, 0));
     }
@@ -369,7 +369,7 @@ describe('ProviderRegistry', () => {
       return { provider, resolveRefresh, rejectRefresh };
     }
 
-    it('loading is true immediately after register and false after sync refresh resolves', async () => {
+    it('loading is true immediately after register and false after immediately-resolved refresh', async () => {
       const provider = createMockProvider('sync');
       registry.register(provider);
 
@@ -510,7 +510,7 @@ describe('ProviderRegistry', () => {
       expect(registry.hasProviders).toBe(false);
     });
 
-    it('dispose clears loading state for in-flight provider', async () => {
+    it('dispose clears loading state for in-flight provider', () => {
       const { provider } = createDeferredProvider('inflight');
       const disposable = registry.register(provider);
 

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -345,6 +345,176 @@ describe('ProviderRegistry', () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
+  describe('loading state and registration race conditions', () => {
+    // Flushes all pending microtasks (promise .then/.catch/.finally chains)
+    function flushMicrotasks(): Promise<void> {
+      return new Promise(resolve => setTimeout(resolve, 0));
+    }
+
+    function createDeferredProvider(id: string) {
+      let resolveRefresh!: () => void;
+      let rejectRefresh!: (err: Error) => void;
+      const refreshPromise = new Promise<void>((resolve, reject) => {
+        resolveRefresh = resolve;
+        rejectRefresh = reject;
+      });
+      const emitter = new EventEmitter<DiscoveredItem[]>();
+      const provider: WorkCenterProvider & { fireItems: (items: DiscoveredItem[]) => void } = {
+        id,
+        label: `Provider ${id}`,
+        onDidDiscoverItems: emitter.event,
+        refresh: vi.fn(() => refreshPromise),
+        fireItems: (items) => emitter.fire(items),
+      };
+      return { provider, resolveRefresh, rejectRefresh };
+    }
+
+    it('loading is true immediately after register and false after sync refresh resolves', async () => {
+      const provider = createMockProvider('sync');
+      registry.register(provider);
+
+      // loading is true synchronously after register (microtask hasn't run yet)
+      expect(registry.loading).toBe(true);
+
+      // After microtasks flush, the .finally() runs and loading becomes false
+      await flushMicrotasks();
+      expect(registry.loading).toBe(false);
+    });
+
+    it('loading becomes false after refresh rejects synchronously', async () => {
+      const provider = createMockProvider('fail-sync');
+      vi.mocked(provider.refresh).mockImplementation(() => Promise.reject(new Error('boom')));
+
+      registry.register(provider);
+      expect(registry.loading).toBe(true);
+
+      await flushMicrotasks();
+      expect(registry.loading).toBe(false);
+    });
+
+    it('loading stays true during async refresh until it completes', async () => {
+      const { provider, resolveRefresh } = createDeferredProvider('async');
+      registry.register(provider);
+
+      expect(registry.loading).toBe(true);
+
+      // Even after flushing microtasks, loading remains true because refresh hasn't resolved
+      await flushMicrotasks();
+      expect(registry.loading).toBe(true);
+
+      resolveRefresh();
+      await flushMicrotasks();
+      expect(registry.loading).toBe(false);
+    });
+
+    it('loading stays true during async refresh until it rejects', async () => {
+      const { provider, rejectRefresh } = createDeferredProvider('async-fail');
+      registry.register(provider);
+
+      expect(registry.loading).toBe(true);
+
+      rejectRefresh(new Error('network error'));
+      await flushMicrotasks();
+      expect(registry.loading).toBe(false);
+    });
+
+    it('loading is true until both providers finish when two are registered simultaneously', async () => {
+      const d1 = createDeferredProvider('p1');
+      const d2 = createDeferredProvider('p2');
+
+      registry.register(d1.provider);
+      registry.register(d2.provider);
+
+      expect(registry.loading).toBe(true);
+
+      // Resolve only the first provider
+      d1.resolveRefresh();
+      await flushMicrotasks();
+      // Still loading because p2 hasn't resolved
+      expect(registry.loading).toBe(true);
+
+      // Resolve the second provider
+      d2.resolveRefresh();
+      await flushMicrotasks();
+      expect(registry.loading).toBe(false);
+    });
+
+    it('provider fires onDidChangeDiscoveredItems before refresh returns — loading is still true', async () => {
+      const { provider, resolveRefresh } = createDeferredProvider('race');
+
+      const loadingDuringEvent: boolean[] = [];
+      registry.onDidChangeDiscoveredItems(() => {
+        loadingDuringEvent.push(registry.loading);
+      });
+
+      registry.register(provider);
+
+      // Provider fires items while refresh is still pending
+      provider.fireItems([{ externalId: '1', title: 'Item' }]);
+
+      // The event fired by handleDiscoveredItems should see loading = true
+      // (registration fire + handleDiscoveredItems fire, both while refresh pending)
+      expect(loadingDuringEvent.some(v => v === true)).toBe(true);
+
+      resolveRefresh();
+      await flushMicrotasks();
+      expect(registry.loading).toBe(false);
+    });
+
+    it('onDidChangeDiscoveredItems fires when loading state transitions to false', async () => {
+      const { provider, resolveRefresh } = createDeferredProvider('notif');
+
+      const events: boolean[] = [];
+      registry.onDidChangeDiscoveredItems(() => {
+        events.push(registry.loading);
+      });
+
+      registry.register(provider);
+      // Register fires onDidChangeDiscoveredItems with loading=true
+      expect(events).toContain(true);
+
+      resolveRefresh();
+      await flushMicrotasks();
+      // The .finally() fires onDidChangeDiscoveredItems with loading=false
+      expect(events).toContain(false);
+    });
+
+    it('hasProviders is true after register and false after dispose', () => {
+      expect(registry.hasProviders).toBe(false);
+
+      const provider = createMockProvider('hp');
+      const disposable = registry.register(provider);
+      expect(registry.hasProviders).toBe(true);
+
+      disposable.dispose();
+      expect(registry.hasProviders).toBe(false);
+    });
+
+    it('hasProviders reflects multiple providers correctly', () => {
+      const d1 = registry.register(createMockProvider('a'));
+      const d2 = registry.register(createMockProvider('b'));
+
+      expect(registry.hasProviders).toBe(true);
+
+      d1.dispose();
+      expect(registry.hasProviders).toBe(true);
+
+      d2.dispose();
+      expect(registry.hasProviders).toBe(false);
+    });
+
+    it('dispose clears loading state for in-flight provider', async () => {
+      const { provider } = createDeferredProvider('inflight');
+      const disposable = registry.register(provider);
+
+      expect(registry.loading).toBe(true);
+
+      disposable.dispose();
+      expect(registry.loading).toBe(false);
+      expect(registry.hasProviders).toBe(false);
+    });
+  });
+
   describe('resurfaceDismissed', () => {
     function createResurfaceProvider(id: string): WorkCenterProvider & { fireItems: (items: DiscoveredItem[]) => void } {
       const emitter = new EventEmitter<DiscoveredItem[]>();

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -347,7 +347,8 @@ describe('ProviderRegistry', () => {
   });
 
   describe('loading state and registration race conditions', () => {
-    // Yields a macrotask so pending promise chains (.then/.finally) settle
+    // Schedules a macrotask via setTimeout; before it fires, the JS event loop
+    // flushes all pending microtasks (promise .then/.catch/.finally chains).
     function nextTick(): Promise<void> {
       return new Promise(resolve => setTimeout(resolve, 0));
     }
@@ -440,7 +441,7 @@ describe('ProviderRegistry', () => {
       expect(registry.loading).toBe(false);
     });
 
-    it('provider fires onDidDiscoverItems before refresh returns — loading is still true', async () => {
+    it('provider fires onDidDiscoverItems before refresh resolves — loading is still true', async () => {
       const { provider, resolveRefresh } = createDeferredProvider('race');
 
       let callbackCount = 0;

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -346,8 +346,8 @@ describe('ProviderRegistry', () => {
   });
 
   describe('loading state and registration race conditions', () => {
-    // Flushes all pending microtasks (promise .then/.catch/.finally chains)
-    function flushMicrotasks(): Promise<void> {
+    // Yields to the event loop so pending promise chains (.then/.finally) settle
+    function nextTick(): Promise<void> {
       return new Promise(resolve => setTimeout(resolve, 0));
     }
 
@@ -377,7 +377,7 @@ describe('ProviderRegistry', () => {
       expect(registry.loading).toBe(true);
 
       // After microtasks flush, the .finally() runs and loading becomes false
-      await flushMicrotasks();
+      await nextTick();
       expect(registry.loading).toBe(false);
     });
 
@@ -388,7 +388,7 @@ describe('ProviderRegistry', () => {
       registry.register(provider);
       expect(registry.loading).toBe(true);
 
-      await flushMicrotasks();
+      await nextTick();
       expect(registry.loading).toBe(false);
     });
 
@@ -399,11 +399,11 @@ describe('ProviderRegistry', () => {
       expect(registry.loading).toBe(true);
 
       // Even after flushing microtasks, loading remains true because refresh hasn't resolved
-      await flushMicrotasks();
+      await nextTick();
       expect(registry.loading).toBe(true);
 
       resolveRefresh();
-      await flushMicrotasks();
+      await nextTick();
       expect(registry.loading).toBe(false);
     });
 
@@ -414,7 +414,7 @@ describe('ProviderRegistry', () => {
       expect(registry.loading).toBe(true);
 
       rejectRefresh(new Error('network error'));
-      await flushMicrotasks();
+      await nextTick();
       expect(registry.loading).toBe(false);
     });
 
@@ -429,35 +429,42 @@ describe('ProviderRegistry', () => {
 
       // Resolve only the first provider
       d1.resolveRefresh();
-      await flushMicrotasks();
+      await nextTick();
       // Still loading because p2 hasn't resolved
       expect(registry.loading).toBe(true);
 
       // Resolve the second provider
       d2.resolveRefresh();
-      await flushMicrotasks();
+      await nextTick();
       expect(registry.loading).toBe(false);
     });
 
-    it('provider fires onDidChangeDiscoveredItems before refresh returns — loading is still true', async () => {
+    it('provider fires onDidDiscoverItems before refresh returns — loading is still true', async () => {
       const { provider, resolveRefresh } = createDeferredProvider('race');
 
-      const loadingDuringEvent: boolean[] = [];
-      registry.onDidChangeDiscoveredItems(() => {
-        loadingDuringEvent.push(registry.loading);
+      let callbackCount = 0;
+      let loadingDuringProviderEvent: boolean | undefined;
+      const providerEventObserved = new Promise<void>((resolve) => {
+        registry.onDidChangeDiscoveredItems(() => {
+          callbackCount += 1;
+          if (callbackCount === 2) {
+            loadingDuringProviderEvent = registry.loading;
+            resolve();
+          }
+        });
       });
 
       registry.register(provider);
 
       // Provider fires items while refresh is still pending
       provider.fireItems([{ externalId: '1', title: 'Item' }]);
+      await providerEventObserved;
 
-      // The event fired by handleDiscoveredItems should see loading = true
-      // (registration fire + handleDiscoveredItems fire, both while refresh pending)
-      expect(loadingDuringEvent.some(v => v === true)).toBe(true);
+      // Verify the event caused by provider.fireItems(...) happened before refresh resolved
+      expect(loadingDuringProviderEvent).toBe(true);
 
       resolveRefresh();
-      await flushMicrotasks();
+      await nextTick();
       expect(registry.loading).toBe(false);
     });
 
@@ -474,7 +481,7 @@ describe('ProviderRegistry', () => {
       expect(events).toContain(true);
 
       resolveRefresh();
-      await flushMicrotasks();
+      await nextTick();
       // The .finally() fires onDidChangeDiscoveredItems with loading=false
       expect(events).toContain(false);
     });

--- a/packages/github/src/test/githubProvider.error.test.ts
+++ b/packages/github/src/test/githubProvider.error.test.ts
@@ -63,7 +63,7 @@ describe('GitHubIssueProvider — error handling', () => {
       const listener = vi.fn();
       provider.onDidDiscoverItems(listener);
       await expect(provider.refresh()).resolves.toBeUndefined();
-      expect(listener).not.toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledWith([]);
     });
 
     it('handles TypeError from fetch (e.g. DNS failure)', async () => {
@@ -72,7 +72,7 @@ describe('GitHubIssueProvider — error handling', () => {
       const listener = vi.fn();
       provider.onDidDiscoverItems(listener);
       await expect(provider.refresh()).resolves.toBeUndefined();
-      expect(listener).not.toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledWith([]);
     });
 
     it('handles AbortError from fetch', async () => {
@@ -83,7 +83,7 @@ describe('GitHubIssueProvider — error handling', () => {
       const listener = vi.fn();
       provider.onDidDiscoverItems(listener);
       await expect(provider.refresh()).resolves.toBeUndefined();
-      expect(listener).not.toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledWith([]);
     });
 
     it('handles fetch rejection on configured repo without throwing', async () => {
@@ -204,13 +204,14 @@ describe('GitHubIssueProvider — error handling', () => {
       const listener = vi.fn();
       provider.onDidDiscoverItems(listener);
       await expect(provider.refresh()).resolves.toBeUndefined();
-      expect(listener).not.toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledWith([]);
     });
 
     it('handles empty array response body', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => [],
+        headers: { get: () => null },
       });
 
       const listener = vi.fn();
@@ -230,6 +231,7 @@ describe('GitHubIssueProvider — error handling', () => {
           repository_url: 'https://api.github.com/repos/owner/repo',
           body: undefined,
         }],
+        headers: { get: () => null },
       });
 
       const listener = vi.fn();
@@ -251,6 +253,7 @@ describe('GitHubIssueProvider — error handling', () => {
           repository_url: 'https://api.github.com/repos/owner/repo',
           body: null,
         }],
+        headers: { get: () => null },
       });
 
       const listener = vi.fn();
@@ -379,6 +382,7 @@ describe('GitHubIssueProvider — error handling', () => {
         .mockResolvedValueOnce({
           ok: true,
           json: async () => [createMockIssue(1, 'Good issue', 'good/repo')],
+          headers: { get: () => null },
         })
         .mockResolvedValueOnce({ ok: false, status: 404 });
 
@@ -398,6 +402,7 @@ describe('GitHubIssueProvider — error handling', () => {
         .mockResolvedValueOnce({
           ok: true,
           json: async () => [createMockIssue(1, 'OK', 'good/repo')],
+          headers: { get: () => null },
         })
         .mockResolvedValueOnce({ ok: false, status: 500 })
         .mockResolvedValueOnce({ ok: false, status: 403 });
@@ -416,6 +421,7 @@ describe('GitHubIssueProvider — error handling', () => {
         .mockResolvedValueOnce({
           ok: true,
           json: async () => [createMockIssue(1, 'OK', 'good/repo')],
+          headers: { get: () => null },
         })
         .mockResolvedValueOnce({ ok: false, status: 500 });
 
@@ -433,6 +439,7 @@ describe('GitHubIssueProvider — error handling', () => {
         .mockResolvedValueOnce({
           ok: true,
           json: async () => [createMockIssue(1, 'Works', 'good/repo')],
+          headers: { get: () => null },
         })
         .mockRejectedValueOnce(new Error('ETIMEDOUT'));
 
@@ -466,6 +473,7 @@ describe('GitHubIssueProvider — error handling', () => {
         .mockResolvedValueOnce({
           ok: true,
           json: async () => [createMockIssue(1, 'OK', 'good/repo')],
+          headers: { get: () => null },
         })
         .mockResolvedValueOnce({
           ok: true,
@@ -495,6 +503,7 @@ describe('GitHubIssueProvider — error handling', () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => [],
+        headers: { get: () => null },
       });
 
       const listener = vi.fn();


### PR DESCRIPTION
## test: add provider registration race condition tests

Adds comprehensive tests for ProviderRegistry covering loading state transitions and registration race conditions.

### Tests added

- **Loading state lifecycle**: Verifies loading is 	rue immediately after egister() and transitions to alse after refresh resolves or rejects
- **Async refresh**: Confirms loading stays 	rue during pending async refreshes until completion
- **Multiple providers**: Loading remains 	rue until *all* registered providers finish refreshing
- **Race condition**: Provider fires onDidDiscoverItems while refresh is still pending — asserts loading is still 	rue during the event
- **Event notifications**: onDidChangeDiscoveredItems fires on loading state transitions
- **hasProviders tracking**: Correctly reflects provider count through register/dispose lifecycle
- **Dispose during in-flight refresh**: Clears loading state immediately on dispose
