### PR TITLE
feat: allow archiving items from Focus view

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -180,6 +180,11 @@
           "group": "inline"
         },
         {
+          "command": "workcenter.archiveItem",
+          "when": "view == workcenter.focus",
+          "group": "1_actions"
+        },
+        {
           "command": "workcenter.pauseItem",
           "when": "view == workcenter.focus && viewItem =~ /^active/",
           "group": "1_actions"

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -5,10 +5,13 @@
  *
  * ```
  * New → InProgress → Done → Archived
- * │         ↕
- * │       Paused
+ * │         ↕         ↗
+ * │       Paused ────┘
  * └──────────────────────→ Archived
  * ```
+ *
+ * Both InProgress and Paused may also transition directly to Archived
+ * (for abandoned or no-longer-relevant work).
  */
 export enum WorkItemState {
   /** Freshly created or accepted from the Inbox; sits in the Queue. */

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -6,8 +6,8 @@ import { logger } from './logger';
 
 const VALID_TRANSITIONS: ReadonlyMap<WorkItemState, ReadonlySet<WorkItemState>> = new Map([
   [WorkItemState.New, new Set([WorkItemState.InProgress, WorkItemState.Archived])],
-  [WorkItemState.InProgress, new Set([WorkItemState.Paused, WorkItemState.Done])],
-  [WorkItemState.Paused, new Set([WorkItemState.InProgress])],
+  [WorkItemState.InProgress, new Set([WorkItemState.Paused, WorkItemState.Done, WorkItemState.Archived])],
+  [WorkItemState.Paused, new Set([WorkItemState.InProgress, WorkItemState.Archived])],
   [WorkItemState.Done, new Set([WorkItemState.Archived])],
   [WorkItemState.Archived, new Set<WorkItemState>()],
 ]);

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -550,14 +550,21 @@ describe('WorkGraph', () => {
       expect(graph.getItem(item.id)?.state).toBe(WorkItemState.InProgress);
     });
 
-    it('rejects InProgress → Archived (skipping Done)', async () => {
+    it('allows InProgress → Archived', async () => {
       const item = await graph.createItem({ title: 'Test' });
       await graph.transitionState(item.id, WorkItemState.InProgress);
-      vi.mocked(store.save).mockClear();
-      await expect(graph.transitionState(item.id, WorkItemState.Archived))
-        .rejects.toThrow('Invalid state transition');
-      expect(store.save).not.toHaveBeenCalled();
-      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.InProgress);
+
+      await graph.transitionState(item.id, WorkItemState.Archived);
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Archived);
+    });
+
+    it('allows Paused → Archived', async () => {
+      const item = await graph.createItem({ title: 'Test' });
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Paused);
+
+      await graph.transitionState(item.id, WorkItemState.Archived);
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Archived);
     });
 
     it('rejects undefined state value', async () => {


### PR DESCRIPTION
## Summary

Allow work items in `InProgress` or `Paused` state to be archived directly from the Focus view. Previously, the only way forward from Focus was to complete an item. This adds an escape hatch for abandoned or no-longer-relevant work.

## Changes

- **State machine** (`workGraph.ts`): Added `Archived` to valid transitions from `InProgress` and `Paused`
- **Focus view menu** (`package.json`): Added "Archive" context menu item for all Focus view items
- **Tests** (`workGraph.test.ts`): Replaced the old "rejects InProgress → Archived" test with two new tests covering `InProgress → Archived` and `Paused → Archived`
- **Docs** (`workItem.ts`): Updated the state machine diagram in the `WorkItemState` docstring

The existing `workcenter.archiveItem` command handler works without changes since it simply calls `transitionState(id, Archived)`.

Closes #181
