### PR TITLE
fix: reuse existing editor panel when opening same work item

### DIFF
--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -248,6 +248,24 @@ describe('WorkItemEditorPanel', () => {
 
       expect(window.createWebviewPanel).toHaveBeenCalledTimes(2);
     });
+
+    it('should refresh content when reusing an existing panel', () => {
+      const item = makeItem({ id: 'refresh-1', title: 'Original Title', notes: 'Original Notes' });
+      const mock = createMockWebviewPanel();
+      const wg = createMockWorkGraph(item);
+      vi.mocked(window.createWebviewPanel).mockReturnValue(mock.panel as any);
+
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, wg as any, item);
+
+      // Simulate the item being updated in the work graph
+      const updatedItem = makeItem({ id: 'refresh-1', title: 'Updated Title', notes: 'Updated Notes' });
+      vi.mocked(wg.getItem).mockReturnValue(updatedItem);
+      WorkItemEditorPanel.open(ctx, wg as any, updatedItem);
+
+      expect(mock.panel.title).toBe('Edit: Updated Title');
+      expect(mock.panel.webview.html).toContain('Updated Title');
+    });
   });
 
   describe('HTML generation', () => {

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -174,7 +174,7 @@ describe('WorkItemEditorPanel', () => {
       WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
 
       expect(window.createWebviewPanel).toHaveBeenCalledTimes(1);
-      expect(mock.panel.reveal).toHaveBeenCalledWith(ViewColumn.One);
+      expect(mock.panel.reveal).toHaveBeenCalled();
     });
 
     it('should create separate panels for different items', () => {
@@ -226,7 +226,27 @@ describe('WorkItemEditorPanel', () => {
       WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
 
       expect(mock.panel.reveal).toHaveBeenCalledTimes(1);
-      expect(mock.panel.reveal).toHaveBeenCalledWith(ViewColumn.One);
+      expect(mock.panel.reveal).toHaveBeenCalledWith();
+    });
+
+    it('should allow reopening after dispose() via context subscription', () => {
+      const item = makeItem({ id: 'ctx-dispose', title: 'Context Dispose' });
+      const mock1 = createMockWebviewPanel();
+      const mock2 = createMockWebviewPanel();
+
+      vi.mocked(window.createWebviewPanel)
+        .mockReturnValueOnce(mock1.panel as any)
+        .mockReturnValueOnce(mock2.panel as any);
+
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
+
+      // Dispose via context subscription (the dispose() method path)
+      ctx.subscriptions[ctx.subscriptions.length - 1].dispose();
+
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
+
+      expect(window.createWebviewPanel).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -40,6 +40,7 @@ function createMockWebviewPanel() {
       return { dispose: vi.fn() };
     }),
     dispose: vi.fn(),
+    reveal: vi.fn(),
   };
   return {
     panel,
@@ -119,6 +120,7 @@ function createIntegrationContext(): vscode.ExtensionContext {
 describe('WorkItemEditorPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    WorkItemEditorPanel.clearPanelCache();
   });
 
   describe('open (panel creation)', () => {
@@ -158,6 +160,73 @@ describe('WorkItemEditorPanel', () => {
       openPanel(item, createMockWorkGraph(item), mock);
 
       expect(mock.panel.onDidDispose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('panel reuse', () => {
+    it('should reuse existing panel when opening same item twice', () => {
+      const item = makeItem({ id: 'reuse-1', title: 'Reuse Item' });
+      const mock = createMockWebviewPanel();
+      vi.mocked(window.createWebviewPanel).mockReturnValue(mock.panel as any);
+
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
+
+      expect(window.createWebviewPanel).toHaveBeenCalledTimes(1);
+      expect(mock.panel.reveal).toHaveBeenCalledWith(ViewColumn.One);
+    });
+
+    it('should create separate panels for different items', () => {
+      const item1 = makeItem({ id: 'a', title: 'Item A' });
+      const item2 = makeItem({ id: 'b', title: 'Item B' });
+      const mock1 = createMockWebviewPanel();
+      const mock2 = createMockWebviewPanel();
+      const wg1 = createMockWorkGraph(item1);
+      const wg2 = createMockWorkGraph(item2);
+
+      vi.mocked(window.createWebviewPanel)
+        .mockReturnValueOnce(mock1.panel as any)
+        .mockReturnValueOnce(mock2.panel as any);
+
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, wg1 as any, item1);
+      WorkItemEditorPanel.open(ctx, wg2 as any, item2);
+
+      expect(window.createWebviewPanel).toHaveBeenCalledTimes(2);
+    });
+
+    it('should create new panel after previous one was disposed', () => {
+      const item = makeItem({ id: 'dispose-reopen', title: 'Dispose Item' });
+      const mock1 = createMockWebviewPanel();
+      const mock2 = createMockWebviewPanel();
+
+      vi.mocked(window.createWebviewPanel)
+        .mockReturnValueOnce(mock1.panel as any)
+        .mockReturnValueOnce(mock2.panel as any);
+
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
+      mock1.simulateDispose();
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
+
+      expect(window.createWebviewPanel).toHaveBeenCalledTimes(2);
+    });
+
+    it('should reveal the existing panel on second open', () => {
+      const item = makeItem({ id: 'reveal-1', title: 'Reveal Item' });
+      const mock = createMockWebviewPanel();
+      vi.mocked(window.createWebviewPanel).mockReturnValue(mock.panel as any);
+
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
+
+      expect(mock.panel.reveal).not.toHaveBeenCalled();
+
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, item);
+
+      expect(mock.panel.reveal).toHaveBeenCalledTimes(1);
+      expect(mock.panel.reveal).toHaveBeenCalledWith(ViewColumn.One);
     });
   });
 

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -22,7 +22,7 @@ export class WorkItemEditorPanel {
   ): void {
     const existing = WorkItemEditorPanel.openPanels.get(item.id);
     if (existing) {
-      existing.panel.reveal(vscode.ViewColumn.One);
+      existing.panel.reveal();
       return;
     }
 

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -5,6 +5,7 @@ import { getEditorPanelHtml } from './editorPanelHtml';
 
 export class WorkItemEditorPanel {
   private static readonly viewType = 'workcenter.editItem';
+  private static readonly openPanels = new Map<string, WorkItemEditorPanel>();
   private readonly panel: vscode.WebviewPanel;
   private readonly workGraph: WorkGraph;
   private readonly itemId: string;
@@ -19,6 +20,12 @@ export class WorkItemEditorPanel {
     workGraph: WorkGraph,
     item: WorkItem,
   ): void {
+    const existing = WorkItemEditorPanel.openPanels.get(item.id);
+    if (existing) {
+      existing.panel.reveal(vscode.ViewColumn.One);
+      return;
+    }
+
     const panel = vscode.window.createWebviewPanel(
       WorkItemEditorPanel.viewType,
       `Edit: ${item.title}`,
@@ -27,7 +34,13 @@ export class WorkItemEditorPanel {
     );
 
     const editor = new WorkItemEditorPanel(panel, workGraph, item.id);
+    WorkItemEditorPanel.openPanels.set(item.id, editor);
     context.subscriptions.push({ dispose: () => editor.dispose() });
+  }
+
+  /** @internal Exposed for testing only. */
+  static clearPanelCache(): void {
+    WorkItemEditorPanel.openPanels.clear();
   }
 
   private constructor(
@@ -62,6 +75,7 @@ export class WorkItemEditorPanel {
     this.panel.onDidDispose(() => {
       if (!this.disposed) {
         this.disposed = true;
+        WorkItemEditorPanel.openPanels.delete(this.itemId);
         if (this.debounceTimer) {
           clearTimeout(this.debounceTimer);
           this.debounceTimer = undefined;
@@ -119,6 +133,7 @@ export class WorkItemEditorPanel {
   dispose(): void {
     if (!this.disposed) {
       this.disposed = true;
+      WorkItemEditorPanel.openPanels.delete(this.itemId);
       if (this.debounceTimer) {
         clearTimeout(this.debounceTimer);
         this.debounceTimer = undefined;

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -42,6 +42,10 @@ export class WorkItemEditorPanel {
 
   /** @internal Exposed for testing only. */
   static clearPanelCache(): void {
+    const panels = Array.from(WorkItemEditorPanel.openPanels.values());
+    for (const editor of panels) {
+      editor.dispose();
+    }
     WorkItemEditorPanel.openPanels.clear();
   }
 

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -22,6 +22,8 @@ export class WorkItemEditorPanel {
   ): void {
     const existing = WorkItemEditorPanel.openPanels.get(item.id);
     if (existing) {
+      existing.panel.title = `Edit: ${item.title}`;
+      existing.update();
       existing.panel.reveal();
       return;
     }


### PR DESCRIPTION
## Summary

Fixes #185 — Clicking an item opens a new editor window each time.

## Changes

### Panel reuse (`workItemEditorPanel.ts`)
- Added a static `openPanels` map keyed by `item.id` to cache active editor panels.
- On `open()`, if a panel already exists for the item, it is revealed instead of creating a new one.
- Both `onDidDispose` and `dispose()` clean up the cache entry to allow re-opening after a panel is closed.
- `reveal()` is called without a `ViewColumn` argument so the panel stays in whichever column the user placed it.

### Tests (`workItemEditorPanel.test.ts`)
- Added `reveal` mock to the panel mock factory.
- Added `clearPanelCache()` call in `beforeEach` to isolate static state between tests.
- New test cases:
  - Reuse existing panel when opening same item twice
  - Create separate panels for different items
  - Create new panel after previous one was disposed (via `onDidDispose`)
  - Reveal existing panel on second open (verifies `reveal()` call)
  - Allow reopening after `dispose()` via context subscription (covers the `dispose()` method path)
