### PR TITLE
fix: validate state transitions in WorkGraph.transitionState() (#169)

### DIFF
--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -209,12 +209,12 @@ export class WorkGraph {
 
   /** Transition a work item to a new lifecycle state. */
   async transitionState(id: string, newState: WorkItemState): Promise<void> {
-    if (!Object.values(WorkItemState).includes(newState)) {
-      throw new Error(`Invalid state value: ${String(newState)}. Expected one of: ${Object.values(WorkItemState).join(', ')}`);
-    }
     const item = this.items.get(id);
     if (!item) {
       throw new Error(`Work item not found: ${id}`);
+    }
+    if (!Object.values(WorkItemState).includes(newState)) {
+      throw new Error(`Invalid state value: ${String(newState)}. Expected one of: ${Object.values(WorkItemState).join(', ')}`);
     }
     const allowedTargets = VALID_TRANSITIONS.get(item.state);
     if (!allowedTargets || !allowedTargets.has(newState)) {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -4,6 +4,14 @@ import { WorkItem, WorkItemInput, WorkItemState } from '../models/workItem';
 import { ITaskStore } from '../storage/taskStore';
 import { logger } from './logger';
 
+const VALID_TRANSITIONS: ReadonlyMap<WorkItemState, ReadonlySet<WorkItemState>> = new Map([
+  [WorkItemState.New, new Set([WorkItemState.InProgress])],
+  [WorkItemState.InProgress, new Set([WorkItemState.Paused, WorkItemState.Done])],
+  [WorkItemState.Paused, new Set([WorkItemState.InProgress])],
+  [WorkItemState.Done, new Set([WorkItemState.Archived])],
+  [WorkItemState.Archived, new Set<WorkItemState>()],
+]);
+
 /**
  * In-memory graph of {@link WorkItem}s backed by a persistent {@link ITaskStore}.
  * Provides CRUD operations, state transitions, and ordering.
@@ -204,6 +212,12 @@ export class WorkGraph {
     const item = this.items.get(id);
     if (!item) {
       throw new Error(`Work item not found: ${id}`);
+    }
+    const allowedTargets = VALID_TRANSITIONS.get(item.state);
+    if (!allowedTargets || !allowedTargets.has(newState)) {
+      throw new Error(
+        `Invalid state transition: cannot move from ${item.state} to ${newState}`,
+      );
     }
     const updated = { ...item, state: newState, updatedAt: Date.now() };
     await this.store.save(updated);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -209,6 +209,9 @@ export class WorkGraph {
 
   /** Transition a work item to a new lifecycle state. */
   async transitionState(id: string, newState: WorkItemState): Promise<void> {
+    if (!Object.values(WorkItemState).includes(newState)) {
+      throw new Error(`Invalid state value: ${String(newState)}`);
+    }
     const item = this.items.get(id);
     if (!item) {
       throw new Error(`Work item not found: ${id}`);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -210,7 +210,7 @@ export class WorkGraph {
   /** Transition a work item to a new lifecycle state. */
   async transitionState(id: string, newState: WorkItemState): Promise<void> {
     if (!Object.values(WorkItemState).includes(newState)) {
-      throw new Error(`Invalid state value: ${String(newState)}`);
+      throw new Error(`Invalid state value: ${String(newState)}. Expected one of: ${Object.values(WorkItemState).join(', ')}`);
     }
     const item = this.items.get(id);
     if (!item) {

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -451,10 +451,11 @@ describe('WorkGraph', () => {
       const a = await graph.createItem({ title: 'A' });
       await graph.transitionState(a.id, WorkItemState.InProgress);
       const b = await graph.createItem({ title: 'B' });
-      await graph.transitionState(b.id, WorkItemState.Blocked);
+      await graph.transitionState(b.id, WorkItemState.InProgress);
+      await graph.transitionState(b.id, WorkItemState.Paused);
       await graph.createItem({ title: 'C' }); // stays New
 
-      const active = graph.getItemsByState(WorkItemState.InProgress, WorkItemState.Blocked);
+      const active = graph.getItemsByState(WorkItemState.InProgress, WorkItemState.Paused);
       expect(active).toHaveLength(2);
       expect(active.map((i) => i.title).sort()).toEqual(['A', 'B']);
     });
@@ -475,6 +476,84 @@ describe('WorkGraph', () => {
       await graph.createItem({ title: 'B' });
       const result = graph.getItemsByState(WorkItemState.New, WorkItemState.New);
       expect(result).toHaveLength(2);
+    });
+  });
+
+  describe('state transition validation', () => {
+    it('rejects New → Done (skipping InProgress)', async () => {
+      const item = await graph.createItem({ title: 'Test' });
+      await expect(graph.transitionState(item.id, WorkItemState.Done))
+        .rejects.toThrow('Invalid state transition');
+    });
+
+    it('rejects New → Archived', async () => {
+      const item = await graph.createItem({ title: 'Test' });
+      await expect(graph.transitionState(item.id, WorkItemState.Archived))
+        .rejects.toThrow('Invalid state transition');
+    });
+
+    it('rejects New → Paused', async () => {
+      const item = await graph.createItem({ title: 'Test' });
+      await expect(graph.transitionState(item.id, WorkItemState.Paused))
+        .rejects.toThrow('Invalid state transition');
+    });
+
+    it('rejects Done → New', async () => {
+      const item = await graph.createItem({ title: 'Test' });
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Done);
+      await expect(graph.transitionState(item.id, WorkItemState.New))
+        .rejects.toThrow('Invalid state transition');
+    });
+
+    it('rejects Done → InProgress', async () => {
+      const item = await graph.createItem({ title: 'Test' });
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Done);
+      await expect(graph.transitionState(item.id, WorkItemState.InProgress))
+        .rejects.toThrow('Invalid state transition');
+    });
+
+    it('rejects Archived → New', async () => {
+      const item = await graph.createItem({ title: 'Test' });
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Done);
+      await graph.transitionState(item.id, WorkItemState.Archived);
+      await expect(graph.transitionState(item.id, WorkItemState.New))
+        .rejects.toThrow('Invalid state transition');
+    });
+
+    it('rejects InProgress → New', async () => {
+      const item = await graph.createItem({ title: 'Test' });
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await expect(graph.transitionState(item.id, WorkItemState.New))
+        .rejects.toThrow('Invalid state transition');
+    });
+
+    it('rejects InProgress → Archived (skipping Done)', async () => {
+      const item = await graph.createItem({ title: 'Test' });
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await expect(graph.transitionState(item.id, WorkItemState.Archived))
+        .rejects.toThrow('Invalid state transition');
+    });
+
+    it('allows all valid transitions in the full lifecycle', async () => {
+      const item = await graph.createItem({ title: 'Lifecycle' });
+      // New → InProgress
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.InProgress);
+      // InProgress → Paused
+      await graph.transitionState(item.id, WorkItemState.Paused);
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Paused);
+      // Paused → InProgress
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.InProgress);
+      // InProgress → Done
+      await graph.transitionState(item.id, WorkItemState.Done);
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Done);
+      // Done → Archived
+      await graph.transitionState(item.id, WorkItemState.Archived);
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Archived);
     });
   });
 });

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -482,38 +482,51 @@ describe('WorkGraph', () => {
   describe('state transition validation', () => {
     it('rejects New → Done (skipping InProgress)', async () => {
       const item = await graph.createItem({ title: 'Test' });
-      (store.save as ReturnType<typeof vi.fn>).mockClear();
+      vi.mocked(store.save).mockClear();
       await expect(graph.transitionState(item.id, WorkItemState.Done))
         .rejects.toThrow('Invalid state transition');
       expect(store.save).not.toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
     });
 
     it('rejects New → Archived', async () => {
       const item = await graph.createItem({ title: 'Test' });
+      vi.mocked(store.save).mockClear();
       await expect(graph.transitionState(item.id, WorkItemState.Archived))
         .rejects.toThrow('Invalid state transition');
+      expect(store.save).not.toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
     });
 
     it('rejects New → Paused', async () => {
       const item = await graph.createItem({ title: 'Test' });
+      vi.mocked(store.save).mockClear();
       await expect(graph.transitionState(item.id, WorkItemState.Paused))
         .rejects.toThrow('Invalid state transition');
+      expect(store.save).not.toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
     });
 
     it('rejects Done → New', async () => {
       const item = await graph.createItem({ title: 'Test' });
       await graph.transitionState(item.id, WorkItemState.InProgress);
       await graph.transitionState(item.id, WorkItemState.Done);
+      vi.mocked(store.save).mockClear();
       await expect(graph.transitionState(item.id, WorkItemState.New))
         .rejects.toThrow('Invalid state transition');
+      expect(store.save).not.toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Done);
     });
 
     it('rejects Done → InProgress', async () => {
       const item = await graph.createItem({ title: 'Test' });
       await graph.transitionState(item.id, WorkItemState.InProgress);
       await graph.transitionState(item.id, WorkItemState.Done);
+      vi.mocked(store.save).mockClear();
       await expect(graph.transitionState(item.id, WorkItemState.InProgress))
         .rejects.toThrow('Invalid state transition');
+      expect(store.save).not.toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Done);
     });
 
     it('rejects Archived → New', async () => {

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -482,8 +482,10 @@ describe('WorkGraph', () => {
   describe('state transition validation', () => {
     it('rejects New → Done (skipping InProgress)', async () => {
       const item = await graph.createItem({ title: 'Test' });
+      (store.save as ReturnType<typeof vi.fn>).mockClear();
       await expect(graph.transitionState(item.id, WorkItemState.Done))
         .rejects.toThrow('Invalid state transition');
+      expect(store.save).not.toHaveBeenCalled();
     });
 
     it('rejects New → Archived', async () => {

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -563,8 +563,11 @@ describe('WorkGraph', () => {
 
     it('rejects undefined state value', async () => {
       const item = await graph.createItem({ title: 'Test' });
+      vi.mocked(store.save).mockClear();
       await expect(graph.transitionState(item.id, undefined as any))
         .rejects.toThrow('Invalid state value');
+      expect(store.save).not.toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
     });
 
     it('allows all valid transitions in the full lifecycle', async () => {

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -534,22 +534,37 @@ describe('WorkGraph', () => {
       await graph.transitionState(item.id, WorkItemState.InProgress);
       await graph.transitionState(item.id, WorkItemState.Done);
       await graph.transitionState(item.id, WorkItemState.Archived);
+      vi.mocked(store.save).mockClear();
       await expect(graph.transitionState(item.id, WorkItemState.New))
         .rejects.toThrow('Invalid state transition');
+      expect(store.save).not.toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Archived);
     });
 
     it('rejects InProgress → New', async () => {
       const item = await graph.createItem({ title: 'Test' });
       await graph.transitionState(item.id, WorkItemState.InProgress);
+      vi.mocked(store.save).mockClear();
       await expect(graph.transitionState(item.id, WorkItemState.New))
         .rejects.toThrow('Invalid state transition');
+      expect(store.save).not.toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.InProgress);
     });
 
     it('rejects InProgress → Archived (skipping Done)', async () => {
       const item = await graph.createItem({ title: 'Test' });
       await graph.transitionState(item.id, WorkItemState.InProgress);
+      vi.mocked(store.save).mockClear();
       await expect(graph.transitionState(item.id, WorkItemState.Archived))
         .rejects.toThrow('Invalid state transition');
+      expect(store.save).not.toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.InProgress);
+    });
+
+    it('rejects undefined state value', async () => {
+      const item = await graph.createItem({ title: 'Test' });
+      await expect(graph.transitionState(item.id, undefined as any))
+        .rejects.toThrow('Invalid state value');
     });
 
     it('allows all valid transitions in the full lifecycle', async () => {


### PR DESCRIPTION
Add state transition validation to `WorkGraph.transitionState()` so illegal transitions throw errors instead of silently applying.

## Changes

- Add `VALID_TRANSITIONS` map encoding the legal state machine: New->InProgress, InProgress->Paused|Done, Paused->InProgress, Done->Archived
- Validate requested transition before persisting; throw descriptive error for invalid transitions
- Add 9 new tests covering invalid transitions and full valid lifecycle
- Fix pre-existing test using non-existent `WorkItemState.Blocked` enum value

Closes #169
