### PR TITLE
feat: add reorder support for Focus view items

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -137,6 +137,18 @@
         "icon": "$(arrow-down)"
       },
       {
+        "command": "workcenter.focusMoveUp",
+        "title": "Move Up",
+        "category": "WorkCenter",
+        "icon": "$(arrow-up)"
+      },
+      {
+        "command": "workcenter.focusMoveDown",
+        "title": "Move Down",
+        "category": "WorkCenter",
+        "icon": "$(arrow-down)"
+      },
+      {
         "command": "workcenter.acceptFromInbox",
         "title": "Accept to Queue",
         "category": "WorkCenter",
@@ -197,6 +209,16 @@
         {
           "command": "workcenter.moveDown",
           "when": "view == workcenter.queue",
+          "group": "3_reorder"
+        },
+        {
+          "command": "workcenter.focusMoveUp",
+          "when": "view == workcenter.focus",
+          "group": "3_reorder"
+        },
+        {
+          "command": "workcenter.focusMoveDown",
+          "when": "view == workcenter.focus",
           "group": "3_reorder"
         },
         {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -138,13 +138,13 @@
       },
       {
         "command": "workcenter.focusMoveUp",
-        "title": "Move Up",
+        "title": "Move Up (Focus)",
         "category": "WorkCenter",
         "icon": "$(arrow-up)"
       },
       {
         "command": "workcenter.focusMoveDown",
-        "title": "Move Down",
+        "title": "Move Down (Focus)",
         "category": "WorkCenter",
         "icon": "$(arrow-down)"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -139,13 +139,13 @@
       },
       {
         "command": "workcenter.focusMoveUp",
-        "title": "Move Up (Focus)",
+        "title": "Move Up",
         "category": "WorkCenter",
         "icon": "$(arrow-up)"
       },
       {
         "command": "workcenter.focusMoveDown",
-        "title": "Move Down (Focus)",
+        "title": "Move Down",
         "category": "WorkCenter",
         "icon": "$(arrow-down)"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -138,13 +138,13 @@
       },
       {
         "command": "workcenter.focusMoveUp",
-        "title": "Move Up (Focus)",
+        "title": "Move Up",
         "category": "WorkCenter",
         "icon": "$(arrow-up)"
       },
       {
         "command": "workcenter.focusMoveDown",
-        "title": "Move Down (Focus)",
+        "title": "Move Down",
         "category": "WorkCenter",
         "icon": "$(arrow-down)"
       },
@@ -204,22 +204,22 @@
         {
           "command": "workcenter.moveUp",
           "when": "view == workcenter.queue",
-          "group": "3_reorder"
+          "group": "3_reorder@1"
         },
         {
           "command": "workcenter.moveDown",
           "when": "view == workcenter.queue",
-          "group": "3_reorder"
+          "group": "3_reorder@2"
         },
         {
           "command": "workcenter.focusMoveUp",
           "when": "view == workcenter.focus",
-          "group": "3_reorder"
+          "group": "3_reorder@1"
         },
         {
           "command": "workcenter.focusMoveDown",
           "when": "view == workcenter.focus",
-          "group": "3_reorder"
+          "group": "3_reorder@2"
         },
         {
           "command": "workcenter.openInBrowser",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -139,13 +139,13 @@
       },
       {
         "command": "workcenter.focusMoveUp",
-        "title": "Move Up",
+        "title": "Move Up (Focus)",
         "category": "WorkCenter",
         "icon": "$(arrow-up)"
       },
       {
         "command": "workcenter.focusMoveDown",
-        "title": "Move Down",
+        "title": "Move Down (Focus)",
         "category": "WorkCenter",
         "icon": "$(arrow-down)"
       },

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -173,6 +173,22 @@ async function handleMoveDown(workGraph: WorkGraph, item?: { id?: string }): Pro
   await workGraph.moveItem(item.id, 'down');
 }
 
