### PR TITLE
fix(ado): construct PR URL from org/project/repo when webUrl is undefined (#177)

### DIFF
--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -9,7 +9,7 @@ interface AdoPullRequest {
   repository: {
     name: string;
     project: { name: string };
-    webUrl: string;
+    webUrl?: string;
   };
 }
 
@@ -254,11 +254,12 @@ export class AdoPrReviewProvider extends BaseProvider {
     const items: DiscoveredItem[] = prData.value.map((pr) => {
       const projectName = pr.repository.project.name;
       const repoName = pr.repository.name;
+      const repoUrl = pr.repository.webUrl ?? `https://dev.azure.com/${encodeURIComponent(this.org)}/${encodeURIComponent(projectName)}/_git/${encodeURIComponent(repoName)}`;
       return {
         externalId: `${projectName}/${repoName}/${pr.pullRequestId}`,
         title: `PR ${pr.pullRequestId}: ${pr.title}`,
         description: pr.description?.slice(0, 200),
-        url: `${pr.repository.webUrl}/pullrequest/${pr.pullRequestId}`,
+        url: `${repoUrl}/pullrequest/${pr.pullRequestId}`,
         group: `${projectName}/${repoName}`,
         reason: 'review_requested',
       };

--- a/packages/ado/src/test/adoPrReviewProvider.extended.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.extended.test.ts
@@ -457,6 +457,32 @@ describe('AdoPrReviewProvider — extended', () => {
   });
 
   describe('PR URL construction in results', () => {
+    it('constructs URL from org/project/repo when webUrl is undefined', async () => {
+      const prWithoutWebUrl = {
+        pullRequestId: 99,
+        title: 'No webUrl PR',
+        description: 'A PR without webUrl',
+        repository: {
+          name: 'myrepo',
+          project: { name: 'MyProject' },
+        },
+      };
+
+      mockFetch
+        .mockResolvedValueOnce(mockConnectionData())
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [prWithoutWebUrl] }),
+        });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      const items = listener.mock.calls[0][0];
+      expect(items[0].url).toBe('https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/99');
+    });
+
     it('constructs correct PR URL from repository webUrl', async () => {
       mockFetch
         .mockResolvedValueOnce(mockConnectionData())


### PR DESCRIPTION
## Summary

Fixes #177 — ADO PR URL generation produces `undefined` base URL when `repository.webUrl` is missing from the API response.

## Changes

- Made `webUrl` optional in the `AdoPullRequest` interface to match actual API behavior
- Added a fallback URL construction using `org/project/repo` pattern when `webUrl` is `undefined`
- Used `encodeURIComponent` on all path segments for safety
- Added test covering the `webUrl`-missing scenario
