### PR TITLE
Replace emoji with plain text in tree view descriptions

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -77,6 +77,11 @@ Key files:
 - Migration logic runs on activation before tree registration to seed existing WorkItems as 'accepted'
 - Items with no persisted state default to 'unseen' — allows new providers to introduce items without re-surfacing old ones
 
+### Emoji Removal in Tree Descriptions (Issue #229)
+- Tree item descriptions should use plain text labels, not Unicode emoji — emoji render inconsistently across platforms, fonts, and themes
+- Fixed in `packages/core/src/views/focusTreeProvider.ts` (`getStateLabel`) and `packages/core/src/views/historyTreeProvider.ts` (`getStateLabel`)
+- State is already conveyed by ThemeIcon (`debug-pause`, `check`, `archive`), so descriptions only need plain text: `"paused"`, `"done"`, `"archived"`
+
 ## Code Review Fixes (2026-03-24)
 
 Fixed all Critical (C1-C7) and Important (I1-I8) issues from Keaton's review for PR #1:

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -374,3 +374,15 @@ mockFetch.mockImplementation(async (url: string) => {
 **Key learning:** The bug in issue #189 was present in the codebase. The root cause was explicit resurface logic (`resurfaceDismissed`) that reset dismissed items when they were rediscovered, causing them to reappear. The correct fix was to remove that resurface behavior; the tests now document the expected dismissed-state preservation and guard against future regressions.
 
 
+
+### Issue #229 — Emoji Description Tests Updated (2026-04-12)
+
+**Context:** Issue #229 replaced emoji characters in tree view descriptions with plain text for consistent rendering.
+
+**Files modified:**
+- `packages/core/src/test/focusTreeProvider.test.ts` — Updated assertion: `'⏸ paused'` → `'paused'`
+- `packages/core/src/test/historyTreeProvider.test.ts` — Updated assertions: `'✓ done'` → `'done'`, `'📦 archived'` → `'archived'`
+
+**Pattern:** Description assertions in tree provider tests live in `getTreeItem description` describe blocks. When production description format changes, update both the assertion value and the `it()` label to match.
+
+**Test suite:** 864 tests passing (29 files), 0 failures.

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -383,6 +383,6 @@ mockFetch.mockImplementation(async (url: string) => {
 - `packages/core/src/test/focusTreeProvider.test.ts` — Updated assertion: `'⏸ paused'` → `'paused'`
 - `packages/core/src/test/historyTreeProvider.test.ts` — Updated assertions: `'✓ done'` → `'done'`, `'📦 archived'` → `'archived'`
 
-**Pattern:** Description assertions in tree provider tests live in `getTreeItem description` describe blocks. When production description format changes, update both the assertion value and the `it()` label to match.
+**Pattern:** Description assertions in tree provider tests live in `getTreeItem`-related describe blocks. When production description format changes, update both the assertion value and the `it()` label to match.
 
 **Test suite:** 864 tests passing (29 files), 0 failures.

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -55,7 +55,7 @@ The Focus view shows items you are actively working on. Items here can be in one
 
 Items display a state label next to the title, with icons indicating status:
 - **in progress** — actively being worked on (shown with a ▶ play-circle icon)
-- **⏸ paused** — work is temporarily on hold (shown with a pause icon)
+- **paused** — work is temporarily on hold (shown with a pause icon)
 
 Clicking a Focus item opens the editor panel for that item.
 
@@ -92,8 +92,8 @@ Sources is a browsable library of everything providers know about, regardless of
 The History view shows completed and archived items, sorted by most recently updated (newest first). This provides a record of past work without cluttering the active views.
 
 Items display a state label next to the title:
-- **✓ done** — work that was completed (shown with a ✓ check icon)
-- **📦 archived** — items that were archived (shown with an archive icon)
+- **done** — work that was completed (shown with a check icon)
+- **archived** — items that were archived (shown with an archive icon)
 
 Clicking a History item opens the editor panel to view its details.
 

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -65,9 +65,9 @@ describe('FocusTreeProvider', () => {
       expect(provider.getTreeItem(item).description).toBe('in progress');
     });
 
-    it('should show "⏸ paused" for Paused items', () => {
+    it('should show "paused" for Paused items', () => {
       const item = makeItem({ state: WorkItemState.Paused });
-      expect(provider.getTreeItem(item).description).toBe('⏸ paused');
+      expect(provider.getTreeItem(item).description).toBe('paused');
     });
   });
 

--- a/packages/core/src/test/historyTreeProvider.test.ts
+++ b/packages/core/src/test/historyTreeProvider.test.ts
@@ -171,7 +171,7 @@ describe('HistoryTreeProvider', () => {
       const treeItem = provider.getTreeItem(item);
 
       expect(treeItem.label).toBe('Completed task');
-      expect(treeItem.description).toBe('✓ done');
+      expect(treeItem.description).toBe('done');
       expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.None);
       expect((treeItem.iconPath as any).id).toBe('check');
     });
@@ -181,7 +181,7 @@ describe('HistoryTreeProvider', () => {
       const treeItem = provider.getTreeItem(item);
 
       expect(treeItem.label).toBe('Old task');
-      expect(treeItem.description).toBe('📦 archived');
+      expect(treeItem.description).toBe('archived');
       expect((treeItem.iconPath as any).id).toBe('archive');
     });
 

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -72,7 +72,7 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
       case WorkItemState.InProgress:
         return 'in progress';
       case WorkItemState.Paused:
-        return '⏸ paused';
+        return 'paused';
       default:
         return state;
     }

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -48,9 +48,9 @@ export class HistoryTreeProvider extends WorkItemViewProvider {
   private getStateLabel(state: WorkItemState): string {
     switch (state) {
       case WorkItemState.Done:
-        return '✓ done';
+        return 'done';
       case WorkItemState.Archived:
-        return '📦 archived';
+        return 'archived';
       default:
         return state;
     }


### PR DESCRIPTION
Replace emoji with plain text in tree view descriptions

Closes #229

## Problem

The Focus and History tree views used emoji characters in item descriptions for state indication (`⏸ paused`, `✓ done`, `📦 archived`). These Unicode emoji may render inconsistently across platforms, fonts, and themes — potentially appearing as empty squares or causing layout/accessibility issues.

## Solution

Replaced emoji characters with plain text labels. The state information is already conveyed by the tree item's `ThemeIcon` (`debug-pause`, `check`, `archive`), so descriptions only need readable text.

- `⏸ paused` → `paused`
- `✓ done` → `done`
- `📦 archived` → `archived`

## Changes

- `packages/core/src/views/focusTreeProvider.ts` — Remove emoji from paused description
- `packages/core/src/views/historyTreeProvider.ts` — Remove emoji from done/archived descriptions
- `packages/core/src/test/focusTreeProvider.test.ts` — Update test assertions
- `packages/core/src/test/historyTreeProvider.test.ts` — Update test assertions

## Testing

All 864 core tests pass. Updated 3 test assertions to match new plain text labels.
