### PR TITLE
fix: allow archiving work items directly from New state

### DIFF
--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -5,8 +5,9 @@
  *
  * ```
  * New → InProgress → Done → Archived
- *            ↕
- *          Paused
+ * │         ↕
+ * │       Paused
+ * └──────────────────────→ Archived
  * ```
  */
 export enum WorkItemState {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -5,7 +5,7 @@ import { ITaskStore } from '../storage/taskStore';
 import { logger } from './logger';
 
 const VALID_TRANSITIONS: ReadonlyMap<WorkItemState, ReadonlySet<WorkItemState>> = new Map([
-  [WorkItemState.New, new Set([WorkItemState.InProgress])],
+  [WorkItemState.New, new Set([WorkItemState.InProgress, WorkItemState.Archived])],
   [WorkItemState.InProgress, new Set([WorkItemState.Paused, WorkItemState.Done])],
   [WorkItemState.Paused, new Set([WorkItemState.InProgress])],
   [WorkItemState.Done, new Set([WorkItemState.Archived])],

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -497,7 +497,7 @@ describe('WorkGraph', () => {
       expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Archived);
     });
 
-    it('rejects New → Paused',async () => {
+    it('rejects New → Paused', async () => {
       const item = await graph.createItem({ title: 'Test' });
       vi.mocked(store.save).mockClear();
       await expect(graph.transitionState(item.id, WorkItemState.Paused))

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -497,15 +497,7 @@ describe('WorkGraph', () => {
       expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Archived);
     });
 
-    it('transitions directly from New to Archived', async () => {
-      const item = await graph.createItem({ title: 'Archive from queue' });
-      expect(item.state).toBe(WorkItemState.New);
-      await graph.transitionState(item.id, WorkItemState.Archived);
-      const updated = graph.getItem(item.id);
-      expect(updated?.state).toBe(WorkItemState.Archived);
-    });
-
-    it('rejects New → Paused', async () => {
+    it('rejects New → Paused',async () => {
       const item = await graph.createItem({ title: 'Test' });
       vi.mocked(store.save).mockClear();
       await expect(graph.transitionState(item.id, WorkItemState.Paused))

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -489,13 +489,20 @@ describe('WorkGraph', () => {
       expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
     });
 
-    it('rejects New → Archived', async () => {
+    it('allows New → Archived', async () => {
       const item = await graph.createItem({ title: 'Test' });
       vi.mocked(store.save).mockClear();
-      await expect(graph.transitionState(item.id, WorkItemState.Archived))
-        .rejects.toThrow('Invalid state transition');
-      expect(store.save).not.toHaveBeenCalled();
-      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
+      await graph.transitionState(item.id, WorkItemState.Archived);
+      expect(store.save).toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Archived);
+    });
+
+    it('transitions directly from New to Archived', async () => {
+      const item = await graph.createItem({ title: 'Archive from queue' });
+      expect(item.state).toBe(WorkItemState.New);
+      await graph.transitionState(item.id, WorkItemState.Archived);
+      const updated = graph.getItem(item.id);
+      expect(updated?.state).toBe(WorkItemState.Archived);
     });
 
     it('rejects New → Paused', async () => {


### PR DESCRIPTION
## Summary

Fixes #180 — The Archive action on Queue items failed with `Invalid state transition: cannot move from New to Archived`.

## Problem

The work item state machine only allowed `New → InProgress` as a valid transition from the `New` state. Users who wanted to archive a queue item without starting it first were blocked by the state machine validation.

## Changes

- **`workItem.ts`** — Updated the state diagram to reflect the new `New → Archived` transition.
- **`workGraph.ts`** — Added `Archived` to the set of valid transitions from `New`.
- **`workGraph.test.ts`** — Updated the existing rejection test to verify that `New → Archived` is now allowed.