+async function handleFocusMoveUp(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
+  if (!item?.id) {
+    void vscode.window.showInformationMessage('WorkCenter: Select an item in Focus to move.');
+    return;
+  }
+  await workGraph.moveItem(item.id, 'up');
+}
+
+async function handleFocusMoveDown(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
+  if (!item?.id) {
+    void vscode.window.showInformationMessage('WorkCenter: Select an item in Focus to move.');
+    return;
+  }
+  await workGraph.moveItem(item.id, 'down');
+}
+
 async function handleAcceptFromInbox(
   workGraph: WorkGraph,
   stateStore: DiscoveredStateStore,
@@ -303,6 +319,10 @@ export function registerCommands(
       wrapCommand('Failed to move item up', (item) => handleMoveUp(workGraph, item))),
     vscode.commands.registerCommand('workcenter.moveDown',
       wrapCommand('Failed to move item down', (item) => handleMoveDown(workGraph, item))),
+    vscode.commands.registerCommand('workcenter.focusMoveUp',
+      wrapCommand('Failed to move focus item up', (item) => handleFocusMoveUp(workGraph, item))),
+    vscode.commands.registerCommand('workcenter.focusMoveDown',
+      wrapCommand('Failed to move focus item down', (item) => handleFocusMoveDown(workGraph, item))),
     vscode.commands.registerCommand('workcenter.acceptFromInbox',
       wrapCommand('Failed to accept from inbox', (item: InboxItem) => handleAcceptFromInbox(workGraph, stateStore, item))),
     vscode.commands.registerCommand('workcenter.dismissFromInbox',

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -119,7 +119,7 @@ function createTreeViews(
   const inboxTreeView = vscode.window.createTreeView('workcenter.inbox', { treeDataProvider: inboxProvider });
   const sourcesTreeView = vscode.window.createTreeView('workcenter.sources', { treeDataProvider: sourcesProvider });
   const queueTreeView = vscode.window.createTreeView('workcenter.queue', { treeDataProvider: queueProvider, dragAndDropController: queueProvider });
-  const focusTreeView = vscode.window.createTreeView('workcenter.focus', { treeDataProvider: focusProvider });
+  const focusTreeView = vscode.window.createTreeView('workcenter.focus', { treeDataProvider: focusProvider, dragAndDropController: focusProvider });
   const historyTreeView = vscode.window.createTreeView('workcenter.history', { treeDataProvider: historyProvider });
 
   const inboxSelectionSub = inboxTreeView.onDidChangeSelection((e) => {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -240,10 +240,11 @@ export class WorkGraph {
     const siblings = this.getItemsByState(item.state)
       .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
 
-    // Normalize any missing sortOrder values so swaps are consistent
+    // Normalize sortOrder values to sequential indices so swaps are consistent
+    // even when items have duplicate or missing sortOrder (e.g. after state transitions)
     const toNormalize: WorkItem[] = [];
     for (let i = 0; i < siblings.length; i++) {
-      if (siblings[i].sortOrder === undefined) {
+      if (siblings[i].sortOrder !== i) {
         const normalized = { ...siblings[i], sortOrder: i, updatedAt: Date.now() };
         siblings[i] = normalized;
         toNormalize.push(normalized);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -242,6 +242,7 @@ export class WorkGraph {
 
     // Normalize sortOrder values to sequential indices so swaps are consistent
     // even when items have duplicate or missing sortOrder (e.g. after state transitions)
+    let didMutate = false;
     const toNormalize: WorkItem[] = [];
     for (let i = 0; i < siblings.length; i++) {
       if (siblings[i].sortOrder !== i) {
@@ -256,15 +257,18 @@ export class WorkGraph {
         this.items.set(normalized.id, normalized);
       }
       this.invalidateStateCache();
+      didMutate = true;
     }
 
     const index = siblings.findIndex((s) => s.id === id);
     if (index === -1) {
+      if (didMutate) { this._onDidChange.fire(); }
       return;
     }
 
     const swapIndex = direction === 'up' ? index - 1 : index + 1;
     if (swapIndex < 0 || swapIndex >= siblings.length) {
+      if (didMutate) { this._onDidChange.fire(); }
       return;
     }
 

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -150,6 +150,8 @@ describe('registerCommands', () => {
       'workcenter.runAction',
       'workcenter.moveUp',
       'workcenter.moveDown',
+      'workcenter.focusMoveUp',
+      'workcenter.focusMoveDown',
       'workcenter.acceptFromInbox',
       'workcenter.dismissFromInbox',
       'workcenter.acceptFromSources',
@@ -503,6 +505,54 @@ describe('registerCommands', () => {
       invoke('workcenter.moveDown', {});
       expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
         'WorkCenter: Select an item in the Queue to move.',
+      );
+      expect(workGraph.moveItem).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── focusMoveUp / focusMoveDown ─────────────────────────────────
+
+  describe('workcenter.focusMoveUp', () => {
+    it('calls workGraph.moveItem with "up"', () => {
+      invoke('workcenter.focusMoveUp', { id: 'wc-1' });
+      expect(workGraph.moveItem).toHaveBeenCalledWith('wc-1', 'up');
+    });
+
+    it('shows info message when item is null', () => {
+      invoke('workcenter.focusMoveUp', null);
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'WorkCenter: Select an item in Focus to move.',
+      );
+      expect(workGraph.moveItem).not.toHaveBeenCalled();
+    });
+
+    it('shows info message when item has no id', () => {
+      invoke('workcenter.focusMoveUp', {});
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'WorkCenter: Select an item in Focus to move.',
+      );
+      expect(workGraph.moveItem).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('workcenter.focusMoveDown', () => {
+    it('calls workGraph.moveItem with "down"', () => {
+      invoke('workcenter.focusMoveDown', { id: 'wc-1' });
+      expect(workGraph.moveItem).toHaveBeenCalledWith('wc-1', 'down');
+    });
+
+    it('shows info message when item is undefined', () => {
+      invoke('workcenter.focusMoveDown', undefined);
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'WorkCenter: Select an item in Focus to move.',
+      );
+      expect(workGraph.moveItem).not.toHaveBeenCalled();
+    });
+
+    it('shows info message when item has no id', () => {
+      invoke('workcenter.focusMoveDown', {});
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'WorkCenter: Select an item in Focus to move.',
       );
       expect(workGraph.moveItem).not.toHaveBeenCalled();
     });

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -113,10 +113,21 @@ describe('FocusTreeProvider', () => {
   });
 
   describe('getChildren', () => {
-    it('should return items sorted by title', () => {
+    it('should return items sorted by sortOrder', () => {
+      const items = [
+        makeItem({ id: '2', title: 'Zebra', state: WorkItemState.InProgress, sortOrder: 0 }),
+        makeItem({ id: '1', title: 'Alpha', state: WorkItemState.Paused, sortOrder: 1 }),
+      ];
+      workGraph.getItemsByState.mockReturnValue(items);
+
+      const children = provider.getChildren();
+      expect(children.map(c => c.title)).toEqual(['Zebra', 'Alpha']);
+    });
+
+    it('should sort items without sortOrder after those with sortOrder', () => {
       const items = [
         makeItem({ id: '2', title: 'Zebra', state: WorkItemState.InProgress }),
-        makeItem({ id: '1', title: 'Alpha', state: WorkItemState.Paused }),
+        makeItem({ id: '1', title: 'Alpha', state: WorkItemState.Paused, sortOrder: 0 }),
       ];
       workGraph.getItemsByState.mockReturnValue(items);
 

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -113,26 +113,33 @@ describe('FocusTreeProvider', () => {
   });
 
   describe('getChildren', () => {
-    it('should return items sorted by sortOrder', () => {
+    it('should return items sorted by state priority then sortOrder', () => {
       const items = [
-        makeItem({ id: '2', title: 'Zebra', state: WorkItemState.InProgress, sortOrder: 0 }),
-        makeItem({ id: '1', title: 'Alpha', state: WorkItemState.Paused, sortOrder: 1 }),
+        makeItem({ id: '1', title: 'Paused-0', state: WorkItemState.Paused, sortOrder: 0 }),
+        makeItem({ id: '2', title: 'Active-0', state: WorkItemState.InProgress, sortOrder: 0 }),
+        makeItem({ id: '3', title: 'Active-1', state: WorkItemState.InProgress, sortOrder: 1 }),
+        makeItem({ id: '4', title: 'Paused-1', state: WorkItemState.Paused, sortOrder: 1 }),
       ];
       workGraph.getItemsByState.mockReturnValue(items);
 
       const children = provider.getChildren();
-      expect(children.map(c => c.title)).toEqual(['Zebra', 'Alpha']);
+      expect(children.map(c => c.title)).toEqual([
+        'Active-0', 'Active-1', 'Paused-0', 'Paused-1',
+      ]);
     });
 
-    it('should sort items without sortOrder after those with sortOrder', () => {
+    it('should sort items without sortOrder after those with sortOrder within the same state', () => {
       const items = [
-        makeItem({ id: '2', title: 'Zebra', state: WorkItemState.InProgress }),
-        makeItem({ id: '1', title: 'Alpha', state: WorkItemState.Paused, sortOrder: 0 }),
+        makeItem({ id: '1', title: 'Active-no-order', state: WorkItemState.InProgress }),
+        makeItem({ id: '2', title: 'Active-ordered', state: WorkItemState.InProgress, sortOrder: 0 }),
+        makeItem({ id: '3', title: 'Paused-ordered', state: WorkItemState.Paused, sortOrder: 0 }),
       ];
       workGraph.getItemsByState.mockReturnValue(items);
 
       const children = provider.getChildren();
-      expect(children.map(c => c.title)).toEqual(['Alpha', 'Zebra']);
+      expect(children.map(c => c.title)).toEqual([
+        'Active-ordered', 'Active-no-order', 'Paused-ordered',
+      ]);
     });
 
     it('should request InProgress and Paused states', () => {

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { EventEmitter } from 'vscode';
+import { EventEmitter, DataTransfer, DataTransferItem, window } from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { FocusTreeProvider } from '../views/focusTreeProvider';
+
+const DRAG_MIME_TYPE = 'application/vnd.code.tree.workcenter.focus';
 
 function createMockWorkGraph() {
   const emitter = new EventEmitter<void>();
   return {
     onDidChange: emitter.event,
     getItemsByState: vi.fn((..._states: WorkItemState[]) => [] as WorkItem[]),
+    getItem: vi.fn((_id: string) => undefined as WorkItem | undefined),
+    reorderItem: vi.fn(async (_draggedId: string, _targetId: string) => {}),
+    moveToEnd: vi.fn(async (_id: string) => {}),
     _fire: () => emitter.fire(),
   };
 }
@@ -154,6 +159,58 @@ describe('FocusTreeProvider', () => {
     it('should return empty array when no focus items exist', () => {
       workGraph.getItemsByState.mockReturnValue([]);
       expect(provider.getChildren()).toEqual([]);
+    });
+  });
+
+  describe('handleDrop', () => {
+    it('should reject drop when dragged item and target have different states', async () => {
+      const inProgressItem = makeItem({ id: 'a', state: WorkItemState.InProgress });
+      const pausedItem = makeItem({ id: 'b', state: WorkItemState.Paused });
+      workGraph.getItem.mockReturnValue(inProgressItem);
+
+      const dataTransfer = new DataTransfer();
+      dataTransfer.set(DRAG_MIME_TYPE, new DataTransferItem(['a']));
+
+      await provider.handleDrop(pausedItem, dataTransfer);
+
+      expect(workGraph.reorderItem).not.toHaveBeenCalled();
+      expect(window.showInformationMessage).toHaveBeenCalledWith(
+        'WorkCenter: Cannot reorder items across different states.'
+      );
+    });
+
+    it('should allow drop when dragged item and target have same state', async () => {
+      const item1 = makeItem({ id: 'a', state: WorkItemState.InProgress });
+      const item2 = makeItem({ id: 'b', state: WorkItemState.InProgress });
+      workGraph.getItem.mockReturnValue(item1);
+
+      const dataTransfer = new DataTransfer();
+      dataTransfer.set(DRAG_MIME_TYPE, new DataTransferItem(['a']));
+
+      await provider.handleDrop(item2, dataTransfer);
+
+      expect(workGraph.reorderItem).toHaveBeenCalledWith('a', 'b');
+    });
+
+    it('should call moveToEnd when target is undefined', async () => {
+      const dataTransfer = new DataTransfer();
+      dataTransfer.set(DRAG_MIME_TYPE, new DataTransferItem(['a']));
+
+      await provider.handleDrop(undefined, dataTransfer);
+
+      expect(workGraph.moveToEnd).toHaveBeenCalledWith('a');
+    });
+
+    it('should no-op when dragged item is not found', async () => {
+      const target = makeItem({ id: 'b', state: WorkItemState.InProgress });
+      workGraph.getItem.mockReturnValue(undefined);
+
+      const dataTransfer = new DataTransfer();
+      dataTransfer.set(DRAG_MIME_TYPE, new DataTransferItem(['a']));
+
+      await provider.handleDrop(target, dataTransfer);
+
+      expect(workGraph.reorderItem).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -163,6 +163,10 @@ describe('FocusTreeProvider', () => {
   });
 
   describe('handleDrop', () => {
+    beforeEach(() => {
+      (window.showInformationMessage as ReturnType<typeof vi.fn>).mockClear();
+    });
+
     it('should reject drop when dragged item and target have different states', async () => {
       const inProgressItem = makeItem({ id: 'a', state: WorkItemState.InProgress });
       const pausedItem = makeItem({ id: 'b', state: WorkItemState.Paused });

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -162,6 +162,50 @@ describe('FocusTreeProvider', () => {
     });
   });
 
+  describe('handleDrag', () => {
+    it('serializes dragged item ids into data transfer', () => {
+      const item = makeItem({ id: 'drag-1' });
+      const dataTransfer = new DataTransfer();
+
+      provider.handleDrag([item], dataTransfer);
+
+      const transferItem = dataTransfer.get(DRAG_MIME_TYPE);
+      expect(transferItem).toBeDefined();
+      expect(transferItem!.value).toEqual(['drag-1']);
+    });
+
+    it('serializes multiple dragged item ids', () => {
+      const a = makeItem({ id: 'a' });
+      const b = makeItem({ id: 'b' });
+      const dataTransfer = new DataTransfer();
+
+      provider.handleDrag([a, b], dataTransfer);
+
+      const transferItem = dataTransfer.get(DRAG_MIME_TYPE);
+      expect(transferItem!.value).toEqual(['a', 'b']);
+    });
+
+    it('uses the correct MIME type', () => {
+      const item = makeItem({ id: 'mime-check' });
+      const dataTransfer = new DataTransfer();
+
+      provider.handleDrag([item], dataTransfer);
+
+      expect(dataTransfer.get(DRAG_MIME_TYPE)).toBeDefined();
+      expect(dataTransfer.get('text/plain')).toBeUndefined();
+    });
+  });
+
+  describe('drag/drop mime types', () => {
+    it('exposes correct dropMimeTypes', () => {
+      expect(provider.dropMimeTypes).toEqual([DRAG_MIME_TYPE]);
+    });
+
+    it('exposes correct dragMimeTypes', () => {
+      expect(provider.dragMimeTypes).toEqual([DRAG_MIME_TYPE]);
+    });
+  });
+
   describe('handleDrop', () => {
     beforeEach(() => {
       (window.showInformationMessage as ReturnType<typeof vi.fn>).mockClear();
@@ -215,6 +259,49 @@ describe('FocusTreeProvider', () => {
       await provider.handleDrop(target, dataTransfer);
 
       expect(workGraph.reorderItem).not.toHaveBeenCalled();
+    });
+
+    it('should no-op when no transfer item exists', async () => {
+      const target = makeItem({ id: 'a', state: WorkItemState.InProgress });
+      const dataTransfer = new DataTransfer();
+
+      await provider.handleDrop(target, dataTransfer);
+
+      expect(workGraph.reorderItem).not.toHaveBeenCalled();
+      expect(workGraph.moveToEnd).not.toHaveBeenCalled();
+    });
+
+    it('should no-op when transfer value is not an array', async () => {
+      const target = makeItem({ id: 'a', state: WorkItemState.InProgress });
+      const dataTransfer = new DataTransfer();
+      dataTransfer.set(DRAG_MIME_TYPE, new DataTransferItem('not-an-array'));
+
+      await provider.handleDrop(target, dataTransfer);
+
+      expect(workGraph.reorderItem).not.toHaveBeenCalled();
+      expect(workGraph.moveToEnd).not.toHaveBeenCalled();
+    });
+
+    it('should no-op when transfer value contains non-string', async () => {
+      const target = makeItem({ id: 'a', state: WorkItemState.InProgress });
+      const dataTransfer = new DataTransfer();
+      dataTransfer.set(DRAG_MIME_TYPE, new DataTransferItem([123]));
+
+      await provider.handleDrop(target, dataTransfer);
+
+      expect(workGraph.reorderItem).not.toHaveBeenCalled();
+      expect(workGraph.moveToEnd).not.toHaveBeenCalled();
+    });
+
+    it('should no-op when dragging multiple items', async () => {
+      const target = makeItem({ id: 'c', state: WorkItemState.InProgress });
+      const dataTransfer = new DataTransfer();
+      dataTransfer.set(DRAG_MIME_TYPE, new DataTransferItem(['a', 'b']));
+
+      await provider.handleDrop(target, dataTransfer);
+
+      expect(workGraph.reorderItem).not.toHaveBeenCalled();
+      expect(workGraph.moveToEnd).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -23,6 +23,7 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<WorkItem>, vsc
 
   getTreeItem(item: WorkItem): vscode.TreeItem {
     const treeItem = new vscode.TreeItem(item.title, vscode.TreeItemCollapsibleState.None);
+    treeItem.id = item.id;
     treeItem.description = this.getStateLabel(item.state);
     treeItem.tooltip = this.buildTooltip(item);
     treeItem.iconPath = this.getIcon(item.state);

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -100,6 +100,7 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<WorkItem>, vsc
     const draggedId = draggedIds[0];
 
     if (!target) {
+      // moveToEnd is inherently state-scoped — no cross-state guard needed
       await this.workGraph.moveToEnd(draggedId);
       return;
     }

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -106,6 +106,16 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<WorkItem>, vsc
 
     if (draggedId === target.id) { return; }
 
+    const draggedItem = this.workGraph.getItem(draggedId);
+    if (!draggedItem) { return; }
+
+    if (draggedItem.state !== target.state) {
+      void vscode.window.showInformationMessage(
+        'WorkCenter: Cannot reorder items across different states.'
+      );
+      return;
+    }
+
     await this.workGraph.reorderItem(draggedId, target.id);
   }
 

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -2,7 +2,11 @@ import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 
-export class FocusTreeProvider implements vscode.TreeDataProvider<WorkItem> {
+const DRAG_MIME_TYPE = 'application/vnd.code.tree.workcenter.focus';
+
+export class FocusTreeProvider implements vscode.TreeDataProvider<WorkItem>, vscode.TreeDragAndDropController<WorkItem> {
+  readonly dropMimeTypes = [DRAG_MIME_TYPE];
+  readonly dragMimeTypes = [DRAG_MIME_TYPE];
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private readonly disposables: vscode.Disposable[] = [];
@@ -38,7 +42,7 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<WorkItem> {
     return this.workGraph.getItemsByState(
       WorkItemState.InProgress,
       WorkItemState.Paused,
-    ).sort((a, b) => a.title.localeCompare(b.title));
+    ).sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
   }
 
   private getStateLabel(state: WorkItemState): string {
@@ -61,6 +65,30 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<WorkItem> {
       default:
         return new vscode.ThemeIcon('circle-outline');
     }
+  }
+
+  handleDrag(source: readonly WorkItem[], dataTransfer: vscode.DataTransfer): void {
+    dataTransfer.set(DRAG_MIME_TYPE, new vscode.DataTransferItem(source.map(s => s.id)));
+  }
+
+  async handleDrop(target: WorkItem | undefined, dataTransfer: vscode.DataTransfer): Promise<void> {
+    const transferItem = dataTransfer.get(DRAG_MIME_TYPE);
+    if (!transferItem) { return; }
+
+    const rawValue: unknown = transferItem.value;
+    if (!Array.isArray(rawValue) || rawValue.length !== 1 || typeof rawValue[0] !== 'string') { return; }
+
+    const draggedIds: string[] = rawValue;
+    const draggedId = draggedIds[0];
+
+    if (!target) {
+      await this.workGraph.moveToEnd(draggedId);
+      return;
+    }
+
+    if (draggedId === target.id) { return; }
+
+    await this.workGraph.reorderItem(draggedId, target.id);
   }
 
   private buildTooltip(item: WorkItem): vscode.MarkdownString {

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -42,7 +42,25 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<WorkItem>, vsc
     return this.workGraph.getItemsByState(
       WorkItemState.InProgress,
       WorkItemState.Paused,
-    ).sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
+    ).sort((a, b) => {
+      const statePriorityDifference = this.getFocusStatePriority(a.state) - this.getFocusStatePriority(b.state);
+      if (statePriorityDifference !== 0) {
+        return statePriorityDifference;
+      }
+
+      return (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER);
+    });
+  }
+
+  private getFocusStatePriority(state: WorkItemState): number {
+    switch (state) {
+      case WorkItemState.InProgress:
+        return 0;
+      case WorkItemState.Paused:
+        return 1;
+      default:
+        return Number.MAX_SAFE_INTEGER;
+    }
   }
 
   private getStateLabel(state: WorkItemState): string {


### PR DESCRIPTION
## Summary

Add drag-and-drop reordering and move up/down commands for work items in the Focus view, matching the existing Queue view pattern.

## Changes

- **`focusTreeProvider.ts`** — Implement `TreeDragAndDropController<WorkItem>` with `handleDrag`/`handleDrop` methods; sort by `sortOrder` instead of title
- **`commands.ts`** — Add `workcenter.focusMoveUp` and `workcenter.focusMoveDown` command handlers
- **`extension.ts`** — Register `dragAndDropController` on the Focus tree view
- **`package.json`** — Declare new commands and add context menu entries for Focus items
- **`focusTreeProvider.test.ts`** — Update sorting test to verify `sortOrder`-based ordering; add test for items without `sortOrder`

## Testing

- All 697 existing tests pass
- Updated Focus tree provider test to validate new sort behavior

Closes #188
