### PR TITLE
fix: allow archiving items directly from New state (#180)

### DIFF
--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -5,8 +5,9 @@
  *
  * ```
  * New → InProgress → Done → Archived
- *            ↕
- *          Paused
+ * │         ↕
+ * │       Paused
+ * └──────────────────────→ Archived
  * ```
  */
 export enum WorkItemState {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -5,7 +5,7 @@ import { ITaskStore } from '../storage/taskStore';
 import { logger } from './logger';
 
 const VALID_TRANSITIONS: ReadonlyMap<WorkItemState, ReadonlySet<WorkItemState>> = new Map([
-  [WorkItemState.New, new Set([WorkItemState.InProgress])],
+  [WorkItemState.New, new Set([WorkItemState.InProgress, WorkItemState.Archived])],
   [WorkItemState.InProgress, new Set([WorkItemState.Paused, WorkItemState.Done])],
   [WorkItemState.Paused, new Set([WorkItemState.InProgress])],
   [WorkItemState.Done, new Set([WorkItemState.Archived])],

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -489,13 +489,20 @@ describe('WorkGraph', () => {
       expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
     });
 
-    it('rejects New → Archived', async () => {
+    it('allows New → Archived', async () => {
       const item = await graph.createItem({ title: 'Test' });
       vi.mocked(store.save).mockClear();
-      await expect(graph.transitionState(item.id, WorkItemState.Archived))
-        .rejects.toThrow('Invalid state transition');
-      expect(store.save).not.toHaveBeenCalled();
-      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
+      await graph.transitionState(item.id, WorkItemState.Archived);
+      expect(store.save).toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Archived);
+    });
+
+    it('transitions directly from New to Archived', async () => {
+      const item = await graph.createItem({ title: 'Archive from queue' });
+      expect(item.state).toBe(WorkItemState.New);
+      await graph.transitionState(item.id, WorkItemState.Archived);
+      const updated = graph.getItem(item.id);
+      expect(updated?.state).toBe(WorkItemState.Archived);
     });
 
     it('rejects New → Paused', async () => {


### PR DESCRIPTION
Closes #180

The Archive action on Queue items now works correctly. Items in `New` state can be archived directly without first transitioning through `InProgress` → `Done`.

## Changes
- Added `Archived` to valid transitions from `New` state in `workGraph.ts`
- Updated state machine diagram in `workItem.ts`

## Tests
- Updated existing rejection test to verify `New → Archived` now succeeds
- Added explicit test for direct `New → Archived` transition
