### PR TITLE
test: add ProviderRegistry state and rapid update tests

### DIFF
--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -491,9 +491,8 @@ describe('ProviderRegistry', () => {
 
       // Each fire triggers handleDiscoveredItems, so unseenListener fires per batch
       await vi.waitFor(() => expect(unseenListener).toHaveBeenCalledTimes(3));
-      expect(unseenListener).toHaveBeenNthCalledWith(1, 1);
-      expect(unseenListener).toHaveBeenNthCalledWith(2, 1);
-      expect(unseenListener).toHaveBeenNthCalledWith(3, 1);
+      // Each call should report exactly 1 new unseen item (order may vary with async)
+      expect(unseenListener.mock.calls.every((args) => args.length === 1 && args[0] === 1)).toBe(true);
     });
   });
 

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -389,11 +389,18 @@ describe('ProviderRegistry', () => {
       registry.register(p2);
       expect(registry.loading).toBe(true);
 
-      resolveP1();
-      await vi.waitFor(() => {
-        // p1 done, p2 still loading
-        expect(registry.loading).toBe(true);
+      const p1RefreshCompleted = new Promise<void>((resolve) => {
+        const disposable = registry.onDidChangeDiscoveredItems(() => {
+          disposable.dispose();
+          resolve();
+        });
       });
+
+      resolveP1();
+      await p1RefreshCompleted;
+
+      // p1 finished and emitted its update; p2 should still keep loading true
+      expect(registry.loading).toBe(true);
 
       resolveP2();
       await vi.waitFor(() => expect(registry.loading).toBe(false));
@@ -493,6 +500,9 @@ describe('ProviderRegistry', () => {
       const provider = createMockProvider('empty');
       registry.register(provider);
 
+      // Wait for initial refresh to complete so we isolate the empty-fire behavior
+      await vi.waitFor(() => expect(registry.loading).toBe(false));
+
       const changeListener = vi.fn();
       registry.onDidChangeDiscoveredItems(changeListener);
 
@@ -550,15 +560,19 @@ describe('ProviderRegistry', () => {
       expect(registry.loading).toBe(false);
     });
 
-    it('fires onDidChangeDiscoveredItems on deregistration', () => {
+    it('fires onDidChangeDiscoveredItems on deregistration', async () => {
       const provider = createMockProvider('notify');
       const disposable = registry.register(provider);
+
+      // Wait for initial refresh to complete
+      await vi.waitFor(() => expect(registry.loading).toBe(false));
 
       const listener = vi.fn();
       registry.onDidChangeDiscoveredItems(listener);
 
       disposable.dispose();
-      expect(listener).toHaveBeenCalled();
+
+      await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(1));
     });
 
     it('fires onDidRegisterProvider on registration', () => {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -515,30 +515,6 @@ describe('ProviderRegistry', () => {
       expect(stateStore.setStates).not.toHaveBeenCalled();
     });
 
-    it('handles items with duplicate externalIds in a single fire', async () => {
-      const provider = createMockProvider('dupes');
-      registry.register(provider);
-
-      provider.fireItems([
-        { externalId: 'same', title: 'First occurrence' },
-        { externalId: 'same', title: 'Second occurrence' },
-      ]);
-
-      await vi.waitFor(() => {
-        const items = registry.getDiscoveredItems('dupes');
-        expect(items).toHaveLength(2);
-      });
-
-      // Both items are stored as-is (provider is responsible for deduplication)
-      // But setStates should receive two entries for the same externalId
-      await vi.waitFor(() => {
-        expect(stateStore.setStates).toHaveBeenCalledWith([
-          { providerId: 'dupes', externalId: 'same', state: 'unseen' },
-          { providerId: 'dupes', externalId: 'same', state: 'unseen' },
-        ]);
-      });
-    });
-
     it('deregistration clears discovered items', () => {
       const provider = createMockProvider('clearme');
       const disposable = registry.register(provider);

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -492,8 +492,10 @@ describe('ProviderRegistry', () => {
 
       // Each fire triggers handleDiscoveredItems, so unseenListener fires per batch
       await vi.waitFor(() => expect(unseenListener).toHaveBeenCalledTimes(3));
-      // Each call should report exactly 1 new unseen item (order may vary with async)
-      expect(unseenListener.mock.calls.every((args) => args.length === 1 && args[0] === 1)).toBe(true);
+      // Each call should report exactly 1 new unseen item
+      expect(unseenListener).toHaveBeenNthCalledWith(1, 1);
+      expect(unseenListener).toHaveBeenNthCalledWith(2, 1);
+      expect(unseenListener).toHaveBeenNthCalledWith(3, 1);
     });
   });
 

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -351,9 +351,13 @@ describe('ProviderRegistry', () => {
       const provider = createMockProvider('loader');
       // Make refresh hang so loading stays true
       provider.refresh = vi.fn(() => new Promise(() => {}));
-      registry.register(provider);
+      const registration = registry.register(provider);
 
-      expect(registry.loading).toBe(true);
+      try {
+        expect(registry.loading).toBe(true);
+      } finally {
+        registration.dispose();
+      }
     });
 
     it('loading becomes false after provider refresh resolves', async () => {
@@ -507,6 +511,7 @@ describe('ProviderRegistry', () => {
       // Wait for initial refresh to complete so we isolate the empty-fire behavior
       await vi.waitFor(() => expect(registry.loading).toBe(false));
 
+      stateStore.setStates.mockClear();
       const changeListener = vi.fn();
       registry.onDidChangeDiscoveredItems(changeListener);
 

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -425,7 +425,7 @@ describe('ProviderRegistry', () => {
     });
   });
 
-  describe('event coalescing and rapid updates', () => {
+  describe('rapid updates', () => {
     it('handles rapid item fires from the same provider', async () => {
       const provider = createMockProvider('rapid');
       registry.register(provider);
@@ -447,14 +447,16 @@ describe('ProviderRegistry', () => {
       const provider = createMockProvider('rapid');
       registry.register(provider);
 
+      // Wait for registration/refresh to fully complete
+      await vi.waitFor(() => expect(registry.loading).toBe(false));
+
       const listener = vi.fn();
       registry.onDidChangeDiscoveredItems(listener);
 
       provider.fireItems([{ externalId: '1', title: 'A' }]);
       provider.fireItems([{ externalId: '2', title: 'B' }]);
 
-      // Each fire triggers a change event; the loading-clear from refresh may also fire
-      await vi.waitFor(() => expect(listener.mock.calls.length).toBeGreaterThanOrEqual(2));
+      await vi.waitFor(() => expect(listener).toHaveBeenCalledTimes(2));
     });
 
     it('handles interleaved fires from multiple providers', async () => {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -345,6 +345,231 @@ describe('ProviderRegistry', () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
+  describe('loading state', () => {
+    it('loading is true immediately after registration', () => {
+      const provider = createMockProvider('loader');
+      // Make refresh hang so loading stays true
+      provider.refresh = vi.fn(() => new Promise(() => {}));
+      registry.register(provider);
+
+      expect(registry.loading).toBe(true);
+    });
+
+    it('loading becomes false after provider refresh resolves', async () => {
+      const provider = createMockProvider('loader');
+      let resolveRefresh!: () => void;
+      provider.refresh = vi.fn(() => new Promise<void>((r) => { resolveRefresh = r; }));
+      registry.register(provider);
+
+      expect(registry.loading).toBe(true);
+      resolveRefresh();
+      await vi.waitFor(() => expect(registry.loading).toBe(false));
+    });
+
+    it('loading becomes false even when provider refresh rejects', async () => {
+      const provider = createMockProvider('loader');
+      let rejectRefresh!: (err: Error) => void;
+      provider.refresh = vi.fn(() => new Promise<void>((_, rej) => { rejectRefresh = rej; }));
+      registry.register(provider);
+
+      expect(registry.loading).toBe(true);
+      rejectRefresh(new Error('fail'));
+      await vi.waitFor(() => expect(registry.loading).toBe(false));
+    });
+
+    it('loading tracks multiple providers independently', async () => {
+      let resolveP1!: () => void;
+      let resolveP2!: () => void;
+      const p1 = createMockProvider('p1');
+      const p2 = createMockProvider('p2');
+      p1.refresh = vi.fn(() => new Promise<void>((r) => { resolveP1 = r; }));
+      p2.refresh = vi.fn(() => new Promise<void>((r) => { resolveP2 = r; }));
+
+      registry.register(p1);
+      registry.register(p2);
+      expect(registry.loading).toBe(true);
+
+      resolveP1();
+      await vi.waitFor(() => {
+        // p1 done, p2 still loading
+        expect(registry.loading).toBe(true);
+      });
+
+      resolveP2();
+      await vi.waitFor(() => expect(registry.loading).toBe(false));
+    });
+  });
+
+  describe('hasProviders', () => {
+    it('is false when no providers registered', () => {
+      expect(registry.hasProviders).toBe(false);
+    });
+
+    it('is true after registering a provider', () => {
+      registry.register(createMockProvider('p1'));
+      expect(registry.hasProviders).toBe(true);
+    });
+
+    it('becomes false after deregistering all providers', () => {
+      const d = registry.register(createMockProvider('p1'));
+      expect(registry.hasProviders).toBe(true);
+      d.dispose();
+      expect(registry.hasProviders).toBe(false);
+    });
+  });
+
+  describe('event coalescing and rapid updates', () => {
+    it('handles rapid item fires from the same provider', async () => {
+      const provider = createMockProvider('rapid');
+      registry.register(provider);
+
+      // Fire items rapidly in succession
+      provider.fireItems([{ externalId: '1', title: 'First' }]);
+      provider.fireItems([{ externalId: '2', title: 'Second' }]);
+      provider.fireItems([{ externalId: '3', title: 'Third' }]);
+
+      // Last fire wins — items are replaced, not accumulated
+      await vi.waitFor(() => {
+        const items = registry.getDiscoveredItems('rapid');
+        expect(items).toHaveLength(1);
+        expect(items[0].externalId).toBe('3');
+      });
+    });
+
+    it('fires onDidChangeDiscoveredItems for each rapid update', async () => {
+      const provider = createMockProvider('rapid');
+      registry.register(provider);
+
+      const listener = vi.fn();
+      registry.onDidChangeDiscoveredItems(listener);
+
+      provider.fireItems([{ externalId: '1', title: 'A' }]);
+      provider.fireItems([{ externalId: '2', title: 'B' }]);
+
+      // Each fire triggers a change event; the loading-clear from refresh may also fire
+      await vi.waitFor(() => expect(listener.mock.calls.length).toBeGreaterThanOrEqual(2));
+    });
+
+    it('handles interleaved fires from multiple providers', async () => {
+      const p1 = createMockProvider('alpha');
+      const p2 = createMockProvider('beta');
+      registry.register(p1);
+      registry.register(p2);
+
+      p1.fireItems([{ externalId: 'a1', title: 'Alpha 1' }]);
+      p2.fireItems([{ externalId: 'b1', title: 'Beta 1' }]);
+      p1.fireItems([{ externalId: 'a2', title: 'Alpha 2' }]);
+
+      await vi.waitFor(() => {
+        expect(registry.getDiscoveredItems('alpha')).toHaveLength(1);
+        expect(registry.getDiscoveredItems('alpha')[0].externalId).toBe('a2');
+        expect(registry.getDiscoveredItems('beta')).toHaveLength(1);
+        expect(registry.getDiscoveredItems('beta')[0].externalId).toBe('b1');
+      });
+    });
+
+    it('correctly counts new unseen items across rapid fires', async () => {
+      const provider = createMockProvider('rapid');
+      registry.register(provider);
+
+      const unseenListener = vi.fn();
+      registry.onDidAddNewUnseenItems(unseenListener);
+
+      // Rapid fires — each produces a new unseen item
+      provider.fireItems([{ externalId: '1', title: 'One' }]);
+      provider.fireItems([{ externalId: '2', title: 'Two' }]);
+      provider.fireItems([{ externalId: '3', title: 'Three' }]);
+
+      // Each fire triggers handleDiscoveredItems, so unseenListener fires per batch
+      await vi.waitFor(() => expect(unseenListener).toHaveBeenCalledTimes(3));
+      expect(unseenListener).toHaveBeenNthCalledWith(1, 1);
+      expect(unseenListener).toHaveBeenNthCalledWith(2, 1);
+      expect(unseenListener).toHaveBeenNthCalledWith(3, 1);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty items array from provider', async () => {
+      const provider = createMockProvider('empty');
+      registry.register(provider);
+
+      const changeListener = vi.fn();
+      registry.onDidChangeDiscoveredItems(changeListener);
+
+      provider.fireItems([]);
+
+      await vi.waitFor(() => expect(changeListener).toHaveBeenCalled());
+      expect(registry.getDiscoveredItems('empty')).toEqual([]);
+      // No unseen items to set
+      expect(stateStore.setStates).not.toHaveBeenCalled();
+    });
+
+    it('handles items with duplicate externalIds in a single fire', async () => {
+      const provider = createMockProvider('dupes');
+      registry.register(provider);
+
+      provider.fireItems([
+        { externalId: 'same', title: 'First occurrence' },
+        { externalId: 'same', title: 'Second occurrence' },
+      ]);
+
+      await vi.waitFor(() => {
+        const items = registry.getDiscoveredItems('dupes');
+        expect(items).toHaveLength(2);
+      });
+
+      // Both items are stored as-is (provider is responsible for deduplication)
+      // But setStates should receive two entries for the same externalId
+      await vi.waitFor(() => {
+        expect(stateStore.setStates).toHaveBeenCalledWith([
+          { providerId: 'dupes', externalId: 'same', state: 'unseen' },
+          { providerId: 'dupes', externalId: 'same', state: 'unseen' },
+        ]);
+      });
+    });
+
+    it('deregistration clears discovered items', () => {
+      const provider = createMockProvider('clearme');
+      const disposable = registry.register(provider);
+
+      provider.fireItems([{ externalId: '1', title: 'Item' }]);
+      expect(registry.getDiscoveredItems('clearme')).toHaveLength(1);
+
+      disposable.dispose();
+      expect(registry.getDiscoveredItems('clearme')).toEqual([]);
+    });
+
+    it('deregistration removes loading state', async () => {
+      const provider = createMockProvider('loadclear');
+      // Make refresh hang
+      provider.refresh = vi.fn(() => new Promise(() => {}));
+      const disposable = registry.register(provider);
+
+      expect(registry.loading).toBe(true);
+      disposable.dispose();
+      expect(registry.loading).toBe(false);
+    });
+
+    it('fires onDidChangeDiscoveredItems on deregistration', () => {
+      const provider = createMockProvider('notify');
+      const disposable = registry.register(provider);
+
+      const listener = vi.fn();
+      registry.onDidChangeDiscoveredItems(listener);
+
+      disposable.dispose();
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it('fires onDidRegisterProvider on registration', () => {
+      const listener = vi.fn();
+      registry.onDidRegisterProvider(listener);
+
+      registry.register(createMockProvider('notifyreg'));
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('resurfaceDismissed', () => {
     function createResurfaceProvider(id: string): WorkCenterProvider & { fireItems: (items: DiscoveredItem[]) => void } {
       const emitter = new EventEmitter<DiscoveredItem[]>();


### PR DESCRIPTION
## Summary

Add comprehensive tests for ProviderRegistry covering:

- **Loading state** — tracks loading across registration, resolve, reject, and multiple providers
- **hasProviders** — verifies boolean flag on register/deregister
- **Rapid updates** — rapid fires from same/multiple providers, event counts, unseen item tracking
- **Edge cases** — empty arrays, deregistration cleanup (items, loading, events), registration events
