### PR TITLE
feat: add ability to move items from Focus to Queue

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -153,6 +153,12 @@
         "title": "Accept to Queue",
         "category": "WorkCenter",
         "icon": "$(arrow-right)"
+      },
+      {
+        "command": "workcenter.moveToQueue",
+        "title": "Move to Queue",
+        "category": "WorkCenter",
+        "icon": "$(arrow-left)"
       }
     ],
     "menus": {
@@ -187,6 +193,11 @@
         {
           "command": "workcenter.resumeItem",
           "when": "view == workcenter.focus && viewItem =~ /^paused/",
+          "group": "1_actions"
+        },
+        {
+          "command": "workcenter.moveToQueue",
+          "when": "view == workcenter.focus",
           "group": "1_actions"
         },
         {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -197,7 +197,7 @@
         },
         {
           "command": "workcenter.moveToQueue",
-          "when": "view == workcenter.focus",
+          "when": "view == workcenter.focus && viewItem =~ /^(active|paused)/",
           "group": "1_actions"
         },
         {

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -86,6 +86,11 @@ async function handleResumeItem(workGraph: WorkGraph, item?: { id?: string }): P
   await workGraph.transitionState(item.id, WorkItemState.InProgress);
 }
 
+async function handleMoveToQueue(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
+  if (!item?.id) { return; }
+  await workGraph.transitionState(item.id, WorkItemState.New);
+}
+
 function handleEditItem(
   context: vscode.ExtensionContext,
   workGraph: WorkGraph,
@@ -303,6 +308,8 @@ export function registerCommands(
       wrapCommand('Failed to move item up', (item) => handleMoveUp(workGraph, item))),
     vscode.commands.registerCommand('workcenter.moveDown',
       wrapCommand('Failed to move item down', (item) => handleMoveDown(workGraph, item))),
+    vscode.commands.registerCommand('workcenter.moveToQueue',
+      wrapCommand('Failed to move to queue', (item) => handleMoveToQueue(workGraph, item))),
     vscode.commands.registerCommand('workcenter.acceptFromInbox',
       wrapCommand('Failed to accept from inbox', (item: InboxItem) => handleAcceptFromInbox(workGraph, stateStore, item))),
     vscode.commands.registerCommand('workcenter.dismissFromInbox',

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -309,7 +309,7 @@ export function registerCommands(
     vscode.commands.registerCommand('workcenter.moveDown',
       wrapCommand('Failed to move item down', (item) => handleMoveDown(workGraph, item))),
     vscode.commands.registerCommand('workcenter.moveToQueue',
-      wrapCommand('Failed to move to queue', (item) => handleMoveToQueue(workGraph, item))),
+      wrapCommand('Failed to move item to queue', (item) => handleMoveToQueue(workGraph, item))),
     vscode.commands.registerCommand('workcenter.acceptFromInbox',
       wrapCommand('Failed to accept from inbox', (item: InboxItem) => handleAcceptFromInbox(workGraph, stateStore, item))),
     vscode.commands.registerCommand('workcenter.dismissFromInbox',

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -5,8 +5,10 @@
  *
  * ```
  * New → InProgress → Done → Archived
- * │         ↕
- * │       Paused
+ * │    ↕    ↕
+ * │  Paused │
+ * │    ↓    │
+ * │   New ←─┘
  * └──────────────────────→ Archived
  * ```
  */

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -5,11 +5,10 @@
  *
  * ```
  * New → InProgress → Done → Archived
- * │    ↕    ↕
- * │  Paused │
- * │    ↓    │
- * │   New ←─┘
- * └──────────────────────→ Archived
+ * ↑       ↕
+ * │     Paused
+ * └───────┘
+ * New ──────────────────→ Archived
  * ```
  */
 export enum WorkItemState {

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -4,12 +4,12 @@
  * Items move through these states following the work-item state machine:
  *
  * ```
- * New → InProgress → Done → Archived
- * ↑       ↕
- * │     Paused
- * └───────┘
- * New ──────────────────→ Archived
+ * New ──→ InProgress ──→ Done ──→ Archived
+ * ↑          ↕
+ * │        Paused
+ * └──────────┘
  * ```
+ * New may also transition directly to Archived.
  */
 export enum WorkItemState {
   /** Freshly created or accepted from the Inbox; sits in the Queue. */

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -222,7 +222,16 @@ export class WorkGraph {
         `Invalid state transition: cannot move from ${item.state} to ${newState}`,
       );
     }
-    const updated = { ...item, state: newState, updatedAt: Date.now() };
+    const updated: WorkItem = { ...item, state: newState, updatedAt: Date.now() };
+    // When returning to Queue, assign a fresh sortOrder to avoid collisions
+    if (newState === WorkItemState.New) {
+      const newItems = this.getItemsByState(WorkItemState.New);
+      const maxOrder = Math.max(
+        newItems.length - 1,
+        newItems.reduce((max, i) => Math.max(max, i.sortOrder ?? -1), -1),
+      );
+      updated.sortOrder = maxOrder + 1;
+    }
     await this.store.save(updated);
     this.items.set(id, updated);
     this.invalidateStateCache();

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -6,8 +6,8 @@ import { logger } from './logger';
 
 const VALID_TRANSITIONS: ReadonlyMap<WorkItemState, ReadonlySet<WorkItemState>> = new Map([
   [WorkItemState.New, new Set([WorkItemState.InProgress, WorkItemState.Archived])],
-  [WorkItemState.InProgress, new Set([WorkItemState.Paused, WorkItemState.Done])],
-  [WorkItemState.Paused, new Set([WorkItemState.InProgress])],
+  [WorkItemState.InProgress, new Set([WorkItemState.Paused, WorkItemState.Done, WorkItemState.New])],
+  [WorkItemState.Paused, new Set([WorkItemState.InProgress, WorkItemState.New])],
   [WorkItemState.Done, new Set([WorkItemState.Archived])],
   [WorkItemState.Archived, new Set<WorkItemState>()],
 ]);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -94,6 +94,17 @@ export class WorkGraph {
     this.invalidateStateCache();
   }
 
+  /** Return the next available sortOrder for items in the given state. */
+  private nextSortOrder(state: WorkItemState): number {
+    const items = this.getItemsByState(state);
+    // Account for legacy items that may not have sortOrder assigned
+    const maxOrder = Math.max(
+      items.length - 1,
+      items.reduce((max, i) => Math.max(max, i.sortOrder ?? -1), -1),
+    );
+    return maxOrder + 1;
+  }
+
   /** Return all work items. */
   getAll(): WorkItem[] {
     return Array.from(this.items.values());
@@ -154,12 +165,7 @@ export class WorkGraph {
     input: WorkItemInput,
     provenance?: { providerId: string; externalId: string; url?: string },
   ): Promise<WorkItem> {
-    const existingItems = this.getItemsByState(WorkItemState.New);
-    // Account for legacy items that may not have sortOrder assigned
-    const maxOrder = Math.max(
-      existingItems.length - 1,
-      existingItems.reduce((max, i) => Math.max(max, i.sortOrder ?? -1), -1),
-    );
+    const sortOrder = this.nextSortOrder(WorkItemState.New);
     const item: WorkItem = {
       id: generateId(),
       title: input.title,
@@ -168,7 +174,7 @@ export class WorkGraph {
       providerId: provenance?.providerId,
       externalId: provenance?.externalId,
       url: provenance?.url,
-      sortOrder: maxOrder + 1,
+      sortOrder,
       createdAt: Date.now(),
       updatedAt: Date.now(),
     };
@@ -225,12 +231,7 @@ export class WorkGraph {
     const updated: WorkItem = { ...item, state: newState, updatedAt: Date.now() };
     // When returning to Queue, assign a fresh sortOrder to avoid collisions
     if (newState === WorkItemState.New) {
-      const newItems = this.getItemsByState(WorkItemState.New);
-      const maxOrder = Math.max(
-        newItems.length - 1,
-        newItems.reduce((max, i) => Math.max(max, i.sortOrder ?? -1), -1),
-      );
-      updated.sortOrder = maxOrder + 1;
+      updated.sortOrder = this.nextSortOrder(WorkItemState.New);
     }
     await this.store.save(updated);
     this.items.set(id, updated);

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -150,6 +150,7 @@ describe('registerCommands', () => {
       'workcenter.runAction',
       'workcenter.moveUp',
       'workcenter.moveDown',
+      'workcenter.moveToQueue',
       'workcenter.acceptFromInbox',
       'workcenter.dismissFromInbox',
       'workcenter.acceptFromSources',
@@ -200,6 +201,7 @@ describe('registerCommands', () => {
       ['workcenter.completeItem', WorkItemState.Done],
       ['workcenter.pauseItem', WorkItemState.Paused],
       ['workcenter.resumeItem', WorkItemState.InProgress],
+      ['workcenter.moveToQueue', WorkItemState.New],
     ];
 
     for (const [cmd, expectedState] of transitions) {

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -559,6 +559,18 @@ describe('WorkGraph', () => {
       expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
     });
 
+    it('assigns a fresh sortOrder when moving back to New', async () => {
+      const itemA = await graph.createItem({ title: 'A' });
+      const itemB = await graph.createItem({ title: 'B' });
+      // Move A to InProgress (leaves B in Queue with sortOrder 1)
+      await graph.transitionState(itemA.id, WorkItemState.InProgress);
+      // Move A back to New — should get sortOrder after B
+      await graph.transitionState(itemA.id, WorkItemState.New);
+      const returned = graph.getItem(itemA.id)!;
+      const remaining = graph.getItem(itemB.id)!;
+      expect(returned.sortOrder).toBeGreaterThan(remaining.sortOrder!);
+    });
+
     it('rejects InProgress → Archived (skipping Done)', async () => {
       const item = await graph.createItem({ title: 'Test' });
       await graph.transitionState(item.id, WorkItemState.InProgress);

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -540,14 +540,23 @@ describe('WorkGraph', () => {
       expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Archived);
     });
 
-    it('rejects InProgress → New', async () => {
+    it('allows InProgress → New (move to queue)', async () => {
       const item = await graph.createItem({ title: 'Test' });
       await graph.transitionState(item.id, WorkItemState.InProgress);
       vi.mocked(store.save).mockClear();
-      await expect(graph.transitionState(item.id, WorkItemState.New))
-        .rejects.toThrow('Invalid state transition');
-      expect(store.save).not.toHaveBeenCalled();
-      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.New);
+      expect(store.save).toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
+    });
+
+    it('allows Paused → New (move to queue)', async () => {
+      const item = await graph.createItem({ title: 'Test' });
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Paused);
+      vi.mocked(store.save).mockClear();
+      await graph.transitionState(item.id, WorkItemState.New);
+      expect(store.save).toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
     });
 
     it('rejects InProgress → Archived (skipping Done)', async () => {


### PR DESCRIPTION
## Summary

Add the ability to move work items from the Focus view back to the Queue by transitioning them from `InProgress` or `Paused` state back to `New`.

## Changes

- **`workGraph.ts`** — Updated `VALID_TRANSITIONS` to allow `InProgress → New` and `Paused → New`
- **`commands.ts`** — Added `handleMoveToQueue` handler and registered `workcenter.moveToQueue` command
- **`package.json`** — Added command declaration with `$(arrow-left)` icon and context menu entry in Focus view (`1_actions` group)
- **`workItem.ts`** — Updated state machine diagram in doc comment
- **Tests** — Updated `workGraph.test.ts` (replaced rejection test with allowance tests for both transitions) and `commands.test.ts` (added new command to registration and transition tests)

## Testing

All 698 core tests pass. Build succeeds across all packages.

Closes #187
