### PR TITLE
fix: hide 'Continue to next file' on last PR file

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -314,3 +314,10 @@ The queue view was displaying raw provider IDs (e.g., `github`, `ado`) in tree i
 ### Learnings
 - **Icon mapping in Sources view**: `packages/core/src/views/sourcesTreeProvider.ts` maps `InboxState` to `ThemeIcon` names via `switch (state)` in `getTreeItem()`: `accepted` → `check`, `dismissed` → `circle-slash`, `unseen` → `circle-outline`. Previously simpler branching lumped dismissed and unseen together.
 - **Key file**: `packages/core/src/views/sourcesTreeProvider.ts` — the `getTreeItem()` method for `item` kind elements assigns icons based on `stateStore.getState()` result.
+
+## Issue #252: Walkthrough last-file followup fix (2025-07-25)
+
+### Learnings
+- **Walkthrough phase signaling**: The `workcenter-signalPhase` virtual tool in `walkthroughParticipant.ts` controls which followup buttons VS Code displays after each LLM response. Phases map to different button sets in `provideFollowups()`.
+- **Adding a phase value**: To distinguish "last file" from "mid-walkthrough", added `lastFile` to the signalPhase enum. The prompt instructs the LLM to signal `lastFile` instead of `walkthrough` when presenting the final file in the reading order. This is simpler and more reliable than trying to track file indices in the participant code.
+- **Key files**: `walkthroughParticipant.ts` (phase enum + followup provider), `walkthroughPrompt.ts` (LLM instructions for when to signal each phase).

--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -30,6 +30,22 @@ Key files:
 
 ## Learnings
 
+### PR #256 — provideFollowups + lastFile Phase Tests (2026-07-23)
+
+**Tests added:** 7 new tests in `packages/ai-reviewer/src/test/walkthroughParticipant.test.ts` (12 → 19)
+
+**New describe block: `provideFollowups`** — 6 tests covering all phase→button mappings:
+- `summary` → 3 buttons (Start walkthrough, Adjust order, Skip to wrap-up)
+- `lastFile` → 2 buttons (Go deeper, Wrap up) — new phase added in PR #252
+- `walkthrough` → 3 buttons (Next file, Go deeper, Wrap up)
+- `wrapup` / `error` / `no-url` → empty array
+
+**New handleRequest test:** `signalPhase with lastFile updates ChatResult metadata` — mirrors existing `wrapup` signalPhase test pattern.
+
+**Testing pattern: accessing `followupProvider`** — After `participant.register()`, the mock `chat.createChatParticipant` return value has its `followupProvider` property set by production code. Access via `vi.mocked(chat.createChatParticipant).mock.results[0].value.followupProvider` to call `provideFollowups` directly with controlled `ChatResult` metadata.
+
+**Gotcha: multi-worktree environment** — Main worktree (`C:\repos\workcenter`) may be on a different branch. Use `git worktree add` to create a dedicated worktree for the target branch, install deps, run tests, commit, and push from there.
+
 ### Phase 2 Test Writing (2026-03-24)
 
 **Tests added:** 42 new tests across 4 files (19 core + 23 github)

--- a/.squad/agents/keaton/history.md
+++ b/.squad/agents/keaton/history.md
@@ -134,4 +134,34 @@ Detailed findings and patterns documented in:
 - `.squad/decisions.md` — "Test Update Patterns" (2026-03-25)
 - `.squad/orchestration-log/` — Keaton, Fenster, Hockney review logs
 
