### PR TITLE
feat: add flat/tree layout toggle for all views

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -279,7 +279,7 @@
         },
         {
           "command": "workcenter.archiveItem",
-          "when": "view == workcenter.focus",
+          "when": "view == workcenter.focus && viewItem =~ /^(active|paused)/",
           "group": "1_actions"
         },
         {
@@ -309,12 +309,12 @@
         },
         {
           "command": "workcenter.focusMoveUp",
-          "when": "view == workcenter.focus",
+          "when": "view == workcenter.focus && viewItem =~ /^(active|paused)/",
           "group": "3_reorder@1"
         },
         {
           "command": "workcenter.focusMoveDown",
-          "when": "view == workcenter.focus",
+          "when": "view == workcenter.focus && viewItem =~ /^(active|paused)/",
           "group": "3_reorder@2"
         },
         {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,6 +33,19 @@
           "type": "boolean",
           "default": true,
           "description": "Show a notification when new items arrive in the Inbox"
+        },
+        "workcenter.viewLayout": {
+          "type": "object",
+          "default": {},
+          "description": "Per-view layout mode. Keys are view names (inbox, queue, focus, history, sources) and values are 'flat' or 'tree'.",
+          "properties": {
+            "inbox": { "type": "string", "enum": ["flat", "tree"], "default": "tree" },
+            "queue": { "type": "string", "enum": ["flat", "tree"], "default": "flat" },
+            "focus": { "type": "string", "enum": ["flat", "tree"], "default": "flat" },
+            "history": { "type": "string", "enum": ["flat", "tree"], "default": "flat" },
+            "sources": { "type": "string", "enum": ["flat", "tree"], "default": "tree" }
+          },
+          "additionalProperties": false
         }
       }
     },
@@ -153,6 +166,36 @@
         "title": "Accept to Queue",
         "category": "WorkCenter",
         "icon": "$(arrow-right)"
