### PR TITLE
fix: use crypto.randomUUID() for work item IDs

### DIFF
--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'crypto';
 import * as vscode from 'vscode';
 import { WorkItem, WorkItemInput, WorkItemState } from '../models/workItem';
 import { ITaskStore } from '../storage/taskStore';
@@ -394,5 +395,5 @@ export class WorkGraph {
 }
 
 function generateId(): string {
-  return `wc-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  return `wc-${crypto.randomUUID()}`;
 }

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -41,6 +41,14 @@ describe('WorkGraph', () => {
     expect(a.id).not.toBe(b.id);
   });
 
+  it('generates IDs with wc- prefix followed by a valid UUID', async () => {
+    const item = await graph.createItem({ title: 'UUID check' });
+    const uuidPart = item.id.slice(3);
+    const uuidV4Regex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+    expect(item.id).toMatch(/^wc-/);
+    expect(uuidPart).toMatch(uuidV4Regex);
+  });
+
   it('gets items by state', async () => {
     await graph.createItem({ title: 'A' });
     await graph.createItem({ title: 'B' });


### PR DESCRIPTION
## Summary

Fixes #154 — Security: Work item IDs use non-cryptographic Math.random()

### Problem
`generateId()` in `workGraph.ts` used `Math.random()` which is predictable if the approximate creation time is known.

### Fix
Replaced with `crypto.randomUUID()` (Node.js built-in):
- IDs now use format `wc-{uuid-v4}` instead of `wc-{timestamp}-{random}`
- Cryptographically secure, unpredictable
- Follows existing convention (`crypto` already used in `editorPanelHtml.ts` for CSP nonces)

### Backward Compatibility
- `WorkItem.id` is typed as `string` with no format constraints
- No regex-based ID parsing anywhere in the codebase
- Old-format IDs in existing stores load without issue alongside new UUID-based IDs
- No migration needed

### Tests
- Added test verifying `wc-` prefix and valid UUID v4 format
- All 648 existing tests continue to pass