+## Triage Round 1 — 18 Squad Issues (2026-07-23)
+
+**Status:** COMPLETE — All 18 issues routed and triage comments posted.
+
+### Routing Summary
+
+| Route | Count | Issues |
+|-------|-------|--------|
+| squad:fenster | 17 | 255, 254, 253, 252, 250, 249, 243, 240, 233, 232, 228, 226, 225, 219, 218, 217, 215 |
+| squad:keaton | 1 | 234 |
+
+### Key Decisions
+
+1. **Issue #234 (Done vs Archived)** — Routed to Keaton for architecture/UX decision. This requires clarifying state machine semantics (auto-archive? explicit? time-based?) before Fenster can implement. Will need a design decision in `.squad/decisions.md` before work begins.
+
+2. **Issue #253 & #254 (AI Actions)** — Both routed to Fenster. #253 (shared repo) is Large complexity and may unlock #254 (model selection). Fenster should evaluate sequencing.
+
+3. **Issue #225 (Onboarding)** — Marked Large complexity. This is a significant UX feature that might benefit from user research or early prototyping before full implementation.
+
+4. **Dependencies flagged:**
+   - #254, #253, #240 form a cluster around AI actions and URL handling
+   - #249 (Inbox→Focus shortcut) is independent but related to state machine changes
+   - #243 (re-requested reviews) requires new provider-level signals
+
+### Triage Process Notes
+
+- All 18 issues read via `gh issue view` and analyzed for scope/routing
+- Comments include: assignment, complexity (small/medium/large), category, dependencies, implementation notes
+- All comments posted safely with `--body-file` to avoid PowerShell backtick escaping issues
+
 

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -2,6 +2,51 @@
 
 ## Active Decisions
 
