### PR TITLE
fix: make ReadStateStore.deleteMany() return Promise<void>

### DIFF
--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -51,8 +51,9 @@ export class ReadStateStore {
    * Atomically delete keys and persist, with rollback on write failure.
    * Both deletes and write are serialized through the writeQueue.
    */
-  deleteMany(keys: string[]): void {
-    this.enqueue(async () => {
+  async deleteMany(keys: string[]): Promise<void> {
+    if (!this.loaded) { await this.load(); }
+    return this.enqueue(async () => {
       const actuallyDeleted: string[] = [];
       for (const key of keys) {
         if (this.items.delete(key)) {
@@ -66,10 +67,8 @@ export class ReadStateStore {
         for (const key of actuallyDeleted) {
           this.items.add(key);
         }
-        logger.error('Failed to save read state, rolled back deletions', err);
+        throw err;
       }
-    }).catch(() => {
-      // Error already handled inside enqueue with rollback
     });
   }
 

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -57,7 +57,7 @@ function createMockReadStateStore() {
       items.add(key);
       return true;
     }),
-    deleteMany: vi.fn((keys: string[]) => {
+    deleteMany: vi.fn(async (keys: string[]) => {
       for (const key of keys) { items.delete(key); }
     }),
     keys: vi.fn(() => items.values()),

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -54,8 +54,7 @@ describe('ReadStateStore', () => {
     await store.add('gh::1');
     await store.add('gh::2');
     await store.add('gh::3');
-    store.deleteMany(['gh::1', 'gh::3']);
-    await store.flush();
+    await store.deleteMany(['gh::1', 'gh::3']);
 
     expect(store.has('gh::1')).toBe(false);
     expect(store.has('gh::2')).toBe(true);
@@ -69,8 +68,7 @@ describe('ReadStateStore', () => {
   it('should ignore non-existent keys in deleteMany', async () => {
     await store.load();
     await store.add('gh::1');
-    store.deleteMany(['gh::nonexistent']);
-    await store.flush();
+    await store.deleteMany(['gh::nonexistent']);
 
     expect(store.has('gh::1')).toBe(true);
   });
@@ -199,6 +197,36 @@ describe('ReadStateStore', () => {
     // Restore path and reset write queue so afterEach cleanup succeeds
     (store as any).filePath = originalPath;
     (store as any).writeQueue = Promise.resolve();
+  });
+
+  it('should propagate write errors from deleteMany', async () => {
+    await store.load();
+    await store.add('gh::1');
+    await store.flush();
+
+    // Point to invalid path to trigger write error
+    const originalPath = (store as any).filePath;
+    (store as any).filePath = path.join(tmpDir, '\0invalid');
+
+    await expect(store.deleteMany(['gh::1'])).rejects.toThrow();
+
+    // Verify rollback - key should still be present
+    expect(store.has('gh::1')).toBe(true);
+
+    // Restore path and reset write queue so afterEach cleanup succeeds
+    (store as any).filePath = originalPath;
+    (store as any).writeQueue = Promise.resolve();
+  });
+
+  it('should auto-load when deleteMany() is called before load()', async () => {
+    const filePath = path.join(tmpDir, 'read-state.json');
+    await fs.writeFile(filePath, JSON.stringify(['gh::existing', 'gh::remove']), 'utf-8');
+
+    const freshStore = new ReadStateStore(tmpDir);
+    await freshStore.deleteMany(['gh::remove']);
+
+    expect(freshStore.has('gh::existing')).toBe(true);
+    expect(freshStore.has('gh::remove')).toBe(false);
   });
 
   it('should auto-load when add() is called before load()', async () => {

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -3,6 +3,7 @@ import { DiscoveredItem } from '../api/types';
 import { ProviderRegistry } from '../services/providerRegistry';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import { ReadStateStore } from '../storage/readStateStore';
+import { logger } from '../services/logger';
 
 export interface InboxProviderNode {
   kind: 'provider';
@@ -95,7 +96,9 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       }
     }
     if (keysToDelete.length > 0) {
-      this.readStateStore.deleteMany(keysToDelete);
+      void this.readStateStore.deleteMany(keysToDelete).catch(err =>
+        logger.error('Failed to prune read state', err)
+      );
     }
   }
 


### PR DESCRIPTION
Make `ReadStateStore.deleteMany()` return `Promise<void>` so callers can await completion and errors propagate instead of being silently swallowed.

## Changes

- Change `deleteMany()` return type from `void` to `Promise<void>`
- Return the enqueue promise instead of discarding it
- Remove `.catch()` that swallowed errors; re-throw on write failure
- Add auto-load guard (consistent with `add()`)
- Update production caller in `inboxTreeProvider.ts` to handle the promise with `void ... .catch()`
- Update mock in `inboxTreeProvider.test.ts` to return async
- Add tests for error propagation and auto-load behavior

Closes #167
