### PR TITLE
fix: reuse existing editor panel when opening same work item (#185)

### DIFF
--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -40,6 +40,7 @@ function createMockWebviewPanel() {
       return { dispose: vi.fn() };
     }),
     dispose: vi.fn(),
+    reveal: vi.fn(),
   };
   return {
     panel,
@@ -119,6 +120,7 @@ function createIntegrationContext(): vscode.ExtensionContext {
 describe('WorkItemEditorPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    WorkItemEditorPanel.clearPanelCache();
   });
 
   describe('open (panel creation)', () => {
@@ -158,6 +160,73 @@ describe('WorkItemEditorPanel', () => {
       openPanel(item, createMockWorkGraph(item), mock);
 
       expect(mock.panel.onDidDispose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('panel reuse', () => {
+    it('should reuse existing panel when opening same item twice', () => {
+      const item = makeItem({ id: 'reuse-1', title: 'Reuse Item' });
+      const mock = createMockWebviewPanel();
+      vi.mocked(window.createWebviewPanel).mockReturnValue(mock.panel as any);
+
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
+
+      expect(window.createWebviewPanel).toHaveBeenCalledTimes(1);
+      expect(mock.panel.reveal).toHaveBeenCalledWith(ViewColumn.One);
+    });
+
+    it('should create separate panels for different items', () => {
+      const item1 = makeItem({ id: 'a', title: 'Item A' });
+      const item2 = makeItem({ id: 'b', title: 'Item B' });
+      const mock1 = createMockWebviewPanel();
+      const mock2 = createMockWebviewPanel();
+      const wg1 = createMockWorkGraph(item1);
+      const wg2 = createMockWorkGraph(item2);
+
+      vi.mocked(window.createWebviewPanel)
+        .mockReturnValueOnce(mock1.panel as any)
+        .mockReturnValueOnce(mock2.panel as any);
+
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, wg1 as any, item1);
+      WorkItemEditorPanel.open(ctx, wg2 as any, item2);
+
+      expect(window.createWebviewPanel).toHaveBeenCalledTimes(2);
+    });
+
+    it('should create new panel after previous one was disposed', () => {
+      const item = makeItem({ id: 'dispose-reopen', title: 'Dispose Item' });
+      const mock1 = createMockWebviewPanel();
+      const mock2 = createMockWebviewPanel();
+
+      vi.mocked(window.createWebviewPanel)
+        .mockReturnValueOnce(mock1.panel as any)
+        .mockReturnValueOnce(mock2.panel as any);
+
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
+      mock1.simulateDispose();
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
+
+      expect(window.createWebviewPanel).toHaveBeenCalledTimes(2);
+    });
+
+    it('should reveal the existing panel on second open', () => {
+      const item = makeItem({ id: 'reveal-1', title: 'Reveal Item' });
+      const mock = createMockWebviewPanel();
+      vi.mocked(window.createWebviewPanel).mockReturnValue(mock.panel as any);
+
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
+
+      expect(mock.panel.reveal).not.toHaveBeenCalled();
+
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
+
+      expect(mock.panel.reveal).toHaveBeenCalledTimes(1);
+      expect(mock.panel.reveal).toHaveBeenCalledWith(ViewColumn.One);
     });
   });
 

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -5,6 +5,7 @@ import { getEditorPanelHtml } from './editorPanelHtml';
 
 export class WorkItemEditorPanel {
   private static readonly viewType = 'workcenter.editItem';
+  private static readonly openPanels = new Map<string, WorkItemEditorPanel>();
   private readonly panel: vscode.WebviewPanel;
   private readonly workGraph: WorkGraph;
   private readonly itemId: string;
@@ -19,6 +20,12 @@ export class WorkItemEditorPanel {
     workGraph: WorkGraph,
     item: WorkItem,
   ): void {
+    const existing = WorkItemEditorPanel.openPanels.get(item.id);
+    if (existing) {
+      existing.panel.reveal(vscode.ViewColumn.One);
+      return;
+    }
+
     const panel = vscode.window.createWebviewPanel(
       WorkItemEditorPanel.viewType,
       `Edit: ${item.title}`,
@@ -27,7 +34,13 @@ export class WorkItemEditorPanel {
     );
 
     const editor = new WorkItemEditorPanel(panel, workGraph, item.id);
+    WorkItemEditorPanel.openPanels.set(item.id, editor);
     context.subscriptions.push({ dispose: () => editor.dispose() });
+  }
+
+  /** @internal Exposed for testing only. */
+  static clearPanelCache(): void {
+    WorkItemEditorPanel.openPanels.clear();
   }
 
   private constructor(
@@ -62,6 +75,7 @@ export class WorkItemEditorPanel {
     this.panel.onDidDispose(() => {
       if (!this.disposed) {
         this.disposed = true;
+        WorkItemEditorPanel.openPanels.delete(this.itemId);
         if (this.debounceTimer) {
           clearTimeout(this.debounceTimer);
           this.debounceTimer = undefined;
@@ -119,6 +133,7 @@ export class WorkItemEditorPanel {
   dispose(): void {
     if (!this.disposed) {
       this.disposed = true;
+      WorkItemEditorPanel.openPanels.delete(this.itemId);
       if (this.debounceTimer) {
         clearTimeout(this.debounceTimer);
         this.debounceTimer = undefined;


### PR DESCRIPTION
Closes #185

Clicking a work item in the tree view now reuses the existing editor panel instead of opening a new one each time.

## Changes
- Added static panel tracking map to `WorkItemEditorPanel`
- `open()` now checks for existing panel and reveals it via `panel.reveal()`
- Panel is removed from tracking map on dispose

## Tests
- Added tests for panel reuse, separate panels for different items, cleanup on dispose, and reveal behavior
