### PR TITLE
fix: allow Open in Browser for Inbox and Sources items

### DIFF
--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -99,11 +99,11 @@ function handleEditItem(
 }
 
 async function handleOpenInBrowser(workGraph: WorkGraph, item?: { id?: string; url?: string }): Promise<void> {
-  if (!item?.id) {
+  if (!item?.id && !item?.url) {
     vscode.window.showWarningMessage('WorkCenter: Select an item to open in the browser.');
     return;
   }
-  const workItem = workGraph.getItem(item.id);
+  const workItem = item.id ? workGraph.getItem(item.id) : undefined;
   const url = workItem?.url ?? item.url;
   if (!url) {
     vscode.window.showWarningMessage('This item has no URL to open.');

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -100,25 +100,25 @@ function handleEditItem(
 
 async function handleOpenInBrowser(workGraph: WorkGraph, item?: { id?: string; url?: string }): Promise<void> {
   if (!item || (!item.id && !item.url)) {
-    vscode.window.showWarningMessage('WorkCenter: Select an item to open in the browser.');
+    void vscode.window.showWarningMessage('WorkCenter: Select an item to open in the browser.');
     return;
   }
   const workItem = item.id ? workGraph.getItem(item.id) : undefined;
   const url = workItem?.url ?? item.url;
   if (!url) {
-    vscode.window.showWarningMessage('This item has no URL to open.');
+    void vscode.window.showWarningMessage('This item has no URL to open.');
     return;
   }
   const safeUrl = isSafeUrl(url);
   if (!safeUrl) {
     const display = url.length > 100 ? url.slice(0, 100) + '…' : url;
     const sanitized = display.replace(/[\n\r]/g, ' ');
-    vscode.window.showWarningMessage(`Cannot open non-web URL: ${sanitized}`);
+    void vscode.window.showWarningMessage(`Cannot open non-web URL: ${sanitized}`);
     return;
   }
   const opened = await vscode.env.openExternal(vscode.Uri.parse(safeUrl.href));
   if (!opened) {
-    vscode.window.showWarningMessage('Failed to open URL in the browser.');
+    void vscode.window.showWarningMessage('Failed to open URL in the browser.');
   }
 }
 

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -99,7 +99,7 @@ function handleEditItem(
 }
 
 async function handleOpenInBrowser(workGraph: WorkGraph, item?: { id?: string; url?: string }): Promise<void> {
-  if (!item?.id && !item?.url) {
+  if (!item || (!item.id && !item.url)) {
     vscode.window.showWarningMessage('WorkCenter: Select an item to open in the browser.');
     return;
   }

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -322,6 +322,31 @@ describe('registerCommands', () => {
       );
       expect(vscode.env.openExternal).not.toHaveBeenCalled();
     });
+
+    it('opens url from item without id (Inbox/Sources items)', async () => {
+      await invoke('workcenter.openInBrowser', { url: 'https://provider-item.com' });
+
+      expect(vscode.Uri.parse).toHaveBeenCalledWith('https://provider-item.com/');
+      expect(vscode.env.openExternal).toHaveBeenCalled();
+    });
+
+    it('rejects unsafe url-only item (Inbox/Sources)', async () => {
+      await invoke('workcenter.openInBrowser', { url: 'javascript:alert(1)' });
+
+      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Cannot open non-web URL'),
+      );
+      expect(vscode.env.openExternal).not.toHaveBeenCalled();
+    });
+
+    it('shows warning when item has neither id nor url', async () => {
+      await invoke('workcenter.openInBrowser', {});
+
+      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+        'WorkCenter: Select an item to open in the browser.',
+      );
+      expect(vscode.env.openExternal).not.toHaveBeenCalled();
+    });
   });
 
   // ── runAction ────────────────────────────────────────────────────

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -326,6 +326,7 @@ describe('registerCommands', () => {
     it('opens url from item without id (Inbox/Sources items)', async () => {
       await invoke('workcenter.openInBrowser', { url: 'https://provider-item.com' });
 
+      expect(workGraph.getItem).not.toHaveBeenCalled();
       expect(vscode.Uri.parse).toHaveBeenCalledWith('https://provider-item.com/');
       expect(vscode.env.openExternal).toHaveBeenCalled();
     });


### PR DESCRIPTION
The `handleOpenInBrowser` guard rejected items without an `id` property, but Inbox and Sources tree items only carry `url` (not `id`). This relaxes the guard so items with a `url` but no `id` can proceed directly.

## Changes

- Changed guard from `!item?.id` to `!item?.id && !item?.url` so url-only items pass through
- Skip `workGraph.getItem()` lookup when `id` is absent
- Added tests for the url-only path (happy path, unsafe URL, and empty object)

Fixes #179