+### Triage Round 1 Summary — 18 Squad Issues (2026-04-14)
+
+**Lead:** Keaton  
+**Status:** COMPLETE
+
+Triaged all 18 open issues labeled `squad`. Routed 17 to squad:fenster (feature & bug implementation) and 1 to squad:keaton (architecture decision #234). All issues received triage comments with complexity assessment, category, and implementation notes.
+
+**Key Routing:**
+- **squad:fenster (17 issues):** Features and bugs across AI actions, UI enhancements, inbox/queue/focus flow, onboarding, and history visibility
+- **squad:keaton (1 issue):** #234 — Design decision for Done vs Archived state semantics
+
+**Complexity Breakdown:**
+- Small (5): #252, #228, #219, #217, #255
+- Medium (9): #254, #250, #249, #243, #240, #233, #232, #226, #218, #215
+- Large (3): #253, #225
+
+**Implementation Sequencing:** High-priority unblocked issues (#228, #219, #217, #252, #255) can start immediately. Large coordination issues (#253, #254, #240, #225, #226) require careful sequencing due to dependencies.
+
+**References:**
+- Issue #234 (Done vs Archived decision)
+- `.squad/agents/keaton/history.md` — Updated with triage outcomes
+
+---
+
+### Issue #234 — Done vs Archived Distinction (2026-04-14)
+
+**Lead:** Keaton  
+**Status:** DECISION REQUIRED
+
+Users are confused about the distinction between "Done" and "Archived" states in WorkCenter. Need to clarify:
+1. **Done → Archived lifecycle** — Should Done items automatically archive after N days, or require explicit user action?
+2. **User-facing semantics** — Is "Done" = finished vs "Archived" = never see again?
+3. **Provider closure signals** — Should GitHub issue closure auto-mark WorkCenter item Done?
+4. **History view organization** — Should Done and Archived appear together or in separate sections?
+
+**Current Model:** Two terminal states in WorkItem state machine (Done and Archived) but unclear user-facing purpose and transition rules.
+
+**Action Required:** Keaton to write design decision document clarifying semantics and transition rules, then Fenster implements based on clarified intent.
+
+**References:**
+- First issue to surface this UX confusion
+- Decision document location: `.squad/decisions.md` (this entry)
+
+---
+
 ### BasePrAction Extraction Pattern (2026-07-22)
 
 **Author:** Fenster (Extension Dev)  

--- a/packages/ai-reviewer/src/test/walkthroughParticipant.test.ts
+++ b/packages/ai-reviewer/src/test/walkthroughParticipant.test.ts
@@ -264,6 +264,31 @@ describe('WalkthroughParticipant', () => {
       expect(response.markdown).toHaveBeenCalledWith('File contents analyzed.');
     });
 
+    it('signalPhase with lastFile updates ChatResult metadata', async () => {
+      const mockModel = {
+        sendRequest: vi.fn().mockResolvedValue({
+          stream: (async function* () {
+            yield new LanguageModelTextPart('Last file analysis.');
+            yield new LanguageModelToolCallPart('phase-2', 'workcenter-signalPhase', { phase: 'lastFile' });
+          })(),
+        }),
+      };
+
+      participant.register();
+      const handler = vi.mocked(chat.createChatParticipant).mock.calls[0][1];
+
+      const request = createMockRequest('Walk me through https://github.com/owner/repo/pull/42', mockModel);
+      const context = createMockContext([new ChatRequestTurn('previous turn')]);
+      const response = createMockResponse();
+      const token = { isCancellationRequested: false };
+
+      const result = await handler(request, context, response, token);
+
+      expect(lm.invokeTool).not.toHaveBeenCalled();
+      expect(mockModel.sendRequest).toHaveBeenCalledTimes(1);
+      expect((result as { metadata?: Record<string, unknown> }).metadata?.phase).toBe('lastFile');
+    });
+
     it('signalPhase updates ChatResult metadata without triggering another loop', async () => {
       const mockModel = {
         sendRequest: vi.fn().mockResolvedValue({
@@ -290,6 +315,94 @@ describe('WalkthroughParticipant', () => {
       expect(mockModel.sendRequest).toHaveBeenCalledTimes(1);
       // Phase should be in the result metadata
       expect((result as { metadata?: Record<string, unknown> }).metadata?.phase).toBe('wrapup');
+    });
+  });
+
+  describe('provideFollowups', () => {
+    function getFollowupProvider() {
+      participant.register();
+      const mockParticipant = vi.mocked(chat.createChatParticipant).mock.results[0].value;
+      return mockParticipant.followupProvider as {
+        provideFollowups: (
+          result: { metadata?: Record<string, unknown> },
+          context: unknown,
+          token: unknown,
+        ) => { prompt: string; label: string }[];
+      };
+    }
+
+    it('returns Start/Adjust/Skip buttons for summary phase', () => {
+      const provider = getFollowupProvider();
+      const followups = provider.provideFollowups(
+        { metadata: { phase: 'summary' } },
+        { history: [] },
+        { isCancellationRequested: false },
+      );
+
+      expect(followups).toHaveLength(3);
+      expect(followups[0].label).toContain('Start walkthrough');
+      expect(followups[1].label).toContain('Adjust order');
+      expect(followups[2].label).toContain('Skip to wrap-up');
+    });
+
+    it('returns Go deeper/Wrap up buttons for lastFile phase', () => {
+      const provider = getFollowupProvider();
+      const followups = provider.provideFollowups(
+        { metadata: { phase: 'lastFile' } },
+        { history: [] },
+        { isCancellationRequested: false },
+      );
+
+      expect(followups).toHaveLength(2);
+      expect(followups[0].label).toContain('Go deeper');
+      expect(followups[1].label).toContain('Wrap up');
+    });
+
+    it('returns Next file/Go deeper/Wrap up buttons for walkthrough phase', () => {
+      const provider = getFollowupProvider();
+      const followups = provider.provideFollowups(
+        { metadata: { phase: 'walkthrough' } },
+        { history: [] },
+        { isCancellationRequested: false },
+      );
+
+      expect(followups).toHaveLength(3);
+      expect(followups[0].label).toContain('Next file');
+      expect(followups[1].label).toContain('Go deeper');
+      expect(followups[2].label).toContain('Wrap up');
+    });
+
+    it('returns empty array for wrapup phase', () => {
+      const provider = getFollowupProvider();
+      const followups = provider.provideFollowups(
+        { metadata: { phase: 'wrapup' } },
+        { history: [] },
+        { isCancellationRequested: false },
+      );
+
+      expect(followups).toEqual([]);
+    });
+
+    it('returns empty array for error phase', () => {
+      const provider = getFollowupProvider();
+      const followups = provider.provideFollowups(
+        { metadata: { phase: 'error' } },
+        { history: [] },
+        { isCancellationRequested: false },
+      );
+
+      expect(followups).toEqual([]);
+    });
+
+    it('returns empty array for no-url phase', () => {
+      const provider = getFollowupProvider();
+      const followups = provider.provideFollowups(
+        { metadata: { phase: 'no-url' } },
+        { history: [] },
+        { isCancellationRequested: false },
+      );
+
+      expect(followups).toEqual([]);
     });
   });
 });

--- a/packages/ai-reviewer/src/walkthroughParticipant.ts
+++ b/packages/ai-reviewer/src/walkthroughParticipant.ts
@@ -39,6 +39,13 @@ export class WalkthroughParticipant {
       ];
     }
 
+    if (phase === 'lastFile') {
+      return [
+        { prompt: 'Go deeper — show callers and related code', label: '🔍 Go deeper' },
+        { prompt: 'Wrap up — show the final summary', label: '✅ Wrap up' },
+      ];
+    }
+
     // During file-by-file walkthrough (default)
     return [
       { prompt: 'Continue to the next file', label: '▶️ Next file' },
@@ -138,8 +145,8 @@ export class WalkthroughParticipant {
           properties: {
             phase: {
               type: 'string' as const,
-              enum: ['summary', 'walkthrough', 'wrapup'],
-              description: 'Current phase: "summary" after presenting the opening overview, "walkthrough" during file-by-file presentation, "wrapup" after the final wrap-up.',
+              enum: ['summary', 'walkthrough', 'lastFile', 'wrapup'],
+              description: 'Current phase: "summary" after presenting the opening overview, "walkthrough" during file-by-file presentation, "lastFile" when presenting the last file in the reading order, "wrapup" after the final wrap-up.',
             },
           },
           required: ['phase'],

--- a/packages/ai-reviewer/src/walkthroughPrompt.ts
+++ b/packages/ai-reviewer/src/walkthroughPrompt.ts
@@ -34,7 +34,7 @@ You have access to tools for exploring the PR's code. Use them proactively:
 - **workcenter-getFileDiff** — Get the diff for a specific file. Pass the same refs plus a \`filePath\`.
 - **workcenter-searchCode** — Search the codebase with git grep. Pass \`worktreePath: "${info.worktreePath}"\`, \`pattern\`, and optionally \`fileGlob\`.
 - **workcenter-gitLog** — Get recent commit history. Pass \`worktreePath: "${info.worktreePath}"\` and optionally \`filePath\` and \`maxCount\`.
-- **workcenter-signalPhase** — **Call this at the end of every response** to signal the current walkthrough phase. Pass \`phase: "summary"\` after presenting the opening overview, \`phase: "walkthrough"\` during the file-by-file presentation, or \`phase: "wrapup"\` after the final wrap-up. This controls which follow-up action buttons the user sees.
+- **workcenter-signalPhase** — **Call this at the end of every response** to signal the current walkthrough phase. Pass \`phase: "summary"\` after presenting the opening overview, \`phase: "walkthrough"\` during the file-by-file presentation, \`phase: "lastFile"\` when presenting the **last file** in the reading order (so the UI omits the "Next file" button), or \`phase: "wrapup"\` after the final wrap-up. This controls which follow-up action buttons the user sees.
 
 **Important:** Before presenting each file, use workcenter-readFile to read the full source file — not just the diff hunks. Use workcenter-searchCode to find callers of modified functions to understand the impact of changes. Use workcenter-getFileDiff for per-file diffs.
 
@@ -110,6 +110,8 @@ Display the filename as a navigable link, change type (modified/added/deleted/re
 
 **Pause and invite questions:**
 After each file or group, check in naturally — "Does this make sense? Any questions before we move on?"
+
+**Important — last file signaling:** When you are presenting the **last file** (or last group) in the reading order, signal \`phase: "lastFile"\` instead of \`phase: "walkthrough"\`. This tells the UI to hide the "Next file" button and offer a "Wrap up" action instead.
 
 ### Step 3: Wrap Up
 


### PR DESCRIPTION
## Summary

Fixes #252 — The AI Walkthrough chat participant showed a "Continue to next file" suggestion button even on the last file of the PR, which was confusing and non-functional.

## Changes

### `walkthroughParticipant.ts`
- Added `lastFile` to the `workcenter-signalPhase` tool's phase enum
- Added a `lastFile` case in `provideFollowups()` that shows "Go deeper" and "Wrap up" instead of "Next file"

### `walkthroughPrompt.ts`
- Updated the signalPhase tool description to document the new `lastFile` phase
- Added explicit instructions in Step 2 telling the LLM to signal `lastFile` instead of `walkthrough` when presenting the last file in the reading order

## How it works

The walkthrough LLM already tracks which file it's presenting relative to the reading order it established. The new `lastFile` phase lets it signal "I'm on the last one" so the UI can adapt the follow-up buttons accordingly. No "Next file" button appears — instead the user sees "Wrap up" to proceed to the final summary.

## Testing

- All 124 ai-reviewer tests pass
- Build succeeds with no errors
