### PR TITLE
Provider label cache

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -4,6 +4,7 @@ import { WorkCenterApiImpl } from './api/workCenterApi';
 import { JsonTaskStore } from './storage/jsonTaskStore';
 import { DiscoveredStateStore } from './storage/discoveredStateStore';
 import { ReadStateStore } from './storage/readStateStore';
+import { ProviderLabelCache } from './storage/providerLabelCache';
 import { WorkGraph } from './services/workGraph';
 import { ProviderRegistry } from './services/providerRegistry';
 import { ActionRegistry } from './services/actionRegistry';
@@ -60,7 +61,7 @@ function initializeLogging(context: vscode.ExtensionContext): void {
   );
 }
 
-async function loadStores(storagePath: string): Promise<{ workGraph: WorkGraph; stateStore: DiscoveredStateStore; readStateStore: ReadStateStore }> {
+async function loadStores(storagePath: string): Promise<{ workGraph: WorkGraph; stateStore: DiscoveredStateStore; readStateStore: ReadStateStore; labelCache: ProviderLabelCache }> {
   const store = new JsonTaskStore(storagePath);
   const wg = new WorkGraph(store);
   workGraph = wg;
@@ -76,7 +77,11 @@ async function loadStores(storagePath: string): Promise<{ workGraph: WorkGraph; 
   await readStateStore.load();
   logger.debug('Loaded read state');
 
-  return { workGraph: wg, stateStore: ss, readStateStore };
+  const labelCache = new ProviderLabelCache(storagePath);
+  await labelCache.load();
+  logger.debug('Loaded provider label cache');
+
+  return { workGraph: wg, stateStore: ss, readStateStore, labelCache };
 }
 
 async function migrateDiscoveredState(workGraph: WorkGraph, stateStore: DiscoveredStateStore): Promise<void> {
@@ -281,10 +286,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<WorkCe
 
   const initStart = performance.now();
   const storagePath = context.globalStorageUri.fsPath;
-  const { workGraph: wg, stateStore: ss, readStateStore } = await loadStores(storagePath);
+  const { workGraph: wg, stateStore: ss, readStateStore, labelCache } = await loadStores(storagePath);
   await migrateDiscoveredState(wg, ss);
 
-  const pr = new ProviderRegistry(ss);
+  const pr = new ProviderRegistry(ss, labelCache);
   providerRegistry = pr;
   const ar = new ActionRegistry();
   actionRegistry = ar;

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -78,8 +78,12 @@ async function loadStores(storagePath: string): Promise<{ workGraph: WorkGraph; 
   logger.debug('Loaded read state');
 
   const labelCache = new ProviderLabelCache(storagePath);
-  await labelCache.load();
-  logger.debug('Loaded provider label cache');
+  try {
+    await labelCache.load();
+    logger.debug('Loaded provider label cache');
+  } catch (err) {
+    logger.debug('Failed to load provider label cache; continuing with empty cache', err);
+  }
 
   return { workGraph: wg, stateStore: ss, readStateStore, labelCache };
 }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -118,7 +118,7 @@ export class ProviderRegistry {
    * Get the human-readable label for a provider.
    *
    * @param providerId - The provider identifier.
-   * @returns The provider's label, or the raw `providerId` if the provider is not registered.
+   * @returns The registered provider's live label if available; otherwise a cached label if one exists; otherwise the raw `providerId`.
    */
   getProviderLabel(providerId: string): string {
     return this.providers.get(providerId)?.label ?? this.labelCache?.get(providerId) ?? providerId;

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { WorkCenterProvider, DiscoveredItem } from '../api/types';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
+import { ProviderLabelCache } from '../storage/providerLabelCache';
 import { logger } from './logger';
 
 /**
@@ -45,6 +46,7 @@ export class ProviderRegistry {
 
   constructor(
     private readonly stateStore: DiscoveredStateStore,
+    private readonly labelCache?: ProviderLabelCache,
   ) {}
 
   /**
@@ -63,6 +65,9 @@ export class ProviderRegistry {
     }
 
     this.providers.set(provider.id, provider);
+    if (this.labelCache) {
+      void this.labelCache.set(provider.id, provider.label).catch(() => {});
+    }
     if (!this.discoveredItems.has(provider.id)) {
       this.discoveredItems.set(provider.id, []);
     }
@@ -114,7 +119,7 @@ export class ProviderRegistry {
    * @returns The provider's label, or the raw `providerId` if the provider is not registered.
    */
   getProviderLabel(providerId: string): string {
-    return this.providers.get(providerId)?.label ?? providerId;
+    return this.providers.get(providerId)?.label ?? this.labelCache?.get(providerId) ?? providerId;
   }
 
   /**

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -67,7 +67,7 @@ export class ProviderRegistry {
     this.providers.set(provider.id, provider);
     if (this.labelCache) {
       void this.labelCache.set(provider.id, provider.label).catch(err => {
-        logger.debug('Failed to cache provider label', err);
+        logger.debug(`Failed to cache provider label for provider ${provider.id} (label: ${provider.label})`, err);
       });
     }
     if (!this.discoveredItems.has(provider.id)) {

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -66,7 +66,9 @@ export class ProviderRegistry {
 
     this.providers.set(provider.id, provider);
     if (this.labelCache) {
-      void this.labelCache.set(provider.id, provider.label).catch(() => {});
+      void this.labelCache.set(provider.id, provider.label).catch(err => {
+        logger.debug('Failed to cache provider label', err);
+      });
     }
     if (!this.discoveredItems.has(provider.id)) {
       this.discoveredItems.set(provider.id, []);

--- a/packages/core/src/storage/providerLabelCache.ts
+++ b/packages/core/src/storage/providerLabelCache.ts
@@ -95,7 +95,7 @@ export class ProviderLabelCache {
   }
 
   private async save(): Promise<void> {
-    const obj: Record<string, string> = {};
+    const obj = Object.create(null) as Record<string, string>;
     for (const [key, value] of this.labels) {
       obj[key] = value;
     }

--- a/packages/core/src/storage/providerLabelCache.ts
+++ b/packages/core/src/storage/providerLabelCache.ts
@@ -66,11 +66,15 @@ export class ProviderLabelCache {
     try {
       data = JSON.parse(raw);
     } catch {
+      logger.warn('Failed to parse provider label cache — backing up and resetting to empty');
+      await this.backupInvalidFile();
       this.labels.clear();
       return;
     }
 
     if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      logger.warn('Provider label cache does not contain a valid object — backing up and resetting to empty');
+      await this.backupInvalidFile();
       this.labels.clear();
       return;
     }
@@ -78,6 +82,8 @@ export class ProviderLabelCache {
     const nextLabels = new Map<string, string>();
     for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
       if (typeof value !== 'string') {
+        logger.warn('Provider label cache contains non-string values — backing up and resetting to empty');
+        await this.backupInvalidFile();
         this.labels.clear();
         return;
       }
@@ -98,7 +104,8 @@ export class ProviderLabelCache {
   /** Update the cached label for a provider and persist to disk. */
   async set(providerId: string, label: string): Promise<void> {
     if (this.labels.get(providerId) === label) {
-      return; // No change
+      await this.writeQueue; // Ensure any in-flight writes have settled
+      return;
     }
     const hadPrevious = this.labels.has(providerId);
     const previousLabel = this.labels.get(providerId);
@@ -136,5 +143,15 @@ export class ProviderLabelCache {
     const dir = path.dirname(this.filePath);
     await fs.promises.mkdir(dir, { recursive: true });
     await fs.promises.writeFile(this.filePath, JSON.stringify(obj, null, 2), 'utf-8');
+  }
+
+  private async backupInvalidFile(): Promise<void> {
+    try {
+      const backupPath = `${this.filePath}.corrupt.${Date.now()}`;
+      await fs.promises.rename(this.filePath, backupPath);
+      logger.warn(`Backed up invalid provider label cache to ${backupPath}`);
+    } catch {
+      // Best-effort backup
+    }
   }
 }

--- a/packages/core/src/storage/providerLabelCache.ts
+++ b/packages/core/src/storage/providerLabelCache.ts
@@ -48,6 +48,11 @@ export class ProviderLabelCache {
     try {
       raw = await fs.promises.readFile(this.filePath, 'utf-8');
     } catch (error) {
+      const fsError = error as NodeJS.ErrnoException;
+      if (fsError.code === 'ENOENT') {
+        this.labels.clear();
+        return;
+      }
       logger.warn(`Failed to read provider label cache from ${this.filePath}:`, error);
       throw error;
     }

--- a/packages/core/src/storage/providerLabelCache.ts
+++ b/packages/core/src/storage/providerLabelCache.ts
@@ -43,8 +43,24 @@ export class ProviderLabelCache {
     if (this.labels.get(providerId) === label) {
       return; // No change
     }
+    const hadPrevious = this.labels.has(providerId);
+    const previousLabel = this.labels.get(providerId);
     this.labels.set(providerId, label);
-    await this.enqueue(() => this.save());
+    await this.enqueue(async () => {
+      try {
+        await this.save();
+      } catch (error) {
+        // Roll back in-memory state so future set() calls retry persistence
+        if (this.labels.get(providerId) === label) {
+          if (hadPrevious && previousLabel !== undefined) {
+            this.labels.set(providerId, previousLabel);
+          } else {
+            this.labels.delete(providerId);
+          }
+        }
+        throw error;
+      }
+    });
   }
 
   private enqueue(op: () => Promise<void>): Promise<void> {

--- a/packages/core/src/storage/providerLabelCache.ts
+++ b/packages/core/src/storage/providerLabelCache.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { logger } from '../services/logger';
 
 /**
  * Persists a mapping of providerId → display label so that tree views
@@ -26,7 +27,7 @@ export class ProviderLabelCache {
         this.labels.clear();
         return;
       }
-      console.warn(`Failed to read provider label cache from ${this.filePath}:`, error);
+      logger.warn(`Failed to read provider label cache from ${this.filePath}:`, error);
       throw error;
     }
 

--- a/packages/core/src/storage/providerLabelCache.ts
+++ b/packages/core/src/storage/providerLabelCache.ts
@@ -35,7 +35,7 @@ export class ProviderLabelCache {
     if (!stats.isFile()) {
       logger.warn(`Provider label cache path is not a regular file: ${this.filePath} — removing`);
       try {
-        await fs.promises.rm(this.filePath, { force: true });
+        await fs.promises.rm(this.filePath, { recursive: true, force: true });
       } catch {
         // Best-effort cleanup
       }

--- a/packages/core/src/storage/providerLabelCache.ts
+++ b/packages/core/src/storage/providerLabelCache.ts
@@ -33,7 +33,12 @@ export class ProviderLabelCache {
     }
 
     if (!stats.isFile()) {
-      logger.warn(`Provider label cache path is not a regular file: ${this.filePath}`);
+      logger.warn(`Provider label cache path is not a regular file: ${this.filePath} — removing`);
+      try {
+        await fs.promises.rm(this.filePath, { force: true });
+      } catch {
+        // Best-effort cleanup
+      }
       this.labels.clear();
       return;
     }
@@ -116,7 +121,10 @@ export class ProviderLabelCache {
   }
 
   private enqueue(op: () => Promise<void>): Promise<void> {
-    this.writeQueue = this.writeQueue.then(op, () => op());
+    this.writeQueue = this.writeQueue.then(op, error => {
+      logger.warn('Previous provider label cache write failed; continuing with next queued write.', error);
+      return op();
+    });
     return this.writeQueue;
   }
 

--- a/packages/core/src/storage/providerLabelCache.ts
+++ b/packages/core/src/storage/providerLabelCache.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { logger } from '../services/logger';
+import { MAX_STORE_FILE_SIZE } from './limits';
 
 /**
  * Persists a mapping of providerId → display label so that tree views
@@ -18,15 +19,35 @@ export class ProviderLabelCache {
 
   /** Load cached labels from disk. Safe to call even if the file does not exist. */
   async load(): Promise<void> {
-    let raw: string;
+    let stats: fs.Stats;
     try {
-      raw = await fs.promises.readFile(this.filePath, 'utf-8');
+      stats = await fs.promises.stat(this.filePath);
     } catch (error) {
       const fsError = error as NodeJS.ErrnoException;
       if (fsError.code === 'ENOENT') {
         this.labels.clear();
         return;
       }
+      logger.warn(`Failed to stat provider label cache at ${this.filePath}:`, error);
+      throw error;
+    }
+
+    if (!stats.isFile()) {
+      logger.warn(`Provider label cache path is not a regular file: ${this.filePath}`);
+      this.labels.clear();
+      return;
+    }
+
+    if (stats.size > MAX_STORE_FILE_SIZE) {
+      logger.warn(`Provider label cache exceeds ${MAX_STORE_FILE_SIZE} bytes — resetting to empty`);
+      this.labels.clear();
+      return;
+    }
+
+    let raw: string;
+    try {
+      raw = await fs.promises.readFile(this.filePath, 'utf-8');
+    } catch (error) {
       logger.warn(`Failed to read provider label cache from ${this.filePath}:`, error);
       throw error;
     }

--- a/packages/core/src/storage/providerLabelCache.ts
+++ b/packages/core/src/storage/providerLabelCache.ts
@@ -1,0 +1,58 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Persists a mapping of providerId → display label so that tree views
+ * can show human-friendly group names immediately on startup, before
+ * provider extensions have registered.
+ */
+export class ProviderLabelCache {
+  private labels = new Map<string, string>();
+  private readonly filePath: string;
+
+  constructor(storagePath: string) {
+    this.filePath = path.join(storagePath, 'provider-labels.json');
+  }
+
+  /** Load cached labels from disk. Safe to call even if the file does not exist. */
+  async load(): Promise<void> {
+    try {
+      const raw = await fs.promises.readFile(this.filePath, 'utf-8');
+      const data: unknown = JSON.parse(raw);
+      if (data && typeof data === 'object' && !Array.isArray(data)) {
+        this.labels.clear();
+        for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+          if (typeof key === 'string' && typeof value === 'string') {
+            this.labels.set(key, value);
+          }
+        }
+      }
+    } catch {
+      // File doesn't exist yet or is corrupted — start with empty cache
+    }
+  }
+
+  /** Get a cached label for a provider, or undefined if not cached. */
+  get(providerId: string): string | undefined {
+    return this.labels.get(providerId);
+  }
+
+  /** Update the cached label for a provider and persist to disk. */
+  async set(providerId: string, label: string): Promise<void> {
+    if (this.labels.get(providerId) === label) {
+      return; // No change
+    }
+    this.labels.set(providerId, label);
+    await this.save();
+  }
+
+  private async save(): Promise<void> {
+    const obj: Record<string, string> = {};
+    for (const [key, value] of this.labels) {
+      obj[key] = value;
+    }
+    const dir = path.dirname(this.filePath);
+    await fs.promises.mkdir(dir, { recursive: true });
+    await fs.promises.writeFile(this.filePath, JSON.stringify(obj, null, 2), 'utf-8');
+  }
+}

--- a/packages/core/src/storage/providerLabelCache.ts
+++ b/packages/core/src/storage/providerLabelCache.ts
@@ -17,19 +17,44 @@ export class ProviderLabelCache {
 
   /** Load cached labels from disk. Safe to call even if the file does not exist. */
   async load(): Promise<void> {
+    let raw: string;
     try {
-      const raw = await fs.promises.readFile(this.filePath, 'utf-8');
-      const data: unknown = JSON.parse(raw);
-      if (data && typeof data === 'object' && !Array.isArray(data)) {
+      raw = await fs.promises.readFile(this.filePath, 'utf-8');
+    } catch (error) {
+      const fsError = error as NodeJS.ErrnoException;
+      if (fsError.code === 'ENOENT') {
         this.labels.clear();
-        for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
-          if (typeof key === 'string' && typeof value === 'string') {
-            this.labels.set(key, value);
-          }
-        }
+        return;
       }
+      console.warn(`Failed to read provider label cache from ${this.filePath}:`, error);
+      throw error;
+    }
+
+    let data: unknown;
+    try {
+      data = JSON.parse(raw);
     } catch {
-      // File doesn't exist yet or is corrupted — start with empty cache
+      this.labels.clear();
+      return;
+    }
+
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      this.labels.clear();
+      return;
+    }
+
+    const nextLabels = new Map<string, string>();
+    for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
+      if (typeof value !== 'string') {
+        this.labels.clear();
+        return;
+      }
+      nextLabels.set(key, value);
+    }
+
+    this.labels.clear();
+    for (const [key, value] of nextLabels) {
+      this.labels.set(key, value);
     }
   }
 

--- a/packages/core/src/storage/providerLabelCache.ts
+++ b/packages/core/src/storage/providerLabelCache.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 export class ProviderLabelCache {
   private labels = new Map<string, string>();
   private readonly filePath: string;
+  private writeQueue: Promise<void> = Promise.resolve();
 
   constructor(storagePath: string) {
     this.filePath = path.join(storagePath, 'provider-labels.json');
@@ -43,7 +44,12 @@ export class ProviderLabelCache {
       return; // No change
     }
     this.labels.set(providerId, label);
-    await this.save();
+    await this.enqueue(() => this.save());
+  }
+
+  private enqueue(op: () => Promise<void>): Promise<void> {
+    this.writeQueue = this.writeQueue.then(op, () => op());
+    return this.writeQueue;
   }
 
   private async save(): Promise<void> {

--- a/packages/core/src/test/providerLabelCache.test.ts
+++ b/packages/core/src/test/providerLabelCache.test.ts
@@ -72,14 +72,14 @@ describe('ProviderLabelCache', () => {
     expect(cache.get('not')).toBeUndefined();
   });
 
-  it('skips non-string values on load', async () => {
+  it('clears cache when non-string values are present on load', async () => {
     const filePath = path.join(tmpDir, 'provider-labels.json');
     await fs.writeFile(filePath, JSON.stringify({ github: 'GitHub Issues', bad: 42 }), 'utf-8');
 
     const cache = new ProviderLabelCache(tmpDir);
     await cache.load();
 
-    expect(cache.get('github')).toBe('GitHub Issues');
+    expect(cache.get('github')).toBeUndefined();
     expect(cache.get('bad')).toBeUndefined();
   });
 

--- a/packages/core/src/test/providerLabelCache.test.ts
+++ b/packages/core/src/test/providerLabelCache.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'fs/promises';
+import * as nodeFs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { ProviderLabelCache } from '../storage/providerLabelCache';
@@ -87,15 +88,12 @@ describe('ProviderLabelCache', () => {
     const cache = new ProviderLabelCache(tmpDir);
     await cache.set('github', 'GitHub Issues');
 
-    const filePath = path.join(tmpDir, 'provider-labels.json');
-    const statBefore = await fs.stat(filePath);
+    const writeFileSpy = vi.spyOn(nodeFs.promises, 'writeFile');
 
-    // Wait a tiny bit so mtime would differ if written
-    await new Promise(r => setTimeout(r, 50));
     await cache.set('github', 'GitHub Issues'); // same value
 
-    const statAfter = await fs.stat(filePath);
-    expect(statAfter.mtimeMs).toBe(statBefore.mtimeMs);
+    expect(writeFileSpy).not.toHaveBeenCalled();
+    writeFileSpy.mockRestore();
   });
 
   it('creates storage directory if it does not exist', async () => {

--- a/packages/core/src/test/providerLabelCache.test.ts
+++ b/packages/core/src/test/providerLabelCache.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { ProviderLabelCache } from '../storage/providerLabelCache';
+
+describe('ProviderLabelCache', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'workcenter-label-cache-test-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns undefined for unknown providers', () => {
+    const cache = new ProviderLabelCache(tmpDir);
+    expect(cache.get('unknown')).toBeUndefined();
+  });
+
+  it('returns the label after set', async () => {
+    const cache = new ProviderLabelCache(tmpDir);
+    await cache.set('github', 'GitHub Issues');
+    expect(cache.get('github')).toBe('GitHub Issues');
+  });
+
+  it('persists labels to disk', async () => {
+    const cache = new ProviderLabelCache(tmpDir);
+    await cache.set('github', 'GitHub Issues');
+
+    const filePath = path.join(tmpDir, 'provider-labels.json');
+    const raw = await fs.readFile(filePath, 'utf-8');
+    const data = JSON.parse(raw);
+    expect(data).toEqual({ github: 'GitHub Issues' });
+  });
+
+  it('loads labels from disk', async () => {
+    // Write a cache file manually
+    const filePath = path.join(tmpDir, 'provider-labels.json');
+    await fs.writeFile(filePath, JSON.stringify({ github: 'GitHub Issues', jira: 'Jira' }), 'utf-8');
+
+    const cache = new ProviderLabelCache(tmpDir);
+    await cache.load();
+
+    expect(cache.get('github')).toBe('GitHub Issues');
+    expect(cache.get('jira')).toBe('Jira');
+  });
+
+  it('handles missing file gracefully on load', async () => {
+    const cache = new ProviderLabelCache(tmpDir);
+    await cache.load(); // should not throw
+    expect(cache.get('anything')).toBeUndefined();
+  });
+
+  it('handles corrupted file gracefully on load', async () => {
+    const filePath = path.join(tmpDir, 'provider-labels.json');
+    await fs.writeFile(filePath, 'not-valid-json!!!', 'utf-8');
+
+    const cache = new ProviderLabelCache(tmpDir);
+    await cache.load(); // should not throw
+    expect(cache.get('anything')).toBeUndefined();
+  });
+
+  it('handles array JSON gracefully on load', async () => {
+    const filePath = path.join(tmpDir, 'provider-labels.json');
+    await fs.writeFile(filePath, '["not", "an", "object"]', 'utf-8');
+
+    const cache = new ProviderLabelCache(tmpDir);
+    await cache.load(); // should not throw — arrays are skipped
+    expect(cache.get('not')).toBeUndefined();
+  });
+
+  it('skips non-string values on load', async () => {
+    const filePath = path.join(tmpDir, 'provider-labels.json');
+    await fs.writeFile(filePath, JSON.stringify({ github: 'GitHub Issues', bad: 42 }), 'utf-8');
+
+    const cache = new ProviderLabelCache(tmpDir);
+    await cache.load();
+
+    expect(cache.get('github')).toBe('GitHub Issues');
+    expect(cache.get('bad')).toBeUndefined();
+  });
+
+  it('does not write to disk when value is unchanged', async () => {
+    const cache = new ProviderLabelCache(tmpDir);
+    await cache.set('github', 'GitHub Issues');
+
+    const filePath = path.join(tmpDir, 'provider-labels.json');
+    const statBefore = await fs.stat(filePath);
+
+    // Wait a tiny bit so mtime would differ if written
+    await new Promise(r => setTimeout(r, 50));
+    await cache.set('github', 'GitHub Issues'); // same value
+
+    const statAfter = await fs.stat(filePath);
+    expect(statAfter.mtimeMs).toBe(statBefore.mtimeMs);
+  });
+
+  it('creates storage directory if it does not exist', async () => {
+    const nestedDir = path.join(tmpDir, 'nested', 'dir');
+    const cache = new ProviderLabelCache(nestedDir);
+    await cache.set('github', 'GitHub Issues');
+
+    const filePath = path.join(nestedDir, 'provider-labels.json');
+    const raw = await fs.readFile(filePath, 'utf-8');
+    expect(JSON.parse(raw)).toEqual({ github: 'GitHub Issues' });
+  });
+
+  it('round-trips multiple labels', async () => {
+    const cache1 = new ProviderLabelCache(tmpDir);
+    await cache1.set('github', 'GitHub Issues');
+    await cache1.set('jira', 'Jira Board');
+    await cache1.set('ado', 'Azure DevOps');
+
+    const cache2 = new ProviderLabelCache(tmpDir);
+    await cache2.load();
+
+    expect(cache2.get('github')).toBe('GitHub Issues');
+    expect(cache2.get('jira')).toBe('Jira Board');
+    expect(cache2.get('ado')).toBe('Azure DevOps');
+  });
+});

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -221,6 +221,54 @@ describe('ProviderRegistry', () => {
     expect(registry.getProviderLabel('unknown')).toBe('unknown');
   });
 
+  describe('getProviderLabel with label cache', () => {
+    function createMockLabelCache(entries?: Record<string, string>) {
+      const cache = new Map<string, string>(Object.entries(entries ?? {}));
+      return {
+        get: vi.fn((id: string) => cache.get(id)),
+        set: vi.fn(async (id: string, label: string) => { cache.set(id, label); }),
+        load: vi.fn(async () => {}),
+      };
+    }
+
+    it('falls back to cached label when provider is not registered', () => {
+      const labelCache = createMockLabelCache({ github: 'GitHub Issues' });
+      const reg = new ProviderRegistry(stateStore, labelCache as any);
+
+      expect(reg.getProviderLabel('github')).toBe('GitHub Issues');
+    });
+
+    it('returns raw id when neither provider nor cache has label', () => {
+      const labelCache = createMockLabelCache();
+      const reg = new ProviderRegistry(stateStore, labelCache as any);
+
+      expect(reg.getProviderLabel('unknown')).toBe('unknown');
+    });
+
+    it('prefers live provider label over cached label', () => {
+      const labelCache = createMockLabelCache({ gh: 'Old Label' });
+      const reg = new ProviderRegistry(stateStore, labelCache as any);
+      const provider = createMockProvider('gh'); // label is "Provider gh"
+      reg.register(provider);
+
+      expect(reg.getProviderLabel('gh')).toBe('Provider gh');
+    });
+
+    it('updates cache when provider registers', () => {
+      const labelCache = createMockLabelCache();
+      const reg = new ProviderRegistry(stateStore, labelCache as any);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      expect(labelCache.set).toHaveBeenCalledWith('gh', 'Provider gh');
+    });
+
+    it('works without a label cache (undefined)', () => {
+      const reg = new ProviderRegistry(stateStore);
+      expect(reg.getProviderLabel('unknown')).toBe('unknown');
+    });
+  });
+
   it('returns empty array from getDiscoveredItems for unknown provider', () => {
     expect(registry.getDiscoveredItems('nonexistent')).toEqual([]);
   });


### PR DESCRIPTION
- **Cache provider labels for immediate display on startup (#209)**
- **Add write queue serialization and debug logging for provider label cache**
