### PR TITLE
Add clickable source URL link to editor panel

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -26,6 +26,7 @@ Key files:
 
 ## Learnings
 
+- **Editor panel source URL link (Issue #219):** Webview CSP has `default-src 'none'`, so `<a href>` tags won't navigate. Used `vscode.postMessage({ type: 'openUrl' })` from webview → extension host handles with `vscode.env.openExternal(vscode.Uri.parse(url))`. The link element uses `data-url` attribute (escaped via `escapeAttr`) and a JS click handler. Both `env.openExternal` and `Uri.parse` are already in the core vscode mock. The `editorPanelHtml.test.ts` already had 3 source-link tests pre-written; added 2 tests in `workItemEditorPanel.test.ts` for the message handler.
 - GitHub package (`packages/github/`) vscode mock lives at `packages/github/src/test/__mocks__/vscode.ts`, aliased in `vitest.config.ts` — mirrors core mock pattern but adds `authentication`, `workspace`, `extensions` mocks.
 - Mock includes: `authentication.getSession` (resolves with `{ accessToken: 'mock-token' }`), `workspace.getConfiguration` (returns `.get(key, default)` stub), `workspace.workspaceFolders`, `extensions.getExtension`, `commands.executeCommand`, `Uri.file`, `window.showErrorMessage`.
 - Root `npm install` handles all workspace deps via npm workspaces. Root `npm run build` runs esbuild in both packages.

--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -26,7 +26,7 @@ Key files:
 
 ## Learnings
 
-- **Editor panel source URL link (Issue #219):** Webview CSP has `default-src 'none'`, so `<a href>` tags won't navigate. Used `vscode.postMessage({ type: 'openUrl' })` from webview → extension host handles with `vscode.env.openExternal(vscode.Uri.parse(url))`. The link element uses `data-url` attribute (escaped via `escapeAttr`) and a JS click handler. Both `env.openExternal` and `Uri.parse` are already in the core vscode mock. The `editorPanelHtml.test.ts` already had 3 source-link tests pre-written; added 2 tests in `workItemEditorPanel.test.ts` for the message handler.
+- **Editor panel source URL link (Issue #219):** Webview CSP has `default-src 'none'`, so direct navigation won't work. Used `vscode.postMessage({ type: 'openUrl' })` from webview → extension host validates with `isSafeUrl()` and opens via `vscode.env.openExternal()`. Renders as a `<button>` with `data-url` attribute (escaped via `escapeAttr`). Added 3 HTML tests in `editorPanelHtml.test.ts` and 4 message handler tests in `workItemEditorPanel.test.ts` (including javascript:/data: scheme rejection).
 - GitHub package (`packages/github/`) vscode mock lives at `packages/github/src/test/__mocks__/vscode.ts`, aliased in `vitest.config.ts` — mirrors core mock pattern but adds `authentication`, `workspace`, `extensions` mocks.
 - Mock includes: `authentication.getSession` (resolves with `{ accessToken: 'mock-token' }`), `workspace.getConfiguration` (returns `.get(key, default)` stub), `workspace.workspaceFolders`, `extensions.getExtension`, `commands.executeCommand`, `Uri.file`, `window.showErrorMessage`.
 - Root `npm install` handles all workspace deps via npm workspaces. Root `npm run build` runs esbuild in both packages.

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -377,11 +377,11 @@ mockFetch.mockImplementation(async (url: string) => {
 
 **Tests added:** 3 new tests in `packages/core/src/test/editorPanelHtml.test.ts` under `describe('source URL link')`:
 
-1. **renders a clickable link when item has a url** — Verifies `<a>` tag with `id="source-link"`, `data-url` attribute containing the URL, and "Open in source" text
+1. **renders a clickable link when item has a url** — Verifies `<button>` tag with `id="source-link"`, `data-url` attribute containing the URL, and "Open in source" text
 2. **does not render a link when item has no url** — Verifies no `source-link` element or "Open in source" text when `url` is undefined
 3. **escapes HTML entities in the url to prevent XSS** — Verifies `escapeAttr` prevents attribute breakout with `"><script>alert(1)</script>` payload
 
 **Implementation detail:** Fenster's implementation uses `data-url` + `postMessage({ type: 'openUrl' })` pattern (not a direct `href`), since VS Code webview CSP blocks external navigation. The `<button>` element provides native keyboard accessibility.
 
-**Test results:** 12 tests in editorPanelHtml.test.ts (up from 9), 868 total tests passing.
+**Test results:** 12 tests in editorPanelHtml.test.ts (up from 9), 871 core tests passing.
 

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -373,4 +373,15 @@ mockFetch.mockImplementation(async (url: string) => {
 
 **Key learning:** The bug in issue #189 was present in the codebase. The root cause was explicit resurface logic (`resurfaceDismissed`) that reset dismissed items when they were rediscovered, causing them to reappear. The correct fix was to remove that resurface behavior; the tests now document the expected dismissed-state preservation and guard against future regressions.
 
+### Editor Source URL Link Tests (Issue #219)
+
+**Tests added:** 3 new tests in `packages/core/src/test/editorPanelHtml.test.ts` under `describe('source URL link')`:
+
+1. **renders a clickable link when item has a url** — Verifies `<a>` tag with `id="source-link"`, `data-url` attribute containing the URL, and "Open in source" text
+2. **does not render a link when item has no url** — Verifies no `source-link` element or "Open in source" text when `url` is undefined
+3. **escapes HTML entities in the url to prevent XSS** — Verifies `escapeAttr` prevents attribute breakout with `"><script>alert(1)</script>` payload
+
+**Implementation detail:** Fenster's implementation uses `data-url` + `postMessage({ type: 'openUrl' })` pattern (not a direct `href`), since VS Code webview CSP blocks external navigation. The `<a>` tag uses `role="link"` and `tabindex="0"` for accessibility.
+
+**Test results:** 12 tests in editorPanelHtml.test.ts (up from 9), 868 total tests passing.
 

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -381,7 +381,7 @@ mockFetch.mockImplementation(async (url: string) => {
 2. **does not render a link when item has no url** — Verifies no `source-link` element or "Open in source" text when `url` is undefined
 3. **escapes HTML entities in the url to prevent XSS** — Verifies `escapeAttr` prevents attribute breakout with `"><script>alert(1)</script>` payload
 
-**Implementation detail:** Fenster's implementation uses `data-url` + `postMessage({ type: 'openUrl' })` pattern (not a direct `href`), since VS Code webview CSP blocks external navigation. The `<a>` tag uses `role="link"` and `tabindex="0"` for accessibility.
+**Implementation detail:** Fenster's implementation uses `data-url` + `postMessage({ type: 'openUrl' })` pattern (not a direct `href`), since VS Code webview CSP blocks external navigation. The `<button>` element provides native keyboard accessibility.
 
 **Test results:** 12 tests in editorPanelHtml.test.ts (up from 9), 868 total tests passing.
 

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -82,20 +82,20 @@ describe('getEditorPanelHtml', () => {
     expect(nonce1).not.toBe(nonce2);
   });
 
-  describe('source URL link', () => {
+  describe('browser URL link', () => {
     it('renders a clickable link when item has a url', () => {
       const item = makeItem({ url: 'https://github.com/org/repo/issues/42' });
       const html = getEditorPanelHtml({ cspSource, item });
       expect(html).toContain('id="source-link"');
       expect(html).toMatch(/<button\s[^>]*data-url="https:\/\/github\.com\/org\/repo\/issues\/42"/);
-      expect(html).toContain('Open in source');
+      expect(html).toContain('Open in browser');
     });
 
     it('does not render a link when item has no url', () => {
       const item = makeItem({ url: undefined });
       const html = getEditorPanelHtml({ cspSource, item });
       expect(html).not.toContain('id="source-link"');
-      expect(html).not.toContain('Open in source');
+      expect(html).not.toContain('Open in browser');
     });
 
     it('escapes HTML entities in the url to prevent XSS', () => {

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -81,4 +81,28 @@ describe('getEditorPanelHtml', () => {
     const nonce2 = html2.match(/nonce="([^"]+)"/)![1];
     expect(nonce1).not.toBe(nonce2);
   });
+
+  describe('source URL link', () => {
+    it('renders a clickable link when item has a url', () => {
+      const item = makeItem({ url: 'https://github.com/org/repo/issues/42' });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).toContain('id="source-link"');
+      expect(html).toMatch(/<a\s[^>]*data-url="https:\/\/github\.com\/org\/repo\/issues\/42"/);
+      expect(html).toContain('Open in source');
+    });
+
+    it('does not render a link when item has no url', () => {
+      const item = makeItem({ url: undefined });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).not.toContain('id="source-link"');
+      expect(html).not.toContain('Open in source');
+    });
+
+    it('escapes HTML entities in the url to prevent XSS', () => {
+      const item = makeItem({ url: 'https://evil.com/"><script>alert(1)</script>' });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).not.toContain('<script>alert(1)</script>');
+      expect(html).toContain('&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
+    });
+  });
 });

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -87,7 +87,7 @@ describe('getEditorPanelHtml', () => {
       const item = makeItem({ url: 'https://github.com/org/repo/issues/42' });
       const html = getEditorPanelHtml({ cspSource, item });
       expect(html).toContain('id="source-link"');
-      expect(html).toMatch(/<a\s[^>]*data-url="https:\/\/github\.com\/org\/repo\/issues\/42"/);
+      expect(html).toMatch(/<button\s[^>]*data-url="https:\/\/github\.com\/org\/repo\/issues\/42"/);
       expect(html).toContain('Open in source');
     });
 

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -373,6 +373,28 @@ describe('WorkItemEditorPanel', () => {
 
       expect(vscode.env.openExternal).not.toHaveBeenCalled();
     });
+
+    it('should not call openExternal for javascript: URL', () => {
+      const item = makeItem();
+      const workGraph = createMockWorkGraph(item);
+      const mock = createMockWebviewPanel();
+      openPanel(item, workGraph, mock);
+
+      mock.simulateMessage({ type: 'openUrl', url: 'javascript:alert(1)' });
+
+      expect(vscode.env.openExternal).not.toHaveBeenCalled();
+    });
+
+    it('should not call openExternal for data: URL', () => {
+      const item = makeItem();
+      const workGraph = createMockWorkGraph(item);
+      const mock = createMockWebviewPanel();
+      openPanel(item, workGraph, mock);
+
+      mock.simulateMessage({ type: 'openUrl', url: 'data:text/html,<h1>hi</h1>' });
+
+      expect(vscode.env.openExternal).not.toHaveBeenCalled();
+    });
   });
 
   describe('message handling (autosave)', () => {

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -350,6 +350,31 @@ describe('WorkItemEditorPanel', () => {
     });
   });
 
+  describe('message handling (openUrl)', () => {
+    it('should open external URL when openUrl message is received', () => {
+      const item = makeItem({ url: 'https://github.com/org/repo/issues/42' });
+      const workGraph = createMockWorkGraph(item);
+      const mock = createMockWebviewPanel();
+      openPanel(item, workGraph, mock);
+
+      mock.simulateMessage({ type: 'openUrl', url: 'https://github.com/org/repo/issues/42' });
+
+      expect(vscode.env.openExternal).toHaveBeenCalledTimes(1);
+      expect(vscode.Uri.parse).toHaveBeenCalledWith('https://github.com/org/repo/issues/42');
+    });
+
+    it('should not call openExternal when url is not a string', () => {
+      const item = makeItem();
+      const workGraph = createMockWorkGraph(item);
+      const mock = createMockWebviewPanel();
+      openPanel(item, workGraph, mock);
+
+      mock.simulateMessage({ type: 'openUrl', url: 123 });
+
+      expect(vscode.env.openExternal).not.toHaveBeenCalled();
+    });
+  });
+
   describe('message handling (autosave)', () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/packages/core/src/utils/url.ts
+++ b/packages/core/src/utils/url.ts
@@ -1,0 +1,9 @@
+/** Validate that a URL uses a safe scheme (http or https). */
+export function isSafeUrl(url: string): URL | null {
+  try {
+    const parsed = new URL(url);
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') ? parsed : null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -118,7 +118,10 @@ export function getEditorPanelHtml({ cspSource, item }: EditorHtmlOptions): stri
       margin-bottom: 14px;
       color: var(--vscode-textLink-foreground);
       cursor: pointer;
-      text-decoration: none;
+      background: none;
+      border: none;
+      padding: 0;
+      font-family: inherit;
     }
     .source-link:hover {
       color: var(--vscode-textLink-activeForeground);
@@ -128,7 +131,7 @@ export function getEditorPanelHtml({ cspSource, item }: EditorHtmlOptions): stri
 </head>
 <body>
   <h2 id="editor-heading">Edit Work Item</h2>
-${item.url ? `  <a class="source-link" id="source-link" role="link" tabindex="0" data-url="${escapeAttr(item.url)}">↗ Open in source</a>` : ''}
+${item.url ? `  <button type="button" class="source-link" id="source-link" data-url="${escapeAttr(item.url)}">↗ Open in source</button>` : ''}
   <div id="form" role="form" aria-labelledby="editor-heading">
     <div class="field">
       <label for="title">Title</label>

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -110,10 +110,25 @@ export function getEditorPanelHtml({ cspSource, item }: EditorHtmlOptions): stri
       margin-top: 2px;
       display: block;
     }
+    .source-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 0.85em;
+      margin-bottom: 14px;
+      color: var(--vscode-textLink-foreground);
+      cursor: pointer;
+      text-decoration: none;
+    }
+    .source-link:hover {
+      color: var(--vscode-textLink-activeForeground);
+      text-decoration: underline;
+    }
   </style>
 </head>
 <body>
   <h2 id="editor-heading">Edit Work Item</h2>
+${item.url ? `  <a class="source-link" id="source-link" role="link" tabindex="0" data-url="${escapeAttr(item.url)}">↗ Open in source</a>` : ''}
   <div id="form" role="form" aria-labelledby="editor-heading">
     <div class="field">
       <label for="title">Title</label>
@@ -155,6 +170,13 @@ ${item.providerId ? '      <span id="readonly-title-hint" class="hint">Title is 
         }
       }
     });
+
+    const sourceLink = document.getElementById('source-link');
+    if (sourceLink) {
+      sourceLink.addEventListener('click', () => {
+        vscode.postMessage({ type: 'openUrl', url: sourceLink.dataset.url });
+      });
+    }
   </script>
 </body>
 </html>`;

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -104,7 +104,7 @@ export function getEditorPanelHtml({ cspSource, item }: EditorHtmlOptions): stri
 </head>
 <body>
   <h2 id="editor-heading">Edit Work Item</h2>
-${item.url ? `  <button type="button" class="source-link" id="source-link" data-url="${escapeAttr(item.url)}">↗ Open in source</button>` : ''}
+${item.url ? `  <button type="button" class="source-link" id="source-link" data-url="${escapeAttr(item.url)}">Open in browser</button>` : ''}
   <div id="form" role="form" aria-labelledby="editor-heading">
     <div class="field">
       <label for="title">Title</label>

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { WorkItem, WorkItemInput } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import { getEditorPanelHtml } from './editorPanelHtml';
-import { isSafeUrl } from '../commands/commands';
+import { isSafeUrl } from '../utils/url';
 
 export class WorkItemEditorPanel {
   private static readonly viewType = 'workcenter.editItem';
@@ -65,7 +65,7 @@ export class WorkItemEditorPanel {
       if (msg?.type === 'openUrl' && typeof msg.url === 'string') {
         const safeUrl = isSafeUrl(msg.url);
         if (safeUrl) {
-          vscode.env.openExternal(vscode.Uri.parse(safeUrl.href));
+          void vscode.env.openExternal(vscode.Uri.parse(safeUrl.href));
         }
         return;
       }

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -61,6 +61,10 @@ export class WorkItemEditorPanel {
     this.update();
 
     this.messageSubscription = this.panel.webview.onDidReceiveMessage((msg) => {
+      if (msg?.type === 'openUrl' && typeof msg.url === 'string') {
+        vscode.env.openExternal(vscode.Uri.parse(msg.url));
+        return;
+      }
       if (msg?.type === 'autosave' && msg.data && typeof msg.data === 'object') {
         this.pendingData = msg.data;
         if (this.debounceTimer) {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { WorkItem, WorkItemInput } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import { getEditorPanelHtml } from './editorPanelHtml';
+import { isSafeUrl } from '../commands/commands';
 
 export class WorkItemEditorPanel {
   private static readonly viewType = 'workcenter.editItem';
@@ -62,7 +63,10 @@ export class WorkItemEditorPanel {
 
     this.messageSubscription = this.panel.webview.onDidReceiveMessage((msg) => {
       if (msg?.type === 'openUrl' && typeof msg.url === 'string') {
-        vscode.env.openExternal(vscode.Uri.parse(msg.url));
+        const safeUrl = isSafeUrl(msg.url);
+        if (safeUrl) {
+          vscode.env.openExternal(vscode.Uri.parse(safeUrl.href));
+        }
         return;
       }
       if (msg?.type === 'autosave' && msg.data && typeof msg.data === 'object') {


### PR DESCRIPTION
Add clickable source URL link to editor panel

Closes #219

## Problem

Provider-backed work items have a `url` field but the editor panel provided no way to navigate to the source. Users had to go back to the tree view to use "Open in Browser".

## Solution

Added an "Open in source" link below the title in the editor panel that appears when a work item has a `url`. Uses `vscode.postMessage` to send an `openUrl` message to the extension host, which validates the URL scheme via `isSafeUrl()` and opens it via `vscode.env.openExternal` (CSP-safe).

## Changes

- `packages/core/src/views/editorPanelHtml.ts` — Link HTML, CSS, and click handler script
- `packages/core/src/views/workItemEditorPanel.ts` — openUrl message handler with isSafeUrl validation
- `packages/core/src/test/editorPanelHtml.test.ts` — 3 tests (presence, absence, XSS escaping)
- `packages/core/src/test/workItemEditorPanel.test.ts` — 4 tests (happy path, type guard, javascript:/data: rejection)

## Testing

All 871 core tests pass. URL escaping prevents XSS, and scheme validation prevents non-HTTP(S) URLs from being opened.
