### PR TITLE
fix: remove defunct Blocked/WaitingOn state references

### DIFF
--- a/packages/ai-reviewer/src/types.ts
+++ b/packages/ai-reviewer/src/types.ts
@@ -8,7 +8,7 @@ export interface WorkItem {
   id: string;
   title: string;
   description?: string;
-  state: 'New' | 'Triaged' | 'InProgress' | 'Blocked' | 'WaitingOn' | 'Done' | 'Archived';
+  state: 'New' | 'InProgress' | 'Paused' | 'Done' | 'Archived';
   providerId?: string;
   externalId?: string;
   url?: string;

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -86,21 +86,6 @@ async function handleResumeItem(workGraph: WorkGraph, item?: { id?: string }): P
   await workGraph.transitionState(item.id, WorkItemState.InProgress);
 }
 
-async function handleBlockItem(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
-  if (!item?.id) { return; }
-  await workGraph.transitionState(item.id, WorkItemState.Blocked);
-}
-
-async function handleUnblockItem(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
-  if (!item?.id) { return; }
-  await workGraph.transitionState(item.id, WorkItemState.InProgress);
-}
-
-async function handleMarkWaitingOn(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
-  if (!item?.id) { return; }
-  await workGraph.transitionState(item.id, WorkItemState.WaitingOn);
-}
-
 function handleEditItem(
   context: vscode.ExtensionContext,
   workGraph: WorkGraph,
@@ -294,12 +279,6 @@ export function registerCommands(
       wrapCommand('Failed to pause item', (item) => handlePauseItem(workGraph, item))),
     vscode.commands.registerCommand('workcenter.resumeItem',
       wrapCommand('Failed to resume item', (item) => handleResumeItem(workGraph, item))),
-    vscode.commands.registerCommand('workcenter.blockItem',
-      wrapCommand('Failed to block item', (item) => handleBlockItem(workGraph, item))),
-    vscode.commands.registerCommand('workcenter.unblockItem',
-      wrapCommand('Failed to unblock item', (item) => handleUnblockItem(workGraph, item))),
-    vscode.commands.registerCommand('workcenter.markWaitingOn',
-      wrapCommand('Failed to mark item as waiting', (item) => handleMarkWaitingOn(workGraph, item))),
     vscode.commands.registerCommand('workcenter.editItem',
       wrapCommand('Failed to open editor', (item) => handleEditItem(context, workGraph, item))),
     vscode.commands.registerCommand('workcenter.openInBrowser',

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -5,12 +5,9 @@
  *
  * ```
  * New → InProgress → Done → Archived
- *                            ↕    ↕
- *                        Blocked  WaitingOn
+ *            ↕
+ *          Paused
  * ```
- *
- * Typical flow in the current UI: `New` → `InProgress` → `Done` → `Archived`.
- * Items may also move from active work to `Paused`.
  */
 export enum WorkItemState {
   /** Freshly created or accepted from the Inbox; sits in the Queue. */

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -6,8 +6,6 @@ import { logger } from '../services/logger';
 import { MAX_STORE_FILE_SIZE } from './limits';
 
 const validWorkItemStates = new Set<string>(Object.values(WorkItemState));
-// Legacy states that are no longer in the enum but can be migrated
-const legacyWorkItemStates = new Set<string>(['Blocked', 'WaitingOn']);
 
 /**
  * Validates that a parsed JSON value has the required shape of a WorkItem.
@@ -24,7 +22,7 @@ function validateWorkItem(value: unknown, index: number): string | undefined {
   if (typeof obj.title !== 'string' || obj.title.length === 0) {
     return `Item "${obj.id}" at index ${index} is missing a valid "title" (string)`;
   }
-  if (typeof obj.state !== 'string' || (!validWorkItemStates.has(obj.state) && !legacyWorkItemStates.has(obj.state))) {
+  if (typeof obj.state !== 'string' || !validWorkItemStates.has(obj.state)) {
     return `Item "${obj.id}" at index ${index} has invalid "state": ${JSON.stringify(obj.state)}`;
   }
   if (typeof obj.createdAt !== 'number' || !Number.isFinite(obj.createdAt)) {
@@ -143,11 +141,6 @@ export class JsonTaskStore implements ITaskStore {
             item.notes = legacy.description;
           }
           delete legacy.description;
-          needsMigration = true;
-        }
-        // Migrate legacy Blocked/WaitingOn states to Paused
-        if ((item.state as string) === 'Blocked' || (item.state as string) === 'WaitingOn') {
-          item.state = WorkItemState.Paused;
           needsMigration = true;
         }
       }

--- a/packages/core/src/test/actionRegistry.test.ts
+++ b/packages/core/src/test/actionRegistry.test.ts
@@ -146,18 +146,18 @@ describe('ActionRegistry', () => {
       'ip-action',
       (i) => i.state === WorkItemState.InProgress,
     );
-    const blockedOnly = createMockAction(
-      'blocked-action',
-      (i) => i.state === WorkItemState.Blocked,
+    const pausedOnly = createMockAction(
+      'paused-action',
+      (i) => i.state === WorkItemState.Paused,
     );
     registry.register(inProgressOnly);
-    registry.register(blockedOnly);
+    registry.register(pausedOnly);
 
     const ipItem = createWorkItem({ state: WorkItemState.InProgress });
-    const blockedItem = createWorkItem({ state: WorkItemState.Blocked });
+    const pausedItem = createWorkItem({ state: WorkItemState.Paused });
 
     expect(registry.getActionsFor(ipItem)).toEqual([inProgressOnly]);
-    expect(registry.getActionsFor(blockedItem)).toEqual([blockedOnly]);
+    expect(registry.getActionsFor(pausedItem)).toEqual([pausedOnly]);
   });
 
   it('dispose makes getActionsFor return empty for previously matching actions', () => {

--- a/packages/core/src/test/historyTreeProvider.test.ts
+++ b/packages/core/src/test/historyTreeProvider.test.ts
@@ -42,7 +42,7 @@ describe('HistoryTreeProvider', () => {
       workGraph._setItems([
         makeItem({ id: '1', title: 'In progress', state: WorkItemState.InProgress }),
         makeItem({ id: '2', title: 'New', state: WorkItemState.New }),
-        makeItem({ id: '3', title: 'Blocked', state: WorkItemState.Blocked }),
+        makeItem({ id: '3', title: 'Paused', state: WorkItemState.Paused }),
       ]);
       expect(provider.getChildren()).toEqual([]);
     });

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -343,57 +343,6 @@ describe('JsonTaskStore', () => {
     });
   });
 
-  it('migrates legacy Blocked state to Paused on load', async () => {
-    const filePath = path.join(tmpDir, 'workitems.json');
-    const legacy = [{
-      id: 'blocked-1',
-      title: 'Blocked item',
-      state: 'Blocked',
-      createdAt: 1000,
-      updatedAt: 1000,
-    }];
-    await fs.mkdir(tmpDir, { recursive: true });
-    await fs.writeFile(filePath, JSON.stringify(legacy), 'utf-8');
-
-    const items = await store.loadAll();
-    expect(items).toHaveLength(1);
-    expect(items[0].state).toBe(WorkItemState.Paused);
-  });
-
-  it('migrates legacy WaitingOn state to Paused on load', async () => {
-    const filePath = path.join(tmpDir, 'workitems.json');
-    const legacy = [{
-      id: 'waiting-1',
-      title: 'Waiting item',
-      state: 'WaitingOn',
-      createdAt: 1000,
-      updatedAt: 1000,
-    }];
-    await fs.mkdir(tmpDir, { recursive: true });
-    await fs.writeFile(filePath, JSON.stringify(legacy), 'utf-8');
-
-    const items = await store.loadAll();
-    expect(items).toHaveLength(1);
-    expect(items[0].state).toBe(WorkItemState.Paused);
-  });
-
-  it('persists migrated Blocked/WaitingOn→Paused back to disk', async () => {
-    const filePath = path.join(tmpDir, 'workitems.json');
-    const legacy = [
-      { id: 'b-1', title: 'Blocked', state: 'Blocked', createdAt: 1000, updatedAt: 1000 },
-      { id: 'w-1', title: 'Waiting', state: 'WaitingOn', createdAt: 1000, updatedAt: 1000 },
-    ];
-    await fs.mkdir(tmpDir, { recursive: true });
-    await fs.writeFile(filePath, JSON.stringify(legacy), 'utf-8');
-
-    await store.loadAll();
-
-    const raw = await fs.readFile(filePath, 'utf-8');
-    const persisted = JSON.parse(raw);
-    expect(persisted).toHaveLength(2);
-    expect(persisted[0].state).toBe(WorkItemState.Paused);
-    expect(persisted[1].state).toBe(WorkItemState.Paused);
-  });
 
   describe('file size limits', () => {
     afterEach(() => {

--- a/packages/core/src/test/migration.test.ts
+++ b/packages/core/src/test/migration.test.ts
@@ -268,7 +268,7 @@ describe('Batch migration (matches extension.ts setStates path)', () => {
     expect(stateStore.setStates).not.toHaveBeenCalled();
   });
 
-  it('should migrate items in Done, Archived, InProgress, and Paused states', async () => {
+  it('should migrate provider-backed items regardless of their lifecycle state', async () => {
     const items = [
       makeWorkItem({ id: 'done1', providerId: 'gh', externalId: 'e-done', state: WorkItemState.Done }),
       makeWorkItem({ id: 'arch1', providerId: 'gh', externalId: 'e-archived', state: WorkItemState.Archived }),

--- a/packages/core/src/test/migration.test.ts
+++ b/packages/core/src/test/migration.test.ts
@@ -268,12 +268,12 @@ describe('Batch migration (matches extension.ts setStates path)', () => {
     expect(stateStore.setStates).not.toHaveBeenCalled();
   });
 
-  it('should migrate items in Done, Archived, InProgress, and Blocked states', async () => {
+  it('should migrate items in Done, Archived, InProgress, and Paused states', async () => {
     const items = [
       makeWorkItem({ id: 'done1', providerId: 'gh', externalId: 'e-done', state: WorkItemState.Done }),
       makeWorkItem({ id: 'arch1', providerId: 'gh', externalId: 'e-archived', state: WorkItemState.Archived }),
       makeWorkItem({ id: 'ip1', providerId: 'gh', externalId: 'e-inprogress', state: WorkItemState.InProgress }),
-      makeWorkItem({ id: 'bl1', providerId: 'gh', externalId: 'e-blocked', state: WorkItemState.Blocked }),
+      makeWorkItem({ id: 'p1', providerId: 'gh', externalId: 'e-paused', state: WorkItemState.Paused }),
     ];
     const store = createMockStore(items);
     const graph = new WorkGraph(store);
@@ -289,7 +289,7 @@ describe('Batch migration (matches extension.ts setStates path)', () => {
         { providerId: 'gh', externalId: 'e-done', state: 'accepted' },
         { providerId: 'gh', externalId: 'e-archived', state: 'accepted' },
         { providerId: 'gh', externalId: 'e-inprogress', state: 'accepted' },
-        { providerId: 'gh', externalId: 'e-blocked', state: 'accepted' },
+        { providerId: 'gh', externalId: 'e-paused', state: 'accepted' },
       ]),
     );
   });

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -451,10 +451,10 @@ describe('WorkGraph', () => {
       const a = await graph.createItem({ title: 'A' });
       await graph.transitionState(a.id, WorkItemState.InProgress);
       const b = await graph.createItem({ title: 'B' });
-      await graph.transitionState(b.id, WorkItemState.Blocked);
+      await graph.transitionState(b.id, WorkItemState.Paused);
       await graph.createItem({ title: 'C' }); // stays New
 
-      const active = graph.getItemsByState(WorkItemState.InProgress, WorkItemState.Blocked);
+      const active = graph.getItemsByState(WorkItemState.InProgress, WorkItemState.Paused);
       expect(active).toHaveLength(2);
       expect(active.map((i) => i.title).sort()).toEqual(['A', 'B']);
     });


### PR DESCRIPTION
Remove defunct Blocked/WaitingOn state references that silently corrupt work items at runtime.

## Changes

- Delete `handleBlockItem`, `handleUnblockItem`, `handleMarkWaitingOn` command handlers and their `registerCommand` calls
- Fix state machine diagram in `workItem.ts` to reflect actual valid states
- Remove `legacyWorkItemStates` set and Blocked/WaitingOn migration code from `JsonTaskStore`
- Update `ai-reviewer/types.ts` to match core enum
- Update all test fixtures referencing Blocked/WaitingOn

**Note:** This is an intentional breaking change for any persisted `workitems.json` files still containing `"state": "Blocked"` or `"state": "WaitingOn"`. These states were already broken at runtime (evaluating to `undefined` via esbuild), so no working data is lost.

Closes #166
