### PR TITLE
fix: use appendText for user content in tooltips

### DIFF
--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -543,6 +543,64 @@ describe('InboxTreeProvider', () => {
       const afterTitle = tooltip.value.replace(/\*\*Title:\*\* /, '').replace('Bug fix', '').trim();
       expect(afterTitle).toBe('');
     });
+
+    it('uses appendText for title to prevent markdown injection', () => {
+      const maliciousTitle = '[Click me](command:workbench.action.terminal.sendSequence)';
+      const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: maliciousTitle };
+
+      const appendTextSpy = vi.spyOn(MarkdownString.prototype, 'appendText');
+      const appendMarkdownSpy = vi.spyOn(MarkdownString.prototype, 'appendMarkdown');
+
+      provider.getTreeItem(item);
+
+      const textCalls = appendTextSpy.mock.calls.map(c => c[0]);
+      const mdCalls = appendMarkdownSpy.mock.calls.map(c => c[0]);
+
+      expect(textCalls).toContainEqual(maliciousTitle);
+      expect(mdCalls).not.toContainEqual(maliciousTitle);
+
+      appendTextSpy.mockRestore();
+      appendMarkdownSpy.mockRestore();
+    });
+
+    it('uses appendText for description to prevent markdown injection', () => {
+      const maliciousDesc = '![img](https://evil.com/track.png)';
+      const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Safe', description: maliciousDesc };
+
+      const appendTextSpy = vi.spyOn(MarkdownString.prototype, 'appendText');
+      const appendMarkdownSpy = vi.spyOn(MarkdownString.prototype, 'appendMarkdown');
+
+      provider.getTreeItem(item);
+
+      const textCalls = appendTextSpy.mock.calls.map(c => c[0]);
+      const mdCalls = appendMarkdownSpy.mock.calls.map(c => c[0]);
+
+      expect(textCalls).toContainEqual(expect.stringContaining(maliciousDesc));
+      expect(mdCalls).not.toContainEqual(expect.stringContaining(maliciousDesc));
+
+      appendTextSpy.mockRestore();
+      appendMarkdownSpy.mockRestore();
+    });
+
+    it('uses appendText for reason to prevent markdown injection', () => {
+      const maliciousReason = '[evil](command:exec)';
+      const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Safe', reason: maliciousReason };
+
+      const appendTextSpy = vi.spyOn(MarkdownString.prototype, 'appendText');
+      const appendMarkdownSpy = vi.spyOn(MarkdownString.prototype, 'appendMarkdown');
+
+      provider.getTreeItem(item);
+
+      const textCalls = appendTextSpy.mock.calls.map(c => c[0]);
+      const mdCalls = appendMarkdownSpy.mock.calls.map(c => c[0]);
+
+      const formattedReason = maliciousReason.replace(/_/g, ' ').replace(/^./, c => c.toUpperCase());
+      expect(textCalls).toContainEqual(formattedReason);
+      expect(mdCalls).not.toContainEqual(formattedReason);
+
+      appendTextSpy.mockRestore();
+      appendMarkdownSpy.mockRestore();
+    });
   });
 
   describe('getChildren for item node', () => {

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -539,8 +539,8 @@ describe('InboxTreeProvider', () => {
       expect(treeItem.tooltip).toBeInstanceOf(MarkdownString);
       const tooltip = treeItem.tooltip as MarkdownString;
       expect(tooltip.value).toContain('Bug fix');
-      // Should not contain extra content beyond the title
-      const afterTitle = tooltip.value.replace(/\*\*Bug fix\*\*/, '').trim();
+      // Should not contain extra content beyond the title label
+      const afterTitle = tooltip.value.replace(/\*\*Title:\*\* /, '').replace('Bug fix', '').trim();
       expect(afterTitle).toBe('');
     });
   });

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -141,7 +141,7 @@ describe('QueueTreeProvider', () => {
       expect((treeItem.iconPath as any).id).toBe('circle-filled');
     });
 
