### PR TITLE
feat: support multiple ADO organizations via unified project list

### DIFF
--- a/packages/ado/package.json
+++ b/packages/ado/package.json
@@ -22,19 +22,13 @@
     "configuration": {
       "title": "WorkCenter Azure DevOps",
       "properties": {
-        "workcenterAdo.organization": {
-          "type": "string",
-          "default": "",
-          "description": "(Deprecated) Azure DevOps organization name. Use workcenterAdo.projects with 'org' or 'org/project' entries instead.",
-          "deprecationMessage": "Use workcenterAdo.projects with entries like 'myorg' or 'myorg/myproject' instead."
-        },
         "workcenterAdo.projects": {
           "type": "array",
           "items": {
             "type": "string"
           },
           "default": [],
-          "description": "Azure DevOps organizations and projects to monitor. Each entry is either '<org>' (monitor entire organization) or '<org>/<project>' (monitor a specific project). Supports multiple organizations. For backward compatibility, plain project names are treated as projects under workcenterAdo.organization if that setting is configured."
+          "description": "Azure DevOps organizations and projects to monitor. Each entry is either '<org>' (monitor entire organization) or '<org>/<project>' (monitor a specific project). Supports multiple organizations."
         },
         "workcenterAdo.refreshIntervalSeconds": {
           "type": "number",

--- a/packages/ado/package.json
+++ b/packages/ado/package.json
@@ -25,7 +25,8 @@
         "workcenterAdo.organization": {
           "type": "string",
           "default": "",
-          "description": "Azure DevOps organization name"
+          "description": "(Deprecated) Azure DevOps organization name. Use workcenterAdo.projects with 'org' or 'org/project' entries instead.",
+          "deprecationMessage": "Use workcenterAdo.projects with entries like 'myorg' or 'myorg/myproject' instead."
         },
         "workcenterAdo.projects": {
           "type": "array",
@@ -33,7 +34,7 @@
             "type": "string"
           },
           "default": [],
-          "description": "Azure DevOps projects to monitor. Leave empty to fetch assigned work items and PRs across the entire organization."
+          "description": "Azure DevOps organizations and projects to monitor. Each entry is either '<org>' (monitor entire organization) or '<org>/<project>' (monitor a specific project). Supports multiple organizations. For backward compatibility, plain project names are treated as projects under workcenterAdo.organization if that setting is configured."
         },
         "workcenterAdo.refreshIntervalSeconds": {
           "type": "number",

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -102,7 +102,8 @@ export class AdoPrReviewProvider extends BaseProvider {
 
   private async fetchAndPublishPrs(accessToken: string, isUserTriggered: boolean, sessionAccountId: string): Promise<void> {
     const allItems: DiscoveredItem[] = [];
-    const failures: string[] = [];
+    const identityFailures: string[] = [];
+    const fetchFailures: string[] = [];
 
     for (const orgConfig of this.orgConfigs) {
       if (!isValidUrlSegment(orgConfig.org)) {
@@ -112,7 +113,7 @@ export class AdoPrReviewProvider extends BaseProvider {
 
       const userId = await this.getUserId(accessToken, orgConfig.org, sessionAccountId);
       if (!userId) {
-        failures.push(`${orgConfig.org} (user identity)`);
+        identityFailures.push(orgConfig.org);
         logger.warn(`Failed to determine Azure DevOps user identity for org ${orgConfig.org}`);
         continue;
       }
@@ -144,10 +145,10 @@ export class AdoPrReviewProvider extends BaseProvider {
           const { items, failed } = result.value;
           allItems.push(...items);
           if (failed) {
-            failures.push(target);
+            fetchFailures.push(target);
           }
         } else {
-          failures.push(target);
+          fetchFailures.push(target);
           logger.error(
             `Failed to fetch PR reviews from ${target}:`,
             (result as PromiseRejectedResult).reason,
@@ -159,10 +160,19 @@ export class AdoPrReviewProvider extends BaseProvider {
     this._onDidDiscoverItems.fire(allItems);
     logger.info(`Discovered ${allItems.length} ADO PR reviews`);
 
-    if (failures.length > 0) {
-      const message = failures.length === 1
-        ? `Failed to fetch PR reviews from ${failures[0]}`
-        : `Failed to fetch PR reviews from ${failures.length} projects`;
+    const messages: string[] = [];
+    if (identityFailures.length > 0) {
+      messages.push(`user identity failed for ${identityFailures.join(', ')}`);
+    }
+    if (fetchFailures.length > 0) {
+      messages.push(
+        fetchFailures.length === 1
+          ? `failed to fetch from ${fetchFailures[0]}`
+          : `failed to fetch from ${fetchFailures.length} sources`,
+      );
+    }
+    if (messages.length > 0) {
+      const message = `PR review errors: ${messages.join('; ')}`;
       if (isUserTriggered) {
         void vscode.window.showWarningMessage(`WorkCenter ADO: ${message}`);
       }

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -112,11 +112,8 @@ export class AdoPrReviewProvider extends BaseProvider {
 
       const userId = await this.getUserId(accessToken, orgConfig.org, sessionAccountId);
       if (!userId) {
-        const message = 'Failed to determine Azure DevOps user identity';
-        if (isUserTriggered) {
-          void vscode.window.showWarningMessage(`WorkCenter ADO: ${message}`);
-        }
-        logger.warn(message);
+        failures.push(`${orgConfig.org} (user identity)`);
+        logger.warn(`Failed to determine Azure DevOps user identity for org ${orgConfig.org}`);
         continue;
       }
 

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -201,14 +201,14 @@ export class AdoPrReviewProvider extends BaseProvider {
         },
       );
     } catch (err) {
-      logger.error('Network error fetching connection data:', err);
+      logger.error(`Network error fetching connection data for org ${org}:`, err);
       this._cachedUserIds.delete(org);
       return undefined;
     }
 
     if (!response.ok) {
       const body = await response.text().catch(() => '');
-      logger.error(`Failed to fetch connection data: ${response.status} ${body}`);
+      logger.error(`Failed to fetch connection data for org ${org}: ${response.status} ${body}`);
       this._cachedUserIds.delete(org);
       return undefined;
     }
@@ -217,7 +217,7 @@ export class AdoPrReviewProvider extends BaseProvider {
     try {
       data = (await response.json()) as ConnectionData;
     } catch (err) {
-      logger.error('Failed to parse connection data response:', err);
+      logger.error(`Failed to parse connection data response for org ${org}:`, err);
       this._cachedUserIds.delete(org);
       return undefined;
     }

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -137,14 +137,16 @@ export class AdoPrReviewProvider extends BaseProvider {
       );
 
       results.forEach((result, index) => {
+        const project = projectList[index];
+        const target = project ? `${orgConfig.org}/${project}` : orgConfig.org;
+
         if (result.status === 'fulfilled') {
           const { items, failed } = result.value;
           allItems.push(...items);
           if (failed) {
-            failures.push(projectList[index] || orgConfig.org);
+            failures.push(target);
           }
         } else {
-          const target = projectList[index] || orgConfig.org;
           failures.push(target);
           logger.error(
             `Failed to fetch PR reviews from ${target}:`,

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { BaseProvider, DiscoveredItem, isValidUrlSegment } from '@workcenter/shared';
 import { logger } from './logger';
+import { OrgConfig } from './configParser';
 
 interface AdoPullRequest {
   pullRequestId: number;
@@ -33,16 +34,14 @@ export class AdoPrReviewProvider extends BaseProvider {
   readonly id = 'ado-pr-reviews';
   readonly label = 'Azure DevOps PR Reviews';
 
-  private _cachedUserId: string | undefined;
+  private _cachedUserIds = new Map<string, string>();
   private _cachedSessionAccountId: string | undefined;
 
   /**
-   * @param org      - The Azure DevOps organisation name.
-   * @param projects - Project names to query. An empty array queries the whole org.
+   * @param orgConfigs - One or more organization configurations to query.
    */
   constructor(
-    private readonly org: string,
-    private readonly projects: string[],
+    private readonly orgConfigs: OrgConfig[],
   ) {
     super(new vscode.EventEmitter<DiscoveredItem[]>());
   }
@@ -102,62 +101,61 @@ export class AdoPrReviewProvider extends BaseProvider {
   }
 
   private async fetchAndPublishPrs(accessToken: string, isUserTriggered: boolean, sessionAccountId: string): Promise<void> {
-    if (!isValidUrlSegment(this.org)) {
-      logger.warn('Skipping PR fetch: invalid ADO organization name', this.org);
-      this._onDidDiscoverItems.fire([]);
-      return;
-    }
-
-    const userId = await this.getUserId(accessToken, sessionAccountId);
-    if (!userId) {
-      const message = 'Failed to determine Azure DevOps user identity';
-      if (isUserTriggered) {
-        void vscode.window.showWarningMessage(`WorkCenter ADO: ${message}`);
-      }
-      logger.warn(message);
-      this._onDidDiscoverItems.fire([]);
-      return;
-    }
-
-    const validProjects: string[] = [];
-    for (const project of this.projects) {
-      if (project === '' || isValidUrlSegment(project)) {
-        validProjects.push(project);
-      } else {
-        logger.warn('Skipping invalid ADO project name', project);
-      }
-    }
-
-    if (this.projects.length > 0 && validProjects.length === 0) {
-      logger.warn('All configured ADO projects are invalid — skipping PR fetch');
-      this._onDidDiscoverItems.fire([]);
-      return;
-    }
-
-    const projectList = validProjects.length > 0 ? validProjects : [''];
-    const results = await Promise.allSettled(
-      projectList.map(project => this.fetchPrsForProject(accessToken, project, userId)),
-    );
-
     const allItems: DiscoveredItem[] = [];
     const failures: string[] = [];
 
-    results.forEach((result, index) => {
-      if (result.status === 'fulfilled') {
-        const { items, failed } = result.value;
-        allItems.push(...items);
-        if (failed) {
-          failures.push(projectList[index] || this.org);
-        }
-      } else {
-        const target = projectList[index] || this.org;
-        failures.push(target);
-        logger.error(
-          `Failed to fetch PR reviews from ${target}:`,
-          (result as PromiseRejectedResult).reason,
-        );
+    for (const orgConfig of this.orgConfigs) {
+      if (!isValidUrlSegment(orgConfig.org)) {
+        logger.warn('Skipping PR fetch: invalid ADO organization name', orgConfig.org);
+        continue;
       }
-    });
+
+      const userId = await this.getUserId(accessToken, orgConfig.org, sessionAccountId);
+      if (!userId) {
+        const message = 'Failed to determine Azure DevOps user identity';
+        if (isUserTriggered) {
+          void vscode.window.showWarningMessage(`WorkCenter ADO: ${message}`);
+        }
+        logger.warn(message);
+        continue;
+      }
+
+      const validProjects: string[] = [];
+      for (const project of orgConfig.projects) {
+        if (project === '' || isValidUrlSegment(project)) {
+          validProjects.push(project);
+        } else {
+          logger.warn('Skipping invalid ADO project name', project);
+        }
+      }
+
+      if (orgConfig.projects.length > 0 && validProjects.length === 0) {
+        logger.warn('All configured ADO projects are invalid — skipping PR fetch');
+        continue;
+      }
+
+      const projectList = validProjects.length > 0 ? validProjects : [''];
+      const results = await Promise.allSettled(
+        projectList.map(project => this.fetchPrsForProject(accessToken, orgConfig.org, project, userId)),
+      );
+
+      results.forEach((result, index) => {
+        if (result.status === 'fulfilled') {
+          const { items, failed } = result.value;
+          allItems.push(...items);
+          if (failed) {
+            failures.push(projectList[index] || orgConfig.org);
+          }
+        } else {
+          const target = projectList[index] || orgConfig.org;
+          failures.push(target);
+          logger.error(
+            `Failed to fetch PR reviews from ${target}:`,
+            (result as PromiseRejectedResult).reason,
+          );
+        }
+      });
+    }
 
     this._onDidDiscoverItems.fire(allItems);
     logger.info(`Discovered ${allItems.length} ADO PR reviews`);
@@ -173,31 +171,36 @@ export class AdoPrReviewProvider extends BaseProvider {
     }
   }
 
-  private async getUserId(token: string, sessionAccountId: string): Promise<string | undefined> {
-    if (this._cachedUserId && this._cachedSessionAccountId === sessionAccountId) {
-      return this._cachedUserId;
+  private async getUserId(token: string, org: string, sessionAccountId: string): Promise<string | undefined> {
+    // If the auth account changed, clear all cached user IDs
+    if (this._cachedSessionAccountId !== sessionAccountId) {
+      this._cachedUserIds.clear();
+      this._cachedSessionAccountId = sessionAccountId;
+    }
+
+    const cached = this._cachedUserIds.get(org);
+    if (cached) {
+      return cached;
     }
 
     let response: Response;
     try {
       response = await fetch(
-        `https://dev.azure.com/${encodeURIComponent(this.org)}/_apis/connectiondata`,
+        `https://dev.azure.com/${encodeURIComponent(org)}/_apis/connectiondata`,
         {
           headers: { Authorization: `Bearer ${token}` },
         },
       );
     } catch (err) {
       logger.error('Network error fetching connection data:', err);
-      this._cachedUserId = undefined;
-      this._cachedSessionAccountId = undefined;
+      this._cachedUserIds.delete(org);
       return undefined;
     }
 
     if (!response.ok) {
       const body = await response.text().catch(() => '');
       logger.error(`Failed to fetch connection data: ${response.status} ${body}`);
-      this._cachedUserId = undefined;
-      this._cachedSessionAccountId = undefined;
+      this._cachedUserIds.delete(org);
       return undefined;
     }
 
@@ -206,31 +209,29 @@ export class AdoPrReviewProvider extends BaseProvider {
       data = (await response.json()) as ConnectionData;
     } catch (err) {
       logger.error('Failed to parse connection data response:', err);
-      this._cachedUserId = undefined;
-      this._cachedSessionAccountId = undefined;
+      this._cachedUserIds.delete(org);
       return undefined;
     }
 
     if (!data?.authenticatedUser?.id) {
-      this._cachedUserId = undefined;
-      this._cachedSessionAccountId = undefined;
+      this._cachedUserIds.delete(org);
       return undefined;
     }
 
-    this._cachedUserId = data.authenticatedUser.id;
-    this._cachedSessionAccountId = sessionAccountId;
-    logger.debug(`Resolved user ID: ${this._cachedUserId}`);
-    return this._cachedUserId;
+    this._cachedUserIds.set(org, data.authenticatedUser.id);
+    logger.debug(`Resolved user ID: ${data.authenticatedUser.id}`);
+    return data.authenticatedUser.id;
   }
 
   private async fetchPrsForProject(
     token: string,
+    org: string,
     project: string,
     reviewerId: string,
   ): Promise<{ items: DiscoveredItem[]; failed: boolean }> {
-    logger.debug(`Fetching PRs for project: ${project || this.org}`);
+    logger.debug(`Fetching PRs for project: ${project || org}`);
     const projectPath = project ? `/${encodeURIComponent(project)}` : '';
-    const url = `https://dev.azure.com/${encodeURIComponent(this.org)}${projectPath}/_apis/git/pullrequests?searchCriteria.reviewerId=${encodeURIComponent(reviewerId)}&searchCriteria.status=active&api-version=7.1`;
+    const url = `https://dev.azure.com/${encodeURIComponent(org)}${projectPath}/_apis/git/pullrequests?searchCriteria.reviewerId=${encodeURIComponent(reviewerId)}&searchCriteria.status=active&api-version=7.1`;
 
     const response = await fetch(url, {
       headers: {
@@ -239,7 +240,7 @@ export class AdoPrReviewProvider extends BaseProvider {
     });
 
     if (!response.ok) {
-      logger.warn(`Failed to fetch PRs for project: ${project || this.org}`);
+      logger.warn(`Failed to fetch PRs for project: ${project || org}`);
       logger.error(`PR fetch failed for project "${project}": ${response.status}`);
       return { items: [], failed: true };
     }
@@ -254,9 +255,9 @@ export class AdoPrReviewProvider extends BaseProvider {
     const items: DiscoveredItem[] = prData.value.map((pr) => {
       const projectName = pr.repository.project.name;
       const repoName = pr.repository.name;
-      const repoUrl = pr.repository.webUrl ?? `https://dev.azure.com/${encodeURIComponent(this.org)}/${encodeURIComponent(projectName)}/_git/${encodeURIComponent(repoName)}`;
+      const repoUrl = pr.repository.webUrl ?? `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(projectName)}/_git/${encodeURIComponent(repoName)}`;
       return {
-        externalId: `${projectName}/${repoName}/${pr.pullRequestId}`,
+        externalId: `${org}/${projectName}/${repoName}/${pr.pullRequestId}`,
         title: `PR ${pr.pullRequestId}: ${pr.title}`,
         description: pr.description?.slice(0, 200),
         url: `${repoUrl}/pullrequest/${pr.pullRequestId}`,

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -228,7 +228,7 @@ export class AdoPrReviewProvider extends BaseProvider {
     }
 
     this._cachedUserIds.set(org, data.authenticatedUser.id);
-    logger.debug(`Resolved user ID: ${data.authenticatedUser.id}`);
+    logger.debug(`Resolved user ID for org ${org}: ${data.authenticatedUser.id}`);
     return data.authenticatedUser.id;
   }
 

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -249,8 +249,9 @@ export class AdoPrReviewProvider extends BaseProvider {
     });
 
     if (!response.ok) {
-      logger.warn(`Failed to fetch PRs for project: ${project || org}`);
-      logger.error(`PR fetch failed for project "${project}": ${response.status}`);
+      const target = project || org;
+      logger.warn(`Failed to fetch PRs for ${target}`);
+      logger.error(`PR fetch failed for ${target}: ${response.status}`);
       return { items: [], failed: true };
     }
 
@@ -258,7 +259,7 @@ export class AdoPrReviewProvider extends BaseProvider {
     try {
       prData = (await response.json()) as { value: AdoPullRequest[] };
     } catch (err) {
-      logger.error(`Failed to parse PR response for project "${project}":`, err);
+      logger.error(`Failed to parse PR response for ${project || org}:`, err);
       return { items: [], failed: true };
     }
     const items: DiscoveredItem[] = prData.value.map((pr) => {

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -130,7 +130,7 @@ export class AdoPrReviewProvider extends BaseProvider {
       }
 
       if (orgConfig.projects.length > 0 && validProjects.length === 0) {
-        logger.warn('All configured ADO projects are invalid — skipping PR fetch');
+        logger.warn(`All configured ADO projects are invalid for org ${orgConfig.org} — skipping PR fetch`);
         continue;
       }
 

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -172,7 +172,7 @@ export class AdoWorkItemProvider extends BaseProvider {
     if (failures.length > 0) {
       const message = failures.length === 1
         ? `Failed to fetch work items from ${failures[0]}`
-        : `Failed to fetch work items from ${failures.length} projects`;
+        : `Failed to fetch work items from ${failures.length} sources`;
       if (isUserTriggered) {
         void vscode.window.showWarningMessage(`WorkCenter ADO: ${message}`);
       }

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { BaseProvider, DiscoveredItem, isValidUrlSegment } from '@workcenter/shared';
 import { logger } from './logger';
+import { OrgConfig } from './configParser';
 
 // Azure DevOps WIQL query response
 interface WiqlResponse {
@@ -53,12 +54,10 @@ export class AdoWorkItemProvider extends BaseProvider {
   private _terminalStatesCache = new Map<string, Set<string>>();
 
   /**
-   * @param org      - The Azure DevOps organisation name.
-   * @param projects - Project names to query. An empty array queries the whole org.
+   * @param orgConfigs - One or more organization configurations to query.
    */
   constructor(
-    private readonly org: string,
-    private readonly projects: string[],
+    private readonly orgConfigs: OrgConfig[],
   ) {
     super(new vscode.EventEmitter<DiscoveredItem[]>());
   }
@@ -118,52 +117,52 @@ export class AdoWorkItemProvider extends BaseProvider {
   }
 
   private async fetchAndPublishWorkItems(accessToken: string, isUserTriggered: boolean): Promise<void> {
-    if (!isValidUrlSegment(this.org)) {
-      logger.warn('Skipping fetch: invalid ADO organization name', this.org);
-      this._onDidDiscoverItems.fire([]);
-      return;
-    }
-
-    const validProjects: string[] = [];
-    for (const project of this.projects) {
-      if (project === '' || isValidUrlSegment(project)) {
-        validProjects.push(project);
-      } else {
-        logger.warn('Skipping invalid ADO project name', project);
-      }
-    }
-
-    if (this.projects.length > 0 && validProjects.length === 0) {
-      logger.warn('All configured ADO projects are invalid — skipping fetch');
-      this._onDidDiscoverItems.fire([]);
-      return;
-    }
-
-    const projectList = validProjects.length > 0 ? validProjects : [''];
-    const results = await Promise.allSettled(
-      projectList.map(project => this.fetchWorkItemsForProject(accessToken, project)),
-    );
-
     const allItems: DiscoveredItem[] = [];
     const failures: string[] = [];
 
-    results.forEach((result, index) => {
-      if (result.status === 'fulfilled') {
-        const { items, failed } = result.value;
-        allItems.push(...items);
-        if (failed) {
-          failures.push(projectList[index] || this.org);
-        }
-      } else {
-        const failureTarget = projectList[index] || this.org;
-        failures.push(failureTarget);
-        const reason = (result as PromiseRejectedResult).reason;
-        logger.warn(
-          `Failed to fetch work items from ${failureTarget}: ` +
-          (reason instanceof Error ? reason.message : String(reason)),
-        );
+    for (const orgConfig of this.orgConfigs) {
+      if (!isValidUrlSegment(orgConfig.org)) {
+        logger.warn('Skipping fetch: invalid ADO organization name', orgConfig.org);
+        continue;
       }
-    });
+
+      const validProjects: string[] = [];
+      for (const project of orgConfig.projects) {
+        if (project === '' || isValidUrlSegment(project)) {
+          validProjects.push(project);
+        } else {
+          logger.warn('Skipping invalid ADO project name', project);
+        }
+      }
+
+      if (orgConfig.projects.length > 0 && validProjects.length === 0) {
+        logger.warn('All configured ADO projects are invalid — skipping fetch');
+        continue;
+      }
+
+      const projectList = validProjects.length > 0 ? validProjects : [''];
+      const results = await Promise.allSettled(
+        projectList.map(project => this.fetchWorkItemsForProject(accessToken, orgConfig.org, project)),
+      );
+
+      results.forEach((result, index) => {
+        if (result.status === 'fulfilled') {
+          const { items, failed } = result.value;
+          allItems.push(...items);
+          if (failed) {
+            failures.push(projectList[index] || orgConfig.org);
+          }
+        } else {
+          const failureTarget = projectList[index] || orgConfig.org;
+          failures.push(failureTarget);
+          const reason = (result as PromiseRejectedResult).reason;
+          logger.warn(
+            `Failed to fetch work items from ${failureTarget}: ` +
+            (reason instanceof Error ? reason.message : String(reason)),
+          );
+        }
+      });
+    }
 
     this._onDidDiscoverItems.fire(allItems);
     logger.info(`Discovered ${allItems.length} ADO work items`);
@@ -181,11 +180,12 @@ export class AdoWorkItemProvider extends BaseProvider {
 
   private async fetchWorkItemsForProject(
     token: string,
+    org: string,
     project: string,
   ): Promise<{ items: DiscoveredItem[]; failed: boolean }> {
-    logger.debug(`Fetching work items for project: ${project || this.org}`);
+    logger.debug(`Fetching work items for project: ${project || org}`);
     const projectPath = project ? `/${encodeURIComponent(project)}` : '';
-    const wiqlUrl = `https://dev.azure.com/${encodeURIComponent(this.org)}${projectPath}/_apis/wit/wiql?api-version=7.1`;
+    const wiqlUrl = `https://dev.azure.com/${encodeURIComponent(org)}${projectPath}/_apis/wit/wiql?api-version=7.1`;
 
     const wiqlQuery = `SELECT [System.Id] FROM WorkItems WHERE [System.AssignedTo] = @Me AND [System.State] <> 'Closed' AND [System.State] <> 'Removed'`;
 
@@ -200,13 +200,13 @@ export class AdoWorkItemProvider extends BaseProvider {
         body: JSON.stringify({ query: wiqlQuery }),
       });
     } catch (err) {
-      logger.error(`Network error querying work items for project "${project || this.org}":`, err);
+      logger.error(`Network error querying work items for project "${project || org}":`, err);
       return { items: [], failed: true };
     }
 
     if (!wiqlResponse.ok) {
-      logger.warn(`Failed to fetch work items for project: ${project || this.org}`);
-      logger.error(`WIQL query failed for project "${project || this.org}": ${wiqlResponse.status}`);
+      logger.warn(`Failed to fetch work items for project: ${project || org}`);
+      logger.error(`WIQL query failed for project "${project || org}": ${wiqlResponse.status}`);
       return { items: [], failed: true };
     }
 
@@ -230,7 +230,7 @@ export class AdoWorkItemProvider extends BaseProvider {
 
     for (let i = 0; i < ids.length; i += batchSize) {
       const batchIds = ids.slice(i, i + batchSize);
-      const detailUrl = `https://dev.azure.com/${encodeURIComponent(this.org)}/_apis/wit/workitems?ids=${batchIds.join(',')}&fields=System.Title,System.Description,System.TeamProject,System.WorkItemType,System.State&$expand=links&api-version=7.1`;
+      const detailUrl = `https://dev.azure.com/${encodeURIComponent(org)}/_apis/wit/workitems?ids=${batchIds.join(',')}&fields=System.Title,System.Description,System.TeamProject,System.WorkItemType,System.State&$expand=links&api-version=7.1`;
 
       let detailResponse: Response;
       try {
@@ -241,7 +241,7 @@ export class AdoWorkItemProvider extends BaseProvider {
         });
       } catch (err) {
         logger.error(
-          `Network error fetching work item details for ${project || this.org} (batch at index ${i}, ids ${batchIds[0]}-${batchIds[batchIds.length - 1]}):`,
+          `Network error fetching work item details for ${project || org} (batch at index ${i}, ids ${batchIds[0]}-${batchIds[batchIds.length - 1]}):`,
           err,
         );
         batchFailed = true;
@@ -267,13 +267,13 @@ export class AdoWorkItemProvider extends BaseProvider {
     }
 
     // Filter out items in terminal state categories
-    const activeWorkItems = await this.filterActiveItems(token, allWorkItems);
+    const activeWorkItems = await this.filterActiveItems(token, org, allWorkItems);
 
     const items: DiscoveredItem[] = activeWorkItems.map((wi) => {
       const projectName = wi.fields['System.TeamProject'];
       const wiType = wi.fields['System.WorkItemType'];
       return {
-        externalId: `${projectName}/${wi.id}`,
+        externalId: `${org}/${projectName}/${wi.id}`,
         title: `${wiType} ${wi.id}: ${wi.fields['System.Title']}`,
         description: wi.fields['System.Description']?.replace(/<[^>]*>/g, '')?.slice(0, 200),
         url: wi._links.html.href,
@@ -288,19 +288,21 @@ export class AdoWorkItemProvider extends BaseProvider {
   /**
    * Fetches terminal states for a given work item type by querying the ADO Work Item Type States API.
    * States with category 'Completed', 'Removed', or 'Resolved' are considered terminal.
-   * Results are cached per project/workItemType pair.
+   * Results are cached per org/project/workItemType triple.
    *
    * @param token - Access token for ADO API
+   * @param org - Organization name
    * @param project - Project name (empty string for org-level)
    * @param workItemType - Work item type name (e.g., 'Task', 'Bug', 'User Story')
    * @returns Set of terminal state names, or empty set on failure (fail open)
    */
   private async fetchTerminalStates(
     token: string,
+    org: string,
     project: string,
     workItemType: string,
   ): Promise<Set<string>> {
-    const cacheKey = `${project}/${workItemType}`;
+    const cacheKey = `${org}/${project}/${workItemType}`;
     
     // Check cache first
     const cached = this._terminalStatesCache.get(cacheKey);
@@ -310,7 +312,7 @@ export class AdoWorkItemProvider extends BaseProvider {
 
     // Build API URL
     const projectPath = project ? `/${encodeURIComponent(project)}` : '';
-    const statesUrl = `https://dev.azure.com/${encodeURIComponent(this.org)}${projectPath}/_apis/wit/workitemtypes/${encodeURIComponent(workItemType)}/states?api-version=7.1`;
+    const statesUrl = `https://dev.azure.com/${encodeURIComponent(org)}${projectPath}/_apis/wit/workitemtypes/${encodeURIComponent(workItemType)}/states?api-version=7.1`;
 
     let response: Response;
     try {
@@ -369,6 +371,7 @@ export class AdoWorkItemProvider extends BaseProvider {
    */
   private async filterActiveItems(
     token: string,
+    org: string,
     workItems: AdoWorkItem[],
   ): Promise<AdoWorkItem[]> {
     if (workItems.length === 0) {
@@ -398,7 +401,7 @@ export class AdoWorkItemProvider extends BaseProvider {
 
     const results = await Promise.all(
       entries.map(async ({ key, project, workItemType }) => {
-        const terminalStates = await this.fetchTerminalStates(token, project, workItemType);
+        const terminalStates = await this.fetchTerminalStates(token, org, project, workItemType);
         return { key, terminalStates };
       }),
     );

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -368,6 +368,7 @@ export class AdoWorkItemProvider extends BaseProvider {
    * and excludes items whose state is terminal.
    *
    * @param token - Access token for ADO API
+   * @param org - ADO organization name
    * @param workItems - All work items to filter
    * @returns Only work items in active states
    */

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -216,7 +216,7 @@ export class AdoWorkItemProvider extends BaseProvider {
     try {
       wiqlData = (await wiqlResponse.json()) as WiqlResponse;
     } catch (err) {
-      logger.error(`Failed to parse WIQL response for project "${project}":`, err);
+      logger.error(`Failed to parse WIQL response for ${project || org}:`, err);
       return { items: [], failed: true };
     }
     logger.debug(`WIQL returned ${wiqlData.workItems.length} work item IDs`);
@@ -251,7 +251,7 @@ export class AdoWorkItemProvider extends BaseProvider {
       }
 
       if (!detailResponse.ok) {
-        logger.error(`Failed to fetch work item details: ${detailResponse.status}`);
+        logger.error(`Failed to fetch work item details for ${project || org}: ${detailResponse.status}`);
         batchFailed = true;
         continue;
       }
@@ -260,7 +260,7 @@ export class AdoWorkItemProvider extends BaseProvider {
       try {
         detailData = (await detailResponse.json()) as { value: AdoWorkItem[] };
       } catch (err) {
-        logger.error('Failed to parse work item detail response:', err);
+        logger.error(`Failed to parse work item detail response for ${project || org}:`, err);
         batchFailed = true;
         continue;
       }

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -136,7 +136,7 @@ export class AdoWorkItemProvider extends BaseProvider {
       }
 
       if (orgConfig.projects.length > 0 && validProjects.length === 0) {
-        logger.warn('All configured ADO projects are invalid — skipping fetch');
+        logger.warn(`All configured ADO projects are invalid for org ${orgConfig.org} — skipping fetch`);
         continue;
       }
 

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -146,14 +146,16 @@ export class AdoWorkItemProvider extends BaseProvider {
       );
 
       results.forEach((result, index) => {
+        const project = projectList[index];
+        const failureTarget = project ? `${orgConfig.org}/${project}` : orgConfig.org;
+
         if (result.status === 'fulfilled') {
           const { items, failed } = result.value;
           allItems.push(...items);
           if (failed) {
-            failures.push(projectList[index] || orgConfig.org);
+            failures.push(failureTarget);
           }
         } else {
-          const failureTarget = projectList[index] || orgConfig.org;
           failures.push(failureTarget);
           const reason = (result as PromiseRejectedResult).reason;
           logger.warn(

--- a/packages/ado/src/configParser.ts
+++ b/packages/ado/src/configParser.ts
@@ -17,9 +17,9 @@ export interface OrgConfig {
  *
  * Legacy backward compatibility: if `projects` contains no valid
  * `<org>/<project>` entries and `legacyOrganization` is non-empty, entries are
- * treated as project names under that organization. Malformed slash entries
- * such as `/`, `org/`, and `/project` are ignored when determining whether to
- * use legacy mode.
+ * treated as project names under that organization. Malformed entries
+ * such as `/`, `org/`, `/project`, and multi-slash entries like `org/proj/extra`
+ * are ignored when determining whether to use legacy mode.
  */
 export function parseAdoProjectsConfig(
   projects: string[],
@@ -28,11 +28,11 @@ export function parseAdoProjectsConfig(
   const trimmedLegacyOrg = legacyOrganization.trim();
 
   // Determine whether entries use new org/project format by checking for
-  // valid slash-separated entries (ignoring malformed ones like "/" or "/proj")
+  // valid slash-separated entries (exactly one slash with non-empty parts)
   const hasNewFormatEntry = projects.some(p => {
     const t = p.trim();
     const idx = t.indexOf('/');
-    return idx > 0 && idx < t.length - 1;
+    return idx > 0 && idx < t.length - 1 && t.lastIndexOf('/') === idx;
   });
 
   // Legacy mode: no entry contains a valid '/' and the deprecated org setting is present
@@ -66,8 +66,8 @@ export function parseAdoProjectsConfig(
     } else {
       const org = trimmed.substring(0, slashIndex).trim();
       const project = trimmed.substring(slashIndex + 1).trim();
-      if (!org || !project) {
-        continue; // skip malformed entries like "/", "org/", or "/project"
+      if (!org || !project || project.includes('/')) {
+        continue; // skip malformed entries like "/", "org/", "/project", or "org/proj/extra"
       }
 
       const existing = orgMap.get(org);

--- a/packages/ado/src/configParser.ts
+++ b/packages/ado/src/configParser.ts
@@ -15,9 +15,11 @@ export interface OrgConfig {
  *   - `<org>` — monitor an entire organization
  *   - `<org>/<project>` — monitor a specific project
  *
- * Legacy backward compatibility: if no entry in `projects` contains `/` and
- * `legacyOrganization` is non-empty, entries are treated as project names
- * under that organization.
+ * Legacy backward compatibility: if `projects` contains no valid
+ * `<org>/<project>` entries and `legacyOrganization` is non-empty, entries are
+ * treated as project names under that organization. Malformed slash entries
+ * such as `/`, `org/`, and `/project` are ignored when determining whether to
+ * use legacy mode.
  */
 export function parseAdoProjectsConfig(
   projects: string[],

--- a/packages/ado/src/configParser.ts
+++ b/packages/ado/src/configParser.ts
@@ -23,11 +23,19 @@ export function parseAdoProjectsConfig(
   projects: string[],
   legacyOrganization: string,
 ): OrgConfig[] {
-  const hasNewFormatEntry = projects.some(p => p.includes('/'));
+  const trimmedLegacyOrg = legacyOrganization.trim();
 
-  // Legacy mode: no entry contains '/' and the deprecated org setting is present
-  if (!hasNewFormatEntry && legacyOrganization) {
-    return [{ org: legacyOrganization, projects: projects.map(p => p.trim()).filter(Boolean) }];
+  // Determine whether entries use new org/project format by checking for
+  // valid slash-separated entries (ignoring malformed ones like "/" or "/proj")
+  const hasNewFormatEntry = projects.some(p => {
+    const t = p.trim();
+    const idx = t.indexOf('/');
+    return idx > 0 && idx < t.length - 1;
+  });
+
+  // Legacy mode: no entry contains a valid '/' and the deprecated org setting is present
+  if (!hasNewFormatEntry && trimmedLegacyOrg) {
+    return [{ org: trimmedLegacyOrg, projects: projects.map(p => p.trim()).filter(Boolean) }];
   }
 
   // Nothing to monitor
@@ -54,8 +62,8 @@ export function parseAdoProjectsConfig(
         orgMap.set(trimmed, { projects: [], wholeOrg: true });
       }
     } else {
-      const org = trimmed.substring(0, slashIndex);
-      const project = trimmed.substring(slashIndex + 1);
+      const org = trimmed.substring(0, slashIndex).trim();
+      const project = trimmed.substring(slashIndex + 1).trim();
       if (!org || !project) {
         continue; // skip malformed entries like "/", "org/", or "/project"
       }

--- a/packages/ado/src/configParser.ts
+++ b/packages/ado/src/configParser.ts
@@ -1,0 +1,78 @@
+/**
+ * Describes a single ADO organization and which projects to monitor within it.
+ * An empty `projects` array means monitor the entire organization.
+ */
+export interface OrgConfig {
+  org: string;
+  projects: string[];
+}
+
+/**
+ * Parses the `workcenterAdo.projects` and (deprecated) `workcenterAdo.organization`
+ * settings into a list of per-organization configurations.
+ *
+ * New-format entries in `projects`:
+ *   - `<org>` — monitor an entire organization
+ *   - `<org>/<project>` — monitor a specific project
+ *
+ * Legacy backward compatibility: if no entry in `projects` contains `/` and
+ * `legacyOrganization` is non-empty, entries are treated as project names
+ * under that organization.
+ */
+export function parseAdoProjectsConfig(
+  projects: string[],
+  legacyOrganization: string,
+): OrgConfig[] {
+  const hasNewFormatEntry = projects.some(p => p.includes('/'));
+
+  // Legacy mode: no entry contains '/' and the deprecated org setting is present
+  if (!hasNewFormatEntry && legacyOrganization) {
+    return [{ org: legacyOrganization, projects: projects.map(p => p.trim()).filter(Boolean) }];
+  }
+
+  // Nothing to monitor
+  if (projects.length === 0) {
+    return [];
+  }
+
+  // New format parsing
+  const orgMap = new Map<string, { projects: string[]; wholeOrg: boolean }>();
+
+  for (const entry of projects) {
+    const trimmed = entry.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    const slashIndex = trimmed.indexOf('/');
+    if (slashIndex === -1) {
+      // Org-only entry: monitor entire organization
+      const existing = orgMap.get(trimmed);
+      if (existing) {
+        existing.wholeOrg = true;
+      } else {
+        orgMap.set(trimmed, { projects: [], wholeOrg: true });
+      }
+    } else {
+      const org = trimmed.substring(0, slashIndex);
+      const project = trimmed.substring(slashIndex + 1);
+      if (!org || !project) {
+        continue; // skip malformed entries like "/", "org/", or "/project"
+      }
+
+      const existing = orgMap.get(org);
+      if (existing) {
+        if (!existing.wholeOrg && !existing.projects.includes(project)) {
+          existing.projects.push(project);
+        }
+      } else {
+        orgMap.set(org, { projects: [project], wholeOrg: false });
+      }
+    }
+  }
+
+  return [...orgMap.entries()].map(([org, config]) => ({
+    org,
+    projects: config.wholeOrg ? [] : config.projects,
+  }));
+}

--- a/packages/ado/src/configParser.ts
+++ b/packages/ado/src/configParser.ts
@@ -8,44 +8,23 @@ export interface OrgConfig {
 }
 
 /**
- * Parses the `workcenterAdo.projects` and (deprecated) `workcenterAdo.organization`
- * settings into a list of per-organization configurations.
+ * Parses the `workcenterAdo.projects` setting into a list of per-organization
+ * configurations.
  *
- * New-format entries in `projects`:
+ * Entries in `projects`:
  *   - `<org>` — monitor an entire organization
  *   - `<org>/<project>` — monitor a specific project
  *
- * Legacy backward compatibility: if `projects` contains no valid
- * `<org>/<project>` entries and `legacyOrganization` is non-empty, entries are
- * treated as project names under that organization. Malformed entries
- * such as `/`, `org/`, `/project`, and multi-slash entries like `org/proj/extra`
- * are ignored when determining whether to use legacy mode.
+ * Malformed entries such as `/`, `org/`, `/project`, and multi-slash entries
+ * like `org/proj/extra` are silently skipped.
  */
 export function parseAdoProjectsConfig(
   projects: string[],
-  legacyOrganization: string,
 ): OrgConfig[] {
-  const trimmedLegacyOrg = legacyOrganization.trim();
-
-  // Determine whether entries use new org/project format by checking for
-  // valid slash-separated entries (exactly one slash with non-empty parts)
-  const hasNewFormatEntry = projects.some(p => {
-    const t = p.trim();
-    const idx = t.indexOf('/');
-    return idx > 0 && idx < t.length - 1 && t.lastIndexOf('/') === idx;
-  });
-
-  // Legacy mode: no entry contains a valid '/' and the deprecated org setting is present
-  if (!hasNewFormatEntry && trimmedLegacyOrg) {
-    return [{ org: trimmedLegacyOrg, projects: [...new Set(projects.map(p => p.trim()).filter(Boolean))] }];
-  }
-
-  // Nothing to monitor
   if (projects.length === 0) {
     return [];
   }
 
-  // New format parsing
   const orgMap = new Map<string, { projects: string[]; wholeOrg: boolean }>();
 
   for (const entry of projects) {

--- a/packages/ado/src/configParser.ts
+++ b/packages/ado/src/configParser.ts
@@ -37,7 +37,7 @@ export function parseAdoProjectsConfig(
 
   // Legacy mode: no entry contains a valid '/' and the deprecated org setting is present
   if (!hasNewFormatEntry && trimmedLegacyOrg) {
-    return [{ org: trimmedLegacyOrg, projects: projects.map(p => p.trim()).filter(Boolean) }];
+    return [{ org: trimmedLegacyOrg, projects: [...new Set(projects.map(p => p.trim()).filter(Boolean))] }];
   }
 
   // Nothing to monitor

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { AdoWorkItemProvider } from './adoWorkItemProvider';
 import { AdoPrReviewProvider } from './adoPrReviewProvider';
+import { parseAdoProjectsConfig } from './configParser';
 import { validateRefreshInterval } from '@workcenter/shared';
 import { initLogger, setLogLevel, logger, resolveLogLevel } from './logger';
 
@@ -69,13 +70,17 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
     prProvider = undefined;
 
     const config = vscode.workspace.getConfiguration('workcenterAdo');
-    const org = config.get<string>('organization', '');
+    const legacyOrg = config.get<string>('organization', '');
     const projects = config.get<string[]>('projects', []);
 
-    if (!org) {
-      logger.info('No organization configured — set workcenterAdo.organization to enable ADO providers');
+    const orgConfigs = parseAdoProjectsConfig(projects, legacyOrg);
+
+    if (orgConfigs.length === 0) {
+      logger.info('No organizations configured — set workcenterAdo.projects to enable ADO providers');
       if (!orgWarningShown) {
-        vscode.window.showWarningMessage('WorkCenter ADO: Azure DevOps organization not configured. Set workcenterAdo.organization in settings.');
+        vscode.window.showWarningMessage(
+          'WorkCenter ADO: No Azure DevOps organizations configured. Add entries to workcenterAdo.projects (e.g. "myorg" or "myorg/myproject").',
+        );
         orgWarningShown = true;
       }
       return;
@@ -83,14 +88,14 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
 
     orgWarningShown = false;
 
-    logger.debug(`Configuration: org=${org}, projects=[${projects.join(', ')}]`);
+    logger.debug(`Configuration: ${orgConfigs.map(c => c.projects.length > 0 ? c.projects.map(p => `${c.org}/${p}`).join(', ') : c.org).join('; ')}`);
 
     const intervalSeconds = validateRefreshInterval(
       config.get<number>('refreshIntervalSeconds', 300), logger,
     );
 
-    workItemProvider = new AdoWorkItemProvider(org, projects);
-    prProvider = new AdoPrReviewProvider(org, projects);
+    workItemProvider = new AdoWorkItemProvider(orgConfigs);
+    prProvider = new AdoPrReviewProvider(orgConfigs);
 
     workItemProvider.startPeriodicRefresh(intervalSeconds);
     prProvider.startPeriodicRefresh(intervalSeconds);

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -76,12 +76,23 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
     const orgConfigs = parseAdoProjectsConfig(projects, legacyOrg);
 
     if (orgConfigs.length === 0) {
-      logger.info('No organizations configured — set workcenterAdo.projects to enable ADO providers');
-      if (!orgWarningShown) {
-        void vscode.window.showWarningMessage(
-          'WorkCenter ADO: No Azure DevOps organizations configured. Add entries to workcenterAdo.projects (e.g. "myorg" or "myorg/myproject").',
-        );
-        orgWarningShown = true;
+      const hasEntries = projects.some(p => p.trim().length > 0);
+      if (hasEntries) {
+        logger.info('All workcenterAdo.projects entries are invalid — entries must be "org" or "org/project"');
+        if (!orgWarningShown) {
+          void vscode.window.showWarningMessage(
+            'WorkCenter ADO: All workcenterAdo.projects entries are invalid. Each entry must be "org" or "org/project".',
+          );
+          orgWarningShown = true;
+        }
+      } else {
+        logger.info('No organizations configured — set workcenterAdo.projects to enable ADO providers');
+        if (!orgWarningShown) {
+          void vscode.window.showWarningMessage(
+            'WorkCenter ADO: No Azure DevOps organizations configured. Add entries to workcenterAdo.projects (e.g. "myorg" or "myorg/myproject").',
+          );
+          orgWarningShown = true;
+        }
       }
       return;
     }

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -70,10 +70,9 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
     prProvider = undefined;
 
     const config = vscode.workspace.getConfiguration('workcenterAdo');
-    const legacyOrg = config.get<string>('organization', '');
     const projects = config.get<string[]>('projects', []);
 
-    const orgConfigs = parseAdoProjectsConfig(projects, legacyOrg);
+    const orgConfigs = parseAdoProjectsConfig(projects);
 
     if (orgConfigs.length === 0) {
       const hasEntries = projects.some(p => p.trim().length > 0);
@@ -122,7 +121,6 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
   _context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration(e => {
       if (
-        e.affectsConfiguration('workcenterAdo.organization') ||
         e.affectsConfiguration('workcenterAdo.projects') ||
         e.affectsConfiguration('workcenterAdo.refreshIntervalSeconds')
       ) {

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -78,7 +78,7 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
     if (orgConfigs.length === 0) {
       logger.info('No organizations configured — set workcenterAdo.projects to enable ADO providers');
       if (!orgWarningShown) {
-        vscode.window.showWarningMessage(
+        void vscode.window.showWarningMessage(
           'WorkCenter ADO: No Azure DevOps organizations configured. Add entries to workcenterAdo.projects (e.g. "myorg" or "myorg/myproject").',
         );
         orgWarningShown = true;

--- a/packages/ado/src/test/adoPrReviewProvider.extended.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.extended.test.ts
@@ -249,7 +249,7 @@ describe('AdoPrReviewProvider — extended', () => {
       await provider.refresh();
 
       expect(window.showWarningMessage).toHaveBeenCalledWith(
-        expect.stringContaining('2 projects'),
+        expect.stringContaining('2 sources'),
       );
     });
 
@@ -277,7 +277,7 @@ describe('AdoPrReviewProvider — extended', () => {
       expect(items[0].group).toBe('GoodProj/goodrepo');
 
       expect(window.showWarningMessage).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to fetch PR reviews from BadProj'),
+        expect.stringContaining('BadProj'),
       );
     });
   });

--- a/packages/ado/src/test/adoPrReviewProvider.extended.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.extended.test.ts
@@ -40,7 +40,7 @@ describe('AdoPrReviewProvider — extended', () => {
     vi.clearAllMocks();
     mockFetch.mockReset();
     vi.stubGlobal('fetch', mockFetch);
-    provider = new AdoPrReviewProvider('myorg', ['MyProject']);
+    provider = new AdoPrReviewProvider([{ org: 'myorg', projects: ['MyProject'] }]);
     mockAuthSession();
   });
 
@@ -206,7 +206,7 @@ describe('AdoPrReviewProvider — extended', () => {
   describe('multiple projects', () => {
     it('fetches PRs for each configured project', async () => {
       provider.dispose();
-      provider = new AdoPrReviewProvider('myorg', ['ProjectA', 'ProjectB']);
+      provider = new AdoPrReviewProvider([{ org: 'myorg', projects: ['ProjectA', 'ProjectB'] }]);
       mockAuthSession();
 
       mockFetch
@@ -238,7 +238,7 @@ describe('AdoPrReviewProvider — extended', () => {
 
     it('reports multiple project failures', async () => {
       provider.dispose();
-      provider = new AdoPrReviewProvider('myorg', ['ProjA', 'ProjB']);
+      provider = new AdoPrReviewProvider([{ org: 'myorg', projects: ['ProjA', 'ProjB'] }]);
       mockAuthSession();
 
       mockFetch
@@ -255,7 +255,7 @@ describe('AdoPrReviewProvider — extended', () => {
 
     it('handles mixed success and failure across projects', async () => {
       provider.dispose();
-      provider = new AdoPrReviewProvider('myorg', ['GoodProj', 'BadProj']);
+      provider = new AdoPrReviewProvider([{ org: 'myorg', projects: ['GoodProj', 'BadProj'] }]);
       mockAuthSession();
 
       mockFetch
@@ -312,7 +312,7 @@ describe('AdoPrReviewProvider — extended', () => {
   describe('URL construction', () => {
     it('URL-encodes org and project names with special characters', async () => {
       provider.dispose();
-      provider = new AdoPrReviewProvider('my org', ['My Project']);
+      provider = new AdoPrReviewProvider([{ org: 'my org', projects: ['My Project'] }]);
       mockAuthSession();
 
       mockFetch

--- a/packages/ado/src/test/adoPrReviewProvider.extended.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.extended.test.ts
@@ -139,7 +139,7 @@ describe('AdoPrReviewProvider — extended', () => {
       // Should fire empty items and show warning
       expect(listener).toHaveBeenCalledWith([]);
       expect(window.showWarningMessage).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to determine Azure DevOps user identity'),
+        expect.stringContaining('user identity'),
       );
     });
 
@@ -155,7 +155,7 @@ describe('AdoPrReviewProvider — extended', () => {
 
       expect(listener).toHaveBeenCalledWith([]);
       expect(window.showWarningMessage).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to determine Azure DevOps user identity'),
+        expect.stringContaining('user identity'),
       );
     });
 

--- a/packages/ado/src/test/adoPrReviewProvider.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.test.ts
@@ -23,7 +23,7 @@ describe('AdoPrReviewProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubGlobal('fetch', mockFetch);
-    provider = new AdoPrReviewProvider('myorg', ['MyProject']);
+    provider = new AdoPrReviewProvider([{ org: 'myorg', projects: ['MyProject'] }]);
 
     vi.mocked(authentication.getSession).mockResolvedValue({
       accessToken: 'test-token',
@@ -147,7 +147,7 @@ describe('AdoPrReviewProvider', () => {
     const items = listener.mock.calls[0][0];
     expect(items).toHaveLength(1);
     expect(items[0]).toEqual({
-      externalId: 'MyProject/myrepo/101',
+      externalId: 'myorg/MyProject/myrepo/101',
       title: 'PR 101: Fix bug',
       description: 'Description for PR 101',
       url: 'https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/101',
@@ -255,9 +255,9 @@ describe('AdoPrReviewProvider', () => {
 
     const items = listener.mock.calls[0][0];
     expect(items).toHaveLength(2);
-    expect(items[0].externalId).toBe('ProjectA/repo1/1');
+    expect(items[0].externalId).toBe('myorg/ProjectA/repo1/1');
     expect(items[0].group).toBe('ProjectA/repo1');
-    expect(items[1].externalId).toBe('ProjectA/repo2/2');
+    expect(items[1].externalId).toBe('myorg/ProjectA/repo2/2');
     expect(items[1].group).toBe('ProjectA/repo2');
   });
 
@@ -382,7 +382,7 @@ describe('AdoPrReviewProvider', () => {
 
   it('uses org-level PR URL when no projects are configured', async () => {
     provider.dispose();
-    provider = new AdoPrReviewProvider('myorg', []);
+    provider = new AdoPrReviewProvider([{ org: 'myorg', projects: [] }]);
 
     vi.mocked(authentication.getSession).mockResolvedValue({
       accessToken: 'test-token',
@@ -490,7 +490,7 @@ describe('AdoPrReviewProvider', () => {
 
   it('fires empty items when org name is invalid', async () => {
     provider.dispose();
-    provider = new AdoPrReviewProvider('../evil', ['MyProject']);
+    provider = new AdoPrReviewProvider([{ org: '../evil', projects: ['MyProject'] }]);
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
@@ -503,7 +503,7 @@ describe('AdoPrReviewProvider', () => {
 
   it('skips invalid projects and fetches only valid ones', async () => {
     provider.dispose();
-    provider = new AdoPrReviewProvider('myorg', ['ValidProject', '../bad', 'AlsoValid']);
+    provider = new AdoPrReviewProvider([{ org: 'myorg', projects: ['ValidProject', '../bad', 'AlsoValid'] }]);
 
     // Connection data + 2 valid project PR fetches
     mockFetch
@@ -524,7 +524,7 @@ describe('AdoPrReviewProvider', () => {
 
   it('fires empty items when all configured projects are invalid', async () => {
     provider.dispose();
-    provider = new AdoPrReviewProvider('myorg', ['../bad', '?evil']);
+    provider = new AdoPrReviewProvider([{ org: 'myorg', projects: ['../bad', '?evil'] }]);
 
     // Connection data call still happens before project validation
     mockFetch.mockResolvedValueOnce({

--- a/packages/ado/src/test/adoPrReviewProvider.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.test.ts
@@ -352,7 +352,7 @@ describe('AdoPrReviewProvider', () => {
 
     expect(listener).toHaveBeenCalledWith([]);
     expect(window.showWarningMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to fetch PR reviews'),
+      expect.stringContaining('failed to fetch from'),
     );
   });
 

--- a/packages/ado/src/test/adoPrReviewProvider.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.test.ts
@@ -310,7 +310,7 @@ describe('AdoPrReviewProvider', () => {
     await provider.refresh();
 
     expect(window.showWarningMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to determine Azure DevOps user identity'),
+      expect.stringContaining('user identity'),
     );
   });
 

--- a/packages/ado/src/test/adoWorkItemProvider.extended.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.extended.test.ts
@@ -677,7 +677,7 @@ describe('AdoWorkItemProvider — extended', () => {
 
       // Should warn about the failed project
       expect(window.showWarningMessage).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to fetch work items from BadProject'),
+        expect.stringContaining('BadProject'),
       );
     });
   });

--- a/packages/ado/src/test/adoWorkItemProvider.extended.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.extended.test.ts
@@ -49,7 +49,7 @@ describe('AdoWorkItemProvider — extended', () => {
     vi.clearAllMocks();
     mockFetch.mockReset();
     vi.stubGlobal('fetch', mockFetch);
-    provider = new AdoWorkItemProvider('myorg', ['MyProject']);
+    provider = new AdoWorkItemProvider([{ org: 'myorg', projects: ['MyProject'] }]);
     mockAuthSession();
 
     // Default fallback: states API calls return no terminal states (items pass through)
@@ -87,7 +87,7 @@ describe('AdoWorkItemProvider — extended', () => {
 
     it('URL-encodes org and project names with special characters', async () => {
       provider.dispose();
-      provider = new AdoWorkItemProvider('my org', ['My Project']);
+      provider = new AdoWorkItemProvider([{ org: 'my org', projects: ['My Project'] }]);
       mockAuthSession();
 
       mockFetch.mockResolvedValueOnce({
@@ -142,9 +142,9 @@ describe('AdoWorkItemProvider — extended', () => {
       // Only Active and New items should be published (Resolved is terminal)
       const items = listener.mock.calls[0][0];
       expect(items).toHaveLength(2);
-      expect(items.map((i: any) => i.externalId)).toContain('MyProject/1'); // Active
-      expect(items.map((i: any) => i.externalId)).toContain('MyProject/3'); // New
-      expect(items.map((i: any) => i.externalId)).not.toContain('MyProject/2'); // Resolved
+      expect(items.map((i: any) => i.externalId)).toContain('myorg/MyProject/1'); // Active
+      expect(items.map((i: any) => i.externalId)).toContain('myorg/MyProject/3'); // New
+      expect(items.map((i: any) => i.externalId)).not.toContain('myorg/MyProject/2'); // Resolved
     });
 
     it('handles multiple work item types with different state definitions', async () => {
@@ -397,7 +397,7 @@ describe('AdoWorkItemProvider — extended', () => {
 
     it('handles org-level query (no project)', async () => {
       provider.dispose();
-      provider = new AdoWorkItemProvider('myorg', []); // Empty projects array
+      provider = new AdoWorkItemProvider([{ org: 'myorg', projects: [] }]); // Empty projects array
       mockAuthSession();
 
       mockFetch.mockResolvedValueOnce({
@@ -596,7 +596,7 @@ describe('AdoWorkItemProvider — extended', () => {
   describe('multiple projects', () => {
     it('fetches work items for each configured project', async () => {
       provider.dispose();
-      provider = new AdoWorkItemProvider('myorg', ['ProjectA', 'ProjectB']);
+      provider = new AdoWorkItemProvider([{ org: 'myorg', projects: ['ProjectA', 'ProjectB'] }]);
       mockAuthSession();
 
       // ProjectA WIQL + detail
@@ -632,7 +632,7 @@ describe('AdoWorkItemProvider — extended', () => {
 
     it('reports multiple project failures', async () => {
       provider.dispose();
-      provider = new AdoWorkItemProvider('myorg', ['ProjectA', 'ProjectB']);
+      provider = new AdoWorkItemProvider([{ org: 'myorg', projects: ['ProjectA', 'ProjectB'] }]);
       mockAuthSession();
 
       mockFetch
@@ -648,7 +648,7 @@ describe('AdoWorkItemProvider — extended', () => {
 
     it('handles mix of successful and failed project fetches', async () => {
       provider.dispose();
-      provider = new AdoWorkItemProvider('myorg', ['GoodProject', 'BadProject']);
+      provider = new AdoWorkItemProvider([{ org: 'myorg', projects: ['GoodProject', 'BadProject'] }]);
       mockAuthSession();
 
       // GoodProject: success

--- a/packages/ado/src/test/adoWorkItemProvider.extended.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.extended.test.ts
@@ -642,7 +642,7 @@ describe('AdoWorkItemProvider — extended', () => {
       await provider.refresh();
 
       expect(window.showWarningMessage).toHaveBeenCalledWith(
-        expect.stringContaining('2 projects'),
+        expect.stringContaining('2 sources'),
       );
     });
 

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -32,7 +32,7 @@ describe('AdoWorkItemProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubGlobal('fetch', mockFetch);
-    provider = new AdoWorkItemProvider('myorg', ['MyProject']);
+    provider = new AdoWorkItemProvider([{ org: 'myorg', projects: ['MyProject'] }]);
 
     vi.mocked(authentication.getSession).mockResolvedValue({
       accessToken: 'test-token',
@@ -109,7 +109,7 @@ describe('AdoWorkItemProvider', () => {
     const items = listener.mock.calls[0][0];
     expect(items).toHaveLength(2);
     expect(items[0]).toEqual({
-      externalId: 'MyProject/1',
+      externalId: 'myorg/MyProject/1',
       title: 'User Story 1: Fix login bug',
       description: 'Description for 1',
       url: 'https://dev.azure.com/myorg/MyProject/_workitems/edit/1',
@@ -117,7 +117,7 @@ describe('AdoWorkItemProvider', () => {
       reason: 'assigned',
     });
     expect(items[1]).toEqual({
-      externalId: 'MyProject/2',
+      externalId: 'myorg/MyProject/2',
       title: 'Bug 2: Add search',
       description: 'Description for 2',
       url: 'https://dev.azure.com/myorg/MyProject/_workitems/edit/2',
@@ -401,7 +401,7 @@ describe('AdoWorkItemProvider', () => {
 
   it('uses org-level WIQL when no projects are configured', async () => {
     provider.dispose();
-    provider = new AdoWorkItemProvider('myorg', []);
+    provider = new AdoWorkItemProvider([{ org: 'myorg', projects: [] }]);
 
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -420,7 +420,7 @@ describe('AdoWorkItemProvider', () => {
 
   it('fires empty items when org name is invalid', async () => {
     provider.dispose();
-    provider = new AdoWorkItemProvider('../evil', ['MyProject']);
+    provider = new AdoWorkItemProvider([{ org: '../evil', projects: ['MyProject'] }]);
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
@@ -433,7 +433,7 @@ describe('AdoWorkItemProvider', () => {
 
   it('skips invalid projects and fetches only valid ones', async () => {
     provider.dispose();
-    provider = new AdoWorkItemProvider('myorg', ['ValidProject', '../bad', 'AlsoValid']);
+    provider = new AdoWorkItemProvider([{ org: 'myorg', projects: ['ValidProject', '../bad', 'AlsoValid'] }]);
 
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: async () => createWiqlResponse([]) })
@@ -456,7 +456,7 @@ describe('AdoWorkItemProvider', () => {
 
   it('fires empty items when all configured projects are invalid', async () => {
     provider.dispose();
-    provider = new AdoWorkItemProvider('myorg', ['../bad', '?evil']);
+    provider = new AdoWorkItemProvider([{ org: 'myorg', projects: ['../bad', '?evil'] }]);
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);

--- a/packages/ado/src/test/configEdgeCases.test.ts
+++ b/packages/ado/src/test/configEdgeCases.test.ts
@@ -129,14 +129,8 @@ describe('ADO provider config edge cases', () => {
     // With the new config parser, providers are created when orgConfigs is non-empty
 
     it('no configuration at all yields no org configs', () => {
-      const result = parseAdoProjectsConfig([], '');
+      const result = parseAdoProjectsConfig([]);
       expect(result).toHaveLength(0);
-    });
-
-    it('legacy org alone yields one org config', () => {
-      const result = parseAdoProjectsConfig([], 'myorg');
-      expect(result).toHaveLength(1);
-      expect(result[0].org).toBe('myorg');
     });
   });
 
@@ -241,7 +235,6 @@ describe('ADO provider config edge cases', () => {
 
     it('affectsConfiguration matches all ADO config keys', () => {
       const relevantKeys = [
-        'workcenterAdo.organization',
         'workcenterAdo.projects',
         'workcenterAdo.refreshIntervalSeconds',
       ];
@@ -249,7 +242,6 @@ describe('ADO provider config edge cases', () => {
       for (const key of relevantKeys) {
         const event = { affectsConfiguration: (k: string) => k === key };
         const shouldReconfigure =
-          event.affectsConfiguration('workcenterAdo.organization') ||
           event.affectsConfiguration('workcenterAdo.projects') ||
           event.affectsConfiguration('workcenterAdo.refreshIntervalSeconds');
         expect(shouldReconfigure).toBe(true);
@@ -266,7 +258,6 @@ describe('ADO provider config edge cases', () => {
       for (const key of unrelatedKeys) {
         const event = { affectsConfiguration: (k: string) => k === key };
         const shouldReconfigure =
-          event.affectsConfiguration('workcenterAdo.organization') ||
           event.affectsConfiguration('workcenterAdo.projects') ||
           event.affectsConfiguration('workcenterAdo.refreshIntervalSeconds');
         expect(shouldReconfigure).toBe(false);
@@ -282,8 +273,7 @@ describe('ADO provider config edge cases', () => {
 
     beforeEach(() => {
       configValues = {
-        organization: 'myorg',
-        projects: ['ProjectA'],
+        projects: ['myorg/ProjectA'],
         refreshIntervalSeconds: 0, // Disable timers to prevent leaks in tests
       };
       configChangeListeners = [];
@@ -325,7 +315,6 @@ describe('ADO provider config edge cases', () => {
     });
 
     it('does not register providers when no organizations are configured', async () => {
-      configValues.organization = '';
       configValues.projects = [];
 
       const { activate } = await import('../extension');
@@ -334,29 +323,11 @@ describe('ADO provider config edge cases', () => {
       expect(mockRegisterProvider).not.toHaveBeenCalled();
     });
 
-    it('registers providers when organization is set', async () => {
+    it('registers providers when projects are set', async () => {
       const { activate } = await import('../extension');
       await activate(context);
 
       expect(mockRegisterProvider).toHaveBeenCalledTimes(2);
-    });
-
-    it('reconfigures providers on organization change', async () => {
-      const { activate } = await import('../extension');
-      await activate(context);
-
-      expect(mockRegisterProvider).toHaveBeenCalledTimes(2);
-
-      // Clear both org and projects → providers should be torn down
-      configValues.organization = '';
-      configValues.projects = [];
-      for (const listener of configChangeListeners) {
-        listener({ affectsConfiguration: (k: string) => k === 'workcenterAdo.organization' });
-      }
-
-      // No new providers registered (nothing configured)
-      // The dispose calls happen internally — we verify no new registrations
-      expect(mockRegisterProvider).toHaveBeenCalledTimes(2); // still 2 from initial
     });
 
     it('reconfigures providers on projects change', async () => {
@@ -366,7 +337,7 @@ describe('ADO provider config edge cases', () => {
       expect(mockRegisterProvider).toHaveBeenCalledTimes(2);
 
       // Change projects
-      configValues.projects = ['NewProject'];
+      configValues.projects = ['myorg/NewProject'];
       for (const listener of configChangeListeners) {
         listener({ affectsConfiguration: (k: string) => k === 'workcenterAdo.projects' });
       }

--- a/packages/ado/src/test/configEdgeCases.test.ts
+++ b/packages/ado/src/test/configEdgeCases.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { authentication, workspace, extensions } from 'vscode';
 import { AdoWorkItemProvider } from '../adoWorkItemProvider';
 import { AdoPrReviewProvider } from '../adoPrReviewProvider';
+import { parseAdoProjectsConfig } from '../configParser';
 
 const mockFetch = vi.fn();
 
@@ -32,7 +33,7 @@ describe('ADO provider config edge cases', () => {
     });
 
     it('does not start timer for zero interval', () => {
-      const provider = new AdoWorkItemProvider('myorg', []);
+      const provider = new AdoWorkItemProvider([{ org: 'myorg', projects: [] }]);
       const spy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
 
       provider.startPeriodicRefresh(0);
@@ -43,7 +44,7 @@ describe('ADO provider config edge cases', () => {
     });
 
     it('does not start timer for negative interval', () => {
-      const provider = new AdoWorkItemProvider('myorg', []);
+      const provider = new AdoWorkItemProvider([{ org: 'myorg', projects: [] }]);
       const spy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
 
       provider.startPeriodicRefresh(-5);
@@ -54,7 +55,7 @@ describe('ADO provider config edge cases', () => {
     });
 
     it('does not start timer for NaN interval', () => {
-      const provider = new AdoWorkItemProvider('myorg', []);
+      const provider = new AdoWorkItemProvider([{ org: 'myorg', projects: [] }]);
       const spy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
 
       provider.startPeriodicRefresh(NaN);
@@ -65,7 +66,7 @@ describe('ADO provider config edge cases', () => {
     });
 
     it('does not start timer for Infinity', () => {
-      const provider = new AdoWorkItemProvider('myorg', []);
+      const provider = new AdoWorkItemProvider([{ org: 'myorg', projects: [] }]);
       const spy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
 
       provider.startPeriodicRefresh(Infinity);
@@ -76,7 +77,7 @@ describe('ADO provider config edge cases', () => {
     });
 
     it('clamps interval below 60s up to 60s', () => {
-      const provider = new AdoWorkItemProvider('myorg', []);
+      const provider = new AdoWorkItemProvider([{ org: 'myorg', projects: [] }]);
       const spy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
 
       provider.startPeriodicRefresh(10);
@@ -91,7 +92,7 @@ describe('ADO provider config edge cases', () => {
     });
 
     it('PR review provider also rejects NaN interval', () => {
-      const provider = new AdoPrReviewProvider('myorg', []);
+      const provider = new AdoPrReviewProvider([{ org: 'myorg', projects: [] }]);
       const spy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
 
       provider.startPeriodicRefresh(NaN);
@@ -102,7 +103,7 @@ describe('ADO provider config edge cases', () => {
     });
 
     it('PR review provider also rejects negative interval', () => {
-      const provider = new AdoPrReviewProvider('myorg', []);
+      const provider = new AdoPrReviewProvider([{ org: 'myorg', projects: [] }]);
       const spy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
 
       provider.startPeriodicRefresh(-100);
@@ -113,7 +114,7 @@ describe('ADO provider config edge cases', () => {
     });
 
     it('PR review provider also rejects Infinity interval', () => {
-      const provider = new AdoPrReviewProvider('myorg', []);
+      const provider = new AdoPrReviewProvider([{ org: 'myorg', projects: [] }]);
       const spy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
 
       provider.startPeriodicRefresh(Infinity);
@@ -125,24 +126,23 @@ describe('ADO provider config edge cases', () => {
   });
 
   describe('organization config edge cases', () => {
-    // Extension.ts checks: if (!org) { return; } — skips provider creation
+    // With the new config parser, providers are created when orgConfigs is non-empty
 
-    it('missing organization config falls back to empty string (providers skipped)', () => {
-      // config.get<string>('organization', '') returns '' when unset
-      const org = '';
-      expect(!org).toBe(true);
+    it('no configuration at all yields no org configs', () => {
+      const result = parseAdoProjectsConfig([], '');
+      expect(result).toHaveLength(0);
     });
 
-    it('whitespace-only organization is truthy (providers would be created)', () => {
-      // The extension checks if (!org) which does not trim whitespace
-      const org = '   ';
-      expect(!org).toBe(false);
+    it('legacy org alone yields one org config', () => {
+      const result = parseAdoProjectsConfig([], 'myorg');
+      expect(result).toHaveLength(1);
+      expect(result[0].org).toBe('myorg');
     });
   });
 
   describe('projects config edge cases', () => {
     it('empty string project results in org-level WIQL URL', async () => {
-      const provider = new AdoWorkItemProvider('myorg', ['']);
+      const provider = new AdoWorkItemProvider([{ org: 'myorg', projects: [''] }]);
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -163,7 +163,7 @@ describe('ADO provider config edge cases', () => {
     });
 
     it('mix of empty and valid projects fetches both paths', async () => {
-      const provider = new AdoWorkItemProvider('myorg', ['', 'RealProject']);
+      const provider = new AdoWorkItemProvider([{ org: 'myorg', projects: ['', 'RealProject'] }]);
 
       mockFetch
         .mockResolvedValueOnce({
@@ -195,7 +195,7 @@ describe('ADO provider config edge cases', () => {
     });
 
     it('project with special characters is URL-encoded', async () => {
-      const provider = new AdoWorkItemProvider('myorg', ['My Project']);
+      const provider = new AdoWorkItemProvider([{ org: 'myorg', projects: ['My Project'] }]);
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -215,7 +215,7 @@ describe('ADO provider config edge cases', () => {
     });
 
     it('no projects array falls back to org-level query', async () => {
-      const provider = new AdoWorkItemProvider('myorg', []);
+      const provider = new AdoWorkItemProvider([{ org: 'myorg', projects: [] }]);
 
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -324,8 +324,9 @@ describe('ADO provider config edge cases', () => {
       }
     });
 
-    it('does not register providers when organization is empty', async () => {
+    it('does not register providers when no organizations are configured', async () => {
       configValues.organization = '';
+      configValues.projects = [];
 
       const { activate } = await import('../extension');
       await activate(context);
@@ -346,13 +347,14 @@ describe('ADO provider config edge cases', () => {
 
       expect(mockRegisterProvider).toHaveBeenCalledTimes(2);
 
-      // Change org to empty → providers should be torn down
+      // Clear both org and projects → providers should be torn down
       configValues.organization = '';
+      configValues.projects = [];
       for (const listener of configChangeListeners) {
         listener({ affectsConfiguration: (k: string) => k === 'workcenterAdo.organization' });
       }
 
-      // No new providers registered (org is empty now)
+      // No new providers registered (nothing configured)
       // The dispose calls happen internally — we verify no new registrations
       expect(mockRegisterProvider).toHaveBeenCalledTimes(2); // still 2 from initial
     });

--- a/packages/ado/src/test/configParser.test.ts
+++ b/packages/ado/src/test/configParser.test.ts
@@ -1,168 +1,168 @@
 import { describe, it, expect } from 'vitest';
-import { parseAdoProjectsConfig, OrgConfig } from '../configParser';
+import { parseAdoProjectsConfig, type OrgConfig } from '../configParser';
 
 describe('parseAdoProjectsConfig', () => {
   describe('legacy backward compatibility', () => {
     it('treats plain project names as projects under legacyOrganization', () => {
       const result = parseAdoProjectsConfig(['ProjectA', 'ProjectB'], 'myorg');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'myorg', projects: ['ProjectA', 'ProjectB'] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
 
     it('returns whole-org config when projects is empty and legacyOrganization is set', () => {
       const result = parseAdoProjectsConfig([], 'myorg');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'myorg', projects: [] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
 
     it('preserves single project under legacy org', () => {
       const result = parseAdoProjectsConfig(['OnlyProject'], 'myorg');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'myorg', projects: ['OnlyProject'] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
 
     it('trims whitespace-only legacy org to empty (no providers)', () => {
       const result = parseAdoProjectsConfig([], '   ');
-      expect(result).toEqual<OrgConfig[]>([]);
+      expect(result).toEqual([] satisfies OrgConfig[]);
     });
 
     it('trims whitespace from legacy org value', () => {
       const result = parseAdoProjectsConfig(['Proj'], '  myorg  ');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'myorg', projects: ['Proj'] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
   });
 
   describe('new format parsing', () => {
     it('parses org/project entries into grouped configs', () => {
       const result = parseAdoProjectsConfig(['orgA/Proj1', 'orgA/Proj2', 'orgB/Proj3'], '');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'orgA', projects: ['Proj1', 'Proj2'] },
         { org: 'orgB', projects: ['Proj3'] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
 
     it('parses org-only entries as whole-org monitoring', () => {
       const result = parseAdoProjectsConfig(['myorg'], '');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'myorg', projects: [] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
 
     it('handles mix of org-only and org/project entries', () => {
       const result = parseAdoProjectsConfig(['orgA', 'orgB/Proj1'], '');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'orgA', projects: [] },
         { org: 'orgB', projects: ['Proj1'] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
 
     it('org-only entry overrides specific projects for the same org', () => {
       const result = parseAdoProjectsConfig(['myorg/Proj1', 'myorg'], '');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'myorg', projects: [] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
 
     it('org-only entry before specific projects still monitors whole org', () => {
       const result = parseAdoProjectsConfig(['myorg', 'myorg/Proj1'], '');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'myorg', projects: [] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
   });
 
   describe('new format with legacy org set', () => {
     it('uses new format when any entry contains a slash', () => {
       const result = parseAdoProjectsConfig(['orgA/Proj1'], 'legacyOrg');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'orgA', projects: ['Proj1'] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
 
     it('treats plain entries as org-only when mixed with slash entries', () => {
       const result = parseAdoProjectsConfig(['orgA', 'orgB/Proj1'], 'legacyOrg');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'orgA', projects: [] },
         { org: 'orgB', projects: ['Proj1'] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
   });
 
   describe('edge cases', () => {
     it('returns empty array when both projects and org are empty', () => {
       const result = parseAdoProjectsConfig([], '');
-      expect(result).toEqual<OrgConfig[]>([]);
+      expect(result).toEqual([] satisfies OrgConfig[]);
     });
 
     it('skips empty string entries', () => {
       const result = parseAdoProjectsConfig(['', 'orgA/Proj1', ''], '');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'orgA', projects: ['Proj1'] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
 
     it('skips whitespace-only entries', () => {
       const result = parseAdoProjectsConfig(['   ', 'orgA/Proj1'], '');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'orgA', projects: ['Proj1'] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
 
     it('trims whitespace from entries', () => {
       const result = parseAdoProjectsConfig(['  orgA/Proj1  '], '');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'orgA', projects: ['Proj1'] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
 
     it('skips malformed entry with only slash', () => {
       const result = parseAdoProjectsConfig(['/'], '');
-      expect(result).toEqual<OrgConfig[]>([]);
+      expect(result).toEqual([] satisfies OrgConfig[]);
     });
 
     it('skips entry with trailing slash (no project)', () => {
       const result = parseAdoProjectsConfig(['org/'], '');
-      expect(result).toEqual<OrgConfig[]>([]);
+      expect(result).toEqual([] satisfies OrgConfig[]);
     });
 
     it('skips entry with leading slash (no org)', () => {
       const result = parseAdoProjectsConfig(['/project'], '');
-      expect(result).toEqual<OrgConfig[]>([]);
+      expect(result).toEqual([] satisfies OrgConfig[]);
     });
 
     it('malformed slash-only entry does not disable legacy fallback', () => {
       const result = parseAdoProjectsConfig(['ProjectA', '/'], 'myorg');
       // '/' is not a valid new-format entry, so legacy mode applies.
       // The '/' passes through as a project name; downstream validation handles it.
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'myorg', projects: ['ProjectA', '/'] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
 
     it('trims org and project parts after splitting', () => {
       const result = parseAdoProjectsConfig(['org / proj'], '');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'org', projects: ['proj'] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
 
     it('handles entry with multiple slashes (first slash splits)', () => {
       const result = parseAdoProjectsConfig(['org/proj/extra'], '');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'org', projects: ['proj/extra'] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
 
     it('deduplicates projects within the same org', () => {
       const result = parseAdoProjectsConfig(['org/Proj', 'org/Proj'], '');
-      expect(result).toEqual<OrgConfig[]>([
+      expect(result).toEqual([
         { org: 'org', projects: ['Proj'] },
-      ]);
+      ] satisfies OrgConfig[]);
     });
   });
 });

--- a/packages/ado/src/test/configParser.test.ts
+++ b/packages/ado/src/test/configParser.test.ts
@@ -23,6 +23,18 @@ describe('parseAdoProjectsConfig', () => {
         { org: 'myorg', projects: ['OnlyProject'] },
       ]);
     });
+
+    it('trims whitespace-only legacy org to empty (no providers)', () => {
+      const result = parseAdoProjectsConfig([], '   ');
+      expect(result).toEqual<OrgConfig[]>([]);
+    });
+
+    it('trims whitespace from legacy org value', () => {
+      const result = parseAdoProjectsConfig(['Proj'], '  myorg  ');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'myorg', projects: ['Proj'] },
+      ]);
+    });
   });
 
   describe('new format parsing', () => {
@@ -121,6 +133,22 @@ describe('parseAdoProjectsConfig', () => {
     it('skips entry with leading slash (no org)', () => {
       const result = parseAdoProjectsConfig(['/project'], '');
       expect(result).toEqual<OrgConfig[]>([]);
+    });
+
+    it('malformed slash-only entry does not disable legacy fallback', () => {
+      const result = parseAdoProjectsConfig(['ProjectA', '/'], 'myorg');
+      // '/' is not a valid new-format entry, so legacy mode applies.
+      // The '/' passes through as a project name; downstream validation handles it.
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'myorg', projects: ['ProjectA', '/'] },
+      ]);
+    });
+
+    it('trims org and project parts after splitting', () => {
+      const result = parseAdoProjectsConfig(['org / proj'], '');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'org', projects: ['proj'] },
+      ]);
     });
 
     it('handles entry with multiple slashes (first slash splits)', () => {

--- a/packages/ado/src/test/configParser.test.ts
+++ b/packages/ado/src/test/configParser.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import { parseAdoProjectsConfig, OrgConfig } from '../configParser';
+
+describe('parseAdoProjectsConfig', () => {
+  describe('legacy backward compatibility', () => {
+    it('treats plain project names as projects under legacyOrganization', () => {
+      const result = parseAdoProjectsConfig(['ProjectA', 'ProjectB'], 'myorg');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'myorg', projects: ['ProjectA', 'ProjectB'] },
+      ]);
+    });
+
+    it('returns whole-org config when projects is empty and legacyOrganization is set', () => {
+      const result = parseAdoProjectsConfig([], 'myorg');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'myorg', projects: [] },
+      ]);
+    });
+
+    it('preserves single project under legacy org', () => {
+      const result = parseAdoProjectsConfig(['OnlyProject'], 'myorg');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'myorg', projects: ['OnlyProject'] },
+      ]);
+    });
+  });
+
+  describe('new format parsing', () => {
+    it('parses org/project entries into grouped configs', () => {
+      const result = parseAdoProjectsConfig(['orgA/Proj1', 'orgA/Proj2', 'orgB/Proj3'], '');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'orgA', projects: ['Proj1', 'Proj2'] },
+        { org: 'orgB', projects: ['Proj3'] },
+      ]);
+    });
+
+    it('parses org-only entries as whole-org monitoring', () => {
+      const result = parseAdoProjectsConfig(['myorg'], '');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'myorg', projects: [] },
+      ]);
+    });
+
+    it('handles mix of org-only and org/project entries', () => {
+      const result = parseAdoProjectsConfig(['orgA', 'orgB/Proj1'], '');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'orgA', projects: [] },
+        { org: 'orgB', projects: ['Proj1'] },
+      ]);
+    });
+
+    it('org-only entry overrides specific projects for the same org', () => {
+      const result = parseAdoProjectsConfig(['myorg/Proj1', 'myorg'], '');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'myorg', projects: [] },
+      ]);
+    });
+
+    it('org-only entry before specific projects still monitors whole org', () => {
+      const result = parseAdoProjectsConfig(['myorg', 'myorg/Proj1'], '');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'myorg', projects: [] },
+      ]);
+    });
+  });
+
+  describe('new format with legacy org set', () => {
+    it('uses new format when any entry contains a slash', () => {
+      const result = parseAdoProjectsConfig(['orgA/Proj1'], 'legacyOrg');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'orgA', projects: ['Proj1'] },
+      ]);
+    });
+
+    it('treats plain entries as org-only when mixed with slash entries', () => {
+      const result = parseAdoProjectsConfig(['orgA', 'orgB/Proj1'], 'legacyOrg');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'orgA', projects: [] },
+        { org: 'orgB', projects: ['Proj1'] },
+      ]);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty array when both projects and org are empty', () => {
+      const result = parseAdoProjectsConfig([], '');
+      expect(result).toEqual<OrgConfig[]>([]);
+    });
+
+    it('skips empty string entries', () => {
+      const result = parseAdoProjectsConfig(['', 'orgA/Proj1', ''], '');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'orgA', projects: ['Proj1'] },
+      ]);
+    });
+
+    it('skips whitespace-only entries', () => {
+      const result = parseAdoProjectsConfig(['   ', 'orgA/Proj1'], '');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'orgA', projects: ['Proj1'] },
+      ]);
+    });
+
+    it('trims whitespace from entries', () => {
+      const result = parseAdoProjectsConfig(['  orgA/Proj1  '], '');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'orgA', projects: ['Proj1'] },
+      ]);
+    });
+
+    it('skips malformed entry with only slash', () => {
+      const result = parseAdoProjectsConfig(['/'], '');
+      expect(result).toEqual<OrgConfig[]>([]);
+    });
+
+    it('skips entry with trailing slash (no project)', () => {
+      const result = parseAdoProjectsConfig(['org/'], '');
+      expect(result).toEqual<OrgConfig[]>([]);
+    });
+
+    it('skips entry with leading slash (no org)', () => {
+      const result = parseAdoProjectsConfig(['/project'], '');
+      expect(result).toEqual<OrgConfig[]>([]);
+    });
+
+    it('handles entry with multiple slashes (first slash splits)', () => {
+      const result = parseAdoProjectsConfig(['org/proj/extra'], '');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'org', projects: ['proj/extra'] },
+      ]);
+    });
+
+    it('deduplicates projects within the same org', () => {
+      const result = parseAdoProjectsConfig(['org/Proj', 'org/Proj'], '');
+      expect(result).toEqual<OrgConfig[]>([
+        { org: 'org', projects: ['Proj'] },
+      ]);
+    });
+  });
+});

--- a/packages/ado/src/test/configParser.test.ts
+++ b/packages/ado/src/test/configParser.test.ts
@@ -151,10 +151,15 @@ describe('parseAdoProjectsConfig', () => {
       ] satisfies OrgConfig[]);
     });
 
-    it('handles entry with multiple slashes (first slash splits)', () => {
+    it('skips entry with multiple slashes', () => {
       const result = parseAdoProjectsConfig(['org/proj/extra'], '');
+      expect(result).toEqual([] satisfies OrgConfig[]);
+    });
+
+    it('multi-slash entry does not disable legacy fallback', () => {
+      const result = parseAdoProjectsConfig(['ProjectA', 'org/proj/extra'], 'myorg');
       expect(result).toEqual([
-        { org: 'org', projects: ['proj/extra'] },
+        { org: 'myorg', projects: ['ProjectA', 'org/proj/extra'] },
       ] satisfies OrgConfig[]);
     });
 

--- a/packages/ado/src/test/configParser.test.ts
+++ b/packages/ado/src/test/configParser.test.ts
@@ -2,44 +2,9 @@ import { describe, it, expect } from 'vitest';
 import { parseAdoProjectsConfig, type OrgConfig } from '../configParser';
 
 describe('parseAdoProjectsConfig', () => {
-  describe('legacy backward compatibility', () => {
-    it('treats plain project names as projects under legacyOrganization', () => {
-      const result = parseAdoProjectsConfig(['ProjectA', 'ProjectB'], 'myorg');
-      expect(result).toEqual([
-        { org: 'myorg', projects: ['ProjectA', 'ProjectB'] },
-      ] satisfies OrgConfig[]);
-    });
-
-    it('returns whole-org config when projects is empty and legacyOrganization is set', () => {
-      const result = parseAdoProjectsConfig([], 'myorg');
-      expect(result).toEqual([
-        { org: 'myorg', projects: [] },
-      ] satisfies OrgConfig[]);
-    });
-
-    it('preserves single project under legacy org', () => {
-      const result = parseAdoProjectsConfig(['OnlyProject'], 'myorg');
-      expect(result).toEqual([
-        { org: 'myorg', projects: ['OnlyProject'] },
-      ] satisfies OrgConfig[]);
-    });
-
-    it('trims whitespace-only legacy org to empty (no providers)', () => {
-      const result = parseAdoProjectsConfig([], '   ');
-      expect(result).toEqual([] satisfies OrgConfig[]);
-    });
-
-    it('trims whitespace from legacy org value', () => {
-      const result = parseAdoProjectsConfig(['Proj'], '  myorg  ');
-      expect(result).toEqual([
-        { org: 'myorg', projects: ['Proj'] },
-      ] satisfies OrgConfig[]);
-    });
-  });
-
-  describe('new format parsing', () => {
+  describe('parsing', () => {
     it('parses org/project entries into grouped configs', () => {
-      const result = parseAdoProjectsConfig(['orgA/Proj1', 'orgA/Proj2', 'orgB/Proj3'], '');
+      const result = parseAdoProjectsConfig(['orgA/Proj1', 'orgA/Proj2', 'orgB/Proj3']);
       expect(result).toEqual([
         { org: 'orgA', projects: ['Proj1', 'Proj2'] },
         { org: 'orgB', projects: ['Proj3'] },
@@ -47,14 +12,14 @@ describe('parseAdoProjectsConfig', () => {
     });
 
     it('parses org-only entries as whole-org monitoring', () => {
-      const result = parseAdoProjectsConfig(['myorg'], '');
+      const result = parseAdoProjectsConfig(['myorg']);
       expect(result).toEqual([
         { org: 'myorg', projects: [] },
       ] satisfies OrgConfig[]);
     });
 
     it('handles mix of org-only and org/project entries', () => {
-      const result = parseAdoProjectsConfig(['orgA', 'orgB/Proj1'], '');
+      const result = parseAdoProjectsConfig(['orgA', 'orgB/Proj1']);
       expect(result).toEqual([
         { org: 'orgA', projects: [] },
         { org: 'orgB', projects: ['Proj1'] },
@@ -62,109 +27,76 @@ describe('parseAdoProjectsConfig', () => {
     });
 
     it('org-only entry overrides specific projects for the same org', () => {
-      const result = parseAdoProjectsConfig(['myorg/Proj1', 'myorg'], '');
+      const result = parseAdoProjectsConfig(['myorg/Proj1', 'myorg']);
       expect(result).toEqual([
         { org: 'myorg', projects: [] },
       ] satisfies OrgConfig[]);
     });
 
     it('org-only entry before specific projects still monitors whole org', () => {
-      const result = parseAdoProjectsConfig(['myorg', 'myorg/Proj1'], '');
+      const result = parseAdoProjectsConfig(['myorg', 'myorg/Proj1']);
       expect(result).toEqual([
         { org: 'myorg', projects: [] },
       ] satisfies OrgConfig[]);
     });
   });
 
-  describe('new format with legacy org set', () => {
-    it('uses new format when any entry contains a slash', () => {
-      const result = parseAdoProjectsConfig(['orgA/Proj1'], 'legacyOrg');
-      expect(result).toEqual([
-        { org: 'orgA', projects: ['Proj1'] },
-      ] satisfies OrgConfig[]);
-    });
-
-    it('treats plain entries as org-only when mixed with slash entries', () => {
-      const result = parseAdoProjectsConfig(['orgA', 'orgB/Proj1'], 'legacyOrg');
-      expect(result).toEqual([
-        { org: 'orgA', projects: [] },
-        { org: 'orgB', projects: ['Proj1'] },
-      ] satisfies OrgConfig[]);
-    });
-  });
-
   describe('edge cases', () => {
-    it('returns empty array when both projects and org are empty', () => {
-      const result = parseAdoProjectsConfig([], '');
+    it('returns empty array when projects is empty', () => {
+      const result = parseAdoProjectsConfig([]);
       expect(result).toEqual([] satisfies OrgConfig[]);
     });
 
     it('skips empty string entries', () => {
-      const result = parseAdoProjectsConfig(['', 'orgA/Proj1', ''], '');
+      const result = parseAdoProjectsConfig(['', 'orgA/Proj1', '']);
       expect(result).toEqual([
         { org: 'orgA', projects: ['Proj1'] },
       ] satisfies OrgConfig[]);
     });
 
     it('skips whitespace-only entries', () => {
-      const result = parseAdoProjectsConfig(['   ', 'orgA/Proj1'], '');
+      const result = parseAdoProjectsConfig(['   ', 'orgA/Proj1']);
       expect(result).toEqual([
         { org: 'orgA', projects: ['Proj1'] },
       ] satisfies OrgConfig[]);
     });
 
     it('trims whitespace from entries', () => {
-      const result = parseAdoProjectsConfig(['  orgA/Proj1  '], '');
+      const result = parseAdoProjectsConfig(['  orgA/Proj1  ']);
       expect(result).toEqual([
         { org: 'orgA', projects: ['Proj1'] },
       ] satisfies OrgConfig[]);
     });
 
     it('skips malformed entry with only slash', () => {
-      const result = parseAdoProjectsConfig(['/'], '');
+      const result = parseAdoProjectsConfig(['/']);
       expect(result).toEqual([] satisfies OrgConfig[]);
     });
 
     it('skips entry with trailing slash (no project)', () => {
-      const result = parseAdoProjectsConfig(['org/'], '');
+      const result = parseAdoProjectsConfig(['org/']);
       expect(result).toEqual([] satisfies OrgConfig[]);
     });
 
     it('skips entry with leading slash (no org)', () => {
-      const result = parseAdoProjectsConfig(['/project'], '');
+      const result = parseAdoProjectsConfig(['/project']);
       expect(result).toEqual([] satisfies OrgConfig[]);
     });
 
-    it('malformed slash-only entry does not disable legacy fallback', () => {
-      const result = parseAdoProjectsConfig(['ProjectA', '/'], 'myorg');
-      // '/' is not a valid new-format entry, so legacy mode applies.
-      // The '/' passes through as a project name; downstream validation handles it.
-      expect(result).toEqual([
-        { org: 'myorg', projects: ['ProjectA', '/'] },
-      ] satisfies OrgConfig[]);
-    });
-
     it('trims org and project parts after splitting', () => {
-      const result = parseAdoProjectsConfig(['org / proj'], '');
+      const result = parseAdoProjectsConfig(['org / proj']);
       expect(result).toEqual([
         { org: 'org', projects: ['proj'] },
       ] satisfies OrgConfig[]);
     });
 
     it('skips entry with multiple slashes', () => {
-      const result = parseAdoProjectsConfig(['org/proj/extra'], '');
+      const result = parseAdoProjectsConfig(['org/proj/extra']);
       expect(result).toEqual([] satisfies OrgConfig[]);
     });
 
-    it('multi-slash entry does not disable legacy fallback', () => {
-      const result = parseAdoProjectsConfig(['ProjectA', 'org/proj/extra'], 'myorg');
-      expect(result).toEqual([
-        { org: 'myorg', projects: ['ProjectA', 'org/proj/extra'] },
-      ] satisfies OrgConfig[]);
-    });
-
     it('deduplicates projects within the same org', () => {
-      const result = parseAdoProjectsConfig(['org/Proj', 'org/Proj'], '');
+      const result = parseAdoProjectsConfig(['org/Proj', 'org/Proj']);
       expect(result).toEqual([
         { org: 'org', projects: ['Proj'] },
       ] satisfies OrgConfig[]);


### PR DESCRIPTION
## Summary

Support multiple Azure DevOps organizations via a unified `workcenterAdo.projects` setting.

Each entry in `workcenterAdo.projects` can now be either:
- `<org>` — monitor an entire organization
- `<org>/<project>` — monitor a specific project within an organization

This allows users to monitor work items and PR reviews across multiple ADO organizations simultaneously.

## Changes

- **New `configParser.ts`** — Shared config parsing logic that converts the raw settings into per-org configurations.
- **Updated providers** — Both `AdoWorkItemProvider` and `AdoPrReviewProvider` now accept `OrgConfig[]` and iterate over all configured organizations. Per-org user ID caching added for the PR provider.
- **Updated `extension.ts`** — Uses the config parser to derive org configs from the settings. Warning messages distinguish between "nothing configured" and "all entries invalid".
- **Updated `package.json`** — Removed the deprecated `workcenterAdo.organization` setting. `workcenterAdo.projects` description updated to explain the new format.
- **`externalId` scoped to org** — Prevents collisions when the same project name exists in multiple organizations.
- **Terminal states cache scoped to org** — Prevents incorrect cache hits across orgs with different process templates.
- **Config parser tests** — Covers org/project parsing, org-only entries, edge cases (malformed entries, deduplication, whitespace).

## Breaking Change

The deprecated `workcenterAdo.organization` setting has been removed. Users must migrate to the new `workcenterAdo.projects` format using `org` or `org/project` entries.

Closes #186
