### PR TITLE
feat: add manual refresh command for WorkCenter views

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,8 @@
     "onView:workcenter.queue",
     "onView:workcenter.focus",
     "onView:workcenter.sources",
-    "onView:workcenter.history"
+    "onView:workcenter.history",
+    "onCommand:workcenter.refresh"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -153,6 +153,12 @@
         "title": "Accept to Queue",
         "category": "WorkCenter",
         "icon": "$(arrow-right)"
+      },
+      {
+        "command": "workcenter.refresh",
+        "title": "Refresh",
+        "category": "WorkCenter",
+        "icon": "$(refresh)"
       }
     ],
     "menus": {
@@ -160,6 +166,11 @@
         {
           "command": "workcenter.createItem",
           "when": "view == workcenter.queue",
+          "group": "navigation"
+        },
+        {
+          "command": "workcenter.refresh",
+          "when": "view == workcenter.inbox || view == workcenter.queue || view == workcenter.focus || view == workcenter.history || view == workcenter.sources",
           "group": "navigation"
         }
       ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -171,7 +171,7 @@
         },
         {
           "command": "workcenter.refresh",
-          "when": "view == workcenter.inbox || view == workcenter.queue || view == workcenter.focus || view == workcenter.history || view == workcenter.sources",
+          "when": "view == workcenter.inbox || view == workcenter.sources",
           "group": "navigation"
         }
       ],

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import { ActionRegistry } from '../services/actionRegistry';
+import { ProviderRegistry } from '../services/providerRegistry';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
 import { InboxItem } from '../views/inboxTreeProvider';
@@ -228,6 +229,17 @@ async function handleDismissFromInbox(
   }
 }
 
