### PR TITLE
Replace generic editor heading with item title

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -77,6 +77,10 @@ Key files:
 - Migration logic runs on activation before tree registration to seed existing WorkItems as 'accepted'
 - Items with no persisted state default to 'unseen' — allows new providers to introduce items without re-surfacing old ones
 
+### Editor Panel HTML
+- The editor heading (`<h2 id="editor-heading">`) uses `escapeHtml(item.title)` instead of a generic "Edit Work Item" string — keeps it contextual while preserving `aria-labelledby` accessibility (Issue #221)
+- `escapeHtml` and `escapeAttr` are local helpers in `editorPanelHtml.ts` — use `escapeHtml` for text content, `escapeAttr` for attribute values
+
 ## Code Review Fixes (2026-03-24)
 
 Fixed all Critical (C1-C7) and Important (I1-I8) issues from Keaton's review for PR #1:

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -373,4 +373,17 @@ mockFetch.mockImplementation(async (url: string) => {
 
 **Key learning:** The bug in issue #189 was present in the codebase. The root cause was explicit resurface logic (`resurfaceDismissed`) that reset dismissed items when they were rediscovered, causing them to reappear. The correct fix was to remove that resurface behavior; the tests now document the expected dismissed-state preservation and guard against future regressions.
 
+### Editor Contextual Heading Tests (Issue #221)
+
+**Issue:** Replace static "Edit Work Item" heading with the work item's title in the editor panel.
+
+**Tests added:** 3 new tests in `editorPanelHtml.test.ts`:
+
+1. **shows item title in heading instead of generic text** — Verifies heading contains the item's title and no longer contains "Edit Work Item"
+2. **escapes special characters in heading title** — Verifies `<`, `>`, and `&` are HTML-escaped in the heading (uses `escapeHtml`, not `escapeAttr`, so quotes remain unescaped)
+3. **preserves editor-heading id attribute** — Verifies the `id="editor-heading"` and matching `aria-labelledby` are intact
+
+**Key learning:** The heading uses `escapeHtml()` (escapes `<`, `>`, `&`) not `escapeAttr()` (which additionally escapes `"`). This is correct since the title appears as element content, not an attribute value — quotes don't need escaping in element text.
+
+**Test results:** All 867 tests pass (12 in editorPanelHtml suite). Full core package green.
 

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -74,6 +74,26 @@ describe('getEditorPanelHtml', () => {
     expect(html).not.toContain('Title is managed by the provider');
   });
 
+  it('shows item title in heading instead of generic text', () => {
+    const item = makeItem({ title: 'Fix login bug' });
+    const html = getEditorPanelHtml({ cspSource, item });
+    expect(html).toContain('<h2 id="editor-heading">Fix login bug</h2>');
+    expect(html).not.toContain('Edit Work Item');
+  });
+
+  it('escapes special characters in heading title', () => {
+    const item = makeItem({ title: 'Use <div> & "quotes"' });
+    const html = getEditorPanelHtml({ cspSource, item });
+    expect(html).toContain('<h2 id="editor-heading">Use &lt;div&gt; &amp; "quotes"</h2>');
+    expect(html).not.toContain('>Use <div>');
+  });
+
+  it('preserves editor-heading id attribute', () => {
+    const html = getEditorPanelHtml({ cspSource, item: makeItem() });
+    expect(html).toMatch(/<h2 id="editor-heading">/);
+    expect(html).toContain('aria-labelledby="editor-heading"');
+  });
+
   it('generates unique nonces across calls', () => {
     const html1 = getEditorPanelHtml({ cspSource, item: makeItem() });
     const html2 = getEditorPanelHtml({ cspSource, item: makeItem() });

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -847,8 +847,9 @@ describe('WorkItemEditorPanel (integration with WorkGraph)', () => {
       const item = await graph.createItem({ title: 'Task' });
       WorkItemEditorPanel.open(context, graph, item);
 
-      expect(mockPanel.webview.html).toContain('Edit Work Item');
+      expect(mockPanel.webview.html).not.toContain('Edit Work Item');
       expect(mockPanel.webview.html).toContain('Task');
+      expect(mockPanel.webview.html).toContain('id="editor-heading"');
     });
   });
 

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -113,7 +113,7 @@ export function getEditorPanelHtml({ cspSource, item }: EditorHtmlOptions): stri
   </style>
 </head>
 <body>
-  <h2 id="editor-heading">Edit Work Item</h2>
+  <h2 id="editor-heading">${escapeHtml(item.title)}</h2>
   <div id="form" role="form" aria-labelledby="editor-heading">
     <div class="field">
       <label for="title">Title</label>


### PR DESCRIPTION
Replace generic editor heading with item title

Closes #221

## Problem

The editor panel heading always displayed the static text "Edit Work Item" regardless of which item was open. While the tab title showed the item name, the panel body gave no context.

## Solution

Replaced the generic `<h2>Edit Work Item</h2>` heading with `<h2>${escapeHtml(item.title)}</h2>` so the panel displays the actual work item title. The `id="editor-heading"` attribute is preserved for `aria-labelledby` accessibility.

## Changes

- `packages/core/src/views/editorPanelHtml.ts` — 1 line: dynamic title in heading
- `packages/core/src/test/editorPanelHtml.test.ts` — 3 new tests (title rendering, XSS escaping, attribute preservation)
- `packages/core/src/test/workItemEditorPanel.test.ts` — Updated assertion

## Testing

All 867 core tests pass. XSS test verifies HTML entities are properly escaped in the heading.