-    it('builds tooltip with title in bold', async () => {
+    it('builds tooltip with title label and title text', async () => {
       const item = await graph.createItem({ title: 'Important' });
       const treeItem = provider.getTreeItem(item);
       expect(treeItem.tooltip.value).toContain('**Title:** ');

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { DataTransfer, DataTransferItem, TreeItemCollapsibleState } from 'vscode';
+import { DataTransfer, DataTransferItem, MarkdownString, TreeItemCollapsibleState } from 'vscode';
 import { WorkGraph } from '../services/workGraph';
 import { WorkItemState } from '../models/workItem';
 import { ITaskStore } from '../storage/taskStore';
@@ -159,6 +159,45 @@ describe('QueueTreeProvider', () => {
       const item = await graph.createItem({ title: 'Dated' });
       const treeItem = provider.getTreeItem(item);
       expect(treeItem.tooltip.value).toContain('Created:');
+    });
+
+    it('uses appendText for title to prevent markdown injection', async () => {
+      const maliciousTitle = '[Click me](command:workbench.action.terminal.sendSequence)';
+      const item = await graph.createItem({ title: maliciousTitle });
+
+      const appendTextSpy = vi.spyOn(MarkdownString.prototype, 'appendText');
+      const appendMarkdownSpy = vi.spyOn(MarkdownString.prototype, 'appendMarkdown');
+
+      provider.getTreeItem(item);
+
+      const textCalls = appendTextSpy.mock.calls.map(c => c[0]);
+      const mdCalls = appendMarkdownSpy.mock.calls.map(c => c[0]);
+
+      expect(textCalls).toContainEqual(maliciousTitle);
+      expect(mdCalls).not.toContainEqual(maliciousTitle);
+
+      appendTextSpy.mockRestore();
+      appendMarkdownSpy.mockRestore();
+    });
+
+    it('uses appendText for notes to prevent markdown injection', async () => {
+      const maliciousNotes = '![img](https://evil.com/track.png)';
+      const item = await graph.createItem({ title: 'Safe title' });
+      item.notes = maliciousNotes;
+
+      const appendTextSpy = vi.spyOn(MarkdownString.prototype, 'appendText');
+      const appendMarkdownSpy = vi.spyOn(MarkdownString.prototype, 'appendMarkdown');
+
+      provider.getTreeItem(item);
+
+      const textCalls = appendTextSpy.mock.calls.map(c => c[0]);
+      const mdCalls = appendMarkdownSpy.mock.calls.map(c => c[0]);
+
+      expect(textCalls).toContainEqual(expect.stringContaining(maliciousNotes));
+      expect(mdCalls).not.toContainEqual(expect.stringContaining(maliciousNotes));
+
+      appendTextSpy.mockRestore();
+      appendMarkdownSpy.mockRestore();
     });
   });
 

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -144,7 +144,8 @@ describe('QueueTreeProvider', () => {
     it('builds tooltip with title in bold', async () => {
       const item = await graph.createItem({ title: 'Important' });
       const treeItem = provider.getTreeItem(item);
-      expect(treeItem.tooltip.value).toContain('**Important**');
+      expect(treeItem.tooltip.value).toContain('**Title:** ');
+      expect(treeItem.tooltip.value).toContain('Important');
     });
 
     it('includes notes in tooltip when present', async () => {

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -280,7 +280,9 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   private buildTooltip(item: InboxItem): vscode.MarkdownString {
     const md = new vscode.MarkdownString();
-    md.appendMarkdown(`**${item.title}**\n\n`);
+    md.appendMarkdown(`**Title:** `);
+    md.appendText(item.title);
+    md.appendMarkdown(`\n\n`);
     if (item.reason) {
       md.appendMarkdown('*Reason: ');
       md.appendText(this.formatReason(item.reason));

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -37,7 +37,9 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem>, vsc
 
   private buildTooltip(item: WorkItem): vscode.MarkdownString {
     const md = new vscode.MarkdownString();
-    md.appendMarkdown(`**${item.title}**\n\n`);
+    md.appendMarkdown(`**Title:** `);
+    md.appendText(item.title);
+    md.appendMarkdown(`\n\n`);
     if (item.notes) { md.appendText(`${item.notes}\n\n`); }
     md.appendMarkdown(`Created: ${new Date(item.createdAt).toLocaleString()}`);
     return md;


### PR DESCRIPTION
## Summary

Fixes #158 — Security: Markdown injection in Inbox and Queue tooltip rendering

### Problem
`queueTreeProvider.ts` and `inboxTreeProvider.ts` interpolated user-controlled titles directly into `appendMarkdown()`, enabling markdown injection via crafted issue titles (e.g., VS Code command links).

### Fix
Replaced unsafe pattern with the secure pattern already used in focusTreeProvider, sourcesTreeProvider, and historyTreeProvider:
- Uses `appendMarkdown('**Title:** ')` + `appendText(item.title)` 
- `appendText` escapes markdown metacharacters, preventing injection
- Applied consistently in both queueTreeProvider and inboxTreeProvider

### Tests
- 5 new tests (2 queue, 3 inbox) verifying `appendText` is used for user-controlled content
- Tests spy on prototype methods to verify safe API routing
- All 652 tests pass
