### PR TITLE
fix: add JSON validation and file size limits in stores

### DIFF
--- a/packages/core/src/storage/discoveredStateStore.ts
+++ b/packages/core/src/storage/discoveredStateStore.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { logger } from '../services/logger';
+import { MAX_STORE_FILE_SIZE } from './limits';
 
 /** Possible states for a provider-discovered item in the inbox workflow. */
 const inboxStates = ['unseen', 'accepted', 'dismissed'] as const;
@@ -168,6 +169,13 @@ export class DiscoveredStateStore {
   private async doLoad(): Promise<void> {
     try {
       const data = await fs.readFile(this.filePath, 'utf-8');
+      if (data.length > MAX_STORE_FILE_SIZE) {
+        logger.warn(`Discovered state file exceeds ${MAX_STORE_FILE_SIZE} bytes — backing up and resetting to empty`);
+        await this.backupCorruptedFile();
+        this.cache.clear();
+        this.loaded = true;
+        return;
+      }
       let parsed: unknown;
       try {
         parsed = JSON.parse(data);

--- a/packages/core/src/storage/discoveredStateStore.ts
+++ b/packages/core/src/storage/discoveredStateStore.ts
@@ -168,14 +168,15 @@ export class DiscoveredStateStore {
 
   private async doLoad(): Promise<void> {
     try {
-      const data = await fs.readFile(this.filePath, 'utf-8');
-      if (data.length > MAX_STORE_FILE_SIZE) {
+      const stats = await fs.stat(this.filePath);
+      if (stats.size > MAX_STORE_FILE_SIZE) {
         logger.warn(`Discovered state file exceeds ${MAX_STORE_FILE_SIZE} bytes — backing up and resetting to empty`);
         await this.backupCorruptedFile();
         this.cache.clear();
         this.loaded = true;
         return;
       }
+      const data = await fs.readFile(this.filePath, 'utf-8');
       let parsed: unknown;
       try {
         parsed = JSON.parse(data);

--- a/packages/core/src/storage/discoveredStateStore.ts
+++ b/packages/core/src/storage/discoveredStateStore.ts
@@ -169,6 +169,13 @@ export class DiscoveredStateStore {
   private async doLoad(): Promise<void> {
     try {
       const stats = await fs.stat(this.filePath);
+      if (!stats.isFile()) {
+        logger.warn('Discovered state path is not a regular file — backing up and resetting to empty');
+        await this.backupInvalidFile();
+        this.cache.clear();
+        this.loaded = true;
+        return;
+      }
       if (stats.size > MAX_STORE_FILE_SIZE) {
         logger.warn(`Discovered state file exceeds ${MAX_STORE_FILE_SIZE} bytes — backing up and resetting to empty`);
         await this.backupInvalidFile();

--- a/packages/core/src/storage/discoveredStateStore.ts
+++ b/packages/core/src/storage/discoveredStateStore.ts
@@ -171,7 +171,7 @@ export class DiscoveredStateStore {
       const stats = await fs.stat(this.filePath);
       if (stats.size > MAX_STORE_FILE_SIZE) {
         logger.warn(`Discovered state file exceeds ${MAX_STORE_FILE_SIZE} bytes — backing up and resetting to empty`);
-        await this.backupCorruptedFile();
+        await this.backupInvalidFile();
         this.cache.clear();
         this.loaded = true;
         return;
@@ -182,14 +182,14 @@ export class DiscoveredStateStore {
         parsed = JSON.parse(data);
       } catch {
         logger.warn('Failed to parse discovered state file — backing up and resetting to empty');
-        await this.backupCorruptedFile();
+        await this.backupInvalidFile();
         this.cache.clear();
         this.loaded = true;
         return;
       }
       if (!Array.isArray(parsed)) {
         logger.warn('Discovered state file does not contain an array — backing up and resetting to empty');
-        await this.backupCorruptedFile();
+        await this.backupInvalidFile();
         this.cache.clear();
         this.loaded = true;
         return;
@@ -236,13 +236,13 @@ export class DiscoveredStateStore {
     return this.writeQueue;
   }
 
-  private async backupCorruptedFile(): Promise<void> {
+  private async backupInvalidFile(): Promise<void> {
     try {
       const backupPath = `${this.filePath}.corrupt.${Date.now()}`;
       await fs.rename(this.filePath, backupPath);
-      logger.warn(`Backed up corrupted file to ${backupPath}`);
+      logger.warn(`Backed up invalid discovered state file to ${backupPath}`);
     } catch {
-      logger.warn('Failed to back up corrupted discovered state file');
+      logger.warn('Failed to back up invalid discovered state file');
     }
   }
 

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -97,7 +97,7 @@ export class JsonTaskStore implements ITaskStore {
       const stats = await fs.stat(this.filePath);
       if (stats.size > MAX_STORE_FILE_SIZE) {
         logger.warn(`Work items file exceeds ${MAX_STORE_FILE_SIZE} bytes — backing up and resetting to empty`);
-        await this.backupCorruptedFile();
+        await this.backupInvalidFile();
         this.cache = new Map();
         return [];
       }
@@ -107,13 +107,13 @@ export class JsonTaskStore implements ITaskStore {
         parsed = JSON.parse(data);
       } catch {
         logger.warn('Failed to parse work items file — backing up and resetting to empty');
-        await this.backupCorruptedFile();
+        await this.backupInvalidFile();
         this.cache = new Map();
         return [];
       }
       if (!Array.isArray(parsed)) {
         logger.warn('Work items file does not contain an array — backing up and resetting to empty');
-        await this.backupCorruptedFile();
+        await this.backupInvalidFile();
         this.cache = new Map();
         return [];
       }
@@ -273,13 +273,13 @@ export class JsonTaskStore implements ITaskStore {
     return this.writeQueue;
   }
 
-  private async backupCorruptedFile(): Promise<void> {
+  private async backupInvalidFile(): Promise<void> {
     try {
       const backupPath = `${this.filePath}.corrupt.${Date.now()}`;
       await fs.rename(this.filePath, backupPath);
-      logger.warn(`Backed up corrupted file to ${backupPath}`);
+      logger.warn(`Backed up invalid work items file to ${backupPath}`);
     } catch {
-      logger.warn('Failed to back up corrupted work items file');
+      logger.warn('Failed to back up invalid work items file');
     }
   }
 }

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -95,6 +95,12 @@ export class JsonTaskStore implements ITaskStore {
     logger.debug(`Loading work items from ${this.filePath}`);
     try {
       const stats = await fs.stat(this.filePath);
+      if (!stats.isFile()) {
+        logger.warn('Work items path is not a regular file — backing up and resetting to empty');
+        await this.backupInvalidFile();
+        this.cache = new Map();
+        return [];
+      }
       if (stats.size > MAX_STORE_FILE_SIZE) {
         logger.warn(`Work items file exceeds ${MAX_STORE_FILE_SIZE} bytes — backing up and resetting to empty`);
         await this.backupInvalidFile();

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -94,13 +94,14 @@ export class JsonTaskStore implements ITaskStore {
   private async doLoad(): Promise<WorkItem[]> {
     logger.debug(`Loading work items from ${this.filePath}`);
     try {
-      const data = await fs.readFile(this.filePath, 'utf-8');
-      if (data.length > MAX_STORE_FILE_SIZE) {
+      const stats = await fs.stat(this.filePath);
+      if (stats.size > MAX_STORE_FILE_SIZE) {
         logger.warn(`Work items file exceeds ${MAX_STORE_FILE_SIZE} bytes — backing up and resetting to empty`);
         await this.backupCorruptedFile();
         this.cache = new Map();
         return [];
       }
+      const data = await fs.readFile(this.filePath, 'utf-8');
       let parsed: unknown;
       try {
         parsed = JSON.parse(data);

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { ITaskStore } from './taskStore';
 import { logger } from '../services/logger';
+import { MAX_STORE_FILE_SIZE } from './limits';
 
 const validWorkItemStates = new Set<string>(Object.values(WorkItemState));
 // Legacy states that are no longer in the enum but can be migrated
@@ -94,6 +95,12 @@ export class JsonTaskStore implements ITaskStore {
     logger.debug(`Loading work items from ${this.filePath}`);
     try {
       const data = await fs.readFile(this.filePath, 'utf-8');
+      if (data.length > MAX_STORE_FILE_SIZE) {
+        logger.warn(`Work items file exceeds ${MAX_STORE_FILE_SIZE} bytes — backing up and resetting to empty`);
+        await this.backupCorruptedFile();
+        this.cache = new Map();
+        return [];
+      }
       let parsed: unknown;
       try {
         parsed = JSON.parse(data);

--- a/packages/core/src/storage/limits.ts
+++ b/packages/core/src/storage/limits.ts
@@ -1,0 +1,6 @@
+/**
+ * Maximum file size (in bytes) that stores will accept before JSON parsing.
+ * Files exceeding this limit are backed up and the store resets to empty,
+ * guarding against memory exhaustion from corrupted or maliciously large files.
+ */
+export const MAX_STORE_FILE_SIZE = 10 * 1024 * 1024; // 10 MB

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -81,14 +81,15 @@ export class ReadStateStore {
   async load(): Promise<void> {
     if (this.loaded) { return; }
     try {
-      const data = await fs.readFile(this.filePath, 'utf-8');
-      if (data.length > MAX_STORE_FILE_SIZE) {
+      const stats = await fs.stat(this.filePath);
+      if (stats.size > MAX_STORE_FILE_SIZE) {
         logger.warn(`Read state file exceeds ${MAX_STORE_FILE_SIZE} bytes — backing up and resetting to empty`);
         await this.backupCorruptedFile();
         this.items.clear();
         this.loaded = true;
         return;
       }
+      const data = await fs.readFile(this.filePath, 'utf-8');
       let parsed: unknown;
       try {
         parsed = JSON.parse(data);

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -82,6 +82,13 @@ export class ReadStateStore {
     if (this.loaded) { return; }
     try {
       const stats = await fs.stat(this.filePath);
+      if (!stats.isFile()) {
+        logger.warn('Read state path is not a regular file — backing up and resetting to empty');
+        await this.backupInvalidFile();
+        this.items.clear();
+        this.loaded = true;
+        return;
+      }
       if (stats.size > MAX_STORE_FILE_SIZE) {
         logger.warn(`Read state file exceeds ${MAX_STORE_FILE_SIZE} bytes — backing up and resetting to empty`);
         await this.backupInvalidFile();

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { logger } from '../services/logger';
+import { MAX_STORE_FILE_SIZE } from './limits';
 
 /**
  * Persists the set of inbox item IDs that the user has viewed ("read")
@@ -81,10 +82,37 @@ export class ReadStateStore {
     if (this.loaded) { return; }
     try {
       const data = await fs.readFile(this.filePath, 'utf-8');
-      const arr = JSON.parse(data) as string[];
+      if (data.length > MAX_STORE_FILE_SIZE) {
+        logger.warn(`Read state file exceeds ${MAX_STORE_FILE_SIZE} bytes — backing up and resetting to empty`);
+        await this.backupCorruptedFile();
+        this.items.clear();
+        this.loaded = true;
+        return;
+      }
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(data);
+      } catch {
+        logger.warn('Failed to parse read state file — backing up and resetting to empty');
+        await this.backupCorruptedFile();
+        this.items.clear();
+        this.loaded = true;
+        return;
+      }
+      if (!Array.isArray(parsed)) {
+        logger.warn('Read state file does not contain an array — backing up and resetting to empty');
+        await this.backupCorruptedFile();
+        this.items.clear();
+        this.loaded = true;
+        return;
+      }
       this.items.clear();
-      for (const key of arr) {
-        this.items.add(key);
+      for (const item of parsed) {
+        if (typeof item !== 'string') {
+          logger.warn(`Skipping invalid read state entry: expected string, got ${typeof item}`);
+          continue;
+        }
+        this.items.add(item);
       }
       logger.debug(`Loaded read state: ${this.items.size} entries`);
       this.loaded = true;
@@ -108,6 +136,16 @@ export class ReadStateStore {
   private enqueue(op: () => Promise<void>): Promise<void> {
     this.writeQueue = this.writeQueue.then(op, op);
     return this.writeQueue;
+  }
+
+  private async backupCorruptedFile(): Promise<void> {
+    try {
+      const backupPath = `${this.filePath}.corrupt.${Date.now()}`;
+      await fs.rename(this.filePath, backupPath);
+      logger.warn(`Backed up corrupted file to ${backupPath}`);
+    } catch {
+      logger.warn('Failed to back up corrupted read state file');
+    }
   }
 }
 

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -84,7 +84,7 @@ export class ReadStateStore {
       const stats = await fs.stat(this.filePath);
       if (stats.size > MAX_STORE_FILE_SIZE) {
         logger.warn(`Read state file exceeds ${MAX_STORE_FILE_SIZE} bytes — backing up and resetting to empty`);
-        await this.backupCorruptedFile();
+        await this.backupInvalidFile();
         this.items.clear();
         this.loaded = true;
         return;
@@ -95,25 +95,38 @@ export class ReadStateStore {
         parsed = JSON.parse(data);
       } catch {
         logger.warn('Failed to parse read state file — backing up and resetting to empty');
-        await this.backupCorruptedFile();
+        await this.backupInvalidFile();
         this.items.clear();
         this.loaded = true;
         return;
       }
       if (!Array.isArray(parsed)) {
         logger.warn('Read state file does not contain an array — backing up and resetting to empty');
-        await this.backupCorruptedFile();
+        await this.backupInvalidFile();
         this.items.clear();
         this.loaded = true;
         return;
       }
       this.items.clear();
+      const maxInvalidEntryWarnings = 5;
+      let invalidEntryCount = 0;
       for (const item of parsed) {
         if (typeof item !== 'string') {
-          logger.warn(`Skipping invalid read state entry: expected string, got ${typeof item}`);
+          invalidEntryCount += 1;
+          if (invalidEntryCount <= maxInvalidEntryWarnings) {
+            logger.warn(`Skipping invalid read state entry: expected string, got ${typeof item}`);
+          }
           continue;
         }
         this.items.add(item);
+      }
+      if (invalidEntryCount > 0) {
+        const suppressed = invalidEntryCount - maxInvalidEntryWarnings;
+        if (suppressed > 0) {
+          logger.warn(`Skipped ${invalidEntryCount} invalid read state entries (${suppressed} additional warnings suppressed)`);
+        } else {
+          logger.warn(`Skipped ${invalidEntryCount} invalid read state entr${invalidEntryCount === 1 ? 'y' : 'ies'}`);
+        }
       }
       logger.debug(`Loaded read state: ${this.items.size} entries`);
       this.loaded = true;
@@ -139,13 +152,13 @@ export class ReadStateStore {
     return this.writeQueue;
   }
 
-  private async backupCorruptedFile(): Promise<void> {
+  private async backupInvalidFile(): Promise<void> {
     try {
       const backupPath = `${this.filePath}.corrupt.${Date.now()}`;
       await fs.rename(this.filePath, backupPath);
-      logger.warn(`Backed up corrupted file to ${backupPath}`);
+      logger.warn(`Backed up invalid read state file to ${backupPath}`);
     } catch {
-      logger.warn('Failed to back up corrupted read state file');
+      logger.warn('Failed to back up invalid read state file');
     }
   }
 }

--- a/packages/core/src/test/discoveredStateStore.test.ts
+++ b/packages/core/src/test/discoveredStateStore.test.ts
@@ -4,6 +4,9 @@ import * as path from 'path';
 import * as os from 'os';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 
+const mockLimits = vi.hoisted(() => ({ MAX_STORE_FILE_SIZE: 10 * 1024 * 1024 }));
+vi.mock('../storage/limits', () => mockLimits);
+
 describe('DiscoveredStateStore', () => {
   let tmpDir: string;
   let store: DiscoveredStateStore;
@@ -835,6 +838,43 @@ describe('DiscoveredStateStore', () => {
       ]);
 
       expect(listener).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('file size limits', () => {
+    afterEach(() => {
+      mockLimits.MAX_STORE_FILE_SIZE = 10 * 1024 * 1024;
+    });
+
+    it('should back up and reset when file exceeds size limit', async () => {
+      mockLimits.MAX_STORE_FILE_SIZE = 50;
+      const filePath = path.join(tmpDir, 'discovered-state.json');
+      const oversizedContent = JSON.stringify([
+        { providerId: 'gh', externalId: 'issue-with-a-very-long-id-that-pushes-over', inboxState: 'unseen' },
+      ]);
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(filePath, oversizedContent, 'utf-8');
+
+      const records = await store.loadAll();
+      expect(records).toEqual([]);
+
+      const files = await fs.readdir(tmpDir);
+      const backupFiles = files.filter(f => f.startsWith('discovered-state.json.corrupt.'));
+      expect(backupFiles).toHaveLength(1);
+    });
+
+    it('should parse normally when file is just under size limit', async () => {
+      const filePath = path.join(tmpDir, 'discovered-state.json');
+      const content = JSON.stringify([
+        { providerId: 'gh', externalId: '1', inboxState: 'unseen' },
+      ]);
+      mockLimits.MAX_STORE_FILE_SIZE = content.length + 1;
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(filePath, content, 'utf-8');
+
+      const records = await store.loadAll();
+      expect(records).toHaveLength(1);
+      expect(records[0].providerId).toBe('gh');
     });
   });
 });

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -7,6 +7,7 @@ vi.mock('fs/promises', () => ({
   readFile: vi.fn().mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })),
   writeFile: vi.fn().mockResolvedValue(undefined),
   mkdir: vi.fn().mockResolvedValue(undefined),
+  stat: vi.fn().mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })),
 }));
 
 function createExtensionContext(overrides?: Partial<vscode.ExtensionContext>): vscode.ExtensionContext {
@@ -235,6 +236,8 @@ describe('activate()', () => {
     (fs.readFile as ReturnType<typeof vi.fn>)
       .mockResolvedValueOnce(JSON.stringify(workItems))   // workitems.json
       .mockRejectedValueOnce(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })); // discovered-state.json
+    (fs.stat as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({ size: 100 }); // workitems.json stat
 
     await activate(context);
 
@@ -263,6 +266,7 @@ describe('activate()', () => {
   it('recovers gracefully when workitems.json contains invalid JSON', async () => {
     const fs = await import('fs/promises');
     (fs.readFile as ReturnType<typeof vi.fn>).mockResolvedValueOnce('NOT VALID JSON');
+    (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ size: 100 }); // workitems.json stat
 
     await expect(activate(context)).resolves.toBeDefined();
   });

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -237,7 +237,7 @@ describe('activate()', () => {
       .mockResolvedValueOnce(JSON.stringify(workItems))   // workitems.json
       .mockRejectedValueOnce(Object.assign(new Error('ENOENT'), { code: 'ENOENT' })); // discovered-state.json
     (fs.stat as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce({ size: 100 }); // workitems.json stat
+      .mockResolvedValueOnce({ size: 100, isFile: () => true }); // workitems.json stat
 
     await activate(context);
 
@@ -266,7 +266,7 @@ describe('activate()', () => {
   it('recovers gracefully when workitems.json contains invalid JSON', async () => {
     const fs = await import('fs/promises');
     (fs.readFile as ReturnType<typeof vi.fn>).mockResolvedValueOnce('NOT VALID JSON');
-    (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ size: 100 }); // workitems.json stat
+    (fs.stat as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ size: 100, isFile: () => true }); // workitems.json stat
 
     await expect(activate(context)).resolves.toBeDefined();
   });

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -1,9 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as os from 'os';
 import { JsonTaskStore } from '../storage/jsonTaskStore';
 import { WorkItem, WorkItemState } from '../models/workItem';
+
+const mockLimits = vi.hoisted(() => ({ MAX_STORE_FILE_SIZE: 10 * 1024 * 1024 }));
+vi.mock('../storage/limits', () => mockLimits);
 
 describe('JsonTaskStore', () => {
   let tmpDir: string;
@@ -390,5 +393,39 @@ describe('JsonTaskStore', () => {
     expect(persisted).toHaveLength(2);
     expect(persisted[0].state).toBe(WorkItemState.Paused);
     expect(persisted[1].state).toBe(WorkItemState.Paused);
+  });
+
+  describe('file size limits', () => {
+    afterEach(() => {
+      mockLimits.MAX_STORE_FILE_SIZE = 10 * 1024 * 1024;
+    });
+
+    it('should back up and reset when file exceeds size limit', async () => {
+      mockLimits.MAX_STORE_FILE_SIZE = 50;
+      const filePath = path.join(tmpDir, 'workitems.json');
+      const oversizedContent = JSON.stringify([makeItem({ id: 'oversized', title: 'A very long title that pushes the file over the limit' })]);
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(filePath, oversizedContent, 'utf-8');
+
+      const items = await store.loadAll();
+      expect(items).toEqual([]);
+
+      const files = await fs.readdir(tmpDir);
+      const backupFiles = files.filter(f => f.startsWith('workitems.json.corrupt.'));
+      expect(backupFiles).toHaveLength(1);
+    });
+
+    it('should parse normally when file is just under size limit', async () => {
+      const filePath = path.join(tmpDir, 'workitems.json');
+      const item = makeItem({ id: 'ok' });
+      const content = JSON.stringify([item]);
+      mockLimits.MAX_STORE_FILE_SIZE = content.length + 1;
+      await fs.mkdir(tmpDir, { recursive: true });
+      await fs.writeFile(filePath, content, 'utf-8');
+
+      const items = await store.loadAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('ok');
+    });
   });
 });

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -4,6 +4,9 @@ import * as path from 'path';
 import * as os from 'os';
 import { ReadStateStore } from '../storage/readStateStore';
 
+const mockLimits = vi.hoisted(() => ({ MAX_STORE_FILE_SIZE: 10 * 1024 * 1024 }));
+vi.mock('../storage/limits', () => mockLimits);
+
 describe('ReadStateStore', () => {
   let tmpDir: string;
   let store: ReadStateStore;
@@ -93,11 +96,72 @@ describe('ReadStateStore', () => {
     expect(store2.has('gh::3')).toBe(false);
   });
 
-  it('should handle corrupted JSON by throwing', async () => {
+  it('should handle corrupted JSON by backing up and loading empty', async () => {
     const filePath = path.join(tmpDir, 'read-state.json');
     await fs.writeFile(filePath, 'not valid json', 'utf-8');
 
-    await expect(store.load()).rejects.toThrow();
+    await store.load();
+    expect([...store.keys()]).toEqual([]);
+
+    const files = await fs.readdir(tmpDir);
+    const backupFiles = files.filter(f => f.startsWith('read-state.json.corrupt.'));
+    expect(backupFiles).toHaveLength(1);
+  });
+
+  it('should handle non-array JSON by backing up and resetting', async () => {
+    const filePath = path.join(tmpDir, 'read-state.json');
+    await fs.writeFile(filePath, JSON.stringify({ not: 'an array' }), 'utf-8');
+
+    await store.load();
+    expect([...store.keys()]).toEqual([]);
+
+    const files = await fs.readdir(tmpDir);
+    const backupFiles = files.filter(f => f.startsWith('read-state.json.corrupt.'));
+    expect(backupFiles).toHaveLength(1);
+  });
+
+  it('should skip non-string elements in the array', async () => {
+    const filePath = path.join(tmpDir, 'read-state.json');
+    await fs.writeFile(
+      filePath,
+      JSON.stringify(['valid::1', 42, null, true, 'valid::2', { obj: true }]),
+      'utf-8',
+    );
+
+    await store.load();
+    const keys = [...store.keys()].sort();
+    expect(keys).toEqual(['valid::1', 'valid::2']);
+  });
+
+  describe('file size limits', () => {
+    afterEach(() => {
+      mockLimits.MAX_STORE_FILE_SIZE = 10 * 1024 * 1024;
+    });
+
+    it('should back up and reset when file exceeds size limit', async () => {
+      mockLimits.MAX_STORE_FILE_SIZE = 50;
+      const filePath = path.join(tmpDir, 'read-state.json');
+      const oversizedContent = JSON.stringify(['a'.repeat(60)]);
+      await fs.writeFile(filePath, oversizedContent, 'utf-8');
+
+      await store.load();
+      expect([...store.keys()]).toEqual([]);
+
+      const files = await fs.readdir(tmpDir);
+      const backupFiles = files.filter(f => f.startsWith('read-state.json.corrupt.'));
+      expect(backupFiles).toHaveLength(1);
+    });
+
+    it('should parse normally when file is just under size limit', async () => {
+      const filePath = path.join(tmpDir, 'read-state.json');
+      const content = JSON.stringify(['gh::1', 'gh::2']);
+      mockLimits.MAX_STORE_FILE_SIZE = content.length + 1;
+      await fs.writeFile(filePath, content, 'utf-8');
+
+      await store.load();
+      expect(store.has('gh::1')).toBe(true);
+      expect(store.has('gh::2')).toBe(true);
+    });
   });
 
   it('should create storage directory if it does not exist', async () => {


### PR DESCRIPTION
## Summary

Fixes #153 — Security: Unvalidated JSON deserialization and missing file size limits in stores

### Problem
1. `ReadStateStore` used `JSON.parse(data) as string[]` with no runtime validation — corrupted files could inject non-string values
2. None of the three stores validated file size before parsing, risking OOM on large files

### Fix
**Part 1 — ReadStateStore validation:**
- Validates parsed JSON is an array
- Skips non-string elements with per-item warning
- Backs up corrupted files and resets to empty (matches pattern in other stores)

**Part 2 — File size limits (all 3 stores):**
- Shared `MAX_STORE_FILE_SIZE` constant (10MB) in new `limits.ts`
- Size check before `JSON.parse` in `readStateStore.ts`, `jsonTaskStore.ts`, `discoveredStateStore.ts`
- Backup + reset on oversized files

### Tests
- Fixed 1 failing test (behavior changed from throw to backup-and-recover)
- Added 8 new tests: validation (non-array, non-string elements), size limits (over/under) across all 3 stores