+      },
+      {
+        "command": "workcenter.toggleInboxLayout",
+        "title": "Toggle Inbox Layout",
+        "category": "WorkCenter",
+        "icon": "$(list-tree)"
+      },
+      {
+        "command": "workcenter.toggleQueueLayout",
+        "title": "Toggle Queue Layout",
+        "category": "WorkCenter",
+        "icon": "$(list-tree)"
+      },
+      {
+        "command": "workcenter.toggleFocusLayout",
+        "title": "Toggle Focus Layout",
+        "category": "WorkCenter",
+        "icon": "$(list-tree)"
+      },
+      {
+        "command": "workcenter.toggleHistoryLayout",
+        "title": "Toggle History Layout",
+        "category": "WorkCenter",
+        "icon": "$(list-tree)"
+      },
+      {
+        "command": "workcenter.toggleSourcesLayout",
+        "title": "Toggle Sources Layout",
+        "category": "WorkCenter",
+        "icon": "$(list-tree)"
       }
     ],
     "menus": {
@@ -160,6 +203,31 @@
         {
           "command": "workcenter.createItem",
           "when": "view == workcenter.queue",
+          "group": "navigation"
+        },
+        {
+          "command": "workcenter.toggleInboxLayout",
+          "when": "view == workcenter.inbox",
+          "group": "navigation"
+        },
+        {
+          "command": "workcenter.toggleQueueLayout",
+          "when": "view == workcenter.queue",
+          "group": "navigation"
+        },
+        {
+          "command": "workcenter.toggleFocusLayout",
+          "when": "view == workcenter.focus",
+          "group": "navigation"
+        },
+        {
+          "command": "workcenter.toggleHistoryLayout",
+          "when": "view == workcenter.history",
+          "group": "navigation"
+        },
+        {
+          "command": "workcenter.toggleSourcesLayout",
+          "when": "view == workcenter.sources",
           "group": "navigation"
         }
       ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -244,7 +244,7 @@
         },
         {
           "command": "workcenter.completeItem",
-          "when": "view == workcenter.focus",
+          "when": "view == workcenter.focus && viewItem =~ /^(active|paused)/",
           "group": "inline"
         },
         {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -288,7 +288,7 @@
         },
         {
           "command": "workcenter.deleteItem",
-          "when": "view == workcenter.queue",
+          "when": "view == workcenter.queue && viewItem =~ /^queueItem/",
           "group": "1_actions"
         },
         {
@@ -383,7 +383,7 @@
         },
         {
           "command": "workcenter.deleteItem",
-          "when": "view == workcenter.history",
+          "when": "view == workcenter.history && viewItem =~ /^historyItem/",
           "group": "1_actions"
         }
       ]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -234,12 +234,12 @@
       "view/item/context": [
         {
           "command": "workcenter.acceptToFocus",
-          "when": "view == workcenter.queue",
+          "when": "view == workcenter.queue && viewItem =~ /^queueItem/",
           "group": "inline"
         },
         {
           "command": "workcenter.archiveItem",
-          "when": "view == workcenter.queue",
+          "when": "view == workcenter.queue && viewItem =~ /^queueItem/",
           "group": "1_actions"
         },
         {
@@ -259,12 +259,12 @@
         },
         {
           "command": "workcenter.moveUp",
-          "when": "view == workcenter.queue",
+          "when": "view == workcenter.queue && viewItem =~ /^queueItem/",
           "group": "3_reorder"
         },
         {
           "command": "workcenter.moveDown",
-          "when": "view == workcenter.queue",
+          "when": "view == workcenter.queue && viewItem =~ /^queueItem/",
           "group": "3_reorder"
         },
         {
@@ -274,7 +274,7 @@
         },
         {
           "command": "workcenter.runAction",
-          "when": "view == workcenter.queue || view == workcenter.focus",
+          "when": "(view == workcenter.queue && viewItem =~ /^queueItem/) || (view == workcenter.focus && viewItem =~ /^(active|paused)/)",
           "group": "0_actions"
         },
         {

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -7,6 +7,7 @@ import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
 import { InboxItem } from '../views/inboxTreeProvider';
 import { SourceItemNode } from '../views/sourcesTreeProvider';
 import { logger } from '../services/logger';
+import { toggleViewLayout, ViewId } from '../views/viewLayout';
 
 /** Builds a work-item title, optionally prefixed with the provider group. */
 function formatItemTitle(item: { group?: string; title: string }): string {
@@ -309,5 +310,15 @@ export function registerCommands(
       wrapCommand('Failed to dismiss from inbox', (item: InboxItem) => handleDismissFromInbox(stateStore, item))),
     vscode.commands.registerCommand('workcenter.acceptFromSources',
       wrapCommand('Failed to accept from sources', (item: SourceItemNode) => handleAcceptFromSources(workGraph, stateStore, item))),
+    vscode.commands.registerCommand('workcenter.toggleInboxLayout',
+      wrapCommand('Failed to toggle inbox layout', () => toggleViewLayout('inbox'))),
+    vscode.commands.registerCommand('workcenter.toggleQueueLayout',
+      wrapCommand('Failed to toggle queue layout', () => toggleViewLayout('queue'))),
+    vscode.commands.registerCommand('workcenter.toggleFocusLayout',
+      wrapCommand('Failed to toggle focus layout', () => toggleViewLayout('focus'))),
+    vscode.commands.registerCommand('workcenter.toggleHistoryLayout',
+      wrapCommand('Failed to toggle history layout', () => toggleViewLayout('history'))),
+    vscode.commands.registerCommand('workcenter.toggleSourcesLayout',
+      wrapCommand('Failed to toggle sources layout', () => toggleViewLayout('sources'))),
   );
 }

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -219,7 +219,7 @@ async function handleAcceptFromInbox(
   try {
     createdItem = await workGraph.createItem(
       { title: formatItemTitle(item) },
-      { providerId: item.providerId, externalId: item.externalId, url: item.url },
+      { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group },
     );
   } catch (err: unknown) {
     handleCommandError('Failed to accept inbox item', err);
@@ -285,7 +285,7 @@ async function handleAcceptFromSources(
   try {
     createdItem = await workGraph.createItem(
       { title: formatItemTitle(item) },
-      { providerId: item.providerId, externalId: item.externalId, url: item.url },
+      { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group },
     );
   } catch (err: unknown) {
     handleCommandError('Failed to accept sources item', err);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -7,7 +7,7 @@ import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
 import { InboxItem } from '../views/inboxTreeProvider';
 import { SourceItemNode } from '../views/sourcesTreeProvider';
 import { logger } from '../services/logger';
-import { toggleViewLayout, ViewId } from '../views/viewLayout';
+import { toggleViewLayout } from '../views/viewLayout';
 
 /** Builds a work-item title, optionally prefixed with the provider group. */
 function formatItemTitle(item: { group?: string; title: string }): string {

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -112,10 +112,10 @@ function createTreeViews(
   workGraph: WorkGraph,
 ) {
   const inboxProvider = new InboxTreeProvider(providerRegistry, stateStore, readStateStore);
-  const queueProvider = new QueueTreeProvider(workGraph);
-  const focusProvider = new FocusTreeProvider(workGraph);
+  const queueProvider = new QueueTreeProvider(workGraph, providerRegistry);
+  const focusProvider = new FocusTreeProvider(workGraph, providerRegistry);
   const sourcesProvider = new SourcesTreeProvider(providerRegistry, stateStore);
-  const historyProvider = new HistoryTreeProvider(workGraph);
+  const historyProvider = new HistoryTreeProvider(workGraph, providerRegistry);
 
   // Apply persisted layout settings
   inboxProvider.layout = getViewLayout('inbox');

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -15,6 +15,7 @@ import { HistoryTreeProvider } from './views/historyTreeProvider';
 import { registerCommands } from './commands/commands';
 import { initLogger, setLogLevel, logger, resolveLogLevel } from './services/logger';
 import { getInboxUnseenCount } from './services/inboxBadge';
+import { getViewLayout, ViewId } from './views/viewLayout';
 import { performance } from 'perf_hooks';
 
 export type { WorkCenterApi, WorkCenterProvider, WorkCenterAction, DiscoveredItem, Disposable } from './api/types';
@@ -115,6 +116,13 @@ function createTreeViews(
   const focusProvider = new FocusTreeProvider(workGraph);
   const sourcesProvider = new SourcesTreeProvider(providerRegistry, stateStore);
   const historyProvider = new HistoryTreeProvider(workGraph);
+
+  // Apply persisted layout settings
+  inboxProvider.layout = getViewLayout('inbox');
+  queueProvider.layout = getViewLayout('queue');
+  focusProvider.layout = getViewLayout('focus');
+  sourcesProvider.layout = getViewLayout('sources');
+  historyProvider.layout = getViewLayout('history');
 
   const inboxTreeView = vscode.window.createTreeView('workcenter.inbox', { treeDataProvider: inboxProvider });
   const sourcesTreeView = vscode.window.createTreeView('workcenter.sources', { treeDataProvider: sourcesProvider });
@@ -311,6 +319,30 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
   const commandRegStart = performance.now();
   registerCommands(context, wg, ar, ss);
   logger.info(`Command registration took ${Math.round(performance.now() - commandRegStart)}ms`);
+
+  // Set context keys and listen for layout changes
+  const viewIds: ViewId[] = ['inbox', 'queue', 'focus', 'history', 'sources'];
+  const providerMap: Record<ViewId, { layout: import('./views/viewLayout').ViewLayout }> = {
+    inbox: providers.inboxProvider,
+    queue: providers.queueProvider,
+    focus: providers.focusProvider,
+    history: providers.historyProvider,
+    sources: providers.sourcesProvider,
+  };
+  for (const id of viewIds) {
+    void vscode.commands.executeCommand('setContext', `workcenter.${id}Layout`, getViewLayout(id));
+  }
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeConfiguration(safeHandler('Error handling viewLayout configuration change', (e) => {
+      if (e.affectsConfiguration('workcenter.viewLayout')) {
+        for (const id of viewIds) {
+          const layout = getViewLayout(id);
+          providerMap[id].layout = layout;
+          void vscode.commands.executeCommand('setContext', `workcenter.${id}Layout`, layout);
+        }
+      }
+    })),
+  );
 
   logger.info(`WorkCenter activated in ${Math.round(performance.now() - activationStart)}ms`);
   return api;

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -50,6 +50,8 @@ export interface WorkItem {
   externalId?: string;
   /** URL to the item in its source system (e.g. GitHub issue page). */
   url?: string;
+  /** Optional grouping key for organizing items within a provider in tree views. */
+  group?: string;
   /** Ordering key within items of the same state. Lower values sort first. */
   sortOrder?: number;
   /** Epoch timestamp (ms) when the item was created. */

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -163,7 +163,7 @@ export class WorkGraph {
   /** Create a new work item, optionally linking it to a provider-discovered source. */
   async createItem(
     input: WorkItemInput,
-    provenance?: { providerId: string; externalId: string; url?: string },
+    provenance?: { providerId: string; externalId: string; url?: string; group?: string },
   ): Promise<WorkItem> {
     const sortOrder = this.nextSortOrder(WorkItemState.New);
     const item: WorkItem = {
@@ -174,6 +174,7 @@ export class WorkGraph {
       providerId: provenance?.providerId,
       externalId: provenance?.externalId,
       url: provenance?.url,
+      group: provenance?.group,
       sortOrder,
       createdAt: Date.now(),
       updatedAt: Date.now(),

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -147,6 +147,7 @@ const workspace = {
   getConfiguration: vi.fn().mockReturnValue({
     get: vi.fn((key: string, defaultValue?: any) => defaultValue),
     update: vi.fn().mockResolvedValue(undefined),
+    inspect: vi.fn(() => undefined),
   }),
   onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
 };

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -146,8 +146,15 @@ class MockDisposable {
 const workspace = {
   getConfiguration: vi.fn().mockReturnValue({
     get: vi.fn((key: string, defaultValue?: any) => defaultValue),
+    update: vi.fn().mockResolvedValue(undefined),
   }),
   onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+};
+
+const ConfigurationTarget = {
+  Global: 1,
+  Workspace: 2,
+  WorkspaceFolder: 3,
 };
 
 export {
@@ -161,6 +168,7 @@ export {
   MockDisposable as Disposable,
   TreeItemCollapsibleState,
   ViewColumn,
+  ConfigurationTarget,
   window,
   commands,
   env,

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -445,6 +445,66 @@ describe('activate()', () => {
       errorSpy.mockRestore();
     }
   });
+
+  // ------------------------------------------------------------------
+  // 18. Sets context keys for all five view layouts on activation
+  // ------------------------------------------------------------------
+  it('sets layout context keys for all five views on activation', async () => {
+    await activate(context);
+
+    const executeCommand = vscode.commands.executeCommand as ReturnType<typeof vi.fn>;
+    const setContextCalls = executeCommand.mock.calls.filter(
+      (c: any[]) => c[0] === 'setContext' && typeof c[1] === 'string' && c[1].endsWith('Layout'),
+    );
+
+    const contextKeys = setContextCalls.map((c: any[]) => c[1]);
+    expect(contextKeys).toContain('workcenter.inboxLayout');
+    expect(contextKeys).toContain('workcenter.queueLayout');
+    expect(contextKeys).toContain('workcenter.focusLayout');
+    expect(contextKeys).toContain('workcenter.historyLayout');
+    expect(contextKeys).toContain('workcenter.sourcesLayout');
+  });
+
+  // ------------------------------------------------------------------
+  // 19. Layout config change updates provider layouts and context keys
+  // ------------------------------------------------------------------
+  it('updates provider layouts and context keys on configuration change', async () => {
+    await activate(context);
+    await flushMicrotasks();
+
+    const executeCommand = vscode.commands.executeCommand as ReturnType<typeof vi.fn>;
+    executeCommand.mockClear();
+
+    // Simulate a configuration change for workcenter.viewLayout
+    const onDidChangeCfg = vscode.workspace.onDidChangeConfiguration as ReturnType<typeof vi.fn>;
+    // Find the viewLayout config listener (the last registered one)
+    const listeners = onDidChangeCfg.mock.calls.map((c: any[]) => c[0]);
+    expect(listeners.length).toBeGreaterThan(0);
+
+    // Mock getConfiguration to return a specific layout
+    (vscode.workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
+      get: vi.fn((_key: string) => {
+        if (_key === 'viewLayout') { return { focus: 'tree', queue: 'tree' }; }
+        return undefined;
+      }),
+      update: vi.fn().mockResolvedValue(undefined),
+      inspect: vi.fn(() => undefined),
+    });
+
+    // Fire configuration change event on all listeners
+    for (const listener of listeners) {
+      listener({ affectsConfiguration: (section: string) => section === 'workcenter.viewLayout' });
+    }
+    await flushMicrotasks();
+
+    // setContext should have been called for all five views
+    const setContextCalls = executeCommand.mock.calls.filter(
+      (c: any[]) => c[0] === 'setContext' && typeof c[1] === 'string' && c[1].endsWith('Layout'),
+    );
+    const contextKeys = setContextCalls.map((c: any[]) => c[1]);
+    expect(contextKeys).toContain('workcenter.focusLayout');
+    expect(contextKeys).toContain('workcenter.queueLayout');
+  });
 });
 
 describe('deactivate()', () => {

--- a/packages/core/src/test/focusTreeProviderLayout.test.ts
+++ b/packages/core/src/test/focusTreeProviderLayout.test.ts
@@ -24,13 +24,20 @@ function makeItem(overrides: Partial<WorkItem> = {}): WorkItem {
   };
 }
 
+function createMockProviderRegistry(labels: Record<string, string> = {}) {
+  return {
+    getProviderLabel: vi.fn((id: string) => labels[id] ?? id),
+  };
+}
+
 describe('FocusTreeProvider layout toggle', () => {
   let workGraph: ReturnType<typeof createMockWorkGraph>;
   let provider: FocusTreeProvider;
+  const providerLabels: Record<string, string> = { github: 'GitHub', jira: 'Jira' };
 
   beforeEach(() => {
     workGraph = createMockWorkGraph();
-    provider = new FocusTreeProvider(workGraph as any);
+    provider = new FocusTreeProvider(workGraph as any, createMockProviderRegistry(providerLabels) as any);
   });
 
   it('defaults to flat layout', () => {
@@ -49,7 +56,7 @@ describe('FocusTreeProvider layout toggle', () => {
       provider.layout = 'tree';
     });
 
-    it('returns provider group nodes at top level', () => {
+    it('returns provider group nodes with display names at top level', () => {
       const items = [
         makeItem({ id: '1', title: 'A', providerId: 'github', state: WorkItemState.InProgress }),
         makeItem({ id: '2', title: 'B', providerId: 'jira', state: WorkItemState.Paused }),
@@ -58,6 +65,9 @@ describe('FocusTreeProvider layout toggle', () => {
       const children = provider.getChildren();
       expect(children).toHaveLength(2);
       expect(children.every(c => isProviderGroupNode(c))).toBe(true);
+      const labels = children.map(c => (c as ProviderGroupNode).label);
+      expect(labels).toContain('GitHub');
+      expect(labels).toContain('Jira');
     });
 
     it('groups items without providerId under "Other"', () => {
@@ -82,9 +92,9 @@ describe('FocusTreeProvider layout toggle', () => {
     });
 
     it('renders group node correctly', () => {
-      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'github', providerId: 'github' };
+      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'GitHub', providerId: 'github' };
       const treeItem = provider.getTreeItem(group);
-      expect(treeItem.label).toBe('github');
+      expect(treeItem.label).toBe('GitHub');
       expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
       expect(treeItem.contextValue).toBe('focusGroup');
       expect((treeItem.iconPath as any).id).toBe('plug');

--- a/packages/core/src/test/focusTreeProviderLayout.test.ts
+++ b/packages/core/src/test/focusTreeProviderLayout.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventEmitter, TreeItemCollapsibleState } from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { FocusTreeProvider } from '../views/focusTreeProvider';
-import { isProviderGroupNode, ProviderGroupNode } from '../views/viewLayout';
+import { isProviderGroupNode, isSubGroupNode, ProviderGroupNode, SubGroupNode } from '../views/viewLayout';
 
 function createMockWorkGraph() {
   const emitter = new EventEmitter<void>();
@@ -104,6 +104,45 @@ describe('FocusTreeProvider layout toggle', () => {
       const group: ProviderGroupNode = { kind: 'providerGroup', label: 'Other', providerId: undefined };
       const treeItem = provider.getTreeItem(group);
       expect((treeItem.iconPath as any).id).toBe('circle-filled');
+    });
+
+    it('groups items by sub-group within a provider', () => {
+      const items = [
+        makeItem({ id: '1', title: 'Bug A', providerId: 'github', state: WorkItemState.InProgress, group: 'bugs' }),
+        makeItem({ id: '2', title: 'Bug B', providerId: 'github', state: WorkItemState.InProgress, group: 'bugs' }),
+        makeItem({ id: '3', title: 'Feature', providerId: 'github', state: WorkItemState.Paused, group: 'features' }),
+        makeItem({ id: '4', title: 'Ungrouped', providerId: 'github', state: WorkItemState.InProgress }),
+      ];
+      workGraph.getItemsByState.mockReturnValue(items);
+      const topLevel = provider.getChildren();
+      expect(topLevel).toHaveLength(1);
+
+      const providerChildren = provider.getChildren(topLevel[0]);
+      const subGroups = providerChildren.filter(c => isSubGroupNode(c)) as SubGroupNode[];
+      const directItems = providerChildren.filter(c => !isSubGroupNode(c));
+      expect(subGroups).toHaveLength(2);
+      expect(subGroups.map(g => g.groupName).sort()).toEqual(['bugs', 'features']);
+      expect(directItems).toHaveLength(1);
+    });
+
+    it('returns items for a sub-group', () => {
+      const items = [
+        makeItem({ id: '1', title: 'Bug A', providerId: 'github', state: WorkItemState.InProgress, group: 'bugs' }),
+        makeItem({ id: '2', title: 'Bug B', providerId: 'github', state: WorkItemState.InProgress, group: 'bugs' }),
+        makeItem({ id: '3', title: 'Feature', providerId: 'github', state: WorkItemState.Paused, group: 'features' }),
+      ];
+      workGraph.getItemsByState.mockReturnValue(items);
+      const subGroup: SubGroupNode = { kind: 'subGroup', label: 'bugs', providerId: 'github', groupName: 'bugs' };
+      const children = provider.getChildren(subGroup);
+      expect(children).toHaveLength(2);
+    });
+
+    it('renders sub-group node with folder icon', () => {
+      const subGroup: SubGroupNode = { kind: 'subGroup', label: 'bugs', providerId: 'github', groupName: 'bugs' };
+      const treeItem = provider.getTreeItem(subGroup);
+      expect(treeItem.label).toBe('bugs');
+      expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
+      expect((treeItem.iconPath as any).id).toBe('folder');
     });
   });
 });

--- a/packages/core/src/test/focusTreeProviderLayout.test.ts
+++ b/packages/core/src/test/focusTreeProviderLayout.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventEmitter, TreeItemCollapsibleState } from 'vscode';
+import { WorkItem, WorkItemState } from '../models/workItem';
+import { FocusTreeProvider } from '../views/focusTreeProvider';
+import { isProviderGroupNode, ProviderGroupNode } from '../views/viewLayout';
+
+function createMockWorkGraph() {
+  const emitter = new EventEmitter<void>();
+  return {
+    onDidChange: emitter.event,
+    getItemsByState: vi.fn((..._states: WorkItemState[]) => [] as WorkItem[]),
+    _fire: () => emitter.fire(),
+  };
+}
+
+function makeItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: 'item-1',
+    title: 'Test item',
+    state: WorkItemState.InProgress,
+    createdAt: 1700000000000,
+    updatedAt: 1700000000000,
+    ...overrides,
+  };
+}
+
+describe('FocusTreeProvider layout toggle', () => {
+  let workGraph: ReturnType<typeof createMockWorkGraph>;
+  let provider: FocusTreeProvider;
+
+  beforeEach(() => {
+    workGraph = createMockWorkGraph();
+    provider = new FocusTreeProvider(workGraph as any);
+  });
+
+  it('defaults to flat layout', () => {
+    expect(provider.layout).toBe('flat');
+  });
+
+  it('fires tree data change when layout changes', () => {
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.layout = 'tree';
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  describe('tree mode', () => {
+    beforeEach(() => {
+      provider.layout = 'tree';
+    });
+
+    it('returns provider group nodes at top level', () => {
+      const items = [
+        makeItem({ id: '1', title: 'A', providerId: 'github', state: WorkItemState.InProgress }),
+        makeItem({ id: '2', title: 'B', providerId: 'jira', state: WorkItemState.Paused }),
+      ];
+      workGraph.getItemsByState.mockReturnValue(items);
+      const children = provider.getChildren();
+      expect(children).toHaveLength(2);
+      expect(children.every(c => isProviderGroupNode(c))).toBe(true);
+    });
+
+    it('groups items without providerId under "Other"', () => {
+      const items = [
+        makeItem({ id: '1', title: 'Manual', state: WorkItemState.InProgress }),
+      ];
+      workGraph.getItemsByState.mockReturnValue(items);
+      const children = provider.getChildren();
+      expect(children).toHaveLength(1);
+      expect((children[0] as ProviderGroupNode).label).toBe('Other');
+    });
+
+    it('returns items for a provider group', () => {
+      const items = [
+        makeItem({ id: '1', title: 'A', providerId: 'github', state: WorkItemState.InProgress }),
+        makeItem({ id: '2', title: 'B', providerId: 'jira', state: WorkItemState.Paused }),
+      ];
+      workGraph.getItemsByState.mockReturnValue(items);
+      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'github', providerId: 'github' };
+      const children = provider.getChildren(group);
+      expect(children.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders group node correctly', () => {
+      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'github', providerId: 'github' };
+      const treeItem = provider.getTreeItem(group);
+      expect(treeItem.label).toBe('github');
+      expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
+      expect(treeItem.contextValue).toBe('focusGroup');
+      expect((treeItem.iconPath as any).id).toBe('plug');
+    });
+
+    it('renders "Other" group with circle-filled icon', () => {
+      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'Other', providerId: undefined };
+      const treeItem = provider.getTreeItem(group);
+      expect((treeItem.iconPath as any).id).toBe('circle-filled');
+    });
+  });
+});

--- a/packages/core/src/test/historyTreeProviderLayout.test.ts
+++ b/packages/core/src/test/historyTreeProviderLayout.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventEmitter, TreeItemCollapsibleState } from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { HistoryTreeProvider } from '../views/historyTreeProvider';
-import { isProviderGroupNode, ProviderGroupNode } from '../views/viewLayout';
+import { isProviderGroupNode, isSubGroupNode, ProviderGroupNode, SubGroupNode } from '../views/viewLayout';
 
 function createMockWorkGraph(items: WorkItem[] = []) {
   const emitter = new EventEmitter<void>();
@@ -130,6 +130,42 @@ describe('HistoryTreeProvider layout toggle', () => {
     it('returns empty for item node children', () => {
       const item = makeItem({ id: '1', title: 'X', state: WorkItemState.Done });
       expect(provider.getChildren(item)).toEqual([]);
+    });
+
+    it('groups items by sub-group within a provider', () => {
+      workGraph._setItems([
+        makeItem({ id: '1', title: 'Bug A', state: WorkItemState.Done, providerId: 'github', group: 'bugs' }),
+        makeItem({ id: '2', title: 'Bug B', state: WorkItemState.Done, providerId: 'github', group: 'bugs' }),
+        makeItem({ id: '3', title: 'Feature', state: WorkItemState.Done, providerId: 'github', group: 'features' }),
+        makeItem({ id: '4', title: 'Ungrouped', state: WorkItemState.Done, providerId: 'github' }),
+      ]);
+      const topLevel = provider.getChildren();
+      expect(topLevel).toHaveLength(1);
+
+      const providerChildren = provider.getChildren(topLevel[0]);
+      const subGroups = providerChildren.filter(c => isSubGroupNode(c)) as SubGroupNode[];
+      const directItems = providerChildren.filter(c => !isSubGroupNode(c));
+      expect(subGroups).toHaveLength(2);
+      expect(subGroups.map(g => g.groupName).sort()).toEqual(['bugs', 'features']);
+      expect(directItems).toHaveLength(1);
+    });
+
+    it('returns items for a sub-group', () => {
+      workGraph._setItems([
+        makeItem({ id: '1', title: 'Bug A', state: WorkItemState.Done, providerId: 'github', group: 'bugs' }),
+        makeItem({ id: '2', title: 'Bug B', state: WorkItemState.Archived, providerId: 'github', group: 'bugs' }),
+      ]);
+      const subGroup: SubGroupNode = { kind: 'subGroup', label: 'bugs', providerId: 'github', groupName: 'bugs' };
+      const children = provider.getChildren(subGroup);
+      expect(children).toHaveLength(2);
+    });
+
+    it('renders sub-group node with folder icon', () => {
+      const subGroup: SubGroupNode = { kind: 'subGroup', label: 'bugs', providerId: 'github', groupName: 'bugs' };
+      const treeItem = provider.getTreeItem(subGroup);
+      expect(treeItem.label).toBe('bugs');
+      expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
+      expect((treeItem.iconPath as any).id).toBe('folder');
     });
   });
 });

--- a/packages/core/src/test/historyTreeProviderLayout.test.ts
+++ b/packages/core/src/test/historyTreeProviderLayout.test.ts
@@ -25,13 +25,20 @@ function makeItem(overrides: Partial<WorkItem> & { id: string; title: string }):
   };
 }
 
+function createMockProviderRegistry(labels: Record<string, string> = {}) {
+  return {
+    getProviderLabel: vi.fn((id: string) => labels[id] ?? id),
+  };
+}
+
 describe('HistoryTreeProvider layout toggle', () => {
   let workGraph: ReturnType<typeof createMockWorkGraph>;
   let provider: HistoryTreeProvider;
+  const providerLabels: Record<string, string> = { github: 'GitHub', jira: 'Jira', alpha: 'Alpha Provider' };
 
   beforeEach(() => {
     workGraph = createMockWorkGraph();
-    provider = new HistoryTreeProvider(workGraph as any);
+    provider = new HistoryTreeProvider(workGraph as any, createMockProviderRegistry(providerLabels) as any);
   });
 
   it('defaults to flat layout', () => {
@@ -88,7 +95,7 @@ describe('HistoryTreeProvider layout toggle', () => {
       expect(children).toHaveLength(2);
       const labels = children.map(c => (c as ProviderGroupNode).label);
       expect(labels).toContain('Other');
-      expect(labels).toContain('github');
+      expect(labels).toContain('GitHub');
     });
 
     it('sorts "Other" group last', () => {
@@ -113,9 +120,9 @@ describe('HistoryTreeProvider layout toggle', () => {
     });
 
     it('renders group node as collapsed tree item', () => {
-      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'github', providerId: 'github' };
+      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'GitHub', providerId: 'github' };
       const treeItem = provider.getTreeItem(group);
-      expect(treeItem.label).toBe('github');
+      expect(treeItem.label).toBe('GitHub');
       expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
       expect(treeItem.contextValue).toBe('historyGroup');
     });

--- a/packages/core/src/test/historyTreeProviderLayout.test.ts
+++ b/packages/core/src/test/historyTreeProviderLayout.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventEmitter, TreeItemCollapsibleState } from 'vscode';
+import { WorkItem, WorkItemState } from '../models/workItem';
+import { HistoryTreeProvider } from '../views/historyTreeProvider';
+import { isProviderGroupNode, ProviderGroupNode } from '../views/viewLayout';
+
+function createMockWorkGraph(items: WorkItem[] = []) {
+  const emitter = new EventEmitter<void>();
+  return {
+    getItemsByState: vi.fn((...states: WorkItemState[]) =>
+      items.filter(i => states.includes(i.state)),
+    ),
+    onDidChange: emitter.event,
+    _fire: () => emitter.fire(),
+    _setItems: (newItems: WorkItem[]) => { items = newItems; },
+  };
+}
+
+function makeItem(overrides: Partial<WorkItem> & { id: string; title: string }): WorkItem {
+  return {
+    state: WorkItemState.Done,
+    createdAt: 1000,
+    updatedAt: 2000,
+    ...overrides,
+  };
+}
+
+describe('HistoryTreeProvider layout toggle', () => {
+  let workGraph: ReturnType<typeof createMockWorkGraph>;
+  let provider: HistoryTreeProvider;
+
+  beforeEach(() => {
+    workGraph = createMockWorkGraph();
+    provider = new HistoryTreeProvider(workGraph as any);
+  });
+
+  it('defaults to flat layout', () => {
+    expect(provider.layout).toBe('flat');
+  });
+
+  it('fires tree data change when layout changes', () => {
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.layout = 'tree';
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire when setting same layout', () => {
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.layout = 'flat';
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  describe('flat mode (default)', () => {
+    it('returns work items directly', () => {
+      workGraph._setItems([
+        makeItem({ id: '1', title: 'Done item', state: WorkItemState.Done }),
+        makeItem({ id: '2', title: 'Archived item', state: WorkItemState.Archived }),
+      ]);
+      const children = provider.getChildren();
+      expect(children).toHaveLength(2);
+      expect(children.every(c => !isProviderGroupNode(c))).toBe(true);
+    });
+  });
+
+  describe('tree mode', () => {
+    beforeEach(() => {
+      provider.layout = 'tree';
+    });
+
+    it('returns provider group nodes at top level', () => {
+      workGraph._setItems([
+        makeItem({ id: '1', title: 'A', state: WorkItemState.Done, providerId: 'github' }),
+        makeItem({ id: '2', title: 'B', state: WorkItemState.Done, providerId: 'jira' }),
+      ]);
+      const children = provider.getChildren();
+      expect(children).toHaveLength(2);
+      expect(children.every(c => isProviderGroupNode(c))).toBe(true);
+    });
+
+    it('groups items without providerId under "Other"', () => {
+      workGraph._setItems([
+        makeItem({ id: '1', title: 'Manual', state: WorkItemState.Done }),
+        makeItem({ id: '2', title: 'Provider', state: WorkItemState.Done, providerId: 'github' }),
+      ]);
+      const children = provider.getChildren();
+      expect(children).toHaveLength(2);
+      const labels = children.map(c => (c as ProviderGroupNode).label);
+      expect(labels).toContain('Other');
+      expect(labels).toContain('github');
+    });
+
+    it('sorts "Other" group last', () => {
+      workGraph._setItems([
+        makeItem({ id: '1', title: 'Manual', state: WorkItemState.Done }),
+        makeItem({ id: '2', title: 'Provider', state: WorkItemState.Done, providerId: 'alpha' }),
+      ]);
+      const children = provider.getChildren();
+      expect((children[children.length - 1] as ProviderGroupNode).label).toBe('Other');
+    });
+
+    it('returns items for a provider group', () => {
+      workGraph._setItems([
+        makeItem({ id: '1', title: 'A', state: WorkItemState.Done, providerId: 'github' }),
+        makeItem({ id: '2', title: 'B', state: WorkItemState.Archived, providerId: 'github' }),
+        makeItem({ id: '3', title: 'C', state: WorkItemState.Done, providerId: 'jira' }),
+      ]);
+      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'github', providerId: 'github' };
+      const children = provider.getChildren(group);
+      expect(children).toHaveLength(2);
+      expect(children.every(c => !isProviderGroupNode(c))).toBe(true);
+    });
+
+    it('renders group node as collapsed tree item', () => {
+      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'github', providerId: 'github' };
+      const treeItem = provider.getTreeItem(group);
+      expect(treeItem.label).toBe('github');
+      expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
+      expect(treeItem.contextValue).toBe('historyGroup');
+    });
+
+    it('returns empty for item node children', () => {
+      const item = makeItem({ id: '1', title: 'X', state: WorkItemState.Done });
+      expect(provider.getChildren(item)).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/test/inboxTreeProviderLayout.test.ts
+++ b/packages/core/src/test/inboxTreeProviderLayout.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventEmitter } from 'vscode';
+import { DiscoveredItem } from '../api/types';
+import { InboxTreeProvider, InboxItem } from '../views/inboxTreeProvider';
+
+function createMockStateStore() {
+  const states = new Map<string, string>();
+  const emitter = new EventEmitter<void>();
+  return {
+    getState: vi.fn((pid: string, eid: string) => states.get(`${pid}::${eid}`) as any),
+    setState: vi.fn(),
+    setStates: vi.fn(),
+    onDidChange: emitter.event,
+    _set: (pid: string, eid: string, s: string) => states.set(`${pid}::${eid}`, s),
+    _fire: () => emitter.fire(),
+  };
+}
+
+function createMockReadStateStore() {
+  const keys = new Set<string>();
+  return {
+    has: vi.fn((key: string) => keys.has(key)),
+    add: vi.fn(async (key: string) => { keys.add(key); return true; }),
+    deleteMany: vi.fn(async () => {}),
+    load: vi.fn(async () => {}),
+    keys: vi.fn(() => keys.values()),
+  };
+}
+
+function createMockProviderRegistry() {
+  const items = new Map<string, DiscoveredItem[]>();
+  const labels = new Map<string, string>();
+  const emitter = new EventEmitter<void>();
+  return {
+    loading: false,
+    getAllDiscoveredItems: vi.fn(() => items),
+    getDiscoveredItems: vi.fn((id: string) => items.get(id) ?? []),
+    getProviderLabel: vi.fn((id: string) => labels.get(id) ?? id),
+    onDidChangeDiscoveredItems: emitter.event,
+    _setItems: (pid: string, list: DiscoveredItem[]) => { items.set(pid, list); },
+    _setLabel: (pid: string, label: string) => { labels.set(pid, label); },
+    _fire: () => emitter.fire(),
+  };
+}
+
+describe('InboxTreeProvider layout toggle', () => {
+  let registry: ReturnType<typeof createMockProviderRegistry>;
+  let stateStore: ReturnType<typeof createMockStateStore>;
+  let readStateStore: ReturnType<typeof createMockReadStateStore>;
+  let provider: InboxTreeProvider;
+
+  beforeEach(() => {
+    registry = createMockProviderRegistry();
+    stateStore = createMockStateStore();
+    readStateStore = createMockReadStateStore();
+    provider = new InboxTreeProvider(registry as any, stateStore as any, readStateStore as any);
+  });
+
+  it('defaults to tree layout', () => {
+    expect(provider.layout).toBe('tree');
+  });
+
+  it('fires tree data change when layout changes', () => {
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.layout = 'flat';
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  describe('tree mode (default)', () => {
+    it('returns provider nodes at top level', () => {
+      registry._setLabel('gh', 'GitHub');
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Issue #1' },
+        { externalId: '2', title: 'Issue #2' },
+      ]);
+      const children = provider.getChildren();
+      expect(children).toHaveLength(1);
+      expect(children[0].kind).toBe('provider');
+    });
+  });
+
+  describe('flat mode', () => {
+    beforeEach(() => {
+      provider.layout = 'flat';
+    });
+
+    it('returns all unseen items directly without hierarchy', () => {
+      registry._setLabel('gh', 'GitHub');
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Issue #1', group: 'repo-a' },
+        { externalId: '2', title: 'Issue #2', group: 'repo-b' },
+      ]);
+      const children = provider.getChildren();
+      expect(children).toHaveLength(2);
+      expect(children.every(c => c.kind === 'item')).toBe(true);
+    });
+
+    it('sorts items alphabetically by title', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Zebra' },
+        { externalId: '2', title: 'Alpha' },
+      ]);
+      const children = provider.getChildren();
+      expect(children.map(c => (c as InboxItem).title)).toEqual(['Alpha', 'Zebra']);
+    });
+
+    it('excludes accepted items', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Unseen' },
+        { externalId: '2', title: 'Accepted' },
+      ]);
+      stateStore._set('gh', '2', 'accepted');
+      const children = provider.getChildren();
+      expect(children).toHaveLength(1);
+      expect((children[0] as InboxItem).title).toBe('Unseen');
+    });
+
+    it('includes items from multiple providers', () => {
+      registry._setItems('gh', [{ externalId: '1', title: 'GH Issue' }]);
+      registry._setItems('jira', [{ externalId: '2', title: 'JIRA Issue' }]);
+      const children = provider.getChildren();
+      expect(children).toHaveLength(2);
+    });
+
+    it('returns empty array when no unseen items', () => {
+      registry._setItems('gh', [{ externalId: '1', title: 'Accepted' }]);
+      stateStore._set('gh', '1', 'accepted');
+      const children = provider.getChildren();
+      expect(children).toHaveLength(0);
+    });
+  });
+});

--- a/packages/core/src/test/queueTreeProviderLayout.test.ts
+++ b/packages/core/src/test/queueTreeProviderLayout.test.ts
@@ -162,4 +162,42 @@ describe('QueueTreeProvider layout toggle', () => {
       expect((treeItem.iconPath as any).id).toBe('folder');
     });
   });
+
+  describe('provider registration refresh', () => {
+    it('refreshes tree when provider registers, updating group labels', async () => {
+      // Simulate the startup timing issue: labels resolve to raw IDs before providers register
+      const { EventEmitter } = await import('vscode');
+      const registrationEmitter = new EventEmitter<void>();
+      const labelMap = new Map<string, string>();
+      const lateRegistry = {
+        getProviderLabel: vi.fn((id: string) => labelMap.get(id) ?? id),
+        onDidRegisterProvider: registrationEmitter.event,
+      };
+
+      const lateProvider = new QueueTreeProvider(graph, lateRegistry as any);
+      lateProvider.layout = 'tree';
+
+      await graph.createItem({ title: 'Item' }, { providerId: 'github', externalId: 'ext-1' });
+
+      // Before provider registration: label falls back to raw providerId
+      const childrenBefore = lateProvider.getChildren();
+      expect(childrenBefore).toHaveLength(1);
+      expect((childrenBefore[0] as ProviderGroupNode).label).toBe('github');
+
+      // Simulate provider registering with a display name
+      labelMap.set('github', 'GitHub Issues');
+      const listener = vi.fn();
+      lateProvider.onDidChangeTreeData(listener);
+
+      registrationEmitter.fire();
+
+      // Tree should have refreshed
+      expect(listener).toHaveBeenCalled();
+
+      // After refresh: label resolves to display name
+      const childrenAfter = lateProvider.getChildren();
+      expect(childrenAfter).toHaveLength(1);
+      expect((childrenAfter[0] as ProviderGroupNode).label).toBe('GitHub Issues');
+    });
+  });
 });

--- a/packages/core/src/test/queueTreeProviderLayout.test.ts
+++ b/packages/core/src/test/queueTreeProviderLayout.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TreeItemCollapsibleState } from 'vscode';
+import { WorkGraph } from '../services/workGraph';
+import { WorkItemState } from '../models/workItem';
+import { ITaskStore } from '../storage/taskStore';
+import { QueueTreeProvider } from '../views/queueTreeProvider';
+import { isProviderGroupNode, ProviderGroupNode } from '../views/viewLayout';
+
+function createMockStore(): ITaskStore {
+  const items: Map<string, any> = new Map();
+  return {
+    loadAll: vi.fn(async () => Array.from(items.values())),
+    save: vi.fn(async (item) => { items.set(item.id, item); }),
+    saveAll: vi.fn(async (batch) => { for (const item of batch) { items.set(item.id, item); } }),
+    delete: vi.fn(async (id) => { items.delete(id); }),
+  };
+}
+
+describe('QueueTreeProvider layout toggle', () => {
+  let store: ITaskStore;
+  let graph: WorkGraph;
+  let provider: QueueTreeProvider;
+
+  beforeEach(async () => {
+    store = createMockStore();
+    graph = new WorkGraph(store);
+    await graph.load();
+    provider = new QueueTreeProvider(graph);
+  });
+
+  it('defaults to flat layout', () => {
+    expect(provider.layout).toBe('flat');
+  });
+
+  it('fires tree data change when layout changes', () => {
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.layout = 'tree';
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire when setting same layout', () => {
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.layout = 'flat';
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  describe('flat mode (default)', () => {
+    it('returns work items directly', async () => {
+      await graph.createItem({ title: 'A' });
+      await graph.createItem({ title: 'B' });
+      const children = provider.getChildren();
+      expect(children).toHaveLength(2);
+      expect(children.every(c => !isProviderGroupNode(c))).toBe(true);
+    });
+  });
+
+  describe('tree mode', () => {
+    beforeEach(() => {
+      provider.layout = 'tree';
+    });
+
+    it('returns provider group nodes at top level', async () => {
+      await graph.createItem({ title: 'A' }, { providerId: 'github', externalId: 'ext-1' });
+      await graph.createItem({ title: 'B' }, { providerId: 'jira', externalId: 'ext-2' });
+      const children = provider.getChildren();
+      expect(children).toHaveLength(2);
+      expect(children.every(c => isProviderGroupNode(c))).toBe(true);
+    });
+
+    it('groups manual items under "Other"', async () => {
+      await graph.createItem({ title: 'Manual' });
+      await graph.createItem({ title: 'Provider' }, { providerId: 'github', externalId: 'ext-1' });
+      const children = provider.getChildren();
+      expect(children).toHaveLength(2);
+      const labels = children.map(c => (c as ProviderGroupNode).label);
+      expect(labels).toContain('Other');
+      expect(labels).toContain('github');
+    });
+
+    it('sorts "Other" group last', async () => {
+      await graph.createItem({ title: 'Manual' });
+      await graph.createItem({ title: 'Provider' }, { providerId: 'alpha', externalId: 'ext-1' });
+      const children = provider.getChildren();
+      expect((children[children.length - 1] as ProviderGroupNode).label).toBe('Other');
+    });
+
+    it('returns items for a provider group', async () => {
+      await graph.createItem({ title: 'A' }, { providerId: 'github', externalId: 'ext-1' });
+      await graph.createItem({ title: 'B' }, { providerId: 'github', externalId: 'ext-2' });
+      await graph.createItem({ title: 'C' }, { providerId: 'jira', externalId: 'ext-3' });
+      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'github', providerId: 'github' };
+      const children = provider.getChildren(group);
+      expect(children).toHaveLength(2);
+      expect(children.every(c => !isProviderGroupNode(c))).toBe(true);
+    });
+
+    it('renders group node as collapsed tree item', async () => {
+      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'github', providerId: 'github' };
+      const treeItem = provider.getTreeItem(group);
+      expect(treeItem.label).toBe('github');
+      expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
+      expect(treeItem.contextValue).toBe('queueGroup');
+      expect((treeItem.iconPath as any).id).toBe('plug');
+    });
+
+    it('renders "Other" group with circle-filled icon', () => {
+      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'Other', providerId: undefined };
+      const treeItem = provider.getTreeItem(group);
+      expect((treeItem.iconPath as any).id).toBe('circle-filled');
+    });
+
+    it('returns empty when no items exist', () => {
+      const children = provider.getChildren();
+      expect(children).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/test/queueTreeProviderLayout.test.ts
+++ b/packages/core/src/test/queueTreeProviderLayout.test.ts
@@ -4,7 +4,7 @@ import { WorkGraph } from '../services/workGraph';
 import { WorkItemState } from '../models/workItem';
 import { ITaskStore } from '../storage/taskStore';
 import { QueueTreeProvider } from '../views/queueTreeProvider';
-import { isProviderGroupNode, ProviderGroupNode } from '../views/viewLayout';
+import { isProviderGroupNode, isSubGroupNode, ProviderGroupNode, SubGroupNode } from '../views/viewLayout';
 
 function createMockStore(): ITaskStore {
   const items: Map<string, any> = new Map();
@@ -121,6 +121,45 @@ describe('QueueTreeProvider layout toggle', () => {
     it('returns empty when no items exist', () => {
       const children = provider.getChildren();
       expect(children).toEqual([]);
+    });
+
+    it('groups items by sub-group within a provider', async () => {
+      await graph.createItem({ title: 'Bug A' }, { providerId: 'github', externalId: 'ext-1', group: 'bugs' });
+      await graph.createItem({ title: 'Bug B' }, { providerId: 'github', externalId: 'ext-2', group: 'bugs' });
+      await graph.createItem({ title: 'Feature C' }, { providerId: 'github', externalId: 'ext-3', group: 'features' });
+      await graph.createItem({ title: 'Ungrouped' }, { providerId: 'github', externalId: 'ext-4' });
+
+      const topLevel = provider.getChildren();
+      expect(topLevel).toHaveLength(1);
+      expect(isProviderGroupNode(topLevel[0])).toBe(true);
+
+      const providerChildren = provider.getChildren(topLevel[0]);
+      const subGroups = providerChildren.filter(c => isSubGroupNode(c)) as SubGroupNode[];
+      const directItems = providerChildren.filter(c => !isSubGroupNode(c));
+
+      expect(subGroups).toHaveLength(2);
+      expect(subGroups.map(g => g.groupName).sort()).toEqual(['bugs', 'features']);
+      expect(directItems).toHaveLength(1);
+      expect((directItems[0] as any).title).toBe('Ungrouped');
+    });
+
+    it('returns items for a sub-group', async () => {
+      await graph.createItem({ title: 'Bug A' }, { providerId: 'github', externalId: 'ext-1', group: 'bugs' });
+      await graph.createItem({ title: 'Bug B' }, { providerId: 'github', externalId: 'ext-2', group: 'bugs' });
+      await graph.createItem({ title: 'Feature C' }, { providerId: 'github', externalId: 'ext-3', group: 'features' });
+
+      const subGroup: SubGroupNode = { kind: 'subGroup', label: 'bugs', providerId: 'github', groupName: 'bugs' };
+      const children = provider.getChildren(subGroup);
+      expect(children).toHaveLength(2);
+      expect(children.every(c => !isSubGroupNode(c) && !isProviderGroupNode(c))).toBe(true);
+    });
+
+    it('renders sub-group node with folder icon', () => {
+      const subGroup: SubGroupNode = { kind: 'subGroup', label: 'bugs', providerId: 'github', groupName: 'bugs' };
+      const treeItem = provider.getTreeItem(subGroup);
+      expect(treeItem.label).toBe('bugs');
+      expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
+      expect((treeItem.iconPath as any).id).toBe('folder');
     });
   });
 });

--- a/packages/core/src/test/queueTreeProviderLayout.test.ts
+++ b/packages/core/src/test/queueTreeProviderLayout.test.ts
@@ -20,12 +20,18 @@ describe('QueueTreeProvider layout toggle', () => {
   let store: ITaskStore;
   let graph: WorkGraph;
   let provider: QueueTreeProvider;
+  const mockRegistry = {
+    getProviderLabel: vi.fn((id: string) => {
+      const labels: Record<string, string> = { github: 'GitHub', jira: 'Jira', alpha: 'Alpha Provider' };
+      return labels[id] ?? id;
+    }),
+  };
 
   beforeEach(async () => {
     store = createMockStore();
     graph = new WorkGraph(store);
     await graph.load();
-    provider = new QueueTreeProvider(graph);
+    provider = new QueueTreeProvider(graph, mockRegistry as any);
   });
 
   it('defaults to flat layout', () => {
@@ -76,7 +82,7 @@ describe('QueueTreeProvider layout toggle', () => {
       expect(children).toHaveLength(2);
       const labels = children.map(c => (c as ProviderGroupNode).label);
       expect(labels).toContain('Other');
-      expect(labels).toContain('github');
+      expect(labels).toContain('GitHub');
     });
 
     it('sorts "Other" group last', async () => {
@@ -84,6 +90,7 @@ describe('QueueTreeProvider layout toggle', () => {
       await graph.createItem({ title: 'Provider' }, { providerId: 'alpha', externalId: 'ext-1' });
       const children = provider.getChildren();
       expect((children[children.length - 1] as ProviderGroupNode).label).toBe('Other');
+      expect((children[0] as ProviderGroupNode).label).toBe('Alpha Provider');
     });
 
     it('returns items for a provider group', async () => {
@@ -97,9 +104,9 @@ describe('QueueTreeProvider layout toggle', () => {
     });
 
     it('renders group node as collapsed tree item', async () => {
-      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'github', providerId: 'github' };
+      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'GitHub', providerId: 'github' };
       const treeItem = provider.getTreeItem(group);
-      expect(treeItem.label).toBe('github');
+      expect(treeItem.label).toBe('GitHub');
       expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
       expect(treeItem.contextValue).toBe('queueGroup');
       expect((treeItem.iconPath as any).id).toBe('plug');

--- a/packages/core/src/test/sourcesTreeProviderLayout.test.ts
+++ b/packages/core/src/test/sourcesTreeProviderLayout.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { EventEmitter } from 'vscode';
+import { DiscoveredItem } from '../api/types';
+import { SourcesTreeProvider, SourceItemNode } from '../views/sourcesTreeProvider';
+
+function createMockStateStore() {
+  const cache = new Map<string, string>();
+  const emitter = new EventEmitter<void>();
+  return {
+    getState: vi.fn((pid: string, eid: string) => cache.get(`${pid}::${eid}`) as any),
+    onDidChange: emitter.event,
+    _set: (pid: string, eid: string, state: string) => cache.set(`${pid}::${eid}`, state),
+    _fire: () => emitter.fire(),
+  };
+}
+
+function createMockProviderRegistry() {
+  const items = new Map<string, DiscoveredItem[]>();
+  const labels = new Map<string, string>();
+  const emitter = new EventEmitter<void>();
+  return {
+    getAllDiscoveredItems: vi.fn(() => items),
+    getDiscoveredItems: vi.fn((id: string) => items.get(id) ?? []),
+    getProviderLabel: vi.fn((id: string) => labels.get(id) ?? id),
+    onDidChangeDiscoveredItems: emitter.event,
+    _setItems: (pid: string, list: DiscoveredItem[]) => { items.set(pid, list); },
+    _setLabel: (pid: string, label: string) => { labels.set(pid, label); },
+    _fire: () => emitter.fire(),
+  };
+}
+
+describe('SourcesTreeProvider layout toggle', () => {
+  let stateStore: ReturnType<typeof createMockStateStore>;
+  let registry: ReturnType<typeof createMockProviderRegistry>;
+  let provider: SourcesTreeProvider;
+
+  beforeEach(() => {
+    stateStore = createMockStateStore();
+    registry = createMockProviderRegistry();
+    provider = new SourcesTreeProvider(registry as any, stateStore as any);
+  });
+
+  it('defaults to tree layout', () => {
+    expect(provider.layout).toBe('tree');
+  });
+
+  it('fires tree data change when layout changes', () => {
+    const listener = vi.fn();
+    provider.onDidChangeTreeData(listener);
+    provider.layout = 'flat';
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  describe('tree mode (default)', () => {
+    it('returns provider nodes at top level', () => {
+      registry._setLabel('gh', 'GitHub');
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Issue #1' },
+      ]);
+      const children = provider.getChildren();
+      expect(children).toHaveLength(1);
+      expect(children[0].kind).toBe('provider');
+    });
+  });
+
+  describe('flat mode', () => {
+    beforeEach(() => {
+      provider.layout = 'flat';
+    });
+
+    it('returns all items directly without hierarchy', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Issue #1', group: 'repo-a' },
+        { externalId: '2', title: 'PR #1', group: 'repo-b' },
+      ]);
+      const children = provider.getChildren();
+      expect(children).toHaveLength(2);
+      expect(children.every(c => c.kind === 'item')).toBe(true);
+    });
+
+    it('sorts items alphabetically by title', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Zebra' },
+        { externalId: '2', title: 'Alpha' },
+      ]);
+      const children = provider.getChildren();
+      expect(children.map(c => (c as SourceItemNode).title)).toEqual(['Alpha', 'Zebra']);
+    });
+
+    it('includes items from multiple providers', () => {
+      registry._setItems('gh', [{ externalId: '1', title: 'GH Issue' }]);
+      registry._setItems('jira', [{ externalId: '2', title: 'JIRA Issue' }]);
+      const children = provider.getChildren();
+      expect(children).toHaveLength(2);
+    });
+
+    it('returns empty array when no items exist', () => {
+      const children = provider.getChildren();
+      expect(children).toEqual([]);
+    });
+
+    it('skips providers with no items', () => {
+      registry._setItems('gh', []);
+      registry._setItems('jira', [{ externalId: '1', title: 'A' }]);
+      const children = provider.getChildren();
+      expect(children).toHaveLength(1);
+    });
+  });
+});

--- a/packages/core/src/test/viewLayout.test.ts
+++ b/packages/core/src/test/viewLayout.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { workspace, ConfigurationTarget } from 'vscode';
+import { getViewLayout, toggleViewLayout, isProviderGroupNode, ProviderGroupNode } from '../views/viewLayout';
+
+describe('viewLayout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getViewLayout', () => {
+    it('returns default "tree" for inbox when no config set', () => {
+      expect(getViewLayout('inbox')).toBe('tree');
+    });
+
+    it('returns default "flat" for queue when no config set', () => {
+      expect(getViewLayout('queue')).toBe('flat');
+    });
+
+    it('returns default "flat" for focus when no config set', () => {
+      expect(getViewLayout('focus')).toBe('flat');
+    });
+
+    it('returns default "flat" for history when no config set', () => {
+      expect(getViewLayout('history')).toBe('flat');
+    });
+
+    it('returns default "tree" for sources when no config set', () => {
+      expect(getViewLayout('sources')).toBe('tree');
+    });
+
+    it('returns configured value when set', () => {
+      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
+        get: vi.fn((_key: string, defaultValue?: any) => {
+          if (_key === 'viewLayout') { return { inbox: 'flat' }; }
+          return defaultValue;
+        }),
+      });
+      expect(getViewLayout('inbox')).toBe('flat');
+    });
+
+    it('falls back to default for invalid values', () => {
+      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
+        get: vi.fn((_key: string, defaultValue?: any) => {
+          if (_key === 'viewLayout') { return { inbox: 'invalid' }; }
+          return defaultValue;
+        }),
+      });
+      expect(getViewLayout('inbox')).toBe('tree');
+    });
+  });
+
+  describe('toggleViewLayout', () => {
+    it('toggles from tree to flat', async () => {
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
+        get: vi.fn((_key: string, defaultValue?: any) => {
+          if (_key === 'viewLayout') { return { inbox: 'tree' }; }
+          return defaultValue;
+        }),
+        update: mockUpdate,
+      });
+
+      await toggleViewLayout('inbox');
+      expect(mockUpdate).toHaveBeenCalledWith(
+        'viewLayout',
+        expect.objectContaining({ inbox: 'flat' }),
+        ConfigurationTarget.Global,
+      );
+    });
+
+    it('toggles from flat to tree', async () => {
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
+        get: vi.fn((_key: string, defaultValue?: any) => {
+          if (_key === 'viewLayout') { return { queue: 'flat' }; }
+          return defaultValue;
+        }),
+        update: mockUpdate,
+      });
+
+      await toggleViewLayout('queue');
+      expect(mockUpdate).toHaveBeenCalledWith(
+        'viewLayout',
+        expect.objectContaining({ queue: 'tree' }),
+        ConfigurationTarget.Global,
+      );
+    });
+
+    it('uses default when no config exists yet', async () => {
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
+        get: vi.fn((_key: string, defaultValue?: any) => defaultValue),
+        update: mockUpdate,
+      });
+
+      // sources defaults to 'tree', so toggle should set to 'flat'
+      await toggleViewLayout('sources');
+      expect(mockUpdate).toHaveBeenCalledWith(
+        'viewLayout',
+        expect.objectContaining({ sources: 'flat' }),
+        ConfigurationTarget.Global,
+      );
+    });
+  });
+
+  describe('isProviderGroupNode', () => {
+    it('returns true for valid ProviderGroupNode', () => {
+      const node: ProviderGroupNode = { kind: 'providerGroup', label: 'test', providerId: 'gh' };
+      expect(isProviderGroupNode(node)).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(isProviderGroupNode(null)).toBe(false);
+    });
+
+    it('returns false for undefined', () => {
+      expect(isProviderGroupNode(undefined)).toBe(false);
+    });
+
+    it('returns false for plain object without kind', () => {
+      expect(isProviderGroupNode({ label: 'test' })).toBe(false);
+    });
+
+    it('returns false for object with wrong kind', () => {
+      expect(isProviderGroupNode({ kind: 'item', label: 'test' })).toBe(false);
+    });
+
+    it('returns true for group node with undefined providerId', () => {
+      const node: ProviderGroupNode = { kind: 'providerGroup', label: 'Other', providerId: undefined };
+      expect(isProviderGroupNode(node)).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/test/viewLayout.test.ts
+++ b/packages/core/src/test/viewLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { workspace, ConfigurationTarget } from 'vscode';
+import { workspace, ConfigurationTarget, window } from 'vscode';
 import { getViewLayout, toggleViewLayout, isProviderGroupNode, ProviderGroupNode } from '../views/viewLayout';
 
 describe('viewLayout', () => {
@@ -145,6 +145,25 @@ describe('viewLayout', () => {
         'viewLayout',
         expect.objectContaining({ inbox: 'tree' }),
         ConfigurationTarget.Workspace,
+      );
+    });
+
+    it('shows warning when workspaceFolderValue overrides layout', async () => {
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
+        get: vi.fn((_key: string) => {
+          if (_key === 'viewLayout') { return { queue: 'flat' }; }
+          return undefined;
+        }),
+        update: mockUpdate,
+        inspect: vi.fn(() => ({
+          workspaceFolderValue: { queue: 'flat' },
+        })),
+      });
+
+      await toggleViewLayout('queue');
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('workspace-folder setting'),
       );
     });
   });

--- a/packages/core/src/test/viewLayout.test.ts
+++ b/packages/core/src/test/viewLayout.test.ts
@@ -126,7 +126,7 @@ describe('viewLayout', () => {
       );
     });
 
-    it('prefers workspaceFolder scope when it exists alongside workspace', async () => {
+    it('prefers workspace scope even when workspaceFolder value exists', async () => {
       const mockUpdate = vi.fn().mockResolvedValue(undefined);
       (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
         get: vi.fn((_key: string) => {
@@ -144,7 +144,7 @@ describe('viewLayout', () => {
       expect(mockUpdate).toHaveBeenCalledWith(
         'viewLayout',
         expect.objectContaining({ inbox: 'tree' }),
-        ConfigurationTarget.WorkspaceFolder,
+        ConfigurationTarget.Workspace,
       );
     });
   });

--- a/packages/core/src/test/viewLayout.test.ts
+++ b/packages/core/src/test/viewLayout.test.ts
@@ -126,7 +126,7 @@ describe('viewLayout', () => {
       );
     });
 
-    it('updates workspaceFolder scope when workspaceFolderValue exists', async () => {
+    it('prefers workspace scope over workspaceFolder when both exist', async () => {
       const mockUpdate = vi.fn().mockResolvedValue(undefined);
       (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
         get: vi.fn((_key: string) => {
@@ -135,7 +135,7 @@ describe('viewLayout', () => {
         }),
         update: mockUpdate,
         inspect: vi.fn(() => ({
-          workspaceValue: { inbox: 'tree' },
+          workspaceValue: { inbox: 'flat' },
           workspaceFolderValue: { inbox: 'flat' },
         })),
       });
@@ -144,7 +144,7 @@ describe('viewLayout', () => {
       expect(mockUpdate).toHaveBeenCalledWith(
         'viewLayout',
         expect.objectContaining({ inbox: 'tree' }),
-        ConfigurationTarget.WorkspaceFolder,
+        ConfigurationTarget.Workspace,
       );
     });
   });

--- a/packages/core/src/test/viewLayout.test.ts
+++ b/packages/core/src/test/viewLayout.test.ts
@@ -126,7 +126,7 @@ describe('viewLayout', () => {
       );
     });
 
-    it('prefers workspace scope over workspaceFolder when both exist', async () => {
+    it('prefers workspaceFolder scope when it exists alongside workspace', async () => {
       const mockUpdate = vi.fn().mockResolvedValue(undefined);
       (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
         get: vi.fn((_key: string) => {
@@ -144,7 +144,7 @@ describe('viewLayout', () => {
       expect(mockUpdate).toHaveBeenCalledWith(
         'viewLayout',
         expect.objectContaining({ inbox: 'tree' }),
-        ConfigurationTarget.Workspace,
+        ConfigurationTarget.WorkspaceFolder,
       );
     });
   });

--- a/packages/core/src/test/viewLayout.test.ts
+++ b/packages/core/src/test/viewLayout.test.ts
@@ -104,6 +104,49 @@ describe('viewLayout', () => {
         ConfigurationTarget.Global,
       );
     });
+
+    it('updates workspace scope when workspaceValue exists', async () => {
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
+        get: vi.fn((_key: string) => {
+          if (_key === 'viewLayout') { return { focus: 'flat' }; }
+          return undefined;
+        }),
+        update: mockUpdate,
+        inspect: vi.fn(() => ({
+          workspaceValue: { focus: 'flat' },
+        })),
+      });
+
+      await toggleViewLayout('focus');
+      expect(mockUpdate).toHaveBeenCalledWith(
+        'viewLayout',
+        expect.objectContaining({ focus: 'tree' }),
+        ConfigurationTarget.Workspace,
+      );
+    });
+
+    it('updates workspaceFolder scope when workspaceFolderValue exists', async () => {
+      const mockUpdate = vi.fn().mockResolvedValue(undefined);
+      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
+        get: vi.fn((_key: string) => {
+          if (_key === 'viewLayout') { return { inbox: 'flat' }; }
+          return undefined;
+        }),
+        update: mockUpdate,
+        inspect: vi.fn(() => ({
+          workspaceValue: { inbox: 'tree' },
+          workspaceFolderValue: { inbox: 'flat' },
+        })),
+      });
+
+      await toggleViewLayout('inbox');
+      expect(mockUpdate).toHaveBeenCalledWith(
+        'viewLayout',
+        expect.objectContaining({ inbox: 'tree' }),
+        ConfigurationTarget.WorkspaceFolder,
+      );
+    });
   });
 
   describe('isProviderGroupNode', () => {

--- a/packages/core/src/test/viewLayout.test.ts
+++ b/packages/core/src/test/viewLayout.test.ts
@@ -58,6 +58,7 @@ describe('viewLayout', () => {
           return defaultValue;
         }),
         update: mockUpdate,
+        inspect: vi.fn(() => undefined),
       });
 
       await toggleViewLayout('inbox');
@@ -76,6 +77,7 @@ describe('viewLayout', () => {
           return defaultValue;
         }),
         update: mockUpdate,
+        inspect: vi.fn(() => undefined),
       });
 
       await toggleViewLayout('queue');
@@ -91,6 +93,7 @@ describe('viewLayout', () => {
       (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
         get: vi.fn((_key: string, defaultValue?: any) => defaultValue),
         update: mockUpdate,
+        inspect: vi.fn(() => undefined),
       });
 
       // sources defaults to 'tree', so toggle should set to 'flat'

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -2,38 +2,28 @@ import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import {
-  ViewLayout, ProviderGroupNode, isProviderGroupNode,
-  LayoutState, getTreeModeChildren, createProviderGroupTreeItem,
+  WorkItemElement, WorkItemViewProvider,
 } from './viewLayout';
 
-export type FocusElement = WorkItem | ProviderGroupNode;
+export type FocusElement = WorkItemElement;
 
-export class FocusTreeProvider implements vscode.TreeDataProvider<FocusElement> {
-  private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
-  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
-  private readonly disposables: vscode.Disposable[] = [];
-  private readonly _layoutState: LayoutState;
+export class FocusTreeProvider extends WorkItemViewProvider {
+  protected readonly groupPrefix = 'focus';
+  protected readonly groupContextValue = 'focusGroup';
 
-  get layout(): ViewLayout { return this._layoutState.value; }
-  set layout(value: ViewLayout) { this._layoutState.value = value; }
-
-  constructor(private readonly workGraph: WorkGraph) {
-    this._layoutState = new LayoutState('flat', () => this._onDidChangeTreeData.fire());
-    this.disposables.push(
-      workGraph.onDidChange(() => this._onDidChangeTreeData.fire())
-    );
+  constructor(workGraph: WorkGraph) {
+    super(workGraph, 'flat');
   }
 
-  refresh(): void {
-    this._onDidChangeTreeData.fire();
+  protected getItems(): WorkItem[] {
+    return this.workGraph.getItemsByState(WorkItemState.InProgress, WorkItemState.Paused);
   }
 
-  getTreeItem(element: FocusElement): vscode.TreeItem {
-    if (isProviderGroupNode(element)) {
-      return createProviderGroupTreeItem(element, 'focus', 'focusGroup');
-    }
+  protected sortItems(items: WorkItem[]): WorkItem[] {
+    return items.sort((a, b) => a.title.localeCompare(b.title));
+  }
 
-    const item = element;
+  protected createWorkItemTreeItem(item: WorkItem): vscode.TreeItem {
     const treeItem = new vscode.TreeItem(item.title, vscode.TreeItemCollapsibleState.None);
     treeItem.description = this.getStateLabel(item.state);
     treeItem.tooltip = this.buildTooltip(item);
@@ -48,15 +38,6 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<FocusElement> 
 
     treeItem.command = { command: 'workcenter.editItem', title: 'Open Details', arguments: [item] };
     return treeItem;
-  }
-
-  getChildren(element?: FocusElement): FocusElement[] {
-    return getTreeModeChildren(
-      element,
-      () => this.workGraph.getItemsByState(WorkItemState.InProgress, WorkItemState.Paused),
-      items => items.sort((a, b) => a.title.localeCompare(b.title)),
-      this._layoutState.value,
-    );
   }
 
   private getStateLabel(state: WorkItemState): string {
@@ -94,10 +75,5 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<FocusElement> 
     md.appendMarkdown(`**State:** ${item.state}\n\n`);
     md.appendMarkdown(`**Created:** ${new Date(item.createdAt).toLocaleString()}`);
     return md;
-  }
-
-  dispose(): void {
-    this._onDidChangeTreeData.dispose();
-    this.disposables.forEach(d => d.dispose());
   }
 }

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -3,14 +3,14 @@ import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import { ProviderRegistry } from '../services/providerRegistry';
 import {
-  WorkItemElement, WorkItemViewProvider,
+  WorkItemElement, WorkItemViewProvider, isProviderGroupNode,
 } from './viewLayout';
 
 const DRAG_MIME_TYPE = 'application/vnd.code.tree.workcenter.focus';
 
 export type FocusElement = WorkItemElement;
 
-export class FocusTreeProvider extends WorkItemViewProvider implements vscode.TreeDragAndDropController<WorkItem> {
+export class FocusTreeProvider extends WorkItemViewProvider implements vscode.TreeDragAndDropController<FocusElement> {
   readonly dropMimeTypes = [DRAG_MIME_TYPE];
   readonly dragMimeTypes = [DRAG_MIME_TYPE];
   protected readonly groupPrefix = 'focus';
@@ -84,11 +84,13 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
     }
   }
 
-  handleDrag(source: readonly WorkItem[], dataTransfer: vscode.DataTransfer): void {
-    dataTransfer.set(DRAG_MIME_TYPE, new vscode.DataTransferItem(source.map(s => s.id)));
+  handleDrag(source: readonly FocusElement[], dataTransfer: vscode.DataTransfer): void {
+    const items = source.filter((s): s is WorkItem => !isProviderGroupNode(s));
+    if (items.length === 0) { return; }
+    dataTransfer.set(DRAG_MIME_TYPE, new vscode.DataTransferItem(items.map(s => s.id)));
   }
 
-  async handleDrop(target: WorkItem | undefined, dataTransfer: vscode.DataTransfer): Promise<void> {
+  async handleDrop(target: FocusElement | undefined, dataTransfer: vscode.DataTransfer): Promise<void> {
     const transferItem = dataTransfer.get(DRAG_MIME_TYPE);
     if (!transferItem) { return; }
 
@@ -98,8 +100,8 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
     const draggedIds: string[] = rawValue;
     const draggedId = draggedIds[0];
 
-    if (!target) {
-      // moveToEnd is inherently state-scoped — no cross-state guard needed
+    // Group node targets or no target → move to end
+    if (!target || isProviderGroupNode(target)) {
       await this.workGraph.moveToEnd(draggedId);
       return;
     }

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -1,11 +1,23 @@
 import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
+import { ViewLayout, ProviderGroupNode, isProviderGroupNode } from './viewLayout';
 
-export class FocusTreeProvider implements vscode.TreeDataProvider<WorkItem> {
+export type FocusElement = WorkItem | ProviderGroupNode;
+
+export class FocusTreeProvider implements vscode.TreeDataProvider<FocusElement> {
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private readonly disposables: vscode.Disposable[] = [];
+  private _layout: ViewLayout = 'flat';
+
+  get layout(): ViewLayout { return this._layout; }
+  set layout(value: ViewLayout) {
+    if (this._layout !== value) {
+      this._layout = value;
+      this._onDidChangeTreeData.fire();
+    }
+  }
 
   constructor(private readonly workGraph: WorkGraph) {
     this.disposables.push(
@@ -17,7 +29,16 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<WorkItem> {
     this._onDidChangeTreeData.fire();
   }
 
-  getTreeItem(item: WorkItem): vscode.TreeItem {
+  getTreeItem(element: FocusElement): vscode.TreeItem {
+    if (isProviderGroupNode(element)) {
+      const treeItem = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.Collapsed);
+      treeItem.id = `focus::group::${element.providerId ?? '__other__'}`;
+      treeItem.contextValue = 'focusGroup';
+      treeItem.iconPath = new vscode.ThemeIcon(element.providerId ? 'plug' : 'circle-filled');
+      return treeItem;
+    }
+
+    const item = element;
     const treeItem = new vscode.TreeItem(item.title, vscode.TreeItemCollapsibleState.None);
     treeItem.description = this.getStateLabel(item.state);
     treeItem.tooltip = this.buildTooltip(item);
@@ -34,11 +55,51 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<WorkItem> {
     return treeItem;
   }
 
-  getChildren(): WorkItem[] {
-    return this.workGraph.getItemsByState(
-      WorkItemState.InProgress,
-      WorkItemState.Paused,
-    ).sort((a, b) => a.title.localeCompare(b.title));
+  getChildren(element?: FocusElement): FocusElement[] {
+    if (!element) {
+      const items = this.workGraph.getItemsByState(
+        WorkItemState.InProgress,
+        WorkItemState.Paused,
+      ).sort((a, b) => a.title.localeCompare(b.title));
+
+      if (this._layout === 'flat') {
+        return items;
+      }
+
+      return this.groupByProvider(items);
+    }
+
+    if (isProviderGroupNode(element)) {
+      return this.workGraph.getItemsByState(WorkItemState.InProgress, WorkItemState.Paused)
+        .filter(i => (i.providerId ?? undefined) === element.providerId)
+        .sort((a, b) => a.title.localeCompare(b.title));
+    }
+
+    return [];
+  }
+
+  private groupByProvider(items: WorkItem[]): ProviderGroupNode[] {
+    const groups = new Map<string | undefined, WorkItem[]>();
+    for (const item of items) {
+      const key = item.providerId ?? undefined;
+      const list = groups.get(key) ?? [];
+      list.push(item);
+      groups.set(key, list);
+    }
+
+    const result: ProviderGroupNode[] = [];
+    for (const [providerId] of groups) {
+      result.push({
+        kind: 'providerGroup',
+        label: providerId ?? 'Other',
+        providerId,
+      });
+    }
+    return result.sort((a, b) => {
+      if (!a.providerId) { return 1; }
+      if (!b.providerId) { return -1; }
+      return a.label.localeCompare(b.label);
+    });
   }
 
   private getStateLabel(state: WorkItemState): string {

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -17,7 +17,12 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
   protected readonly groupContextValue = 'focusGroup';
 
   constructor(workGraph: WorkGraph, providerRegistry?: ProviderRegistry) {
-    super(workGraph, 'flat', providerRegistry ? id => providerRegistry.getProviderLabel(id) : undefined);
+    super(
+      workGraph,
+      'flat',
+      providerRegistry ? id => providerRegistry.getProviderLabel(id) : undefined,
+      providerRegistry?.onDidRegisterProvider,
+    );
   }
 
   protected getItems(): WorkItem[] {

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -60,10 +60,10 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<FocusElement> 
       const items = this.workGraph.getItemsByState(
         WorkItemState.InProgress,
         WorkItemState.Paused,
-      ).sort((a, b) => a.title.localeCompare(b.title));
+      );
 
       if (this._layout === 'flat') {
-        return items;
+        return items.sort((a, b) => a.title.localeCompare(b.title));
       }
 
       return this.groupByProvider(items);

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
+import { ProviderRegistry } from '../services/providerRegistry';
 import {
   WorkItemElement, WorkItemViewProvider,
 } from './viewLayout';
@@ -11,8 +12,8 @@ export class FocusTreeProvider extends WorkItemViewProvider {
   protected readonly groupPrefix = 'focus';
   protected readonly groupContextValue = 'focusGroup';
 
-  constructor(workGraph: WorkGraph) {
-    super(workGraph, 'flat');
+  constructor(workGraph: WorkGraph, providerRegistry?: ProviderRegistry) {
+    super(workGraph, 'flat', providerRegistry ? id => providerRegistry.getProviderLabel(id) : undefined);
   }
 
   protected getItems(): WorkItem[] {

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
-import { ViewLayout, ProviderGroupNode, isProviderGroupNode } from './viewLayout';
+import {
+  ViewLayout, ProviderGroupNode, isProviderGroupNode,
+  LayoutState, getTreeModeChildren, createProviderGroupTreeItem,
+} from './viewLayout';
 
 export type FocusElement = WorkItem | ProviderGroupNode;
 
@@ -9,17 +12,13 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<FocusElement> 
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private readonly disposables: vscode.Disposable[] = [];
-  private _layout: ViewLayout = 'flat';
+  private readonly _layoutState: LayoutState;
 
-  get layout(): ViewLayout { return this._layout; }
-  set layout(value: ViewLayout) {
-    if (this._layout !== value) {
-      this._layout = value;
-      this._onDidChangeTreeData.fire();
-    }
-  }
+  get layout(): ViewLayout { return this._layoutState.value; }
+  set layout(value: ViewLayout) { this._layoutState.value = value; }
 
   constructor(private readonly workGraph: WorkGraph) {
+    this._layoutState = new LayoutState('flat', () => this._onDidChangeTreeData.fire());
     this.disposables.push(
       workGraph.onDidChange(() => this._onDidChangeTreeData.fire())
     );
@@ -31,11 +30,7 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<FocusElement> 
 
   getTreeItem(element: FocusElement): vscode.TreeItem {
     if (isProviderGroupNode(element)) {
-      const treeItem = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.Collapsed);
-      treeItem.id = `focus::group::${element.providerId ?? '__other__'}`;
-      treeItem.contextValue = 'focusGroup';
-      treeItem.iconPath = new vscode.ThemeIcon(element.providerId ? 'plug' : 'circle-filled');
-      return treeItem;
+      return createProviderGroupTreeItem(element, 'focus', 'focusGroup');
     }
 
     const item = element;
@@ -56,50 +51,12 @@ export class FocusTreeProvider implements vscode.TreeDataProvider<FocusElement> 
   }
 
   getChildren(element?: FocusElement): FocusElement[] {
-    if (!element) {
-      const items = this.workGraph.getItemsByState(
-        WorkItemState.InProgress,
-        WorkItemState.Paused,
-      );
-
-      if (this._layout === 'flat') {
-        return items.sort((a, b) => a.title.localeCompare(b.title));
-      }
-
-      return this.groupByProvider(items);
-    }
-
-    if (isProviderGroupNode(element)) {
-      return this.workGraph.getItemsByState(WorkItemState.InProgress, WorkItemState.Paused)
-        .filter(i => (i.providerId ?? undefined) === element.providerId)
-        .sort((a, b) => a.title.localeCompare(b.title));
-    }
-
-    return [];
-  }
-
-  private groupByProvider(items: WorkItem[]): ProviderGroupNode[] {
-    const groups = new Map<string | undefined, WorkItem[]>();
-    for (const item of items) {
-      const key = item.providerId ?? undefined;
-      const list = groups.get(key) ?? [];
-      list.push(item);
-      groups.set(key, list);
-    }
-
-    const result: ProviderGroupNode[] = [];
-    for (const [providerId] of groups) {
-      result.push({
-        kind: 'providerGroup',
-        label: providerId ?? 'Other',
-        providerId,
-      });
-    }
-    return result.sort((a, b) => {
-      if (!a.providerId) { return 1; }
-      if (!b.providerId) { return -1; }
-      return a.label.localeCompare(b.label);
-    });
+    return getTreeModeChildren(
+      element,
+      () => this.workGraph.getItemsByState(WorkItemState.InProgress, WorkItemState.Paused),
+      items => items.sort((a, b) => a.title.localeCompare(b.title)),
+      this._layoutState.value,
+    );
   }
 
   private getStateLabel(state: WorkItemState): string {

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -3,7 +3,7 @@ import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import { ProviderRegistry } from '../services/providerRegistry';
 import {
-  WorkItemElement, WorkItemViewProvider, isProviderGroupNode,
+  WorkItemElement, WorkItemViewProvider, isProviderGroupNode, isSubGroupNode,
 } from './viewLayout';
 
 const DRAG_MIME_TYPE = 'application/vnd.code.tree.workcenter.focus';
@@ -85,7 +85,7 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
   }
 
   handleDrag(source: readonly FocusElement[], dataTransfer: vscode.DataTransfer): void {
-    const items = source.filter((s): s is WorkItem => !isProviderGroupNode(s));
+    const items = source.filter((s): s is WorkItem => !isProviderGroupNode(s) && !isSubGroupNode(s));
     if (items.length === 0) { return; }
     dataTransfer.set(DRAG_MIME_TYPE, new vscode.DataTransferItem(items.map(s => s.id)));
   }
@@ -101,7 +101,7 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
     const draggedId = draggedIds[0];
 
     // Group node targets or no target → move to end
-    if (!target || isProviderGroupNode(target)) {
+    if (!target || isProviderGroupNode(target) || isSubGroupNode(target)) {
       await this.workGraph.moveToEnd(draggedId);
       return;
     }

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -2,38 +2,28 @@ import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import {
-  ViewLayout, ProviderGroupNode, isProviderGroupNode,
-  LayoutState, getTreeModeChildren, createProviderGroupTreeItem,
+  WorkItemElement, WorkItemViewProvider,
 } from './viewLayout';
 
-export type HistoryElement = WorkItem | ProviderGroupNode;
+export type HistoryElement = WorkItemElement;
 
-export class HistoryTreeProvider implements vscode.TreeDataProvider<HistoryElement> {
-  private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
-  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
-  private readonly disposables: vscode.Disposable[] = [];
-  private readonly _layoutState: LayoutState;
+export class HistoryTreeProvider extends WorkItemViewProvider {
+  protected readonly groupPrefix = 'history';
+  protected readonly groupContextValue = 'historyGroup';
 
-  get layout(): ViewLayout { return this._layoutState.value; }
-  set layout(value: ViewLayout) { this._layoutState.value = value; }
-
-  constructor(private readonly workGraph: WorkGraph) {
-    this._layoutState = new LayoutState('flat', () => this._onDidChangeTreeData.fire());
-    this.disposables.push(
-      workGraph.onDidChange(() => this._onDidChangeTreeData.fire())
-    );
+  constructor(workGraph: WorkGraph) {
+    super(workGraph, 'flat');
   }
 
-  refresh(): void {
-    this._onDidChangeTreeData.fire();
+  protected getItems(): WorkItem[] {
+    return this.workGraph.getItemsByState(WorkItemState.Done, WorkItemState.Archived);
   }
 
-  getTreeItem(element: HistoryElement): vscode.TreeItem {
-    if (isProviderGroupNode(element)) {
-      return createProviderGroupTreeItem(element, 'history', 'historyGroup');
-    }
+  protected sortItems(items: WorkItem[]): WorkItem[] {
+    return items.sort((a, b) => b.updatedAt - a.updatedAt);
+  }
 
-    const item = element;
+  protected createWorkItemTreeItem(item: WorkItem): vscode.TreeItem {
     const treeItem = new vscode.TreeItem(item.title, vscode.TreeItemCollapsibleState.None);
     treeItem.description = this.getStateLabel(item.state);
     treeItem.tooltip = this.buildTooltip(item);
@@ -41,15 +31,6 @@ export class HistoryTreeProvider implements vscode.TreeDataProvider<HistoryEleme
     treeItem.contextValue = item.url ? 'historyItem.hasUrl' : 'historyItem';
     treeItem.command = { command: 'workcenter.editItem', title: 'Open Details', arguments: [item] };
     return treeItem;
-  }
-
-  getChildren(element?: HistoryElement): HistoryElement[] {
-    return getTreeModeChildren(
-      element,
-      () => this.workGraph.getItemsByState(WorkItemState.Done, WorkItemState.Archived),
-      items => items.sort((a, b) => b.updatedAt - a.updatedAt),
-      this._layoutState.value,
-    );
   }
 
   private getStateLabel(state: WorkItemState): string {
@@ -88,10 +69,5 @@ export class HistoryTreeProvider implements vscode.TreeDataProvider<HistoryEleme
     const timestampLabel = item.state === WorkItemState.Done ? 'Completed at' : item.state === WorkItemState.Archived ? 'Archived at' : 'Last updated';
     md.appendMarkdown(`**${timestampLabel}:** ${new Date(item.updatedAt).toLocaleString()}`);
     return md;
-  }
-
-  dispose(): void {
-    this._onDidChangeTreeData.dispose();
-    this.disposables.forEach(d => d.dispose());
   }
 }

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -1,11 +1,23 @@
 import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
+import { ViewLayout, ProviderGroupNode, isProviderGroupNode } from './viewLayout';
 
-export class HistoryTreeProvider implements vscode.TreeDataProvider<WorkItem> {
+export type HistoryElement = WorkItem | ProviderGroupNode;
+
+export class HistoryTreeProvider implements vscode.TreeDataProvider<HistoryElement> {
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private readonly disposables: vscode.Disposable[] = [];
+  private _layout: ViewLayout = 'flat';
+
+  get layout(): ViewLayout { return this._layout; }
+  set layout(value: ViewLayout) {
+    if (this._layout !== value) {
+      this._layout = value;
+      this._onDidChangeTreeData.fire();
+    }
+  }
 
   constructor(private readonly workGraph: WorkGraph) {
     this.disposables.push(
@@ -17,7 +29,16 @@ export class HistoryTreeProvider implements vscode.TreeDataProvider<WorkItem> {
     this._onDidChangeTreeData.fire();
   }
 
-  getTreeItem(item: WorkItem): vscode.TreeItem {
+  getTreeItem(element: HistoryElement): vscode.TreeItem {
+    if (isProviderGroupNode(element)) {
+      const treeItem = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.Collapsed);
+      treeItem.id = `history::group::${element.providerId ?? '__other__'}`;
+      treeItem.contextValue = 'historyGroup';
+      treeItem.iconPath = new vscode.ThemeIcon(element.providerId ? 'plug' : 'circle-filled');
+      return treeItem;
+    }
+
+    const item = element;
     const treeItem = new vscode.TreeItem(item.title, vscode.TreeItemCollapsibleState.None);
     treeItem.description = this.getStateLabel(item.state);
     treeItem.tooltip = this.buildTooltip(item);
@@ -27,11 +48,51 @@ export class HistoryTreeProvider implements vscode.TreeDataProvider<WorkItem> {
     return treeItem;
   }
 
-  getChildren(): WorkItem[] {
-    return this.workGraph.getItemsByState(
-      WorkItemState.Done,
-      WorkItemState.Archived,
-    ).sort((a, b) => b.updatedAt - a.updatedAt);
+  getChildren(element?: HistoryElement): HistoryElement[] {
+    if (!element) {
+      const items = this.workGraph.getItemsByState(
+        WorkItemState.Done,
+        WorkItemState.Archived,
+      ).sort((a, b) => b.updatedAt - a.updatedAt);
+
+      if (this._layout === 'flat') {
+        return items;
+      }
+
+      return this.groupByProvider(items);
+    }
+
+    if (isProviderGroupNode(element)) {
+      return this.workGraph.getItemsByState(WorkItemState.Done, WorkItemState.Archived)
+        .filter(i => (i.providerId ?? undefined) === element.providerId)
+        .sort((a, b) => b.updatedAt - a.updatedAt);
+    }
+
+    return [];
+  }
+
+  private groupByProvider(items: WorkItem[]): ProviderGroupNode[] {
+    const groups = new Map<string | undefined, WorkItem[]>();
+    for (const item of items) {
+      const key = item.providerId ?? undefined;
+      const list = groups.get(key) ?? [];
+      list.push(item);
+      groups.set(key, list);
+    }
+
+    const result: ProviderGroupNode[] = [];
+    for (const [providerId] of groups) {
+      result.push({
+        kind: 'providerGroup',
+        label: providerId ?? 'Other',
+        providerId,
+      });
+    }
+    return result.sort((a, b) => {
+      if (!a.providerId) { return 1; }
+      if (!b.providerId) { return -1; }
+      return a.label.localeCompare(b.label);
+    });
   }
 
   private getStateLabel(state: WorkItemState): string {

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
-import { ViewLayout, ProviderGroupNode, isProviderGroupNode } from './viewLayout';
+import {
+  ViewLayout, ProviderGroupNode, isProviderGroupNode,
+  LayoutState, getTreeModeChildren, createProviderGroupTreeItem,
+} from './viewLayout';
 
 export type HistoryElement = WorkItem | ProviderGroupNode;
 
@@ -9,17 +12,13 @@ export class HistoryTreeProvider implements vscode.TreeDataProvider<HistoryEleme
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private readonly disposables: vscode.Disposable[] = [];
-  private _layout: ViewLayout = 'flat';
+  private readonly _layoutState: LayoutState;
 
-  get layout(): ViewLayout { return this._layout; }
-  set layout(value: ViewLayout) {
-    if (this._layout !== value) {
-      this._layout = value;
-      this._onDidChangeTreeData.fire();
-    }
-  }
+  get layout(): ViewLayout { return this._layoutState.value; }
+  set layout(value: ViewLayout) { this._layoutState.value = value; }
 
   constructor(private readonly workGraph: WorkGraph) {
+    this._layoutState = new LayoutState('flat', () => this._onDidChangeTreeData.fire());
     this.disposables.push(
       workGraph.onDidChange(() => this._onDidChangeTreeData.fire())
     );
@@ -31,11 +30,7 @@ export class HistoryTreeProvider implements vscode.TreeDataProvider<HistoryEleme
 
   getTreeItem(element: HistoryElement): vscode.TreeItem {
     if (isProviderGroupNode(element)) {
-      const treeItem = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.Collapsed);
-      treeItem.id = `history::group::${element.providerId ?? '__other__'}`;
-      treeItem.contextValue = 'historyGroup';
-      treeItem.iconPath = new vscode.ThemeIcon(element.providerId ? 'plug' : 'circle-filled');
-      return treeItem;
+      return createProviderGroupTreeItem(element, 'history', 'historyGroup');
     }
 
     const item = element;
@@ -49,50 +44,12 @@ export class HistoryTreeProvider implements vscode.TreeDataProvider<HistoryEleme
   }
 
   getChildren(element?: HistoryElement): HistoryElement[] {
-    if (!element) {
-      const items = this.workGraph.getItemsByState(
-        WorkItemState.Done,
-        WorkItemState.Archived,
-      );
-
-      if (this._layout === 'flat') {
-        return items.sort((a, b) => b.updatedAt - a.updatedAt);
-      }
-
-      return this.groupByProvider(items);
-    }
-
-    if (isProviderGroupNode(element)) {
-      return this.workGraph.getItemsByState(WorkItemState.Done, WorkItemState.Archived)
-        .filter(i => (i.providerId ?? undefined) === element.providerId)
-        .sort((a, b) => b.updatedAt - a.updatedAt);
-    }
-
-    return [];
-  }
-
-  private groupByProvider(items: WorkItem[]): ProviderGroupNode[] {
-    const groups = new Map<string | undefined, WorkItem[]>();
-    for (const item of items) {
-      const key = item.providerId ?? undefined;
-      const list = groups.get(key) ?? [];
-      list.push(item);
-      groups.set(key, list);
-    }
-
-    const result: ProviderGroupNode[] = [];
-    for (const [providerId] of groups) {
-      result.push({
-        kind: 'providerGroup',
-        label: providerId ?? 'Other',
-        providerId,
-      });
-    }
-    return result.sort((a, b) => {
-      if (!a.providerId) { return 1; }
-      if (!b.providerId) { return -1; }
-      return a.label.localeCompare(b.label);
-    });
+    return getTreeModeChildren(
+      element,
+      () => this.workGraph.getItemsByState(WorkItemState.Done, WorkItemState.Archived),
+      items => items.sort((a, b) => b.updatedAt - a.updatedAt),
+      this._layoutState.value,
+    );
   }
 
   private getStateLabel(state: WorkItemState): string {

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -53,10 +53,10 @@ export class HistoryTreeProvider implements vscode.TreeDataProvider<HistoryEleme
       const items = this.workGraph.getItemsByState(
         WorkItemState.Done,
         WorkItemState.Archived,
-      ).sort((a, b) => b.updatedAt - a.updatedAt);
+      );
 
       if (this._layout === 'flat') {
-        return items;
+        return items.sort((a, b) => b.updatedAt - a.updatedAt);
       }
 
       return this.groupByProvider(items);

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -13,7 +13,12 @@ export class HistoryTreeProvider extends WorkItemViewProvider {
   protected readonly groupContextValue = 'historyGroup';
 
   constructor(workGraph: WorkGraph, providerRegistry?: ProviderRegistry) {
-    super(workGraph, 'flat', providerRegistry ? id => providerRegistry.getProviderLabel(id) : undefined);
+    super(
+      workGraph,
+      'flat',
+      providerRegistry ? id => providerRegistry.getProviderLabel(id) : undefined,
+      providerRegistry?.onDidRegisterProvider,
+    );
   }
 
   protected getItems(): WorkItem[] {

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
+import { ProviderRegistry } from '../services/providerRegistry';
 import {
   WorkItemElement, WorkItemViewProvider,
 } from './viewLayout';
@@ -11,8 +12,8 @@ export class HistoryTreeProvider extends WorkItemViewProvider {
   protected readonly groupPrefix = 'history';
   protected readonly groupContextValue = 'historyGroup';
 
-  constructor(workGraph: WorkGraph) {
-    super(workGraph, 'flat');
+  constructor(workGraph: WorkGraph, providerRegistry?: ProviderRegistry) {
+    super(workGraph, 'flat', providerRegistry ? id => providerRegistry.getProviderLabel(id) : undefined);
   }
 
   protected getItems(): WorkItem[] {

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -153,6 +153,9 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   }
 
   getParent(element: InboxElement): InboxElement | undefined {
+    if (this._layoutState.value === 'flat') {
+      return undefined;
+    }
     switch (element.kind) {
       case 'provider':
         return undefined;

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -4,7 +4,7 @@ import { ProviderRegistry } from '../services/providerRegistry';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import { ReadStateStore } from '../storage/readStateStore';
 import { logger } from '../services/logger';
-import { ViewLayout } from './viewLayout';
+import { ViewLayout, LayoutState } from './viewLayout';
 
 export interface InboxProviderNode {
   kind: 'provider';
@@ -41,21 +41,17 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   readonly onDidMarkSeen = this._onDidMarkSeen.event;
   private refreshTimer: ReturnType<typeof setTimeout> | undefined;
   static readonly REFRESH_DEBOUNCE_MS = 50;
-  private _layout: ViewLayout = 'tree';
+  private readonly _layoutState: LayoutState;
 
-  get layout(): ViewLayout { return this._layout; }
-  set layout(value: ViewLayout) {
-    if (this._layout !== value) {
-      this._layout = value;
-      this._onDidChangeTreeData.fire();
-    }
-  }
+  get layout(): ViewLayout { return this._layoutState.value; }
+  set layout(value: ViewLayout) { this._layoutState.value = value; }
 
   constructor(
     private readonly providerRegistry: ProviderRegistry,
     private readonly stateStore: DiscoveredStateStore,
     private readonly readStateStore: ReadStateStore,
   ) {
+    this._layoutState = new LayoutState('tree', () => this._onDidChangeTreeData.fire());
     this.disposables.push(
       providerRegistry.onDidChangeDiscoveredItems(() => this.scheduleRefresh()),
       stateStore.onDidChange(() => this.scheduleRefresh()),
@@ -187,7 +183,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   getChildren(element?: InboxElement): InboxElement[] {
     if (!element) {
-      if (this._layout === 'flat') {
+      if (this._layoutState.value === 'flat') {
         return this.getAllUnseenItems();
       }
       const result: InboxProviderNode[] = [];

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -4,6 +4,7 @@ import { ProviderRegistry } from '../services/providerRegistry';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import { ReadStateStore } from '../storage/readStateStore';
 import { logger } from '../services/logger';
+import { ViewLayout } from './viewLayout';
 
 export interface InboxProviderNode {
   kind: 'provider';
@@ -40,6 +41,15 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   readonly onDidMarkSeen = this._onDidMarkSeen.event;
   private refreshTimer: ReturnType<typeof setTimeout> | undefined;
   static readonly REFRESH_DEBOUNCE_MS = 50;
+  private _layout: ViewLayout = 'tree';
+
+  get layout(): ViewLayout { return this._layout; }
+  set layout(value: ViewLayout) {
+    if (this._layout !== value) {
+      this._layout = value;
+      this._onDidChangeTreeData.fire();
+    }
+  }
 
   constructor(
     private readonly providerRegistry: ProviderRegistry,
@@ -177,6 +187,9 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   getChildren(element?: InboxElement): InboxElement[] {
     if (!element) {
+      if (this._layout === 'flat') {
+        return this.getAllUnseenItems();
+      }
       const result: InboxProviderNode[] = [];
       const allItems = this.providerRegistry.getAllDiscoveredItems();
       for (const [providerId] of allItems) {
@@ -200,6 +213,19 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     }
 
     return [];
+  }
+
+  private getAllUnseenItems(): InboxItem[] {
+    const result: InboxItem[] = [];
+    const allItems = this.providerRegistry.getAllDiscoveredItems();
+    for (const [providerId, items] of allItems) {
+      for (const item of items) {
+        const state = this.stateStore.getState(providerId, item.externalId);
+        if (state !== undefined && state !== 'unseen') { continue; }
+        result.push(this.toItemNode(providerId, item));
+      }
+    }
+    return result.sort((a, b) => a.title.localeCompare(b.title));
   }
 
   private getProviderChildren(providerId: string): (InboxGroupNode | InboxItem)[] {

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -1,15 +1,27 @@
 import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
+import { ViewLayout, ProviderGroupNode, isProviderGroupNode } from './viewLayout';
+
+export type QueueElement = WorkItem | ProviderGroupNode;
 
 const DRAG_MIME_TYPE = 'application/vnd.code.tree.workcenter.queue';
 
-export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem>, vscode.TreeDragAndDropController<WorkItem> {
+export class QueueTreeProvider implements vscode.TreeDataProvider<QueueElement>, vscode.TreeDragAndDropController<QueueElement> {
   readonly dropMimeTypes = [DRAG_MIME_TYPE];
   readonly dragMimeTypes = [DRAG_MIME_TYPE];
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private readonly disposables: vscode.Disposable[] = [];
+  private _layout: ViewLayout = 'flat';
+
+  get layout(): ViewLayout { return this._layout; }
+  set layout(value: ViewLayout) {
+    if (this._layout !== value) {
+      this._layout = value;
+      this._onDidChangeTreeData.fire();
+    }
+  }
 
   constructor(private readonly workGraph: WorkGraph) {
     this.disposables.push(
@@ -19,7 +31,16 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem>, vsc
 
   refresh(): void { this._onDidChangeTreeData.fire(); }
 
-  getTreeItem(item: WorkItem): vscode.TreeItem {
+  getTreeItem(element: QueueElement): vscode.TreeItem {
+    if (isProviderGroupNode(element)) {
+      const treeItem = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.Collapsed);
+      treeItem.id = `queue::group::${element.providerId ?? '__other__'}`;
+      treeItem.contextValue = 'queueGroup';
+      treeItem.iconPath = new vscode.ThemeIcon(element.providerId ? 'plug' : 'circle-filled');
+      return treeItem;
+    }
+
+    const item = element;
     const treeItem = new vscode.TreeItem(item.title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = item.id;
     treeItem.description = item.providerId;
@@ -30,9 +51,50 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem>, vsc
     return treeItem;
   }
 
-  getChildren(): WorkItem[] {
-    return this.workGraph.getItemsByState(WorkItemState.New)
-      .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
+  getChildren(element?: QueueElement): QueueElement[] {
+    if (!element) {
+      const items = this.workGraph.getItemsByState(WorkItemState.New)
+        .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
+
+      if (this._layout === 'flat') {
+        return items;
+      }
+
+      return this.groupByProvider(items);
+    }
+
+    if (isProviderGroupNode(element)) {
+      return this.workGraph.getItemsByState(WorkItemState.New)
+        .filter(i => (i.providerId ?? undefined) === element.providerId)
+        .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
+    }
+
+    return [];
+  }
+
+  private groupByProvider(items: WorkItem[]): ProviderGroupNode[] {
+    const groups = new Map<string | undefined, WorkItem[]>();
+    for (const item of items) {
+      const key = item.providerId ?? undefined;
+      const list = groups.get(key) ?? [];
+      list.push(item);
+      groups.set(key, list);
+    }
+
+    const result: ProviderGroupNode[] = [];
+    for (const [providerId] of groups) {
+      result.push({
+        kind: 'providerGroup',
+        label: providerId ?? 'Other',
+        providerId,
+      });
+    }
+    return result.sort((a, b) => {
+      // "Other" group always goes last
+      if (!a.providerId) { return 1; }
+      if (!b.providerId) { return -1; }
+      return a.label.localeCompare(b.label);
+    });
   }
 
   private buildTooltip(item: WorkItem): vscode.MarkdownString {
@@ -45,11 +107,18 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem>, vsc
     return md;
   }
 
-  handleDrag(source: readonly WorkItem[], dataTransfer: vscode.DataTransfer): void {
-    dataTransfer.set(DRAG_MIME_TYPE, new vscode.DataTransferItem(source.map(s => s.id)));
+  handleDrag(source: readonly QueueElement[], dataTransfer: vscode.DataTransfer): void {
+    const items = source.filter((s): s is WorkItem => !isProviderGroupNode(s));
+    if (items.length === 0) { return; }
+    dataTransfer.set(DRAG_MIME_TYPE, new vscode.DataTransferItem(items.map(s => s.id)));
   }
 
-  async handleDrop(target: WorkItem | undefined, dataTransfer: vscode.DataTransfer): Promise<void> {
+  async handleDrop(target: QueueElement | undefined, dataTransfer: vscode.DataTransfer): Promise<void> {
+    // Treat group node targets as "move to end"
+    if (target && isProviderGroupNode(target)) {
+      target = undefined;
+    }
+
     const transferItem = dataTransfer.get(DRAG_MIME_TYPE);
     if (!transferItem) { return; }
 
@@ -65,9 +134,9 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<WorkItem>, vsc
       return;
     }
 
-    if (draggedId === target.id) { return; }
+    if (draggedId === (target as WorkItem).id) { return; }
 
-    await this.workGraph.reorderItem(draggedId, target.id);
+    await this.workGraph.reorderItem(draggedId, (target as WorkItem).id);
   }
 
   dispose(): void {

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -1,7 +1,10 @@
 import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
-import { ViewLayout, ProviderGroupNode, isProviderGroupNode } from './viewLayout';
+import {
+  ViewLayout, ProviderGroupNode, isProviderGroupNode,
+  LayoutState, getTreeModeChildren, createProviderGroupTreeItem,
+} from './viewLayout';
 
 export type QueueElement = WorkItem | ProviderGroupNode;
 
@@ -13,17 +16,13 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<QueueElement>,
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private readonly disposables: vscode.Disposable[] = [];
-  private _layout: ViewLayout = 'flat';
+  private readonly _layoutState: LayoutState;
 
-  get layout(): ViewLayout { return this._layout; }
-  set layout(value: ViewLayout) {
-    if (this._layout !== value) {
-      this._layout = value;
-      this._onDidChangeTreeData.fire();
-    }
-  }
+  get layout(): ViewLayout { return this._layoutState.value; }
+  set layout(value: ViewLayout) { this._layoutState.value = value; }
 
   constructor(private readonly workGraph: WorkGraph) {
+    this._layoutState = new LayoutState('flat', () => this._onDidChangeTreeData.fire());
     this.disposables.push(
       workGraph.onDidChange(() => this._onDidChangeTreeData.fire())
     );
@@ -33,11 +32,7 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<QueueElement>,
 
   getTreeItem(element: QueueElement): vscode.TreeItem {
     if (isProviderGroupNode(element)) {
-      const treeItem = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.Collapsed);
-      treeItem.id = `queue::group::${element.providerId ?? '__other__'}`;
-      treeItem.contextValue = 'queueGroup';
-      treeItem.iconPath = new vscode.ThemeIcon(element.providerId ? 'plug' : 'circle-filled');
-      return treeItem;
+      return createProviderGroupTreeItem(element, 'queue', 'queueGroup');
     }
 
     const item = element;
@@ -51,49 +46,16 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<QueueElement>,
     return treeItem;
   }
 
+  private readonly sortBySortOrder = (items: WorkItem[]): WorkItem[] =>
+    items.sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
+
   getChildren(element?: QueueElement): QueueElement[] {
-    if (!element) {
-      const items = this.workGraph.getItemsByState(WorkItemState.New);
-
-      if (this._layout === 'flat') {
-        return items.sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
-      }
-
-      return this.groupByProvider(items);
-    }
-
-    if (isProviderGroupNode(element)) {
-      return this.workGraph.getItemsByState(WorkItemState.New)
-        .filter(i => (i.providerId ?? undefined) === element.providerId)
-        .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
-    }
-
-    return [];
-  }
-
-  private groupByProvider(items: WorkItem[]): ProviderGroupNode[] {
-    const groups = new Map<string | undefined, WorkItem[]>();
-    for (const item of items) {
-      const key = item.providerId ?? undefined;
-      const list = groups.get(key) ?? [];
-      list.push(item);
-      groups.set(key, list);
-    }
-
-    const result: ProviderGroupNode[] = [];
-    for (const [providerId] of groups) {
-      result.push({
-        kind: 'providerGroup',
-        label: providerId ?? 'Other',
-        providerId,
-      });
-    }
-    return result.sort((a, b) => {
-      // "Other" group always goes last
-      if (!a.providerId) { return 1; }
-      if (!b.providerId) { return -1; }
-      return a.label.localeCompare(b.label);
-    });
+    return getTreeModeChildren(
+      element,
+      () => this.workGraph.getItemsByState(WorkItemState.New),
+      this.sortBySortOrder,
+      this._layoutState.value,
+    );
   }
 
   private buildTooltip(item: WorkItem): vscode.MarkdownString {

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -2,40 +2,32 @@ import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import {
-  ViewLayout, ProviderGroupNode, isProviderGroupNode,
-  LayoutState, getTreeModeChildren, createProviderGroupTreeItem,
+  WorkItemElement, WorkItemViewProvider, isProviderGroupNode,
 } from './viewLayout';
 
-export type QueueElement = WorkItem | ProviderGroupNode;
+export type QueueElement = WorkItemElement;
 
 const DRAG_MIME_TYPE = 'application/vnd.code.tree.workcenter.queue';
 
-export class QueueTreeProvider implements vscode.TreeDataProvider<QueueElement>, vscode.TreeDragAndDropController<QueueElement> {
+export class QueueTreeProvider extends WorkItemViewProvider implements vscode.TreeDragAndDropController<QueueElement> {
   readonly dropMimeTypes = [DRAG_MIME_TYPE];
   readonly dragMimeTypes = [DRAG_MIME_TYPE];
-  private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
-  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
-  private readonly disposables: vscode.Disposable[] = [];
-  private readonly _layoutState: LayoutState;
+  protected readonly groupPrefix = 'queue';
+  protected readonly groupContextValue = 'queueGroup';
 
-  get layout(): ViewLayout { return this._layoutState.value; }
-  set layout(value: ViewLayout) { this._layoutState.value = value; }
-
-  constructor(private readonly workGraph: WorkGraph) {
-    this._layoutState = new LayoutState('flat', () => this._onDidChangeTreeData.fire());
-    this.disposables.push(
-      workGraph.onDidChange(() => this._onDidChangeTreeData.fire())
-    );
+  constructor(workGraph: WorkGraph) {
+    super(workGraph, 'flat');
   }
 
-  refresh(): void { this._onDidChangeTreeData.fire(); }
+  protected getItems(): WorkItem[] {
+    return this.workGraph.getItemsByState(WorkItemState.New);
+  }
 
-  getTreeItem(element: QueueElement): vscode.TreeItem {
-    if (isProviderGroupNode(element)) {
-      return createProviderGroupTreeItem(element, 'queue', 'queueGroup');
-    }
+  protected sortItems(items: WorkItem[]): WorkItem[] {
+    return items.sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
+  }
 
-    const item = element;
+  protected createWorkItemTreeItem(item: WorkItem): vscode.TreeItem {
     const treeItem = new vscode.TreeItem(item.title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = item.id;
     treeItem.description = item.providerId;
@@ -44,18 +36,6 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<QueueElement>,
     treeItem.iconPath = new vscode.ThemeIcon(item.providerId ? 'remote' : 'circle-filled');
     treeItem.command = { command: 'workcenter.editItem', title: 'Open Details', arguments: [item] };
     return treeItem;
-  }
-
-  private readonly sortBySortOrder = (items: WorkItem[]): WorkItem[] =>
-    items.sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
-
-  getChildren(element?: QueueElement): QueueElement[] {
-    return getTreeModeChildren(
-      element,
-      () => this.workGraph.getItemsByState(WorkItemState.New),
-      this.sortBySortOrder,
-      this._layoutState.value,
-    );
   }
 
   private buildTooltip(item: WorkItem): vscode.MarkdownString {
@@ -92,10 +72,5 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<QueueElement>,
     if (draggedId === target.id) { return; }
 
     await this.workGraph.reorderItem(draggedId, target.id);
-  }
-
-  dispose(): void {
-    this._onDidChangeTreeData.dispose();
-    this.disposables.forEach(d => d.dispose());
   }
 }

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -133,9 +133,11 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<QueueElement>,
       return;
     }
 
-    if (draggedId === (target as WorkItem).id) { return; }
+    // After filtering out group nodes above, target is always a WorkItem
+    const targetItem = target as WorkItem;
+    if (draggedId === targetItem.id) { return; }
 
-    await this.workGraph.reorderItem(draggedId, (target as WorkItem).id);
+    await this.workGraph.reorderItem(draggedId, targetItem.id);
   }
 
   dispose(): void {

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -113,31 +113,23 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<QueueElement>,
   }
 
   async handleDrop(target: QueueElement | undefined, dataTransfer: vscode.DataTransfer): Promise<void> {
-    // Treat group node targets as "move to end"
-    if (target && isProviderGroupNode(target)) {
-      target = undefined;
-    }
-
     const transferItem = dataTransfer.get(DRAG_MIME_TYPE);
     if (!transferItem) { return; }
 
     const rawValue: unknown = transferItem.value;
     if (!Array.isArray(rawValue) || rawValue.length !== 1 || typeof rawValue[0] !== 'string') { return; }
 
-    const draggedIds: string[] = rawValue;
+    const draggedId: string = rawValue[0];
 
-    const draggedId = draggedIds[0];
-
-    if (!target) {
+    // Group node targets or no target → move to end
+    if (!target || isProviderGroupNode(target)) {
       await this.workGraph.moveToEnd(draggedId);
       return;
     }
 
-    // After filtering out group nodes above, target is always a WorkItem
-    const targetItem = target as WorkItem;
-    if (draggedId === targetItem.id) { return; }
+    if (draggedId === target.id) { return; }
 
-    await this.workGraph.reorderItem(draggedId, targetItem.id);
+    await this.workGraph.reorderItem(draggedId, target.id);
   }
 
   dispose(): void {

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -17,7 +17,12 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
   protected readonly groupContextValue = 'queueGroup';
 
   constructor(workGraph: WorkGraph, providerRegistry?: ProviderRegistry) {
-    super(workGraph, 'flat', providerRegistry ? id => providerRegistry.getProviderLabel(id) : undefined);
+    super(
+      workGraph,
+      'flat',
+      providerRegistry ? id => providerRegistry.getProviderLabel(id) : undefined,
+      providerRegistry?.onDidRegisterProvider,
+    );
   }
 
   protected getItems(): WorkItem[] {

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -53,11 +53,10 @@ export class QueueTreeProvider implements vscode.TreeDataProvider<QueueElement>,
 
   getChildren(element?: QueueElement): QueueElement[] {
     if (!element) {
-      const items = this.workGraph.getItemsByState(WorkItemState.New)
-        .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
+      const items = this.workGraph.getItemsByState(WorkItemState.New);
 
       if (this._layout === 'flat') {
-        return items;
+        return items.sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
       }
 
       return this.groupByProvider(items);

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
+import { ProviderRegistry } from '../services/providerRegistry';
 import {
   WorkItemElement, WorkItemViewProvider, isProviderGroupNode,
 } from './viewLayout';
@@ -15,8 +16,8 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
   protected readonly groupPrefix = 'queue';
   protected readonly groupContextValue = 'queueGroup';
 
-  constructor(workGraph: WorkGraph) {
-    super(workGraph, 'flat');
+  constructor(workGraph: WorkGraph, providerRegistry?: ProviderRegistry) {
+    super(workGraph, 'flat', providerRegistry ? id => providerRegistry.getProviderLabel(id) : undefined);
   }
 
   protected getItems(): WorkItem[] {

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -3,7 +3,7 @@ import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import { ProviderRegistry } from '../services/providerRegistry';
 import {
-  WorkItemElement, WorkItemViewProvider, isProviderGroupNode,
+  WorkItemElement, WorkItemViewProvider, isProviderGroupNode, isSubGroupNode,
 } from './viewLayout';
 
 export type QueueElement = WorkItemElement;
@@ -50,7 +50,7 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
   }
 
   handleDrag(source: readonly QueueElement[], dataTransfer: vscode.DataTransfer): void {
-    const items = source.filter((s): s is WorkItem => !isProviderGroupNode(s));
+    const items = source.filter((s): s is WorkItem => !isProviderGroupNode(s) && !isSubGroupNode(s));
     if (items.length === 0) { return; }
     dataTransfer.set(DRAG_MIME_TYPE, new vscode.DataTransferItem(items.map(s => s.id)));
   }
@@ -65,7 +65,7 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
     const draggedId: string = rawValue[0];
 
     // Group node targets or no target → move to end
-    if (!target || isProviderGroupNode(target)) {
+    if (!target || isProviderGroupNode(target) || isSubGroupNode(target)) {
       await this.workGraph.moveToEnd(draggedId);
       return;
     }

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { DiscoveredItem } from '../api/types';
 import { ProviderRegistry } from '../services/providerRegistry';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
+import { ViewLayout } from './viewLayout';
 
 export type SourcesElement = SourceProviderNode | SourceGroupNode | SourceItemNode;
 
@@ -31,6 +32,15 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private readonly disposables: vscode.Disposable[] = [];
+  private _layout: ViewLayout = 'tree';
+
+  get layout(): ViewLayout { return this._layout; }
+  set layout(value: ViewLayout) {
+    if (this._layout !== value) {
+      this._layout = value;
+      this._onDidChangeTreeData.fire();
+    }
+  }
 
   constructor(
     private readonly providerRegistry: ProviderRegistry,
@@ -73,6 +83,9 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
 
   getChildren(element?: SourcesElement): SourcesElement[] {
     if (!element) {
+      if (this._layout === 'flat') {
+        return this.getAllItems();
+      }
       const result: SourceProviderNode[] = [];
       const allItems = this.providerRegistry.getAllDiscoveredItems();
       for (const [providerId, items] of allItems) {
@@ -96,6 +109,17 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
     }
 
     return [];
+  }
+
+  private getAllItems(): SourceItemNode[] {
+    const result: SourceItemNode[] = [];
+    const allItems = this.providerRegistry.getAllDiscoveredItems();
+    for (const [providerId, items] of allItems) {
+      for (const item of items) {
+        result.push(this.toItemNode(providerId, item));
+      }
+    }
+    return result.sort((a, b) => a.title.localeCompare(b.title));
   }
 
   private getProviderChildren(providerId: string): SourcesElement[] {

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { DiscoveredItem } from '../api/types';
 import { ProviderRegistry } from '../services/providerRegistry';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
-import { ViewLayout } from './viewLayout';
+import { ViewLayout, LayoutState } from './viewLayout';
 
 export type SourcesElement = SourceProviderNode | SourceGroupNode | SourceItemNode;
 
@@ -32,20 +32,16 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
   private readonly disposables: vscode.Disposable[] = [];
-  private _layout: ViewLayout = 'tree';
+  private readonly _layoutState: LayoutState;
 
-  get layout(): ViewLayout { return this._layout; }
-  set layout(value: ViewLayout) {
-    if (this._layout !== value) {
-      this._layout = value;
-      this._onDidChangeTreeData.fire();
-    }
-  }
+  get layout(): ViewLayout { return this._layoutState.value; }
+  set layout(value: ViewLayout) { this._layoutState.value = value; }
 
   constructor(
     private readonly providerRegistry: ProviderRegistry,
     private readonly stateStore: DiscoveredStateStore,
   ) {
+    this._layoutState = new LayoutState('tree', () => this._onDidChangeTreeData.fire());
     this.disposables.push(
       providerRegistry.onDidChangeDiscoveredItems(() => this._onDidChangeTreeData.fire()),
       stateStore.onDidChange(() => this._onDidChangeTreeData.fire())
@@ -83,7 +79,7 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
 
   getChildren(element?: SourcesElement): SourcesElement[] {
     if (!element) {
-      if (this._layout === 'flat') {
+      if (this._layoutState.value === 'flat') {
         return this.getAllItems();
       }
       const result: SourceProviderNode[] = [];

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -36,11 +36,13 @@ export async function toggleViewLayout(viewId: ViewId): Promise<void> {
   const current = getViewLayout(viewId);
   layouts[viewId] = current === 'flat' ? 'tree' : 'flat';
 
-  // Update in workspace scope if one exists, otherwise global
+  // Update the most specific existing scope so the effective layout changes
   const inspection = config.inspect('viewLayout');
-  const target = inspection?.workspaceValue !== undefined
-    ? vscode.ConfigurationTarget.Workspace
-    : vscode.ConfigurationTarget.Global;
+  const target = inspection?.workspaceFolderValue !== undefined
+    ? vscode.ConfigurationTarget.WorkspaceFolder
+    : inspection?.workspaceValue !== undefined
+      ? vscode.ConfigurationTarget.Workspace
+      : vscode.ConfigurationTarget.Global;
   await config.update('viewLayout', layouts, target);
 }
 

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -26,6 +26,22 @@ export function getViewLayout(viewId: ViewId): ViewLayout {
   return VIEW_DEFAULTS[viewId];
 }
 
+const VALID_VIEW_IDS: ReadonlySet<string> = new Set<ViewId>(['inbox', 'queue', 'focus', 'history', 'sources']);
+
+/** Extract only valid ViewId keys with valid ViewLayout values from an unknown object. */
+function sanitizeLayouts(raw: unknown): Record<string, string> {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return {};
+  }
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(raw as Record<string, unknown>)) {
+    if (VALID_VIEW_IDS.has(key) && (value === 'flat' || value === 'tree')) {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
 /** Toggle the layout for a view between flat and tree and persist the choice. */
 export async function toggleViewLayout(viewId: ViewId): Promise<void> {
   const config = vscode.workspace.getConfiguration('workcenter');
@@ -46,9 +62,7 @@ export async function toggleViewLayout(viewId: ViewId): Promise<void> {
     target = vscode.ConfigurationTarget.Global;
   }
 
-  const layouts: Record<string, string> = (scopeValue && typeof scopeValue === 'object' && !Array.isArray(scopeValue))
-    ? { ...(scopeValue as Record<string, string>) }
-    : {};
+  const layouts = sanitizeLayouts(scopeValue);
   layouts[viewId] = current === 'flat' ? 'tree' : 'flat';
 
   await config.update('viewLayout', layouts, target);

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -126,16 +126,13 @@ function normalizeProviderId(providerId: string | null | undefined): string | un
  * Items without a providerId (or with an empty/whitespace one) are grouped under "Other" (sorted last).
  */
 export function groupByProvider(items: WorkItem[]): ProviderGroupNode[] {
-  const groups = new Map<string | undefined, WorkItem[]>();
+  const seen = new Set<string | undefined>();
   for (const item of items) {
-    const key = normalizeProviderId(item.providerId);
-    const list = groups.get(key) ?? [];
-    list.push(item);
-    groups.set(key, list);
+    seen.add(normalizeProviderId(item.providerId));
   }
 
   const result: ProviderGroupNode[] = [];
-  for (const [providerId] of groups) {
+  for (const providerId of seen) {
     result.push({
       kind: 'providerGroup',
       label: providerId ?? 'Other',
@@ -189,7 +186,8 @@ export function createProviderGroupTreeItem(
   contextValue: string,
 ): vscode.TreeItem {
   const treeItem = new vscode.TreeItem(node.label, vscode.TreeItemCollapsibleState.Collapsed);
-  treeItem.id = `${prefix}::group::${node.providerId ?? '__other__'}`;
+  const idSuffix = node.providerId ? `provider:${node.providerId}` : 'other';
+  treeItem.id = `${prefix}::group::${idSuffix}`;
   treeItem.contextValue = contextValue;
   treeItem.iconPath = new vscode.ThemeIcon(node.providerId ? 'plug' : 'circle-filled');
   return treeItem;

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { WorkItem } from '../models/workItem';
 
 export type ViewLayout = 'flat' | 'tree';
 
@@ -78,4 +79,100 @@ export function isProviderGroupNode(element: unknown): element is ProviderGroupN
     element !== null &&
     (element as Record<string, unknown>).kind === 'providerGroup'
   );
+}
+
+/**
+ * Composable layout state that fires a change event when the layout toggles.
+ * Providers own one of these instead of duplicating the getter/setter boilerplate.
+ */
+export class LayoutState {
+  private _layout: ViewLayout;
+
+  constructor(
+    defaultLayout: ViewLayout,
+    private readonly fireChange: () => void,
+  ) {
+    this._layout = defaultLayout;
+  }
+
+  get value(): ViewLayout { return this._layout; }
+  set value(next: ViewLayout) {
+    if (this._layout !== next) {
+      this._layout = next;
+      this.fireChange();
+    }
+  }
+}
+
+/**
+ * Group WorkItems by providerId into ProviderGroupNodes.
+ * Items without a providerId are grouped under "Other" (sorted last).
+ */
+export function groupByProvider(items: WorkItem[]): ProviderGroupNode[] {
+  const groups = new Map<string | undefined, WorkItem[]>();
+  for (const item of items) {
+    const key = item.providerId ?? undefined;
+    const list = groups.get(key) ?? [];
+    list.push(item);
+    groups.set(key, list);
+  }
+
+  const result: ProviderGroupNode[] = [];
+  for (const [providerId] of groups) {
+    result.push({
+      kind: 'providerGroup',
+      label: providerId ?? 'Other',
+      providerId,
+    });
+  }
+  return result.sort((a, b) => {
+    if (!a.providerId) { return 1; }
+    if (!b.providerId) { return -1; }
+    return a.label.localeCompare(b.label);
+  });
+}
+
+/**
+ * Common getChildren routing for providers that show WorkItems
+ * in either flat or tree (grouped-by-provider) mode.
+ *
+ * @param element   The tree element being expanded (undefined = root)
+ * @param getItems  Returns all relevant WorkItems for this view
+ * @param sortItems Sorts a flat list of items (view-specific ordering)
+ * @param layout    Current layout mode
+ */
+export function getTreeModeChildren(
+  element: WorkItem | ProviderGroupNode | undefined,
+  getItems: () => WorkItem[],
+  sortItems: (items: WorkItem[]) => WorkItem[],
+  layout: ViewLayout,
+): (WorkItem | ProviderGroupNode)[] {
+  if (!element) {
+    const items = getItems();
+    if (layout === 'flat') {
+      return sortItems(items);
+    }
+    return groupByProvider(items);
+  }
+
+  if (isProviderGroupNode(element)) {
+    return sortItems(
+      getItems().filter(i => (i.providerId ?? undefined) === element.providerId),
+    );
+  }
+
+  return [];
+}
+
+/** Create a TreeItem for a ProviderGroupNode with a view-specific id prefix and contextValue. */
+export function createProviderGroupTreeItem(
+  node: ProviderGroupNode,
+  prefix: string,
+  contextValue: string,
+): vscode.TreeItem {
+  const treeItem = new vscode.TreeItem(node.label, vscode.TreeItemCollapsibleState.Collapsed);
+  treeItem.id = `${prefix}::group::${node.providerId ?? '__other__'}`;
+  treeItem.contextValue = contextValue;
+  treeItem.iconPath = new vscode.ThemeIcon(node.providerId ? 'plug' : 'circle-filled');
+  return treeItem;
 }

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -48,23 +48,15 @@ export async function toggleViewLayout(viewId: ViewId): Promise<void> {
   const config = vscode.workspace.getConfiguration('workcenter');
   const current = getViewLayout(viewId);
 
-  // Update at the most-specific scope that already has a value so the toggle
-  // takes effect even when a narrower scope overrides broader ones
-  // (e.g. workspace-folder > workspace > global).
+  // Only target Workspace or Global scope. Workspace-folder scope requires a
+  // resource URI that toggle commands don't have, so updating it without one
+  // could silently write to the wrong folder in multi-root workspaces.
   const inspection = config.inspect('viewLayout');
-  let scopeValue: unknown;
-  let target: vscode.ConfigurationTarget;
-
-  if (inspection?.workspaceFolderValue !== undefined) {
-    scopeValue = inspection.workspaceFolderValue;
-    target = vscode.ConfigurationTarget.WorkspaceFolder;
-  } else if (inspection?.workspaceValue !== undefined) {
-    scopeValue = inspection.workspaceValue;
-    target = vscode.ConfigurationTarget.Workspace;
-  } else {
-    scopeValue = inspection?.globalValue;
-    target = vscode.ConfigurationTarget.Global;
-  }
+  const hasWorkspaceValue = inspection?.workspaceValue !== undefined;
+  const scopeValue = hasWorkspaceValue ? inspection.workspaceValue : inspection?.globalValue;
+  const target = hasWorkspaceValue
+    ? vscode.ConfigurationTarget.Workspace
+    : vscode.ConfigurationTarget.Global;
 
   const layouts = sanitizeLayouts(scopeValue);
   layouts[viewId] = current === 'flat' ? 'tree' : 'flat';

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -1,0 +1,52 @@
+import * as vscode from 'vscode';
+
+export type ViewLayout = 'flat' | 'tree';
+
+export type ViewId = 'inbox' | 'queue' | 'focus' | 'history' | 'sources';
+
+const VIEW_DEFAULTS: Record<ViewId, ViewLayout> = {
+  inbox: 'tree',
+  queue: 'flat',
+  focus: 'flat',
+  history: 'flat',
+  sources: 'tree',
+};
+
+/** Read the persisted layout for a given view, falling back to its default. */
+export function getViewLayout(viewId: ViewId): ViewLayout {
+  const config = vscode.workspace.getConfiguration('workcenter');
+  const layouts = config.get<Record<string, string>>('viewLayout', {});
+  const value = layouts[viewId];
+  if (value === 'flat' || value === 'tree') {
+    return value;
+  }
+  return VIEW_DEFAULTS[viewId];
+}
+
+/** Toggle the layout for a view between flat and tree and persist the choice. */
+export async function toggleViewLayout(viewId: ViewId): Promise<void> {
+  const config = vscode.workspace.getConfiguration('workcenter');
+  const layouts = { ...config.get<Record<string, string>>('viewLayout', {}) };
+  const current = getViewLayout(viewId);
+  layouts[viewId] = current === 'flat' ? 'tree' : 'flat';
+  await config.update('viewLayout', layouts, vscode.ConfigurationTarget.Global);
+}
+
+/**
+ * Group node used by Queue, Focus, and History views in tree mode.
+ * Items that share a providerId are grouped under one of these nodes;
+ * manually-created items (no providerId) are grouped under "Other".
+ */
+export interface ProviderGroupNode {
+  kind: 'providerGroup';
+  label: string;
+  providerId: string | undefined;
+}
+
+export function isProviderGroupNode(element: unknown): element is ProviderGroupNode {
+  return (
+    typeof element === 'object' &&
+    element !== null &&
+    (element as Record<string, unknown>).kind === 'providerGroup'
+  );
+}

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -15,7 +15,10 @@ const VIEW_DEFAULTS: Record<ViewId, ViewLayout> = {
 /** Read the persisted layout for a given view, falling back to its default. */
 export function getViewLayout(viewId: ViewId): ViewLayout {
   const config = vscode.workspace.getConfiguration('workcenter');
-  const layouts = config.get<Record<string, string>>('viewLayout', {});
+  const layoutsRaw: unknown = config.get('viewLayout');
+  const layouts = (layoutsRaw && typeof layoutsRaw === 'object' && !Array.isArray(layoutsRaw))
+    ? layoutsRaw as Record<string, unknown>
+    : {};
   const value = layouts[viewId];
   if (value === 'flat' || value === 'tree') {
     return value;

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -29,20 +29,28 @@ export function getViewLayout(viewId: ViewId): ViewLayout {
 /** Toggle the layout for a view between flat and tree and persist the choice. */
 export async function toggleViewLayout(viewId: ViewId): Promise<void> {
   const config = vscode.workspace.getConfiguration('workcenter');
-  const raw: unknown = config.get('viewLayout');
-  const layouts: Record<string, string> = (raw && typeof raw === 'object' && !Array.isArray(raw))
-    ? { ...(raw as Record<string, string>) }
-    : {};
   const current = getViewLayout(viewId);
+
+  // Determine which scope to update and base the new value on that scope's data
+  const inspection = config.inspect('viewLayout');
+  let scopeValue: unknown;
+  let target: vscode.ConfigurationTarget;
+  if (inspection?.workspaceFolderValue !== undefined) {
+    scopeValue = inspection.workspaceFolderValue;
+    target = vscode.ConfigurationTarget.WorkspaceFolder;
+  } else if (inspection?.workspaceValue !== undefined) {
+    scopeValue = inspection.workspaceValue;
+    target = vscode.ConfigurationTarget.Workspace;
+  } else {
+    scopeValue = inspection?.globalValue;
+    target = vscode.ConfigurationTarget.Global;
+  }
+
+  const layouts: Record<string, string> = (scopeValue && typeof scopeValue === 'object' && !Array.isArray(scopeValue))
+    ? { ...(scopeValue as Record<string, string>) }
+    : {};
   layouts[viewId] = current === 'flat' ? 'tree' : 'flat';
 
-  // Update the most specific existing scope so the effective layout changes
-  const inspection = config.inspect('viewLayout');
-  const target = inspection?.workspaceFolderValue !== undefined
-    ? vscode.ConfigurationTarget.WorkspaceFolder
-    : inspection?.workspaceValue !== undefined
-      ? vscode.ConfigurationTarget.Workspace
-      : vscode.ConfigurationTarget.Global;
   await config.update('viewLayout', layouts, target);
 }
 

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -52,6 +52,14 @@ export async function toggleViewLayout(viewId: ViewId): Promise<void> {
   // resource URI that toggle commands don't have, so updating it without one
   // could silently write to the wrong folder in multi-root workspaces.
   const inspection = config.inspect('viewLayout');
+
+  if (inspection?.workspaceFolderValue !== undefined) {
+    void vscode.window.showWarningMessage(
+      'A workspace-folder setting is overriding the layout for this view. ' +
+      'Update or remove "workcenter.viewLayout" in your folder settings to use the toggle.',
+    );
+  }
+
   const hasWorkspaceValue = inspection?.workspaceValue !== undefined;
   const scopeValue = hasWorkspaceValue ? inspection.workspaceValue : inspection?.globalValue;
   const target = hasWorkspaceValue

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -222,21 +222,16 @@ function getProviderChildren(
     }
   }
 
-  const result: (SubGroupNode | WorkItem)[] = [];
+  const subGroups: SubGroupNode[] = [];
 
   for (const groupName of groups) {
-    result.push({ kind: 'subGroup', label: groupName, providerId, groupName });
+    subGroups.push({ kind: 'subGroup', label: groupName, providerId, groupName });
   }
 
-  for (const item of sortItems(ungrouped)) {
-    result.push(item);
-  }
+  const sortedSubGroups = subGroups.sort((a, b) => a.label.localeCompare(b.label));
+  const sortedUngrouped = sortItems(ungrouped);
 
-  return result.sort((a, b) => {
-    const aLabel = isSubGroupNode(a) ? a.label : a.title;
-    const bLabel = isSubGroupNode(b) ? b.label : b.title;
-    return aLabel.localeCompare(bLabel);
-  });
+  return [...sortedSubGroups, ...sortedUngrouped];
 }
 
 /** Create a TreeItem for a ProviderGroupNode with a view-specific id prefix and contextValue. */

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -133,6 +133,7 @@ export function groupByProvider(items: WorkItem[]): ProviderGroupNode[] {
     });
   }
   return result.sort((a, b) => {
+    if (!a.providerId && !b.providerId) { return 0; }
     if (!a.providerId) { return 1; }
     if (!b.providerId) { return -1; }
     return a.label.localeCompare(b.label);

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -47,20 +47,13 @@ export async function toggleViewLayout(viewId: ViewId): Promise<void> {
   const config = vscode.workspace.getConfiguration('workcenter');
   const current = getViewLayout(viewId);
 
-  // Determine which scope to update and base the new value on that scope's data
+  // Persist this UI preference at workspace scope when available; otherwise use global scope
   const inspection = config.inspect('viewLayout');
-  let scopeValue: unknown;
-  let target: vscode.ConfigurationTarget;
-  if (inspection?.workspaceFolderValue !== undefined) {
-    scopeValue = inspection.workspaceFolderValue;
-    target = vscode.ConfigurationTarget.WorkspaceFolder;
-  } else if (inspection?.workspaceValue !== undefined) {
-    scopeValue = inspection.workspaceValue;
-    target = vscode.ConfigurationTarget.Workspace;
-  } else {
-    scopeValue = inspection?.globalValue;
-    target = vscode.ConfigurationTarget.Global;
-  }
+  const hasWorkspaceValue = inspection?.workspaceValue !== undefined;
+  const scopeValue = hasWorkspaceValue ? inspection.workspaceValue : inspection?.globalValue;
+  const target = hasWorkspaceValue
+    ? vscode.ConfigurationTarget.Workspace
+    : vscode.ConfigurationTarget.Global;
 
   const layouts = sanitizeLayouts(scopeValue);
   layouts[viewId] = current === 'flat' ? 'tree' : 'flat';

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -29,10 +29,19 @@ export function getViewLayout(viewId: ViewId): ViewLayout {
 /** Toggle the layout for a view between flat and tree and persist the choice. */
 export async function toggleViewLayout(viewId: ViewId): Promise<void> {
   const config = vscode.workspace.getConfiguration('workcenter');
-  const layouts = { ...config.get<Record<string, string>>('viewLayout', {}) };
+  const raw: unknown = config.get('viewLayout');
+  const layouts: Record<string, string> = (raw && typeof raw === 'object' && !Array.isArray(raw))
+    ? { ...(raw as Record<string, string>) }
+    : {};
   const current = getViewLayout(viewId);
   layouts[viewId] = current === 'flat' ? 'tree' : 'flat';
-  await config.update('viewLayout', layouts, vscode.ConfigurationTarget.Global);
+
+  // Update in workspace scope if one exists, otherwise global
+  const inspection = config.inspect('viewLayout');
+  const target = inspection?.workspaceValue !== undefined
+    ? vscode.ConfigurationTarget.Workspace
+    : vscode.ConfigurationTarget.Global;
+  await config.update('viewLayout', layouts, target);
 }
 
 /**

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -303,11 +303,17 @@ export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<Wo
     protected readonly workGraph: import('../services/workGraph').WorkGraph,
     defaultLayout: ViewLayout,
     private readonly labelResolver?: LabelResolver,
+    providerChangeEvent?: import('vscode').Event<void>,
   ) {
     this._layoutState = new LayoutState(defaultLayout, () => this._onDidChangeTreeData.fire());
     this.disposables.push(
       workGraph.onDidChange(() => this._onDidChangeTreeData.fire()),
     );
+    if (providerChangeEvent) {
+      this.disposables.push(
+        providerChangeEvent(() => this._onDidChangeTreeData.fire()),
+      );
+    }
   }
 
   refresh(): void { this._onDidChangeTreeData.fire(); }

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -48,13 +48,23 @@ export async function toggleViewLayout(viewId: ViewId): Promise<void> {
   const config = vscode.workspace.getConfiguration('workcenter');
   const current = getViewLayout(viewId);
 
-  // Persist this UI preference at workspace scope when available; otherwise use global scope
+  // Update at the most-specific scope that already has a value so the toggle
+  // takes effect even when a narrower scope overrides broader ones
+  // (e.g. workspace-folder > workspace > global).
   const inspection = config.inspect('viewLayout');
-  const hasWorkspaceValue = inspection?.workspaceValue !== undefined;
-  const scopeValue = hasWorkspaceValue ? inspection.workspaceValue : inspection?.globalValue;
-  const target = hasWorkspaceValue
-    ? vscode.ConfigurationTarget.Workspace
-    : vscode.ConfigurationTarget.Global;
+  let scopeValue: unknown;
+  let target: vscode.ConfigurationTarget;
+
+  if (inspection?.workspaceFolderValue !== undefined) {
+    scopeValue = inspection.workspaceFolderValue;
+    target = vscode.ConfigurationTarget.WorkspaceFolder;
+  } else if (inspection?.workspaceValue !== undefined) {
+    scopeValue = inspection.workspaceValue;
+    target = vscode.ConfigurationTarget.Workspace;
+  } else {
+    scopeValue = inspection?.globalValue;
+    target = vscode.ConfigurationTarget.Global;
+  }
 
   const layouts = sanitizeLayouts(scopeValue);
   layouts[viewId] = current === 'flat' ? 'tree' : 'flat';

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -159,6 +159,10 @@ export function groupByProvider(items: WorkItem[], labelResolver?: LabelResolver
  * Common getChildren routing for providers that show WorkItems
  * in either flat or tree (grouped-by-provider) mode.
  *
+ * Tree mode uses a two-level hierarchy matching the Inbox:
+ *   provider → sub-group (item.group) → items
+ * Items without a group appear directly under the provider node.
+ *
  * @param element        The tree element being expanded (undefined = root)
  * @param getItems       Returns all relevant WorkItems for this view
  * @param sortItems      Sorts a flat list of items (view-specific ordering)
@@ -166,12 +170,12 @@ export function groupByProvider(items: WorkItem[], labelResolver?: LabelResolver
  * @param labelResolver  Optional function that maps a providerId to a display name.
  */
 export function getTreeModeChildren(
-  element: WorkItem | ProviderGroupNode | undefined,
+  element: WorkItem | ProviderGroupNode | SubGroupNode | undefined,
   getItems: () => WorkItem[],
   sortItems: (items: WorkItem[]) => WorkItem[],
   layout: ViewLayout,
   labelResolver?: LabelResolver,
-): (WorkItem | ProviderGroupNode)[] {
+): (WorkItem | ProviderGroupNode | SubGroupNode)[] {
   if (!element) {
     const items = getItems();
     if (layout === 'flat') {
@@ -181,12 +185,58 @@ export function getTreeModeChildren(
   }
 
   if (isProviderGroupNode(element)) {
+    const providerItems = getItems().filter(
+      i => normalizeProviderId(i.providerId) === element.providerId,
+    );
+    return getProviderChildren(providerItems, element.providerId, sortItems);
+  }
+
+  if (isSubGroupNode(element)) {
     return sortItems(
-      getItems().filter(i => normalizeProviderId(i.providerId) === element.providerId),
+      getItems().filter(
+        i => normalizeProviderId(i.providerId) === element.providerId && i.group === element.groupName,
+      ),
     );
   }
 
   return [];
+}
+
+/**
+ * Build children for a provider group node: sub-group nodes for items that
+ * have a `group` value, plus ungrouped items rendered directly.
+ */
+function getProviderChildren(
+  items: WorkItem[],
+  providerId: string | undefined,
+  sortItems: (items: WorkItem[]) => WorkItem[],
+): (SubGroupNode | WorkItem)[] {
+  const groups = new Set<string>();
+  const ungrouped: WorkItem[] = [];
+
+  for (const item of items) {
+    if (item.group) {
+      groups.add(item.group);
+    } else {
+      ungrouped.push(item);
+    }
+  }
+
+  const result: (SubGroupNode | WorkItem)[] = [];
+
+  for (const groupName of groups) {
+    result.push({ kind: 'subGroup', label: groupName, providerId, groupName });
+  }
+
+  for (const item of sortItems(ungrouped)) {
+    result.push(item);
+  }
+
+  return result.sort((a, b) => {
+    const aLabel = isSubGroupNode(a) ? a.label : a.title;
+    const bLabel = isSubGroupNode(b) ? b.label : b.title;
+    return aLabel.localeCompare(bLabel);
+  });
 }
 
 /** Create a TreeItem for a ProviderGroupNode with a view-specific id prefix and contextValue. */
@@ -203,10 +253,42 @@ export function createProviderGroupTreeItem(
   return treeItem;
 }
 
+/** Create a TreeItem for a SubGroupNode. */
+export function createSubGroupTreeItem(
+  node: SubGroupNode,
+  prefix: string,
+): vscode.TreeItem {
+  const treeItem = new vscode.TreeItem(node.label, vscode.TreeItemCollapsibleState.Collapsed);
+  const providerPart = node.providerId ? `provider:${node.providerId}` : 'other';
+  treeItem.id = `${prefix}::subgroup::${providerPart}::${node.groupName}`;
+  treeItem.contextValue = `${prefix}SubGroup`;
+  treeItem.iconPath = new vscode.ThemeIcon('folder');
+  return treeItem;
+}
+
+/**
+ * Sub-group node within a provider group. Groups items that share the same
+ * `item.group` value under a provider node, mirroring the Inbox's two-level hierarchy.
+ */
+export interface SubGroupNode {
+  kind: 'subGroup';
+  label: string;
+  providerId: string | undefined;
+  groupName: string;
+}
+
+export function isSubGroupNode(element: unknown): element is SubGroupNode {
+  return (
+    typeof element === 'object' &&
+    element !== null &&
+    (element as Record<string, unknown>).kind === 'subGroup'
+  );
+}
+
 /**
  * Element type for providers that display WorkItems with optional provider grouping.
  */
-export type WorkItemElement = WorkItem | ProviderGroupNode;
+export type WorkItemElement = WorkItem | ProviderGroupNode | SubGroupNode;
 
 /**
  * Abstract base for Focus, Queue, and History tree providers.
@@ -253,6 +335,9 @@ export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<Wo
   getTreeItem(element: WorkItemElement): vscode.TreeItem {
     if (isProviderGroupNode(element)) {
       return createProviderGroupTreeItem(element, this.groupPrefix, this.groupContextValue);
+    }
+    if (isSubGroupNode(element)) {
+      return createSubGroupTreeItem(element, this.groupPrefix);
     }
     return this.createWorkItemTreeItem(element);
   }

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -184,3 +184,71 @@ export function createProviderGroupTreeItem(
   treeItem.iconPath = new vscode.ThemeIcon(node.providerId ? 'plug' : 'circle-filled');
   return treeItem;
 }
+
+/**
+ * Element type for providers that display WorkItems with optional provider grouping.
+ */
+export type WorkItemElement = WorkItem | ProviderGroupNode;
+
+/**
+ * Abstract base for Focus, Queue, and History tree providers.
+ * Encapsulates the shared layout state, event wiring, getChildren routing,
+ * and getTreeItem delegation so subclasses only define view-specific logic.
+ */
+export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<WorkItemElement> {
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<void>();
+  readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+  protected readonly disposables: vscode.Disposable[] = [];
+  private readonly _layoutState: LayoutState;
+
+  get layout(): ViewLayout { return this._layoutState.value; }
+  set layout(value: ViewLayout) { this._layoutState.value = value; }
+
+  constructor(
+    protected readonly workGraph: import('../services/workGraph').WorkGraph,
+    defaultLayout: ViewLayout,
+  ) {
+    this._layoutState = new LayoutState(defaultLayout, () => this._onDidChangeTreeData.fire());
+    this.disposables.push(
+      workGraph.onDidChange(() => this._onDidChangeTreeData.fire()),
+    );
+  }
+
+  refresh(): void { this._onDidChangeTreeData.fire(); }
+
+  /** Return the WorkItems this view cares about (before sorting). */
+  protected abstract getItems(): WorkItem[];
+
+  /** View-specific sort order applied in both flat and group-expanded modes. */
+  protected abstract sortItems(items: WorkItem[]): WorkItem[];
+
+  /** ID prefix for provider-group tree items (e.g. 'focus', 'queue'). */
+  protected abstract readonly groupPrefix: string;
+
+  /** contextValue for provider-group tree items (e.g. 'focusGroup'). */
+  protected abstract readonly groupContextValue: string;
+
+  /** Create a TreeItem for a WorkItem (not a group node). */
+  protected abstract createWorkItemTreeItem(item: WorkItem): vscode.TreeItem;
+
+  getTreeItem(element: WorkItemElement): vscode.TreeItem {
+    if (isProviderGroupNode(element)) {
+      return createProviderGroupTreeItem(element, this.groupPrefix, this.groupContextValue);
+    }
+    return this.createWorkItemTreeItem(element);
+  }
+
+  getChildren(element?: WorkItemElement): WorkItemElement[] {
+    return getTreeModeChildren(
+      element,
+      () => this.getItems(),
+      items => this.sortItems(items),
+      this._layoutState.value,
+    );
+  }
+
+  dispose(): void {
+    this._onDidChangeTreeData.dispose();
+    this.disposables.forEach(d => d.dispose());
+  }
+}

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -122,10 +122,18 @@ function normalizeProviderId(providerId: string | null | undefined): string | un
 }
 
 /**
+ * Resolves a raw providerId to a human-friendly display name.
+ * When not supplied, the raw providerId is used as-is.
+ */
+export type LabelResolver = (providerId: string) => string;
+
+/**
  * Group WorkItems by providerId into ProviderGroupNodes.
  * Items without a providerId (or with an empty/whitespace one) are grouped under "Other" (sorted last).
+ *
+ * @param labelResolver  Optional function that maps a providerId to a display name.
  */
-export function groupByProvider(items: WorkItem[]): ProviderGroupNode[] {
+export function groupByProvider(items: WorkItem[], labelResolver?: LabelResolver): ProviderGroupNode[] {
   const seen = new Set<string | undefined>();
   for (const item of items) {
     seen.add(normalizeProviderId(item.providerId));
@@ -135,7 +143,7 @@ export function groupByProvider(items: WorkItem[]): ProviderGroupNode[] {
   for (const providerId of seen) {
     result.push({
       kind: 'providerGroup',
-      label: providerId ?? 'Other',
+      label: providerId ? (labelResolver?.(providerId) ?? providerId) : 'Other',
       providerId,
     });
   }
@@ -151,23 +159,25 @@ export function groupByProvider(items: WorkItem[]): ProviderGroupNode[] {
  * Common getChildren routing for providers that show WorkItems
  * in either flat or tree (grouped-by-provider) mode.
  *
- * @param element   The tree element being expanded (undefined = root)
- * @param getItems  Returns all relevant WorkItems for this view
- * @param sortItems Sorts a flat list of items (view-specific ordering)
- * @param layout    Current layout mode
+ * @param element        The tree element being expanded (undefined = root)
+ * @param getItems       Returns all relevant WorkItems for this view
+ * @param sortItems      Sorts a flat list of items (view-specific ordering)
+ * @param layout         Current layout mode
+ * @param labelResolver  Optional function that maps a providerId to a display name.
  */
 export function getTreeModeChildren(
   element: WorkItem | ProviderGroupNode | undefined,
   getItems: () => WorkItem[],
   sortItems: (items: WorkItem[]) => WorkItem[],
   layout: ViewLayout,
+  labelResolver?: LabelResolver,
 ): (WorkItem | ProviderGroupNode)[] {
   if (!element) {
     const items = getItems();
     if (layout === 'flat') {
       return sortItems(items);
     }
-    return groupByProvider(items);
+    return groupByProvider(items, labelResolver);
   }
 
   if (isProviderGroupNode(element)) {
@@ -215,6 +225,7 @@ export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<Wo
   constructor(
     protected readonly workGraph: import('../services/workGraph').WorkGraph,
     defaultLayout: ViewLayout,
+    private readonly labelResolver?: LabelResolver,
   ) {
     this._layoutState = new LayoutState(defaultLayout, () => this._onDidChangeTreeData.fire());
     this.disposables.push(
@@ -252,6 +263,7 @@ export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<Wo
       () => this.getItems(),
       items => this.sortItems(items),
       this._layoutState.value,
+      this.labelResolver,
     );
   }
 

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -105,13 +105,20 @@ export class LayoutState {
 }
 
 /**
+ * Normalize a providerId: treat empty/whitespace-only strings the same as undefined.
+ */
+function normalizeProviderId(providerId: string | null | undefined): string | undefined {
+  return providerId?.trim() || undefined;
+}
+
+/**
  * Group WorkItems by providerId into ProviderGroupNodes.
- * Items without a providerId are grouped under "Other" (sorted last).
+ * Items without a providerId (or with an empty/whitespace one) are grouped under "Other" (sorted last).
  */
 export function groupByProvider(items: WorkItem[]): ProviderGroupNode[] {
   const groups = new Map<string | undefined, WorkItem[]>();
   for (const item of items) {
-    const key = item.providerId ?? undefined;
+    const key = normalizeProviderId(item.providerId);
     const list = groups.get(key) ?? [];
     list.push(item);
     groups.set(key, list);
@@ -157,7 +164,7 @@ export function getTreeModeChildren(
 
   if (isProviderGroupNode(element)) {
     return sortItems(
-      getItems().filter(i => (i.providerId ?? undefined) === element.providerId),
+      getItems().filter(i => normalizeProviderId(i.providerId) === element.providerId),
     );
   }
 


### PR DESCRIPTION
## Summary

Adds a per-view layout toggle for all five WorkCenter views (Inbox, Queue, Focus, History, Sources), allowing users to independently switch each view between flat list and tree layouts.

Closes #190

## Changes

### New: `workcenter.viewLayout` configuration
An object setting where keys are view names (`inbox`, `queue`, `focus`, `history`, `sources`) and values are `flat` or `tree`. Each view has a sensible default (Inbox/Sources default to `tree`, Queue/Focus/History default to `flat`).

### Toggle commands & view title buttons
Five new commands (`workcenter.toggleInboxLayout`, etc.) appear as inline buttons in each view's title bar using the `list-tree` icon.

### Flat mode for tree views (Inbox, Sources)
Shows all items in a single alphabetically-sorted flat list without provider/group hierarchy.

### Tree mode for flat views (Queue, Focus, History)
Groups items by provider (items with a `providerId` get their own group; manually-created items are grouped under "Other"). The "Other" group always sorts last.

### Configuration change listener
Views automatically refresh when the `workcenter.viewLayout` setting changes externally (e.g., from Settings UI). Context keys (`workcenter.inboxLayout`, etc.) are set for potential `when` clause usage.

## Testing
- 60 new tests across 6 test files covering layout switching, grouping logic, group node rendering, and the `viewLayout` utility functions
- All 757 core tests pass (up from 697)
- Full build succeeds across all packages
