### PR TITLE
fix: fire empty discovery events on ADO provider early-return paths

### DIFF
--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -62,6 +62,7 @@ export class AdoPrReviewProvider extends BaseProvider {
     try {
       logger.info('Fetching ADO PR reviews...');
       if (token?.isCancellationRequested) {
+        this._onDidDiscoverItems.fire([]);
         return;
       }
 
@@ -70,11 +71,13 @@ export class AdoPrReviewProvider extends BaseProvider {
       }).catch(() => null);
 
       if (!session || token?.isCancellationRequested) {
+        this._onDidDiscoverItems.fire([]);
         return;
       }
 
       await this.fetchAndPublishPrs(session.accessToken, true, session.account.id);
     } catch (err) {
+      this._onDidDiscoverItems.fire([]);
       logger.error('Failed to fetch PR reviews:', err);
     } finally {
       this._isRefreshing = false;
@@ -89,11 +92,13 @@ export class AdoPrReviewProvider extends BaseProvider {
       }).catch(() => null);
 
       if (!session) {
+        this._onDidDiscoverItems.fire([]);
         return;
       }
 
       await this.fetchAndPublishPrs(session.accessToken, false, session.account.id);
     } catch (err) {
+      this._onDidDiscoverItems.fire([]);
       logger.error('Failed to fetch PR reviews:', err);
     }
   }
