### PR TITLE
Add empty state messages to all tree views

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -27,7 +27,7 @@ Key files:
 ## Learnings
 
 - **Empty state messages** use VS Code's `viewsWelcome` contribution in `packages/core/package.json`. Each entry has a `view` (matching a view ID like `workcenter.inbox`) and `contents` (markdown string). VS Code displays these automatically when a TreeDataProvider returns no children. Command buttons use `[Label](command:commandId)` markdown syntax. No `when` clause needed — VS Code handles the empty-tree condition natively.
-- GitHub package (`packages/github/`) vscode mock lives at`packages/github/src/test/__mocks__/vscode.ts`, aliased in `vitest.config.ts` — mirrors core mock pattern but adds `authentication`, `workspace`, `extensions` mocks.
+- GitHub package (`packages/github/`) vscode mock lives at `packages/github/src/test/__mocks__/vscode.ts`, aliased in `vitest.config.ts` — mirrors core mock pattern but adds `authentication`, `workspace`, `extensions` mocks.
 - Mock includes: `authentication.getSession` (resolves with `{ accessToken: 'mock-token' }`), `workspace.getConfiguration` (returns `.get(key, default)` stub), `workspace.workspaceFolders`, `extensions.getExtension`, `commands.executeCommand`, `Uri.file`, `window.showErrorMessage`.
 - Root `npm install` handles all workspace deps via npm workspaces. Root `npm run build` runs esbuild in both packages.
 - Both packages use esbuild with `--external:vscode --format=cjs --platform=node`.

--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -26,7 +26,8 @@ Key files:
 
 ## Learnings
 
-- GitHub package (`packages/github/`) vscode mock lives at `packages/github/src/test/__mocks__/vscode.ts`, aliased in `vitest.config.ts` — mirrors core mock pattern but adds `authentication`, `workspace`, `extensions` mocks.
+- **Empty state messages** use VS Code's `viewsWelcome` contribution in `packages/core/package.json`. Each entry has a `view` (matching a view ID like `workcenter.inbox`) and `contents` (markdown string). VS Code displays these automatically when a TreeDataProvider returns no children. Command buttons use `[Label](command:commandId)` markdown syntax. No `when` clause needed — VS Code handles the empty-tree condition natively.
+- GitHub package (`packages/github/`) vscode mock lives at`packages/github/src/test/__mocks__/vscode.ts`, aliased in `vitest.config.ts` — mirrors core mock pattern but adds `authentication`, `workspace`, `extensions` mocks.
 - Mock includes: `authentication.getSession` (resolves with `{ accessToken: 'mock-token' }`), `workspace.getConfiguration` (returns `.get(key, default)` stub), `workspace.workspaceFolders`, `extensions.getExtension`, `commands.executeCommand`, `Uri.file`, `window.showErrorMessage`.
 - Root `npm install` handles all workspace deps via npm workspaces. Root `npm run build` runs esbuild in both packages.
 - Both packages use esbuild with `--external:vscode --format=cjs --platform=node`.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -85,6 +85,28 @@
         }
       ]
     },
+    "viewsWelcome": [
+      {
+        "view": "workcenter.inbox",
+        "contents": "No new items.\nProviders will discover items automatically."
+      },
+      {
+        "view": "workcenter.queue",
+        "contents": "No items in your queue.\nAccept items from Inbox or create one manually.\n[Create Work Item](command:workcenter.createItem)"
+      },
+      {
+        "view": "workcenter.focus",
+        "contents": "No active work.\nMove items from Queue to start working on them."
+      },
+      {
+        "view": "workcenter.history",
+        "contents": "Completed and archived items will appear here."
+      },
+      {
+        "view": "workcenter.sources",
+        "contents": "Discovered items from all providers will appear here."
+      }
+    ],
     "commands": [
       {
         "command": "workcenter.createItem",


### PR DESCRIPTION
Add empty state messages to all tree views

Closes #224

## Problem

Every tree view (Inbox, Queue, Focus, History, Sources) shows a blank panel when it contains no items. No welcome message, no guidance text, and no call-to-action to help users understand what the view is for.

## Solution

Added `viewsWelcome` contributions to `packages/core/package.json` for all five views with contextual empty-state messages:

- **Inbox**: "No new items. Providers will discover items automatically."
- **Queue**: "No items in your queue..." + Create Work Item button
- **Focus**: "No active work. Move items from Queue to start working."
- **History**: "Completed and archived items will appear here."
- **Sources**: "Discovered items from all providers will appear here."

## Changes

- `packages/core/package.json` — Added `viewsWelcome` contribution block (22 lines)

## Testing

JSON-only change (no TypeScript). All existing tests pass. VS Code natively displays welcome content when a tree view returns zero children.
