### PR TITLE
fix: add trust boundary validation to plugin API

### DIFF
--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -185,14 +185,16 @@ interface WorkCenterAction {
    * Called each time the user opens the Run Action menu.
    * Use this to filter by provider, state, or other item properties.
    */
-  canRun(item: WorkItem): boolean;
+  canRun(item: Readonly<WorkItem>): boolean;
 
   /**
    * Executes the action. Throw an error to show an error message to the user.
    */
-  run(item: WorkItem): Promise<void>;
+  run(item: Readonly<WorkItem>): Promise<void>;
 }
 ```
+
+> **Note:** `canRun` and `run` receive `Readonly<WorkItem>`. Actions should treat work items as immutable and use WorkCenter commands to make changes rather than mutating the object directly.
 
 ### Registering an Action
 
@@ -268,6 +270,24 @@ Items transition through these states as the user interacts with them in the UI.
 | `Archived` | **History** | Archived items shown in the History view. |
 
 Action authors should use this mapping when implementing `canRun()` — for example, an action that only applies to active work should target `InProgress` and `Paused`.
+
+## Limits and Security
+
+### Item Count Limits
+
+Each provider is capped at **10,000 discovered items** per refresh. If a provider emits more than 10,000 items, excess items are silently truncated from the end and a warning is logged. Design your provider to stay within this limit — for example, by filtering to only relevant items in your `refresh()` implementation.
+
+### Readonly WorkItem in Actions
+
+`canRun()` and `run()` receive `Readonly<WorkItem>`. Actions must not mutate the work item object directly. To update a work item's state, use the appropriate WorkCenter VS Code commands (e.g., `workcenter.startWork`, `workcenter.completeWork`).
+
+### URL Validation
+
+URLs opened via `vscode.env.openExternal` are validated to use `http:` or `https:` schemes only. Other URL schemes (e.g., `file:`, `javascript:`, custom protocols) are rejected. Ensure any URLs your provider or action constructs use standard web URLs.
+
+### Trust Model
+
+Provider extensions have full read access to the data they inject and to the `WorkItem` objects passed to their actions. Provider IDs are first-come-first-served — the VS Code extension API does not expose caller identity, so WorkCenter cannot verify which extension is registering a given provider or action ID. Duplicate IDs are rejected, and all registrations are logged at warn level for auditability.
 
 ## Examples
 
@@ -392,20 +412,20 @@ interface WorkItem {
 interface WorkCenterAction {
   readonly id: string;
   readonly label: string;
-  canRun(item: WorkItem): boolean;
-  run(item: WorkItem): Promise<void>;
+  canRun(item: Readonly<WorkItem>): boolean;
+  run(item: Readonly<WorkItem>): Promise<void>;
 }
 
 class OpenDashboardAction implements WorkCenterAction {
   readonly id = 'my-tasks.openDashboard';
   readonly label = 'Open in Dashboard';
 
-  canRun(item: WorkItem): boolean {
+  canRun(item: Readonly<WorkItem>): boolean {
     // Only show this action for items from our provider
     return item.providerId === 'my-tasks';
   }
 
-  async run(item: WorkItem): Promise<void> {
+  async run(item: Readonly<WorkItem>): Promise<void> {
     if (!item.externalId) {
       vscode.window.showErrorMessage('No external ID found for this item.');
       return;

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -285,10 +285,6 @@ Each provider is capped at **10,000 discovered items** per refresh. If a provide
 
 URLs opened via `vscode.env.openExternal` are validated to use `http:` or `https:` schemes only. Other URL schemes (e.g., `file:`, `javascript:`, custom protocols) are rejected. Ensure any URLs your provider or action constructs use standard web URLs.
 
-### Trust Model
-
-Provider extensions have full read access to the data they inject and to the `WorkItem` objects passed to their actions. Provider IDs are first-come-first-served — the VS Code extension API does not expose caller identity, so WorkCenter cannot verify which extension is registering a given provider or action ID. Duplicate IDs are rejected, and all registrations are logged at warn level for auditability.
-
 ## Examples
 
 ### Minimal Provider

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -53,6 +53,13 @@ export interface WorkCenterProvider {
  * Actions are registered via {@link WorkCenterApi.registerAction} and surfaced
  * dynamically — {@link canRun} is called to determine visibility.
  *
+ * ## Trust model
+ *
+ * Actions receive a **read-only snapshot** of the work item (`Readonly<WorkItem>`).
+ * This prevents accidental or malicious mutation of the core data model by
+ * third-party extensions. Actions that need to modify work-item state should use
+ * the WorkCenter API (e.g. VS Code commands) rather than mutating the object.
+ *
  * @example
  * ```ts
  * const action: WorkCenterAction = {
@@ -72,16 +79,16 @@ export interface WorkCenterAction {
   /**
    * Determine whether this action is applicable to the given work item.
    *
-   * @param item - The work item to test.
+   * @param item - A read-only view of the work item to test.
    * @returns `true` if the action should be offered for this item.
    */
-  canRun(item: WorkItem): boolean;
+  canRun(item: Readonly<WorkItem>): boolean;
   /**
    * Execute the action against the given work item.
    *
-   * @param item - The work item to act on.
+   * @param item - A read-only view of the work item to act on.
    */
-  run(item: WorkItem): Promise<void>;
+  run(item: Readonly<WorkItem>): Promise<void>;
 }
 
 /**

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -55,10 +55,11 @@ export interface WorkCenterProvider {
  *
  * ## Trust model
  *
- * Actions receive a **read-only snapshot** of the work item (`Readonly<WorkItem>`).
- * This prevents accidental or malicious mutation of the core data model by
- * third-party extensions. Actions that need to modify work-item state should use
- * the WorkCenter API (e.g. VS Code commands) rather than mutating the object.
+ * Actions receive a **read-only view** of the work item (`Readonly<WorkItem>`).
+ * This is a TypeScript type-level restriction only; it does not create a
+ * runtime snapshot or frozen copy of the item. Third-party extensions should
+ * treat the object as immutable and use the WorkCenter API (e.g. VS Code
+ * commands) rather than mutating the object.
  *
  * @example
  * ```ts

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -61,6 +61,14 @@ export interface WorkCenterProvider {
  * treat the object as immutable and use the WorkCenter API (e.g. VS Code
  * commands) rather than mutating the object.
  *
+ * ## Migration note
+ *
+ * The `canRun` and `run` signatures changed from `WorkItem` to
+ * `Readonly<WorkItem>`. Extensions that explicitly annotate their parameter
+ * types as `WorkItem` (e.g. `canRun: (item: WorkItem) => ...`) should update
+ * to `Readonly<WorkItem>` or simply omit the annotation and let TypeScript
+ * infer the type.
+ *
  * @example
  * ```ts
  * const action: WorkCenterAction = {

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -61,14 +61,6 @@ export interface WorkCenterProvider {
  * treat the object as immutable and use the WorkCenter API (e.g. VS Code
  * commands) rather than mutating the object.
  *
- * ## Migration note
- *
- * The `canRun` and `run` signatures changed from `WorkItem` to
- * `Readonly<WorkItem>`. Extensions that explicitly annotate their parameter
- * types as `WorkItem` (e.g. `canRun: (item: WorkItem) => ...`) should update
- * to `Readonly<WorkItem>` or simply omit the annotation and let TypeScript
- * infer the type.
- *
  * @example
  * ```ts
  * const action: WorkCenterAction = {

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -12,6 +12,11 @@ import { logger } from './logger';
  */
 export class ProviderRegistry {
   static readonly REFRESH_TIMEOUT_MS = 30_000;
+  /**
+   * Maximum number of discovered items accepted from a single provider per refresh.
+   * Excess items are silently truncated after logging a warning.
+   */
+  static readonly MAX_ITEMS_PER_PROVIDER = 10_000;
   private readonly providers = new Map<string, WorkCenterProvider>();
   private readonly subscriptions = new Map<string, { dispose(): void }>();
   private readonly discoveredItems = new Map<string, DiscoveredItem[]>();
@@ -200,6 +205,12 @@ export class ProviderRegistry {
   private async handleDiscoveredItems(providerId: string, items: DiscoveredItem[]): Promise<void> {
     if (this._disposed) {
       return;
+    }
+    if (items.length > ProviderRegistry.MAX_ITEMS_PER_PROVIDER) {
+      logger.warn(
+        `Provider "${providerId}" emitted ${items.length} items, exceeding the limit of ${ProviderRegistry.MAX_ITEMS_PER_PROVIDER}. Truncating.`,
+      );
+      items = items.slice(0, ProviderRegistry.MAX_ITEMS_PER_PROVIDER);
     }
     logger.info(`Provider ${providerId} discovered ${items.length} items`);
     this.discoveredItems.set(providerId, items);

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -14,7 +14,7 @@ export class ProviderRegistry {
   static readonly REFRESH_TIMEOUT_MS = 30_000;
   /**
    * Maximum number of discovered items accepted from a single provider per refresh.
-   * Excess items are silently truncated after logging a warning.
+   * Excess items are truncated after logging a warning.
    */
   static readonly MAX_ITEMS_PER_PROVIDER = 10_000;
   private readonly providers = new Map<string, WorkCenterProvider>();
@@ -211,6 +211,8 @@ export class ProviderRegistry {
         `Provider "${providerId}" emitted ${items.length} items, exceeding the limit of ${ProviderRegistry.MAX_ITEMS_PER_PROVIDER}. Truncating.`,
       );
       items = items.slice(0, ProviderRegistry.MAX_ITEMS_PER_PROVIDER);
+    } else {
+      items = items.slice();
     }
     logger.info(`Provider ${providerId} discovered ${items.length} items`);
     this.discoveredItems.set(providerId, items);

--- a/packages/core/src/services/registry.ts
+++ b/packages/core/src/services/registry.ts
@@ -1,6 +1,20 @@
 import * as vscode from 'vscode';
 import { logger } from './logger';
 
+/**
+ * Generic registry for named, identifiable items (providers, actions, etc.).
+ *
+ * ## Trust model
+ *
+ * The VS Code extension API does not expose caller identity when an extension
+ * invokes another extension's API. This means we cannot verify *which* extension
+ * is registering a given item — any extension that obtains the WorkCenter API
+ * can register a provider or action with any `id`.
+ *
+ * Mitigation: the registry rejects duplicate IDs and logs every registration at
+ * `warn` level so administrators can audit which items are registered and detect
+ * unexpected registrations via the output channel.
+ */
 export class Registry<T extends { readonly id: string; readonly label: string }> {
   private readonly items = new Map<string, T>();
   private readonly kind: string;
@@ -12,7 +26,8 @@ export class Registry<T extends { readonly id: string; readonly label: string }>
       throw new Error(`${this.kind} already registered: ${item.id}`);
     }
     this.items.set(item.id, item);
-    logger.info(`Registered ${this.kind.toLowerCase()}: ${item.id} (${item.label})`);
+    // Warn-level so admins can audit registrations — VS Code has no caller identity context
+    logger.warn(`Registered ${this.kind.toLowerCase()}: ${item.id} (${item.label})`);
     let disposed = false;
     return new vscode.Disposable(() => {
       if (!disposed && this.items.get(item.id) === item) {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -744,6 +744,125 @@ describe('ProviderRegistry', () => {
     });
   });
 
+  describe('item cap (MAX_ITEMS_PER_PROVIDER)', () => {
+    function makeItems(count: number): DiscoveredItem[] {
+      return Array.from({ length: count }, (_, i) => ({
+        externalId: `item-${i}`,
+        title: `Item ${i}`,
+      }));
+    }
+
+    it('accepts all items when count equals MAX_ITEMS_PER_PROVIDER', async () => {
+      const provider = createMockProvider('exact-cap');
+      registry.register(provider);
+
+      const items = makeItems(ProviderRegistry.MAX_ITEMS_PER_PROVIDER);
+      provider.fireItems(items);
+
+      await vi.waitFor(() => {
+        const stored = registry.getDiscoveredItems('exact-cap');
+        expect(stored).toHaveLength(ProviderRegistry.MAX_ITEMS_PER_PROVIDER);
+      });
+    });
+
+    it('truncates items exceeding MAX_ITEMS_PER_PROVIDER', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn');
+      const provider = createMockProvider('over-cap');
+      registry.register(provider);
+
+      const excess = 50;
+      const items = makeItems(ProviderRegistry.MAX_ITEMS_PER_PROVIDER + excess);
+      provider.fireItems(items);
+
+      await vi.waitFor(() => {
+        const stored = registry.getDiscoveredItems('over-cap');
+        expect(stored).toHaveLength(ProviderRegistry.MAX_ITEMS_PER_PROVIDER);
+      });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`emitted ${ProviderRegistry.MAX_ITEMS_PER_PROVIDER + excess} items`),
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Truncating'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('accepts 0 items without truncation or warning', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn');
+      const provider = createMockProvider('zero-items');
+      registry.register(provider);
+      await vi.waitFor(() => expect(registry.loading).toBe(false));
+      warnSpy.mockClear();
+
+      provider.fireItems([]);
+
+      await vi.waitFor(() => {
+        expect(registry.getDiscoveredItems('zero-items')).toEqual([]);
+      });
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Truncating'),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('preserves order of first N items after truncation', async () => {
+      const provider = createMockProvider('order-check');
+      registry.register(provider);
+
+      const items = makeItems(ProviderRegistry.MAX_ITEMS_PER_PROVIDER + 100);
+      provider.fireItems(items);
+
+      await vi.waitFor(() => {
+        const stored = registry.getDiscoveredItems('order-check');
+        expect(stored).toHaveLength(ProviderRegistry.MAX_ITEMS_PER_PROVIDER);
+        // First and last retained items match original order
+        expect(stored[0].externalId).toBe('item-0');
+        expect(stored[ProviderRegistry.MAX_ITEMS_PER_PROVIDER - 1].externalId)
+          .toBe(`item-${ProviderRegistry.MAX_ITEMS_PER_PROVIDER - 1}`);
+      });
+    });
+
+    it('only truncated items appear in discovered items after cap', async () => {
+      const provider = createMockProvider('truncated-only');
+      registry.register(provider);
+
+      const excess = 25;
+      const total = ProviderRegistry.MAX_ITEMS_PER_PROVIDER + excess;
+      const items = makeItems(total);
+      provider.fireItems(items);
+
+      await vi.waitFor(() => {
+        const stored = registry.getDiscoveredItems('truncated-only');
+        expect(stored).toHaveLength(ProviderRegistry.MAX_ITEMS_PER_PROVIDER);
+        // None of the excess items should be present
+        const ids = new Set(stored.map(i => i.externalId));
+        for (let i = ProviderRegistry.MAX_ITEMS_PER_PROVIDER; i < total; i++) {
+          expect(ids.has(`item-${i}`)).toBe(false);
+        }
+      });
+    });
+
+    it('does not warn when items are at or below the cap', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn');
+      const provider = createMockProvider('under-cap');
+      registry.register(provider);
+      await vi.waitFor(() => expect(registry.loading).toBe(false));
+      warnSpy.mockClear();
+
+      provider.fireItems(makeItems(ProviderRegistry.MAX_ITEMS_PER_PROVIDER));
+
+      await vi.waitFor(() => {
+        expect(registry.getDiscoveredItems('under-cap')).toHaveLength(
+          ProviderRegistry.MAX_ITEMS_PER_PROVIDER,
+        );
+      });
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Truncating'),
+      );
+      warnSpy.mockRestore();
+    });
+  });
+
   describe('resurfaceDismissed', () => {
     function createResurfaceProvider(id: string): WorkCenterProvider & { fireItems: (items: DiscoveredItem[]) => void } {
       const emitter = new EventEmitter<DiscoveredItem[]>();

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -822,7 +822,7 @@ describe('ProviderRegistry', () => {
       });
     });
 
-    it('only truncated items appear in discovered items after cap', async () => {
+    it('excess items are excluded from discovered items after cap', async () => {
       const provider = createMockProvider('truncated-only');
       registry.register(provider);
 
@@ -860,6 +860,25 @@ describe('ProviderRegistry', () => {
         expect.stringContaining('Truncating'),
       );
       warnSpy.mockRestore();
+    });
+
+    it('stores a defensive copy so later mutations to the original array do not affect the registry', async () => {
+      const provider = createMockProvider('defensive-copy');
+      registry.register(provider);
+      await vi.waitFor(() => expect(registry.loading).toBe(false));
+
+      const items = makeItems(3);
+      provider.fireItems(items);
+
+      await vi.waitFor(() => {
+        expect(registry.getDiscoveredItems('defensive-copy')).toHaveLength(3);
+      });
+
+      // Mutate the original array after it was stored
+      items.push({ externalId: 'sneaky', title: 'Sneaky' });
+
+      // The registry should still have only 3 items
+      expect(registry.getDiscoveredItems('defensive-copy')).toHaveLength(3);
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #157 — Security: Plugin API lacks trust boundary validation

### Problem
1. Providers could emit unbounded item arrays, risking memory exhaustion
2. Actions received mutable WorkItem objects with no mutation protection
3. No documentation of the trust model for the plugin API

### Fix
**Unbounded provider data:**
- Added `MAX_ITEMS_PER_PROVIDER` (10,000) cap in `ProviderRegistry.handleDiscoveredItems`
- Truncates excess items with warning log
- Order preserved (first N items kept)

**Action data protection:**
- Changed `WorkCenterAction.canRun`/`run` to accept `Readonly<WorkItem>`
- Prevents accidental mutation at compile time

**Trust model documentation:**
- Added JSDoc documenting the trust model on `Registry` class
- Elevated registration logging to warn level for auditability

### Tests
- 6 new tests: at-cap, over-cap truncation, zero items, order preservation, excess exclusion, no-warn-under-cap
- All 653 tests pass
