### PR TITLE
fix: validate URL scheme before openExternal

### DIFF
--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -15,7 +15,7 @@ function formatItemTitle(item: { group?: string; title: string }): string {
 }
 
 /** Returns true if the URL uses an allowed web scheme (http or https). */
-function isSafeUrl(url: string): boolean {
+export function isSafeUrl(url: string): boolean {
   try {
     const parsed = new URL(url);
     return parsed.protocol === 'http:' || parsed.protocol === 'https:';

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -125,7 +125,9 @@ async function handleOpenInBrowser(workGraph: WorkGraph, item?: { id?: string; u
     return;
   }
   if (!isSafeUrl(url)) {
-    vscode.window.showWarningMessage(`Cannot open non-web URL: ${url}`);
+    const display = url.length > 100 ? url.slice(0, 100) + '…' : url;
+    const sanitized = display.replace(/[\n\r]/g, ' ');
+    vscode.window.showWarningMessage(`Cannot open non-web URL: ${sanitized}`);
     return;
   }
   const opened = await vscode.env.openExternal(vscode.Uri.parse(url));

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -14,6 +14,16 @@ function formatItemTitle(item: { group?: string; title: string }): string {
   return trimmedGroup ? `${trimmedGroup} ${item.title}` : item.title;
 }
 
+/** Returns true if the URL uses an allowed web scheme (http or https). */
+function isSafeUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 /** Log the error and show a user-facing message. */
 function handleCommandError(context: string, err: unknown): void {
   logger.error(context, err);
@@ -114,12 +124,11 @@ async function handleOpenInBrowser(workGraph: WorkGraph, item?: { id?: string; u
     vscode.window.showWarningMessage('This item has no URL to open.');
     return;
   }
-  const uri = vscode.Uri.parse(url);
-  if (uri.scheme !== 'http' && uri.scheme !== 'https') {
+  if (!isSafeUrl(url)) {
     vscode.window.showWarningMessage(`Cannot open non-web URL: ${url}`);
     return;
   }
-  const opened = await vscode.env.openExternal(uri);
+  const opened = await vscode.env.openExternal(vscode.Uri.parse(url));
   if (!opened) {
     vscode.window.showWarningMessage('Failed to open URL in the browser.');
   }

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -14,13 +14,13 @@ function formatItemTitle(item: { group?: string; title: string }): string {
   return trimmedGroup ? `${trimmedGroup} ${item.title}` : item.title;
 }
 
-/** Returns true if the URL uses an allowed web scheme (http or https). */
-export function isSafeUrl(url: string): boolean {
+/** Returns the parsed URL if it uses an allowed web scheme (http or https), or null otherwise. */
+export function isSafeUrl(url: string): URL | null {
   try {
     const parsed = new URL(url);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') ? parsed : null;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -124,13 +124,14 @@ async function handleOpenInBrowser(workGraph: WorkGraph, item?: { id?: string; u
     vscode.window.showWarningMessage('This item has no URL to open.');
     return;
   }
-  if (!isSafeUrl(url)) {
+  const safeUrl = isSafeUrl(url);
+  if (!safeUrl) {
     const display = url.length > 100 ? url.slice(0, 100) + '…' : url;
     const sanitized = display.replace(/[\n\r]/g, ' ');
     vscode.window.showWarningMessage(`Cannot open non-web URL: ${sanitized}`);
     return;
   }
-  const opened = await vscode.env.openExternal(vscode.Uri.parse(url));
+  const opened = await vscode.env.openExternal(vscode.Uri.parse(safeUrl.href));
   if (!opened) {
     vscode.window.showWarningMessage('Failed to open URL in the browser.');
   }

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -239,7 +239,7 @@ describe('registerCommands', () => {
       await invoke('workcenter.openInBrowser', { id: item.id });
 
       expect(vscode.env.openExternal).toHaveBeenCalled();
-      expect(vscode.Uri.parse).toHaveBeenCalledWith('https://example.com');
+      expect(vscode.Uri.parse).toHaveBeenCalledWith('https://example.com/');
     });
 
     it('falls back to item.url when workItem has no url', async () => {
@@ -247,7 +247,7 @@ describe('registerCommands', () => {
 
       await invoke('workcenter.openInBrowser', { id: 'wc-1', url: 'https://fallback.com' });
 
-      expect(vscode.Uri.parse).toHaveBeenCalledWith('https://fallback.com');
+      expect(vscode.Uri.parse).toHaveBeenCalledWith('https://fallback.com/');
       expect(vscode.env.openExternal).toHaveBeenCalled();
     });
 
@@ -272,7 +272,7 @@ describe('registerCommands', () => {
 
       await invoke('workcenter.openInBrowser', { id: 'wc-gone', url: 'https://tree-fallback.com' });
 
-      expect(vscode.Uri.parse).toHaveBeenCalledWith('https://tree-fallback.com');
+      expect(vscode.Uri.parse).toHaveBeenCalledWith('https://tree-fallback.com/');
       expect(vscode.env.openExternal).toHaveBeenCalled();
     });
 
@@ -667,30 +667,34 @@ describe('registerCommands', () => {
 
 describe('isSafeUrl', () => {
   it('accepts http:// URLs', () => {
-    expect(isSafeUrl('http://example.com')).toBe(true);
+    const result = isSafeUrl('http://example.com');
+    expect(result).not.toBeNull();
+    expect(result!.href).toBe('http://example.com/');
   });
 
   it('accepts https:// URLs', () => {
-    expect(isSafeUrl('https://example.com')).toBe(true);
+    const result = isSafeUrl('https://example.com');
+    expect(result).not.toBeNull();
+    expect(result!.href).toBe('https://example.com/');
   });
 
   it('rejects data: URLs', () => {
-    expect(isSafeUrl('data:text/html,<h1>hi</h1>')).toBe(false);
+    expect(isSafeUrl('data:text/html,<h1>hi</h1>')).toBeNull();
   });
 
   it('rejects file: URLs', () => {
-    expect(isSafeUrl('file:///etc/passwd')).toBe(false);
+    expect(isSafeUrl('file:///etc/passwd')).toBeNull();
   });
 
   it('rejects javascript: URLs', () => {
-    expect(isSafeUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeUrl('javascript:alert(1)')).toBeNull();
   });
 
   it('rejects malformed URLs', () => {
-    expect(isSafeUrl('not-a-url')).toBe(false);
+    expect(isSafeUrl('not-a-url')).toBeNull();
   });
 
   it('rejects empty strings', () => {
-    expect(isSafeUrl('')).toBe(false);
+    expect(isSafeUrl('')).toBeNull();
   });
 });

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 import * as vscode from 'vscode';
 import { WorkItemState, type WorkItem } from '../models/workItem';
-import { registerCommands } from '../commands/commands';
+import { registerCommands, isSafeUrl } from '../commands/commands';
 import type { WorkGraph } from '../services/workGraph';
 import type { ActionRegistry } from '../services/actionRegistry';
 import type { DiscoveredStateStore } from '../storage/discoveredStateStore';
@@ -274,6 +274,42 @@ describe('registerCommands', () => {
 
       expect(vscode.Uri.parse).toHaveBeenCalledWith('https://tree-fallback.com');
       expect(vscode.env.openExternal).toHaveBeenCalled();
+    });
+
+    it('shows warning and does not call openExternal for unsafe URL', async () => {
+      const item = createWorkItem({ url: 'javascript:alert(1)' });
+      workGraph.getItem.mockReturnValue(item);
+
+      await invoke('workcenter.openInBrowser', { id: item.id });
+
+      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+        'Cannot open non-web URL: javascript:alert(1)',
+      );
+      expect(vscode.env.openExternal).not.toHaveBeenCalled();
+    });
+
+    it('shows warning and does not call openExternal for data: URL', async () => {
+      const item = createWorkItem({ url: 'data:text/html,<h1>hi</h1>' });
+      workGraph.getItem.mockReturnValue(item);
+
+      await invoke('workcenter.openInBrowser', { id: item.id });
+
+      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Cannot open non-web URL'),
+      );
+      expect(vscode.env.openExternal).not.toHaveBeenCalled();
+    });
+
+    it('shows warning and does not call openExternal for file: URL', async () => {
+      const item = createWorkItem({ url: 'file:///etc/passwd' });
+      workGraph.getItem.mockReturnValue(item);
+
+      await invoke('workcenter.openInBrowser', { id: item.id });
+
+      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Cannot open non-web URL'),
+      );
+      expect(vscode.env.openExternal).not.toHaveBeenCalled();
     });
   });
 
@@ -624,5 +660,37 @@ describe('registerCommands', () => {
         expect.any(Object),
       );
     });
+  });
+});
+
+// ── isSafeUrl (unit tests) ───────────────────────────────────────────
+
+describe('isSafeUrl', () => {
+  it('accepts http:// URLs', () => {
+    expect(isSafeUrl('http://example.com')).toBe(true);
+  });
+
+  it('accepts https:// URLs', () => {
+    expect(isSafeUrl('https://example.com')).toBe(true);
+  });
+
+  it('rejects data: URLs', () => {
+    expect(isSafeUrl('data:text/html,<h1>hi</h1>')).toBe(false);
+  });
+
+  it('rejects file: URLs', () => {
+    expect(isSafeUrl('file:///etc/passwd')).toBe(false);
+  });
+
+  it('rejects javascript: URLs', () => {
+    expect(isSafeUrl('javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(isSafeUrl('not-a-url')).toBe(false);
+  });
+
+  it('rejects empty strings', () => {
+    expect(isSafeUrl('')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #155 — Security: No URL scheme validation before openExternal

### Problem
`handleOpenInBrowser` passed provider-supplied URLs directly to `vscode.env.openExternal()` without validating the scheme. Malicious providers could trigger navigation to dangerous protocols (`data:`, `file:`, `javascript:`).

### Fix
- Added `isSafeUrl()` helper that validates URL scheme is `http:` or `https:` only
- Uses WHATWG `URL` constructor for parsing (handles case normalization, rejects malformed input)
- Shows warning message if URL scheme is not allowed
- Exported for direct unit testing

### Tests
- 7 unit tests for `isSafeUrl`: http ✅, https ✅, data: ✗, file: ✗, javascript: ✗, malformed ✗, empty ✗
- 3 integration tests: unsafe URL blocks openExternal + shows warning
- All 657 tests pass
