### PR TITLE
Remove dead CSS rules and duplicated helper functions

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -255,3 +255,13 @@ Patterns documented in `.squad/decisions.md` under "Code Review Fix Patterns" (2
 - **Dismissed means dismissed**: The original four-view design established that dismissed items are sticky. The `resurfaceDismissed` feature contradicted this core design principle.
 - **Root cause matters**: The first fix (defensive load) was plausible but wrong. The symptom (dismissed items reappearing) had a simpler explanation: code explicitly designed to resurface them.
 - **Reverting cleanly**: When reverting test changes, `git checkout <commit> -- <files>` is the safest approach to restore files to a known-good state before applying new targeted edits.
+
+## Issue #223: Dead CSS and duplicated helpers cleanup (2025-07-23)
+
+### Changes
+- Removed unused CSS rules (`.actions`, `button.primary`, `button.primary:hover`, `button.secondary`) from `packages/core/src/views/editorPanelHtml.ts` — no HTML elements use these classes.
+- Removed dead `getNonce()` (private method), `escapeHtml()`, and `escapeAttr()` (module-level functions) from `packages/core/src/views/workItemEditorPanel.ts` — the actual implementations live in `editorPanelHtml.ts`.
+
+### Key Learnings
+- **Verify before removing**: Always grep the full `src/` tree for references before deleting code that looks dead. In this case, `editorPanelHtml.ts` has the real `getNonce`/`escapeHtml`/`escapeAttr` — the copies in `workItemEditorPanel.ts` were never called.
+- **CSS-in-template-literal cleanup**: CSS rules embedded in template literal strings won't trigger TS compiler errors when unused. Manual inspection of the HTML output is the only way to verify they're dead.

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -373,4 +373,23 @@ mockFetch.mockImplementation(async (url: string) => {
 
 **Key learning:** The bug in issue #189 was present in the codebase. The root cause was explicit resurface logic (`resurfaceDismissed`) that reset dismissed items when they were rediscovered, causing them to reappear. The correct fix was to remove that resurface behavior; the tests now document the expected dismissed-state preservation and guard against future regressions.
 
+### Issue #223 — Dead CSS & Helper Cleanup (2026-07-22)
+
+**Task:** Verify tests after Fenster removed dead CSS (`.actions`, `button.primary`, `button.secondary`) from `editorPanelHtml.ts` and dead helper functions (`getNonce()`, `escapeHtml()`, `escapeAttr()`) from `workItemEditorPanel.ts`.
+
+**Test changes:**
+- Updated 2 test names in `workItemEditorPanel.test.ts` to remove references to deleted functions:
+  - `'escapes special characters in title (via escapeAttr)'` → `'escapes special characters in title'`
+  - `'escapes special characters in notes (via escapeHtml)'` → `'escapes special characters in notes'`
+- No test logic changes needed — the tests validate HTML output behavior, not the removed functions directly
+- `editorPanelHtml.test.ts` (9 tests) unaffected — tests the live `getEditorPanelHtml()` which retains its own `escapeHtml`/`escapeAttr`
+
+**Key files:**
+- `packages/core/src/test/workItemEditorPanel.test.ts` — integration tests for the editor panel
+- `packages/core/src/test/editorPanelHtml.test.ts` — unit tests for HTML generation (unchanged)
+
+**Test results:** 864 passed, 29 test files, 0 failures.
+
+**Key learning:** When dead code is removed, test names referencing that code become misleading even if the test logic is still valid. Update test names to reflect current architecture — in this case, the escaping now lives solely in `editorPanelHtml.ts`, not in `workItemEditorPanel.ts`.
+
 

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -923,7 +923,7 @@ describe('WorkItemEditorPanel (integration with WorkGraph)', () => {
   });
 
   describe('HTML escaping', () => {
-    it('escapes special characters in title (via escapeAttr)', async () => {
+    it('escapes special characters in title', async () => {
       const item = await graph.createItem({ title: 'A & B <script>"alert"</script>' });
       WorkItemEditorPanel.open(context, graph, item);
 
@@ -935,7 +935,7 @@ describe('WorkItemEditorPanel (integration with WorkGraph)', () => {
       expect(html).not.toMatch(/value="[^"]*<script>/);
     });
 
-    it('escapes special characters in notes (via escapeHtml)', async () => {
+    it('escapes special characters in notes', async () => {
       const item = await graph.createItem({ title: 'Task', notes: '<b>bold</b> & "quotes"' });
       WorkItemEditorPanel.open(context, graph, item);
 

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -73,31 +73,6 @@ export function getEditorPanelHtml({ cspSource, item }: EditorHtmlOptions): stri
     .row .field {
       flex: 1;
     }
-    .actions {
-      margin-top: 20px;
-      display: flex;
-      gap: 8px;
-    }
-    button {
-      padding: 6px 16px;
-      border: none;
-      border-radius: 3px;
-      cursor: pointer;
-      font-family: var(--font);
-      font-size: var(--font-size);
-    }
-    button.primary {
-      background: var(--btn-bg);
-      color: var(--btn-fg);
-    }
-    button.primary:hover {
-      background: var(--btn-hover);
-    }
-    button.secondary {
-      background: transparent;
-      color: var(--vscode-foreground);
-      border: 1px solid var(--input-border);
-    }
     input[readonly], textarea[readonly] {
       color: var(--vscode-disabledForeground, var(--vscode-foreground));
       cursor: text;

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -19,9 +19,6 @@ export function getEditorPanelHtml({ cspSource, item }: EditorHtmlOptions): stri
       --input-bg: var(--vscode-input-background);
       --input-fg: var(--vscode-input-foreground);
       --input-border: var(--vscode-input-border, transparent);
-      --btn-bg: var(--vscode-button-background);
-      --btn-fg: var(--vscode-button-foreground);
-      --btn-hover: var(--vscode-button-hoverBackground);
       --font: var(--vscode-font-family, sans-serif);
       --font-size: var(--vscode-font-size, 13px);
     }

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -169,20 +169,4 @@ export class WorkItemEditorPanel {
     });
   }
 
-  private getNonce(): string {
-    let text = '';
-    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    for (let i = 0; i < 32; i++) {
-      text += possible.charAt(Math.floor(Math.random() * possible.length));
-    }
-    return text;
-  }
-}
-
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
-
-function escapeAttr(s: string): string {
-  return escapeHtml(s).replace(/"/g, '&quot;');
 }


### PR DESCRIPTION
Remove dead CSS rules and duplicated helper functions

Closes #223

## Problem

`editorPanelHtml.ts` defined CSS rules for `.actions`, `button.primary`, and `button.secondary` that are never used — no HTML elements in the editor template use these classes. Additionally, `workItemEditorPanel.ts` contained `getNonce()`, `escapeHtml()`, and `escapeAttr()` functions that were never called — identical utilities exist (and are actively used) in `editorPanelHtml.ts`.

## Solution

- Removed 25 lines of dead CSS rules from `editorPanelHtml.ts`
- Removed 16 lines of dead helper functions from `workItemEditorPanel.ts`
- Updated 2 test descriptions to remove stale references to deleted functions

## Changes

- `packages/core/src/views/editorPanelHtml.ts` — Remove unused CSS rules
- `packages/core/src/views/workItemEditorPanel.ts` — Remove dead `getNonce()`, `escapeHtml()`, `escapeAttr()`
- `packages/core/src/test/workItemEditorPanel.test.ts` — Update test names

## Testing

All 864 core tests pass (1,439 total across all packages). No behavioral changes — pure dead code removal.
