### PR TITLE
Add vortex with list icon as extension logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # WorkCenter
 
+<p align="center">
+  <img src="packages/core/resources/workcenter-vortex.svg" alt="WorkCenter Logo" width="64" height="64" />
+</p>
+
 **A unified work hub inside VS Code.**
 
 WorkCenter is a VS Code extension that brings all of your work items — GitHub issues, Azure DevOps work items, PR review requests, investigations, follow-ups, and ad-hoc tasks — into a single, organized sidebar. Instead of juggling browser tabs, notification emails, and sticky notes, you manage everything from where you already write code.
 
 ## The Problem
 
-Developers constantly context-switch between tools. Issues live in GitHub, tasks live in Jira, review requests arrive by email, and ad-hoc follow-ups exist only in your head. Each tool has its own UI, its own notification model, and its own idea of "what's next." The result: work falls through the cracks, and you waste time just figuring out what to do.
+Developers constantly context-switch between tools. Issues live in GitHub, tasks live in Azure DevOps, review requests arrive by email, and ad-hoc follow-ups exist only in your head. Each tool has its own UI, its own notification model, and its own idea of "what's next." The result: work falls through the cracks, and you waste time just figuring out what to do.
 
 ## How WorkCenter Helps
 
-WorkCenter is **not** a replacement for GitHub Issues, Jira, or any other system of record. It is an **aggregation layer** that sits inside VS Code and gives you a personal, unified view of your work:
+WorkCenter is **not** a replacement for GitHub Issues, Azure DevOps, or any other system of record. It is an **aggregation layer** that sits inside VS Code and gives you a personal, unified view of your work:
 
 - **Providers** discover items from external sources (GitHub issues, Azure DevOps work items, PR reviews, and more in the future) and surface them automatically.
 - **You** decide what to accept, what to dismiss, and what to work on next.

--- a/packages/core/resources/workcenter.svg
+++ b/packages/core/resources/workcenter.svg
@@ -1,3 +1,17 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
-  <path fill="#C5C5C5" d="M3 2h10v2H3zm0 3h10v2H3zm0 3h10v2H3zm0 3h10v2H3z"/>
+  <defs>
+    <mask id="list" maskUnits="userSpaceOnUse" x="0" y="0" width="16" height="16">
+      <rect width="16" height="16" fill="white"/>
+      <line x1="6.8" y1="6.85" x2="9.2" y2="6.85" stroke="black" stroke-width="0.8" stroke-linecap="round"/>
+      <line x1="6.8" y1="8" x2="9.2" y2="8" stroke="black" stroke-width="0.8" stroke-linecap="round"/>
+      <line x1="6.8" y1="9.15" x2="9.2" y2="9.15" stroke="black" stroke-width="0.8" stroke-linecap="round"/>
+    </mask>
+  </defs>
+  <g mask="url(#list)">
+    <path d="M 8 2 C 11 2 13 4 13 6.5 C 13 9 11 10 8.5 10 C 7 10 6 9 6 7.5 C 6 6.5 6.5 6 7.5 6" 
+          stroke="#C5C5C5" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <path d="M 8 14 C 5 14 3 12 3 9.5 C 3 7 5 6 7.5 6 C 9 6 10 7 10 8.5 C 10 9.5 9.5 10 8.5 10" 
+          stroke="#C5C5C5" stroke-width="2.5" fill="none" stroke-linecap="round"/>
+    <rect x="6.2" y="6" width="3.6" height="4" rx="0.5" fill="#C5C5C5"/>
+  </g>
 </svg>


### PR DESCRIPTION
Replace placeholder 4-bar icon with vortex design featuring transparent list items in the center convergence. Two spiral arms pull inward toward a task list, conveying the theme of multiple data sources flowing into one unified hub.

Also add the icon to the README header.