+async function handleRefresh(providerRegistry: ProviderRegistry): Promise<void> {
+  logger.info('Manual refresh triggered');
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Window,
+      title: 'WorkCenter: Refreshing…',
+    },
+    () => providerRegistry.refreshAll(),
+  );
+}
+
 async function handleAcceptFromSources(
   workGraph: WorkGraph,
   stateStore: DiscoveredStateStore,
@@ -279,8 +291,11 @@ export function registerCommands(
   workGraph: WorkGraph,
   actionRegistry: ActionRegistry,
   stateStore: DiscoveredStateStore,
+  providerRegistry: ProviderRegistry,
 ): void {
   context.subscriptions.push(
+    vscode.commands.registerCommand('workcenter.refresh',
+      wrapCommand('Failed to refresh', () => handleRefresh(providerRegistry))),
     vscode.commands.registerCommand('workcenter.createItem',
       wrapCommand('Failed to create item', () => handleCreateItem(workGraph))),
     vscode.commands.registerCommand('workcenter.acceptToFocus',

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -309,7 +309,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   );
 
   const commandRegStart = performance.now();
-  registerCommands(context, wg, ar, ss);
+  registerCommands(context, wg, ar, ss, pr);
   logger.info(`Command registration took ${Math.round(performance.now() - commandRegStart)}ms`);
 
   logger.info(`WorkCenter activated in ${Math.round(performance.now() - activationStart)}ms`);

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -52,12 +52,21 @@ class MockTreeItem {
   }
 }
 
+const ProgressLocation = {
+  SourceControl: 1,
+  Window: 10,
+  Notification: 15,
+};
+
 const window = {
   showInputBox: vi.fn(),
   showInformationMessage: vi.fn().mockResolvedValue(undefined),
   showWarningMessage: vi.fn(),
   showErrorMessage: vi.fn(),
   showQuickPick: vi.fn(),
+  withProgress: vi.fn((_options: any, task: (progress: any, token: any) => Promise<any>) =>
+    task({ report: vi.fn() }, { isCancellationRequested: false, onCancellationRequested: vi.fn() }),
+  ),
   registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })),
   createTreeView: vi.fn(() => {
     const selectionEmitter = new MockEventEmitter();
@@ -161,6 +170,7 @@ export {
   MockDisposable as Disposable,
   TreeItemCollapsibleState,
   ViewColumn,
+  ProgressLocation,
   window,
   commands,
   env,

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -64,9 +64,16 @@ const window = {
   showWarningMessage: vi.fn(),
   showErrorMessage: vi.fn(),
   showQuickPick: vi.fn(),
-  withProgress: vi.fn((_options: any, task: (progress: any, token: any) => Promise<any>) =>
-    task({ report: vi.fn() }, { isCancellationRequested: false, onCancellationRequested: vi.fn() }),
-  ),
+  withProgress: vi.fn((_options: any, task: (progress: any, token: any) => Promise<any>) => {
+    const cancellationEmitter = new MockEventEmitter();
+    return task(
+      { report: vi.fn() },
+      {
+        isCancellationRequested: false,
+        onCancellationRequested: cancellationEmitter.event,
+      },
+    );
+  }),
   registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })),
   createTreeView: vi.fn(() => {
     const selectionEmitter = new MockEventEmitter();

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -182,7 +182,7 @@ describe('registerCommands', () => {
       await invoke('workcenter.refresh');
 
       expect(vscode.window.withProgress).toHaveBeenCalledWith(
-        expect.objectContaining({ location: (vscode as any).ProgressLocation.Window }),
+        expect.objectContaining({ location: vscode.ProgressLocation.Window }),
         expect.any(Function),
       );
       expect(providerRegistry.refreshAll).toHaveBeenCalled();

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -4,6 +4,7 @@ import { WorkItemState, type WorkItem } from '../models/workItem';
 import { registerCommands, isSafeUrl } from '../commands/commands';
 import type { WorkGraph } from '../services/workGraph';
 import type { ActionRegistry } from '../services/actionRegistry';
+import type { ProviderRegistry } from '../services/providerRegistry';
 import type { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import type { InboxItem } from '../views/inboxTreeProvider';
 import type { SourceItemNode } from '../views/sourcesTreeProvider';
@@ -86,6 +87,14 @@ function createMockStateStore(): { [K in keyof UsedStateStoreMethods]: Mock } {
   };
 }
 
+type UsedProviderRegistryMethods = Pick<ProviderRegistry, 'refreshAll'>;
+
+function createMockProviderRegistry(): { [K in keyof UsedProviderRegistryMethods]: Mock } {
+  return {
+    refreshAll: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 // ── test setup ───────────────────────────────────────────────────────
 
 // Capture handlers registered via vscode.commands.registerCommand
@@ -101,6 +110,7 @@ describe('registerCommands', () => {
   let workGraph: ReturnType<typeof createMockWorkGraph>;
   let actionRegistry: ReturnType<typeof createMockActionRegistry>;
   let stateStore: ReturnType<typeof createMockStateStore>;
+  let providerRegistry: ReturnType<typeof createMockProviderRegistry>;
   let ctx: vscode.ExtensionContext;
 
   beforeEach(() => {
@@ -121,9 +131,10 @@ describe('registerCommands', () => {
     workGraph = createMockWorkGraph();
     actionRegistry = createMockActionRegistry();
     stateStore = createMockStateStore();
+    providerRegistry = createMockProviderRegistry();
     ctx = createMockContext();
 
-    registerCommands(ctx, workGraph as any, actionRegistry as any, stateStore as any);
+    registerCommands(ctx, workGraph as any, actionRegistry as any, stateStore as any, providerRegistry as any);
   });
 
   // helper to invoke a registered command
@@ -139,6 +150,7 @@ describe('registerCommands', () => {
 
   it('registers all expected commands', () => {
     const expected = [
+      'workcenter.refresh',
       'workcenter.createItem',
       'workcenter.acceptToFocus',
       'workcenter.archiveItem',
@@ -161,6 +173,20 @@ describe('registerCommands', () => {
 
   it('pushes disposables into context.subscriptions', () => {
     expect(ctx.subscriptions.length).toBeGreaterThan(0);
+  });
+
+  // ── refresh ──────────────────────────────────────────────────────
+
+  describe('workcenter.refresh', () => {
+    it('calls providerRegistry.refreshAll and shows progress', async () => {
+      await invoke('workcenter.refresh');
+
+      expect(vscode.window.withProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ location: (vscode as any).ProgressLocation.Window }),
+        expect.any(Function),
+      );
+      expect(providerRegistry.refreshAll).toHaveBeenCalled();
+    });
   });
 
   // ── createItem ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Adds a manual refresh command (`workcenter.refresh`) so users can trigger a re-fetch of all provider data on demand.

## Changes
- **New command**: `workcenter.refresh` — calls `providerRegistry.refreshAll()` with a non-intrusive progress indicator in the VS Code status bar
- **Refresh button**: Added a `$(refresh)` icon button to the title bar of the two provider-backed views (Inbox and Sources). Queue, Focus, and History are local-data views and do not need a refresh button.
- **Command palette**: The command is available as "WorkCenter: Refresh" in the command palette
- Updated `registerCommands()` to accept `ProviderRegistry` as a parameter
- Added `withProgress` and `ProgressLocation` to the VS Code test mock
- Added test coverage for the new command

## Testing
- All existing tests pass
- New test verifies `refreshAll()` is called with progress notification

Closes #176
