### PR TITLE
Fix queue view to show provider label instead of raw ID

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -239,6 +239,26 @@ Patterns documented in `.squad/decisions.md` under "Code Review Fix Patterns" (2
 - **Defensive async loading**: When a synchronous getter reads from an async-loaded cache, ensure the cache is loaded at every call site. Don't rely solely on initialization order guarantees.
 - **Test timing**: When production code adds an async operation to a previously-synchronous code path, tests that fire-and-forget events need to wait for async handlers to complete before asserting on side effects.
 
+## Issue #227: Queue View Provider Labels (2026-04-13)
+
+**Status:** COMPLETE — Provider labels now display in queue view instead of raw IDs
+
+### Summary
+The queue view was displaying raw provider IDs (e.g., `github`, `ado`) in tree items. Extracted `getProviderLabel()` method from `WorkItemViewProvider` base class and applied it in `QueueTreeProvider` to show human-readable labels (e.g., "GitHub", "Azure DevOps").
+
+### Files Modified
+- `packages/core/src/views/queueTreeProvider.ts` — Updated tree item label rendering
+- `packages/core/src/views/baseWorkItemViewProvider.ts` — Extracted `getProviderLabel()` method for reuse across all views
+
+### Key Learnings
+- **Label centralization**: Extracting label lookup into the base class prevents duplication and ensures consistency. Any future view that needs provider labels automatically gets the same logic.
+- **Provider registry lookup**: The `getProviderLabel()` method uses the `ProviderRegistry` to look up the display name. Falls back gracefully if provider not found.
+
+### Result
+- Build: ✅ Passes
+- Tests: 870 total (864 existing + 6 new from Hockney)
+- Commit: `f667e7d` — "Fix queue view to show provider label instead of raw ID (#227)"
+
 ## Issue #189: resurfaceDismissed removal (2025-01-24)
 
 ### Root Cause (Corrected)

--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -248,7 +248,7 @@ The queue view was displaying raw provider IDs (e.g., `github`, `ado`) in tree i
 
 ### Files Modified
 - `packages/core/src/views/queueTreeProvider.ts` — Updated tree item label rendering
-- `packages/core/src/views/baseWorkItemViewProvider.ts` — Extracted `getProviderLabel()` method for reuse across all views
+- `packages/core/src/views/viewLayout.ts` — Extracted `getProviderLabel()` method for reuse across all views
 
 ### Key Learnings
 - **Label centralization**: Extracting label lookup into the base class prevents duplication and ensures consistency. Any future view that needs provider labels automatically gets the same logic.

--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -244,7 +244,7 @@ Patterns documented in `.squad/decisions.md` under "Code Review Fix Patterns" (2
 **Status:** COMPLETE — Provider labels now display in queue view instead of raw IDs
 
 ### Summary
-The queue view was displaying raw provider IDs (e.g., `github`, `ado`) in tree items. Extracted `getProviderLabel()` method from `WorkItemViewProvider` base class and applied it in `QueueTreeProvider` to show human-readable labels (e.g., "GitHub", "Azure DevOps").
+The queue view was displaying raw provider IDs (e.g., `github`, `ado`) in tree items. Extracted `getProviderLabel()` method from `WorkItemViewProvider` base class and applied it in `QueueTreeProvider` to show human-readable labels (e.g., "GitHub Issues").
 
 ### Files Modified
 - `packages/core/src/views/queueTreeProvider.ts` — Updated tree item label rendering

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -394,7 +394,7 @@ Tests verify:
 6. Edge case: items with missing provider IDs
 
 ### Test Infrastructure Notes
-- Used existing `createMockProvider()` and `createMockStore()` patterns from Phase 2
+- Used the existing `createMockStore()` pattern from Phase 2 alongside a local `createMockProviderRegistry()` helper in `queueTreeProvider.test.ts`
 - No new test infrastructure required
 - All assertions validate both display layer and provider lookup mechanism
 

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -373,4 +373,34 @@ mockFetch.mockImplementation(async (url: string) => {
 
 **Key learning:** The bug in issue #189 was present in the codebase. The root cause was explicit resurface logic (`resurfaceDismissed`) that reset dismissed items when they were rediscovered, causing them to reappear. The correct fix was to remove that resurface behavior; the tests now document the expected dismissed-state preservation and guard against future regressions.
 
+## Issue #227: Queue View Provider Labels (2026-04-13)
+
+**Status:** COMPLETE — Provider labels now display in queue view instead of raw IDs  
+**Tester:** Hockney
+
+### Summary
+Added 6 comprehensive test cases to `queueTreeProvider.test.ts` covering the queue view provider label display fix. Tests verify label rendering, provider lookup, and fallback behavior.
+
+### Files Modified
+- `packages/core/src/test/queueTreeProvider.test.ts` — 6 new tests added
+
+### Test Coverage
+Tests verify:
+1. Queue tree items display correct provider labels
+2. Label lookup falls back gracefully when provider not found
+3. Label formatting and display consistency
+4. Integration with `getProviderLabel()` method from base provider
+5. Multiple provider types (GitHub, ADO) correctly labeled
+6. Edge case: items with missing provider IDs
+
+### Test Infrastructure Notes
+- Used existing `createMockProvider()` and `createMockStore()` patterns from Phase 2
+- No new test infrastructure required
+- All assertions validate both display layer and provider lookup mechanism
+
+### Result
+- Tests added: 6 new test cases
+- Suite status: 870 tests passing (864 existing + 6 new)
+- Build: ✅ Passes
+- Commit: `f667e7d` — "Fix queue view to show provider label instead of raw ID (#227)"
 

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -489,14 +489,14 @@ describe('QueueTreeProvider', () => {
       expect(providerRegistry.getProviderLabel).not.toHaveBeenCalled();
     });
 
-    it('should return undefined if resolver returns undefined', async () => {
+    it('should fall back to raw providerId if resolver returns undefined', async () => {
       (providerRegistry.getProviderLabel as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
       const item = await graph.createItem(
         { title: 'Unknown provider' },
         { providerId: 'unknown', externalId: 'ext-1' },
       );
       const treeItem = providerWithResolver.getTreeItem(item);
-      expect(treeItem.description).toBeUndefined();
+      expect(treeItem.description).toBe('unknown');
     });
   });
 });

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -1,9 +1,10 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { DataTransfer, DataTransferItem, MarkdownString, TreeItemCollapsibleState } from 'vscode';
+import { DataTransfer, DataTransferItem, MarkdownString, TreeItemCollapsibleState, EventEmitter } from 'vscode';
 import { WorkGraph } from '../services/workGraph';
 import { WorkItemState } from '../models/workItem';
 import { ITaskStore } from '../storage/taskStore';
 import { QueueTreeProvider } from '../views/queueTreeProvider';
+import { ProviderRegistry } from '../services/providerRegistry';
 
 function createMockStore(): ITaskStore {
   const items: Map<string, any> = new Map();
@@ -13,6 +14,18 @@ function createMockStore(): ITaskStore {
     saveAll: vi.fn(async (batch) => { for (const item of batch) { items.set(item.id, item); } }),
     delete: vi.fn(async (id) => { items.delete(id); }),
   };
+}
+
+function createMockProviderRegistry(): ProviderRegistry {
+  const emitter = new EventEmitter<void>();
+  return {
+    getProviderLabel: vi.fn((id: string) => {
+      if (id === 'github') return 'GitHub Issues';
+      if (id === 'ado') return 'Azure DevOps';
+      return id;
+    }),
+    onDidRegisterProvider: emitter.event,
+  } as any;
 }
 
 const DRAG_MIME_TYPE = 'application/vnd.code.tree.workcenter.queue';
@@ -96,7 +109,7 @@ describe('QueueTreeProvider', () => {
       expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.None);
     });
 
-    it('sets description to providerId', async () => {
+    it('sets description to providerId when no label resolver', async () => {
       const item = await graph.createItem(
         { title: 'From provider' },
         { providerId: 'github', externalId: 'ext-1' },
@@ -424,6 +437,66 @@ describe('QueueTreeProvider', () => {
       await graph.createItem({ title: 'After dispose' });
 
       expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('provider label resolution', () => {
+    let providerRegistry: ProviderRegistry;
+    let providerWithResolver: QueueTreeProvider;
+
+    beforeEach(async () => {
+      providerRegistry = createMockProviderRegistry();
+      providerWithResolver = new QueueTreeProvider(graph, providerRegistry);
+    });
+
+    it('should show resolved label instead of raw providerId for GitHub items', async () => {
+      const item = await graph.createItem(
+        { title: 'GitHub Issue' },
+        { providerId: 'github', externalId: 'issue-123' },
+      );
+      const treeItem = providerWithResolver.getTreeItem(item);
+      expect(treeItem.description).toBe('GitHub Issues');
+    });
+
+    it('should show resolved label instead of raw providerId for ADO items', async () => {
+      const item = await graph.createItem(
+        { title: 'ADO Work Item' },
+        { providerId: 'ado', externalId: 'workitem-456' },
+      );
+      const treeItem = providerWithResolver.getTreeItem(item);
+      expect(treeItem.description).toBe('Azure DevOps');
+    });
+
+    it('should show undefined description for items without providerId', async () => {
+      const item = await graph.createItem({ title: 'Manual item' });
+      const treeItem = providerWithResolver.getTreeItem(item);
+      expect(treeItem.description).toBeUndefined();
+    });
+
+    it('should call getProviderLabel with correct providerId', async () => {
+      const item = await graph.createItem(
+        { title: 'Test' },
+        { providerId: 'github', externalId: 'ext-1' },
+      );
+      providerWithResolver.getTreeItem(item);
+      expect(providerRegistry.getProviderLabel).toHaveBeenCalledWith('github');
+    });
+
+    it('should not call getProviderLabel for items without providerId', async () => {
+      const item = await graph.createItem({ title: 'Manual' });
+      (providerRegistry.getProviderLabel as ReturnType<typeof vi.fn>).mockClear();
+      providerWithResolver.getTreeItem(item);
+      expect(providerRegistry.getProviderLabel).not.toHaveBeenCalled();
+    });
+
+    it('should return undefined if resolver returns undefined', async () => {
+      (providerRegistry.getProviderLabel as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+      const item = await graph.createItem(
+        { title: 'Unknown provider' },
+        { providerId: 'unknown', externalId: 'ext-1' },
+      );
+      const treeItem = providerWithResolver.getTreeItem(item);
+      expect(treeItem.description).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -36,7 +36,7 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
   protected createWorkItemTreeItem(item: WorkItem): vscode.TreeItem {
     const treeItem = new vscode.TreeItem(item.title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = item.id;
-    treeItem.description = item.providerId;
+    treeItem.description = this.getProviderLabel(item.providerId);
     treeItem.tooltip = this.buildTooltip(item);
     treeItem.contextValue = item.url ? 'queueItem.hasUrl' : 'queueItem';
     treeItem.iconPath = new vscode.ThemeIcon(item.providerId ? 'remote' : 'circle-filled');

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -319,10 +319,11 @@ export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<Wo
   refresh(): void { this._onDidChangeTreeData.fire(); }
 
   protected getProviderLabel(providerId: string | undefined): string | undefined {
-    if (!providerId) {
-      return providerId;
+    const normalizedProviderId = providerId?.trim();
+    if (!normalizedProviderId) {
+      return undefined;
     }
-    return this.labelResolver?.(providerId) ?? providerId;
+    return this.labelResolver?.(normalizedProviderId) ?? normalizedProviderId;
   }
 
   /** Return the WorkItems this view cares about (before sorting). */

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -318,6 +318,10 @@ export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<Wo
 
   refresh(): void { this._onDidChangeTreeData.fire(); }
 
+  protected getProviderLabel(providerId: string | undefined): string | undefined {
+    return providerId && this.labelResolver ? this.labelResolver(providerId) : providerId;
+  }
+
   /** Return the WorkItems this view cares about (before sorting). */
   protected abstract getItems(): WorkItem[];
 

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -319,7 +319,10 @@ export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<Wo
   refresh(): void { this._onDidChangeTreeData.fire(); }
 
   protected getProviderLabel(providerId: string | undefined): string | undefined {
-    return providerId && this.labelResolver ? this.labelResolver(providerId) : providerId;
+    if (!providerId) {
+      return providerId;
+    }
+    return this.labelResolver?.(providerId) ?? providerId;
   }
 
   /** Return the WorkItems this view cares about (before sorting). */


### PR DESCRIPTION
Fix queue view to show provider label instead of raw ID

Closes #227

## Problem

The Queue tree view displayed the raw `providerId` string (e.g., `"github"`) as the tree item description. The `ProviderRegistry.getProviderLabel()` method exists and returns the human-readable label, but `QueueTreeProvider` wasn't using it.

## Solution

Added a `getProviderLabel()` protected method to the base `WorkItemViewProvider` class and updated `QueueTreeProvider` to use it. This follows the same pattern already used by `FocusTreeProvider` and `HistoryTreeProvider` for label resolution.

Queue items now display "GitHub Issues" instead of "github", "Azure DevOps" instead of "ado", etc.

## Changes

- `packages/core/src/views/viewLayout.ts` — Added `getProviderLabel()` to base class
- `packages/core/src/views/queueTreeProvider.ts` — Use resolved label instead of raw ID
- `packages/core/src/test/queueTreeProvider.test.ts` — 6 new tests for label resolution

## Testing

All 870 core tests pass (including 6 new). Full suite (1298 tests) green.
