### PR TITLE
Use distinct icon for dismissed items in Sources view

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -255,3 +255,9 @@ Patterns documented in `.squad/decisions.md` under "Code Review Fix Patterns" (2
 - **Dismissed means dismissed**: The original four-view design established that dismissed items are sticky. The `resurfaceDismissed` feature contradicted this core design principle.
 - **Root cause matters**: The first fix (defensive load) was plausible but wrong. The symptom (dismissed items reappearing) had a simpler explanation: code explicitly designed to resurface them.
 - **Reverting cleanly**: When reverting test changes, `git checkout <commit> -- <files>` is the safest approach to restore files to a known-good state before applying new targeted edits.
+
+## Issue #231: Sources view dismissed icon (2025-07-23)
+
+### Learnings
+- **Icon conditional pattern in Sources view**: `sourcesTreeProvider.ts` line 69 uses a chained ternary to map `InboxState` to ThemeIcon names: `accepted` → `check`, `dismissed` → `circle-slash`, `unseen` → `circle-outline`. Previously a simple binary ternary lumped dismissed and unseen together.
+- **Key file**: `packages/core/src/views/sourcesTreeProvider.ts` — the `getTreeItem()` method for `item` kind elements assigns icons based on `stateStore.getState()` result.

--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -259,5 +259,5 @@ Patterns documented in `.squad/decisions.md` under "Code Review Fix Patterns" (2
 ## Issue #231: Sources view dismissed icon (2025-07-23)
 
 ### Learnings
-- **Icon conditional pattern in Sources view**: `sourcesTreeProvider.ts` line 69 uses a chained ternary to map `InboxState` to ThemeIcon names: `accepted` → `check`, `dismissed` → `circle-slash`, `unseen` → `circle-outline`. Previously a simple binary ternary lumped dismissed and unseen together.
+- **Icon mapping in Sources view**: `packages/core/src/views/sourcesTreeProvider.ts` maps `InboxState` to `ThemeIcon` names via `switch (state)` in `getTreeItem()`: `accepted` → `check`, `dismissed` → `circle-slash`, `unseen` → `circle-outline`. Previously simpler branching lumped dismissed and unseen together.
 - **Key file**: `packages/core/src/views/sourcesTreeProvider.ts` — the `getTreeItem()` method for `item` kind elements assigns icons based on `stateStore.getState()` result.

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -89,7 +89,7 @@ Key files:
 **Key pattern:** Use `stateStore.getState.mockReturnValue()` to cycle through states on the same node, then compare icon IDs via Set uniqueness. No need for separate nodes.
 
 **File paths:**
-- Production: `packages/core/src/views/sourcesTreeProvider.ts` (line 69 — three-way ternary: accepted→check, dismissed→circle-slash, unseen→circle-outline)
+- Production: `packages/core/src/views/sourcesTreeProvider.ts` (`switch (state)` selects icons: accepted→check, dismissed→circle-slash, unseen→circle-outline)
 - Tests: `packages/core/src/test/sourcesTreeProvider.test.ts` (getTreeItem describe block)
 
 **Suite metrics:** 865 tests passing (29 test files), 0 failures.

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -79,6 +79,21 @@ Key files:
 - `createMockStateStore()` with backing Map<string, string> and EventEmitter for testing onDidChange subscriptions
 - Migration tested by extracting the for-loop logic from extension.ts into a standalone `runMigration()` function
 
+### Issue #231 — Sources Distinct Icons Test Coverage (2026-07-25)
+
+**Tests updated:** 2 tests rewritten + 1 new test in `sourcesTreeProvider.test.ts`
+- Renamed "should render non-accepted item with circle-outline icon" → "should render unseen item with circle-outline icon" (clearer intent)
+- Updated dismissed test to assert `circle-slash` icon instead of `circle-outline`
+- Added "should use distinct icons for accepted, dismissed, and unseen states" — collects all three icons into a Set and asserts `size === 3`
+
+**Key pattern:** Use `stateStore.getState.mockReturnValue()` to cycle through states on the same node, then compare icon IDs via Set uniqueness. No need for separate nodes.
+
+**File paths:**
+- Production: `packages/core/src/views/sourcesTreeProvider.ts` (line 69 — three-way ternary: accepted→check, dismissed→circle-slash, unseen→circle-outline)
+- Tests: `packages/core/src/test/sourcesTreeProvider.test.ts` (getTreeItem describe block)
+
+**Suite metrics:** 865 tests passing (29 test files), 0 failures.
+
 **Edge cases found:**
 - DiscoveredStateStore: corrupted JSON on disk throws (not silently ignored) — only ENOENT is handled gracefully
 - DiscoveredStateStore: `mkdir({ recursive: true })` creates nested storage directories on first write

--- a/packages/core/src/test/sourcesTreeProvider.test.ts
+++ b/packages/core/src/test/sourcesTreeProvider.test.ts
@@ -284,7 +284,7 @@ describe('SourcesTreeProvider', () => {
       expect((treeItem.iconPath as any).id).toBe('check');
     });
 
-    it('should render non-accepted item with circle-outline icon', () => {
+    it('should render unseen item with circle-outline icon', () => {
       stateStore.getState.mockReturnValue('unseen');
 
       const node: SourceItemNode = {
@@ -294,15 +294,33 @@ describe('SourcesTreeProvider', () => {
       expect((treeItem.iconPath as any).id).toBe('circle-outline');
     });
 
-    it('should render dismissed item with circle-outline icon and dismissed description', () => {
+    it('should render dismissed item with circle-slash icon and dismissed description', () => {
       stateStore.getState.mockReturnValue('dismissed');
 
       const node: SourceItemNode = {
         kind: 'item', providerId: 'gh', externalId: '1', title: 'Dismissed Item',
       };
       const treeItem = provider.getTreeItem(node);
-      expect((treeItem.iconPath as any).id).toBe('circle-outline');
+      expect((treeItem.iconPath as any).id).toBe('circle-slash');
       expect(treeItem.description).toBe('dismissed');
+    });
+
+    it('should use distinct icons for accepted, dismissed, and unseen states', () => {
+      const node: SourceItemNode = {
+        kind: 'item', providerId: 'gh', externalId: '1', title: 'Test Item',
+      };
+
+      stateStore.getState.mockReturnValue('accepted');
+      const acceptedIcon = (provider.getTreeItem(node).iconPath as any).id;
+
+      stateStore.getState.mockReturnValue('dismissed');
+      const dismissedIcon = (provider.getTreeItem(node).iconPath as any).id;
+
+      stateStore.getState.mockReturnValue('unseen');
+      const unseenIcon = (provider.getTreeItem(node).iconPath as any).id;
+
+      const icons = new Set([acceptedIcon, dismissedIcon, unseenIcon]);
+      expect(icons.size).toBe(3);
     });
 
     it('should set contextValue with hasUrl when item has url', () => {

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -66,7 +66,7 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
       }
       case 'item': {
         const state = this.stateStore.getState(element.providerId, element.externalId);
-        const icon = state === 'accepted' ? 'check' : 'circle-outline';
+        const icon = state === 'accepted' ? 'check' : state === 'dismissed' ? 'circle-slash' : 'circle-outline';
         const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
         treeItem.description = state === 'dismissed' ? 'dismissed' : undefined;
         treeItem.tooltip = this.buildItemTooltip(element);

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -66,7 +66,18 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
       }
       case 'item': {
         const state = this.stateStore.getState(element.providerId, element.externalId);
-        const icon = state === 'accepted' ? 'check' : state === 'dismissed' ? 'circle-slash' : 'circle-outline';
+        let icon: string;
+        switch (state) {
+          case 'accepted':
+            icon = 'check';
+            break;
+          case 'dismissed':
+            icon = 'circle-slash';
+            break;
+          default:
+            icon = 'circle-outline';
+            break;
+        }
         const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
         treeItem.description = state === 'dismissed' ? 'dismissed' : undefined;
         treeItem.tooltip = this.buildItemTooltip(element);


### PR DESCRIPTION
Use distinct icon for dismissed items in Sources view

Closes #231

## Problem

In the Sources tree view, both "unseen" and "dismissed" items used the same `circle-outline` icon. The only way to distinguish them was the "dismissed" text in the description field, which is easy to overlook.

## Solution

Updated the icon assignment in `sourcesTreeProvider.ts` to handle all three inbox states with distinct icons:

- `accepted` → `check` (unchanged)
- `dismissed` → `circle-slash` (new — visually conveys "rejected")
- `unseen` → `circle-outline` (unchanged)

## Changes

- `packages/core/src/views/sourcesTreeProvider.ts` — Added dismissed branch to icon conditional
- `packages/core/src/test/sourcesTreeProvider.test.ts` — Updated existing tests + added uniqueness regression guard

## Testing

All 865 core tests pass. New test asserts all three states produce distinct icons via Set uniqueness.
