### PR TITLE
Fix ADO tree view to display org/project in group labels

### DIFF
--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -279,7 +279,7 @@ export class AdoWorkItemProvider extends BaseProvider {
         title: `${wiType} ${wi.id}: ${wi.fields['System.Title']}`,
         description: wi.fields['System.Description']?.replace(/<[^>]*>/g, '')?.slice(0, 200),
         url: wi._links.html.href,
-        group: projectName,
+        group: `${org}/${projectName}`,
         reason: 'assigned',
       };
     });

--- a/packages/ado/src/test/adoWorkItemProvider.extended.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.extended.test.ts
@@ -673,7 +673,7 @@ describe('AdoWorkItemProvider — extended', () => {
 
       const items = listener.mock.calls[0][0];
       expect(items).toHaveLength(1);
-      expect(items[0].group).toBe('GoodProject');
+      expect(items[0].group).toBe('myorg/GoodProject');
 
       // Should warn about the failed project
       expect(window.showWarningMessage).toHaveBeenCalledWith(

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -113,7 +113,7 @@ describe('AdoWorkItemProvider', () => {
       title: 'User Story 1: Fix login bug',
       description: 'Description for 1',
       url: 'https://dev.azure.com/myorg/MyProject/_workitems/edit/1',
-      group: 'MyProject',
+      group: 'myorg/MyProject',
       reason: 'assigned',
     });
     expect(items[1]).toEqual({
@@ -121,7 +121,7 @@ describe('AdoWorkItemProvider', () => {
       title: 'Bug 2: Add search',
       description: 'Description for 2',
       url: 'https://dev.azure.com/myorg/MyProject/_workitems/edit/2',
-      group: 'MyProject',
+      group: 'myorg/MyProject',
       reason: 'assigned',
     });
   });


### PR DESCRIPTION
Change the ADO work item provider to include the organization name
in the group field using the format `org/project` instead of just
the project name. This provides clarity when working across multiple
ADO organizations.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
