### PR TITLE
fix: roll back created item when setState fails during accept

### DIFF
--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -207,8 +207,9 @@ async function handleAcceptFromInbox(
     }
     return;
   }
+  let createdItem: Awaited<ReturnType<typeof workGraph.createItem>>;
   try {
-    await workGraph.createItem(
+    createdItem = await workGraph.createItem(
       { title: formatItemTitle(item) },
       { providerId: item.providerId, externalId: item.externalId, url: item.url },
     );
@@ -219,6 +220,12 @@ async function handleAcceptFromInbox(
   try {
     await stateStore.setState(item.providerId, item.externalId, 'accepted');
   } catch (err: unknown) {
+    // Roll back the created work item to prevent it appearing in Queue while still unseen in Inbox
+    try {
+      await workGraph.deleteItem(createdItem.id);
+    } catch (rollbackErr: unknown) {
+      logger.error('Failed to roll back created item after setState failure', rollbackErr);
+    }
     handleCommandError('Failed to update state after accepting item', err);
   }
 }
@@ -255,8 +262,9 @@ async function handleAcceptFromSources(
     );
     return;
   }
+  let createdItem: Awaited<ReturnType<typeof workGraph.createItem>>;
   try {
-    await workGraph.createItem(
+    createdItem = await workGraph.createItem(
       { title: formatItemTitle(item) },
       { providerId: item.providerId, externalId: item.externalId, url: item.url },
     );
@@ -267,6 +275,12 @@ async function handleAcceptFromSources(
   try {
     await stateStore.setState(item.providerId, item.externalId, 'accepted');
   } catch (err: unknown) {
+    // Roll back the created work item to prevent it appearing in Queue while still unseen in Inbox
+    try {
+      await workGraph.deleteItem(createdItem.id);
+    } catch (rollbackErr: unknown) {
+      logger.error('Failed to roll back created item after setState failure', rollbackErr);
+    }
     handleCommandError('Failed to update state after accepting item', err);
   }
 }

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -275,7 +275,7 @@ async function handleAcceptFromSources(
   try {
     await stateStore.setState(item.providerId, item.externalId, 'accepted');
   } catch (err: unknown) {
-    // Roll back the created work item to prevent it appearing in Queue while still unseen in Inbox
+    // Roll back the created work item to prevent it appearing in Queue while still unseen in Sources
     try {
       await workGraph.deleteItem(createdItem.id);
     } catch (rollbackErr: unknown) {

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -105,6 +105,7 @@ describe('registerCommands', () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.clearAllMocks();
 
     commandHandlers = new Map();
     (vscode.commands.registerCommand as Mock).mockImplementation(

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -8,6 +8,15 @@ import type { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import type { InboxItem } from '../views/inboxTreeProvider';
 import type { SourceItemNode } from '../views/sourcesTreeProvider';
 import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
+import { logger } from '../services/logger';
+
+vi.mock('../services/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
 
 // ── helpers ──────────────────────────────────────────────────────────
 
@@ -46,7 +55,7 @@ function makeSourceItem(overrides: Partial<SourceItemNode> = {}): SourceItemNode
 
 type UsedWorkGraphMethods = Pick<
   WorkGraph,
-  'transitionState' | 'getItem' | 'createItem' | 'findItemByProvenance' | 'moveItem'
+  'transitionState' | 'getItem' | 'createItem' | 'findItemByProvenance' | 'moveItem' | 'deleteItem'
 >;
 
 function createMockWorkGraph(): { [K in keyof UsedWorkGraphMethods]: Mock } {
@@ -56,6 +65,7 @@ function createMockWorkGraph(): { [K in keyof UsedWorkGraphMethods]: Mock } {
     createItem: vi.fn(async () => createWorkItem()),
     findItemByProvenance: vi.fn(),
     moveItem: vi.fn(),
+    deleteItem: vi.fn(),
   };
 }
 
@@ -551,12 +561,34 @@ describe('registerCommands', () => {
       expect(stateStore.setState).not.toHaveBeenCalled();
     });
 
-    it('shows error when setState fails', async () => {
+    it('rolls back created item when setState fails', async () => {
+      const createdItem = createWorkItem({ id: 'wc-new-1' });
       workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem.mockResolvedValue(createdItem);
       stateStore.setState.mockRejectedValue(new Error('disk full'));
 
       await invoke('workcenter.acceptFromInbox', makeInboxItem());
 
+      expect(workGraph.deleteItem).toHaveBeenCalledWith('wc-new-1');
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to update state after accepting item — disk full',
+      );
+    });
+
+    it('logs error when rollback also fails', async () => {
+      const createdItem = createWorkItem({ id: 'wc-new-2' });
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem.mockResolvedValue(createdItem);
+      stateStore.setState.mockRejectedValue(new Error('disk full'));
+      workGraph.deleteItem.mockRejectedValue(new Error('delete failed'));
+
+      await invoke('workcenter.acceptFromInbox', makeInboxItem());
+
+      expect(workGraph.deleteItem).toHaveBeenCalledWith('wc-new-2');
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to roll back created item after setState failure',
+        expect.any(Error),
+      );
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
         'WorkCenter: Failed to update state after accepting item — disk full',
       );
@@ -658,6 +690,39 @@ describe('registerCommands', () => {
       expect(workGraph.createItem).toHaveBeenCalledWith(
         { title: 'myorg/myrepo Source Issue' },
         expect.any(Object),
+      );
+    });
+
+    it('rolls back created item when setState fails for new item', async () => {
+      const createdItem = createWorkItem({ id: 'wc-new-3' });
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem.mockResolvedValue(createdItem);
+      stateStore.setState.mockRejectedValue(new Error('disk full'));
+
+      await invoke('workcenter.acceptFromSources', makeSourceItem());
+
+      expect(workGraph.deleteItem).toHaveBeenCalledWith('wc-new-3');
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to update state after accepting item — disk full',
+      );
+    });
+
+    it('logs error when rollback also fails for new item', async () => {
+      const createdItem = createWorkItem({ id: 'wc-new-4' });
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem.mockResolvedValue(createdItem);
+      stateStore.setState.mockRejectedValue(new Error('disk full'));
+      workGraph.deleteItem.mockRejectedValue(new Error('delete failed'));
+
+      await invoke('workcenter.acceptFromSources', makeSourceItem());
+
+      expect(workGraph.deleteItem).toHaveBeenCalledWith('wc-new-4');
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to roll back created item after setState failure',
+        expect.any(Error),
+      );
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to update state after accepting item — disk full',
       );
     });
   });


### PR DESCRIPTION
Roll back created work item when setState fails during inbox/sources accept to prevent items appearing in both Inbox and Queue.

## Changes

- In `handleAcceptFromInbox` and `handleAcceptFromSources`: if `setState()` fails after `createItem()` succeeds, delete the created work item
- Defensive error handling: rollback failure is logged without masking the original error
- Add 4 new tests covering rollback success and rollback failure paths for both handlers
- Assert `logger.error` is called on rollback failure for observability

Closes #170