@@ -101,6 +106,7 @@ export class AdoPrReviewProvider extends BaseProvider {
   private async fetchAndPublishPrs(accessToken: string, isUserTriggered: boolean, sessionAccountId: string): Promise<void> {
     if (!isValidUrlSegment(this.org)) {
       logger.warn('Skipping PR fetch: invalid ADO organization name', this.org);
+      this._onDidDiscoverItems.fire([]);
       return;
     }
 
@@ -126,6 +132,7 @@ export class AdoPrReviewProvider extends BaseProvider {
 
     if (this.projects.length > 0 && validProjects.length === 0) {
       logger.warn('All configured ADO projects are invalid — skipping PR fetch');
+      this._onDidDiscoverItems.fire([]);
       return;
     }
 

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -62,6 +62,7 @@ export class AdoWorkItemProvider extends BaseProvider {
     try {
       logger.info('Fetching assigned ADO work items...');
       if (token?.isCancellationRequested) {
+        this._onDidDiscoverItems.fire([]);
         return;
       }
 
@@ -70,11 +71,13 @@ export class AdoWorkItemProvider extends BaseProvider {
       }).catch(() => null);
 
       if (!session || token?.isCancellationRequested) {
+        this._onDidDiscoverItems.fire([]);
         return;
       }
 
       await this.fetchAndPublishWorkItems(session.accessToken, true);
     } catch (err) {
+      this._onDidDiscoverItems.fire([]);
       logger.error('Failed to fetch work items:', err);
     } finally {
       this._isRefreshing = false;
@@ -89,11 +92,13 @@ export class AdoWorkItemProvider extends BaseProvider {
       }).catch(() => null);
 
       if (!session) {
+        this._onDidDiscoverItems.fire([]);
         return;
       }
 
       await this.fetchAndPublishWorkItems(session.accessToken, false);
     } catch (err) {
+      this._onDidDiscoverItems.fire([]);
       logger.error('Failed to fetch work items:', err);
     }
   }
@@ -101,6 +106,7 @@ export class AdoWorkItemProvider extends BaseProvider {
   private async fetchAndPublishWorkItems(accessToken: string, isUserTriggered: boolean): Promise<void> {
     if (!isValidUrlSegment(this.org)) {
       logger.warn('Skipping fetch: invalid ADO organization name', this.org);
+      this._onDidDiscoverItems.fire([]);
       return;
     }
 
@@ -115,6 +121,7 @@ export class AdoWorkItemProvider extends BaseProvider {
 
     if (this.projects.length > 0 && validProjects.length === 0) {
       logger.warn('All configured ADO projects are invalid — skipping fetch');
+      this._onDidDiscoverItems.fire([]);
       return;
     }
 

--- a/packages/ado/src/test/adoPrReviewProvider.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.test.ts
@@ -314,8 +314,8 @@ describe('AdoPrReviewProvider', () => {
     );
   });
 
-  it('fires empty items when fetchAndPublishPrs throws in refresh', async () => {
-    mockFetch.mockImplementation(() => { throw new Error('unexpected'); });
+  it('fires empty items when refresh catch block is hit', async () => {
+    vi.spyOn(provider as any, 'fetchAndPublishPrs').mockRejectedValue(new Error('unexpected'));
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
@@ -324,8 +324,8 @@ describe('AdoPrReviewProvider', () => {
     expect(listener).toHaveBeenCalledWith([]);
   });
 
-  it('fires empty items when fetchAndPublishPrs throws in background refresh', async () => {
-    mockFetch.mockImplementation(() => { throw new Error('unexpected'); });
+  it('fires empty items when doBackgroundRefresh catch block is hit', async () => {
+    vi.spyOn(provider as any, 'fetchAndPublishPrs').mockRejectedValue(new Error('unexpected'));
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);

--- a/packages/ado/src/test/adoPrReviewProvider.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.test.ts
@@ -47,14 +47,58 @@ describe('AdoPrReviewProvider', () => {
     expect(provider.resurfaceDismissed).toBe(true);
   });
 
-  it('does nothing when no auth session exists', async () => {
+  it('fires empty items when no auth session exists', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue(undefined as any);
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
     await provider.refresh();
 
-    expect(listener).not.toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledWith([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('fires empty items when cancellation is requested before auth', async () => {
+    const token = { isCancellationRequested: true } as any;
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh(token);
+
+    expect(listener).toHaveBeenCalledWith([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('fires empty items when cancellation is requested after auth', async () => {
+    const token = { isCancellationRequested: false } as any;
+    vi.mocked(authentication.getSession).mockImplementation(async () => {
+      token.isCancellationRequested = true;
+      return {
+        accessToken: 'test-token',
+        id: 'session-1',
+        scopes: ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+        account: { id: '1', label: 'testuser' },
+      } as any;
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh(token);
+
+    expect(listener).toHaveBeenCalledWith([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('fires empty items on background refresh when no session exists', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValue(undefined as any);
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+
+    const refreshBg = (provider as any).refreshInBackground.bind(provider);
+    await refreshBg();
+
+    expect(listener).toHaveBeenCalledWith([]);
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -270,6 +314,28 @@ describe('AdoPrReviewProvider', () => {
     );
   });
 
+  it('fires empty items when fetchAndPublishPrs throws in refresh', async () => {
+    mockFetch.mockImplementation(() => { throw new Error('unexpected'); });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).toHaveBeenCalledWith([]);
+  });
+
+  it('fires empty items when fetchAndPublishPrs throws in background refresh', async () => {
+    mockFetch.mockImplementation(() => { throw new Error('unexpected'); });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+
+    const refreshBg = (provider as any).refreshInBackground.bind(provider);
+    await refreshBg();
+
+    expect(listener).toHaveBeenCalledWith([]);
+  });
+
   it('handles PR fetch failure gracefully', async () => {
     mockFetch
       .mockResolvedValueOnce({
@@ -420,7 +486,7 @@ describe('AdoPrReviewProvider', () => {
     vi.useRealTimers();
   });
 
-  it('skips fetch when org name is invalid', async () => {
+  it('fires empty items when org name is invalid', async () => {
     provider.dispose();
     provider = new AdoPrReviewProvider('../evil', ['MyProject']);
 
@@ -429,7 +495,7 @@ describe('AdoPrReviewProvider', () => {
     await provider.refresh();
 
     expect(mockFetch).not.toHaveBeenCalled();
-    expect(listener).not.toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledWith([]);
   });
 
   it('skips invalid projects and fetches only valid ones', async () => {
@@ -453,7 +519,7 @@ describe('AdoPrReviewProvider', () => {
     expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 
-  it('skips fetch when all configured projects are invalid', async () => {
+  it('fires empty items when all configured projects are invalid', async () => {
     provider.dispose();
     provider = new AdoPrReviewProvider('myorg', ['../bad', '?evil']);
 
@@ -469,6 +535,6 @@ describe('AdoPrReviewProvider', () => {
 
     // Only connection data fetch — no PR fetches
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(listener).not.toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledWith([]);
   });
 });

--- a/packages/ado/src/test/adoPrReviewProvider.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.test.ts
@@ -54,6 +54,7 @@ describe('AdoPrReviewProvider', () => {
     provider.onDidDiscoverItems(listener);
     await provider.refresh();
 
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -65,6 +66,7 @@ describe('AdoPrReviewProvider', () => {
     provider.onDidDiscoverItems(listener);
     await provider.refresh(token);
 
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -85,6 +87,7 @@ describe('AdoPrReviewProvider', () => {
     provider.onDidDiscoverItems(listener);
     await provider.refresh(token);
 
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -98,6 +101,7 @@ describe('AdoPrReviewProvider', () => {
     const refreshBg = (provider as any).refreshInBackground.bind(provider);
     await refreshBg();
 
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -321,6 +325,7 @@ describe('AdoPrReviewProvider', () => {
     provider.onDidDiscoverItems(listener);
     await provider.refresh();
 
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
   });
 
@@ -333,6 +338,7 @@ describe('AdoPrReviewProvider', () => {
     const refreshBg = (provider as any).refreshInBackground.bind(provider);
     await refreshBg();
 
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
   });
 
@@ -495,6 +501,7 @@ describe('AdoPrReviewProvider', () => {
     await provider.refresh();
 
     expect(mockFetch).not.toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
   });
 
@@ -535,6 +542,7 @@ describe('AdoPrReviewProvider', () => {
 
     // Only connection data fetch — no PR fetches
     expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
   });
 });

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -271,8 +271,8 @@ describe('AdoWorkItemProvider', () => {
     expect(listener).toHaveBeenCalledWith([]);
   });
 
-  it('fires empty items when fetchAndPublishWorkItems throws in refresh', async () => {
-    mockFetch.mockImplementation(() => { throw new Error('unexpected'); });
+  it('fires empty items when refresh catch block is hit', async () => {
+    vi.spyOn(provider as any, 'fetchAndPublishWorkItems').mockRejectedValue(new Error('unexpected'));
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
@@ -281,8 +281,8 @@ describe('AdoWorkItemProvider', () => {
     expect(listener).toHaveBeenCalledWith([]);
   });
 
-  it('fires empty items when fetchAndPublishWorkItems throws in background refresh', async () => {
-    mockFetch.mockImplementation(() => { throw new Error('unexpected'); });
+  it('fires empty items when doBackgroundRefresh catch block is hit', async () => {
+    vi.spyOn(provider as any, 'fetchAndPublishWorkItems').mockRejectedValue(new Error('unexpected'));
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -52,14 +52,14 @@ describe('AdoWorkItemProvider', () => {
     expect(provider.label).toBe('Azure DevOps Work Items');
   });
 
-  it('does nothing when no auth session exists', async () => {
+  it('fires empty items when no auth session exists', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue(undefined as any);
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
     await provider.refresh();
 
-    expect(listener).not.toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledWith([]);
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
@@ -217,6 +217,50 @@ describe('AdoWorkItemProvider', () => {
     expect(window.showWarningMessage).not.toHaveBeenCalled();
   });
 
+  it('fires empty items when cancellation is requested before auth', async () => {
+    const token = { isCancellationRequested: true } as any;
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh(token);
+
+    expect(listener).toHaveBeenCalledWith([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('fires empty items when cancellation is requested after auth', async () => {
+    const token = { isCancellationRequested: false } as any;
+    vi.mocked(authentication.getSession).mockImplementation(async () => {
+      token.isCancellationRequested = true;
+      return {
+        accessToken: 'test-token',
+        id: 'session-1',
+        scopes: ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+        account: { id: '1', label: 'testuser' },
+      } as any;
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh(token);
+
+    expect(listener).toHaveBeenCalledWith([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('fires empty items on background refresh when no session exists', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValue(undefined as any);
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+
+    const refreshBg = (provider as any).refreshInBackground.bind(provider);
+    await refreshBg();
+
+    expect(listener).toHaveBeenCalledWith([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it('handles authentication failure gracefully', async () => {
     vi.mocked(authentication.getSession).mockRejectedValue(new Error('Auth failed'));
 
@@ -224,7 +268,29 @@ describe('AdoWorkItemProvider', () => {
     provider.onDidDiscoverItems(listener);
 
     await expect(provider.refresh()).resolves.toBeUndefined();
-    expect(listener).not.toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledWith([]);
+  });
+
+  it('fires empty items when fetchAndPublishWorkItems throws in refresh', async () => {
+    mockFetch.mockImplementation(() => { throw new Error('unexpected'); });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).toHaveBeenCalledWith([]);
+  });
+
+  it('fires empty items when fetchAndPublishWorkItems throws in background refresh', async () => {
+    mockFetch.mockImplementation(() => { throw new Error('unexpected'); });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+
+    const refreshBg = (provider as any).refreshInBackground.bind(provider);
+    await refreshBg();
+
+    expect(listener).toHaveBeenCalledWith([]);
   });
 
   it('startPeriodicRefresh schedules a repeating timer', () => {
@@ -337,7 +403,7 @@ describe('AdoWorkItemProvider', () => {
     );
   });
 
-  it('skips fetch when org name is invalid', async () => {
+  it('fires empty items when org name is invalid', async () => {
     provider.dispose();
     provider = new AdoWorkItemProvider('../evil', ['MyProject']);
 
@@ -346,7 +412,7 @@ describe('AdoWorkItemProvider', () => {
     await provider.refresh();
 
     expect(mockFetch).not.toHaveBeenCalled();
-    expect(listener).not.toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledWith([]);
   });
 
   it('skips invalid projects and fetches only valid ones', async () => {
@@ -372,7 +438,7 @@ describe('AdoWorkItemProvider', () => {
     );
   });
 
-  it('skips fetch when all configured projects are invalid', async () => {
+  it('fires empty items when all configured projects are invalid', async () => {
     provider.dispose();
     provider = new AdoWorkItemProvider('myorg', ['../bad', '?evil']);
 
@@ -381,6 +447,6 @@ describe('AdoWorkItemProvider', () => {
     await provider.refresh();
 
     expect(mockFetch).not.toHaveBeenCalled();
-    expect(listener).not.toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledWith([]);
   });
 });

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -59,6 +59,7 @@ describe('AdoWorkItemProvider', () => {
     provider.onDidDiscoverItems(listener);
     await provider.refresh();
 
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -224,6 +225,7 @@ describe('AdoWorkItemProvider', () => {
     provider.onDidDiscoverItems(listener);
     await provider.refresh(token);
 
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -244,6 +246,7 @@ describe('AdoWorkItemProvider', () => {
     provider.onDidDiscoverItems(listener);
     await provider.refresh(token);
 
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -257,6 +260,7 @@ describe('AdoWorkItemProvider', () => {
     const refreshBg = (provider as any).refreshInBackground.bind(provider);
     await refreshBg();
 
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
     expect(mockFetch).not.toHaveBeenCalled();
   });
@@ -268,6 +272,7 @@ describe('AdoWorkItemProvider', () => {
     provider.onDidDiscoverItems(listener);
 
     await expect(provider.refresh()).resolves.toBeUndefined();
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
   });
 
@@ -278,6 +283,7 @@ describe('AdoWorkItemProvider', () => {
     provider.onDidDiscoverItems(listener);
     await provider.refresh();
 
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
   });
 
@@ -290,6 +296,7 @@ describe('AdoWorkItemProvider', () => {
     const refreshBg = (provider as any).refreshInBackground.bind(provider);
     await refreshBg();
 
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
   });
 
@@ -412,6 +419,7 @@ describe('AdoWorkItemProvider', () => {
     await provider.refresh();
 
     expect(mockFetch).not.toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
   });
 
@@ -447,6 +455,7 @@ describe('AdoWorkItemProvider', () => {
     await provider.refresh();
 
     expect(mockFetch).not.toHaveBeenCalled();
+    expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
   });
 });


### PR DESCRIPTION
Fire empty discovery events on all ADO provider early-return paths so the ProviderRegistry clears stale items when auth, cancellation, or config failures occur.

## Changes

- Add `_onDidDiscoverItems.fire([])` to all early-return paths in `AdoWorkItemProvider` and `AdoPrReviewProvider`:
  - Cancellation before/after auth
  - No session (background refresh)
  - Invalid organization name
  - All configured projects invalid
  - Catch blocks for unexpected fetch errors
- Update existing tests and add new tests for each early-return path

Closes #168
