### PR TITLE
Show org/repo context and provider labels in all views

### DIFF
--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -173,7 +173,7 @@ async function batchAcceptItems(
     try {
       const createdItem = await workGraph.createItem(
         { title: formatItemTitle(item) },
-        { providerId: item.providerId, externalId: item.externalId, url: item.url },
+        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group },
       );
       createdIds.push(createdItem.id);
       stateUpdates.push({ providerId: item.providerId, externalId: item.externalId, state: 'accepted' });

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -173,7 +173,7 @@ async function batchAcceptItems(
     try {
       const createdItem = await workGraph.createItem(
         { title: formatItemTitle(item) },
-        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group },
+        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group?.trim() || undefined },
       );
       createdIds.push(createdItem.id);
       stateUpdates.push({ providerId: item.providerId, externalId: item.externalId, state: 'accepted' });
@@ -450,7 +450,7 @@ async function acceptSingleInboxItem(
   try {
     createdItem = await workGraph.createItem(
       { title: formatItemTitle(item) },
-      { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group },
+      { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group?.trim() || undefined },
     );
   } catch (err: unknown) {
     handleCommandError('Failed to accept inbox item', err);
@@ -548,7 +548,7 @@ async function acceptSingleSourceItem(
   try {
     createdItem = await workGraph.createItem(
       { title: formatItemTitle(item) },
-      { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group },
+      { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group?.trim() || undefined },
     );
   } catch (err: unknown) {
     handleCommandError('Failed to accept sources item', err);

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -877,6 +877,28 @@ describe('registerCommands', () => {
       expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
       expect(workGraph.createItem).toHaveBeenCalledTimes(1);
     });
+
+    it('passes group to createItem when batch-accepting items with group', async () => {
+      const items = [
+        makeInboxItem({ externalId: 'ext-1', title: 'Issue 1', group: 'octocat/repo' }),
+        makeInboxItem({ externalId: 'ext-2', title: 'Issue 2', group: 'octocat/other' }),
+      ];
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem
+        .mockResolvedValueOnce(createWorkItem({ id: 'wc-1' }))
+        .mockResolvedValueOnce(createWorkItem({ id: 'wc-2' }));
+
+      await invoke('workcenter.acceptFromInbox', items[0], items);
+
+      expect(workGraph.createItem).toHaveBeenCalledWith(
+        { title: 'octocat/repo Issue 1' },
+        expect.objectContaining({ providerId: 'github', externalId: 'ext-1', group: 'octocat/repo' }),
+      );
+      expect(workGraph.createItem).toHaveBeenCalledWith(
+        { title: 'octocat/other Issue 2' },
+        expect.objectContaining({ providerId: 'github', externalId: 'ext-2', group: 'octocat/other' }),
+      );
+    });
   });
 
   // ── batch dismissFromInbox (multi-select) ─────────────────────────

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -899,6 +899,19 @@ describe('registerCommands', () => {
         expect.objectContaining({ providerId: 'github', externalId: 'ext-2', group: 'octocat/other' }),
       );
     });
+
+    it('normalizes whitespace-only group to undefined in batch accept', async () => {
+      const items = [makeInboxItem({ externalId: 'ext-ws', title: 'Whitespace', group: '  ' })];
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem.mockResolvedValueOnce(createWorkItem({ id: 'wc-ws' }));
+
+      await invoke('workcenter.acceptFromInbox', items[0], items);
+
+      expect(workGraph.createItem).toHaveBeenCalledWith(
+        { title: 'Whitespace' },
+        expect.objectContaining({ group: undefined }),
+      );
+    });
   });
 
   // ── batch dismissFromInbox (multi-select) ─────────────────────────

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -84,6 +84,12 @@ describe('FocusTreeProvider', () => {
       const item = makeItem({ state: WorkItemState.InProgress, group: undefined });
       expect(provider.getTreeItem(item).description).toBe('in progress');
     });
+
+    it('should omit group in tree layout', () => {
+      provider.layout = 'tree';
+      const item = makeItem({ state: WorkItemState.InProgress, group: 'octocat/repo' });
+      expect(provider.getTreeItem(item).description).toBe('in progress');
+    });
   });
 
   describe('getTreeItem icon', () => {

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -69,6 +69,21 @@ describe('FocusTreeProvider', () => {
       const item = makeItem({ state: WorkItemState.Paused });
       expect(provider.getTreeItem(item).description).toBe('paused');
     });
+
+    it('should show "in progress · group" when item has a group', () => {
+      const item = makeItem({ state: WorkItemState.InProgress, group: 'octocat/repo' });
+      expect(provider.getTreeItem(item).description).toBe('in progress · octocat/repo');
+    });
+
+    it('should show "paused · group" when paused item has a group', () => {
+      const item = makeItem({ state: WorkItemState.Paused, group: 'octocat/repo' });
+      expect(provider.getTreeItem(item).description).toBe('paused · octocat/repo');
+    });
+
+    it('should show state only when group is undefined', () => {
+      const item = makeItem({ state: WorkItemState.InProgress, group: undefined });
+      expect(provider.getTreeItem(item).description).toBe('in progress');
+    });
   });
 
   describe('getTreeItem icon', () => {

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -70,14 +70,14 @@ describe('FocusTreeProvider', () => {
       expect(provider.getTreeItem(item).description).toBe('paused');
     });
 
-    it('should show "in progress · group" when item has a group', () => {
+    it('should show "group · in progress" when item has a group', () => {
       const item = makeItem({ state: WorkItemState.InProgress, group: 'octocat/repo' });
-      expect(provider.getTreeItem(item).description).toBe('in progress · octocat/repo');
+      expect(provider.getTreeItem(item).description).toBe('octocat/repo · in progress');
     });
 
-    it('should show "paused · group" when paused item has a group', () => {
+    it('should show "group · paused" when paused item has a group', () => {
       const item = makeItem({ state: WorkItemState.Paused, group: 'octocat/repo' });
-      expect(provider.getTreeItem(item).description).toBe('paused · octocat/repo');
+      expect(provider.getTreeItem(item).description).toBe('octocat/repo · paused');
     });
 
     it('should show state only when group is undefined', () => {

--- a/packages/core/src/test/historyTreeProvider.test.ts
+++ b/packages/core/src/test/historyTreeProvider.test.ts
@@ -185,6 +185,24 @@ describe('HistoryTreeProvider', () => {
       expect((treeItem.iconPath as any).id).toBe('archive');
     });
 
+    it('should show "done · group" when Done item has a group', () => {
+      const item = makeItem({ id: '1', title: 'Done task', state: WorkItemState.Done, group: 'octocat/repo' });
+      const treeItem = provider.getTreeItem(item);
+      expect(treeItem.description).toBe('done · octocat/repo');
+    });
+
+    it('should show "archived · group" when Archived item has a group', () => {
+      const item = makeItem({ id: '1', title: 'Old task', state: WorkItemState.Archived, group: 'octocat/repo' });
+      const treeItem = provider.getTreeItem(item);
+      expect(treeItem.description).toBe('archived · octocat/repo');
+    });
+
+    it('should show state only when group is undefined', () => {
+      const item = makeItem({ id: '1', title: 'Task', state: WorkItemState.Done, group: undefined });
+      const treeItem = provider.getTreeItem(item);
+      expect(treeItem.description).toBe('done');
+    });
+
     it('should use circle-outline icon for unexpected state', () => {
       const item = makeItem({ id: '1', title: 'X', state: WorkItemState.InProgress });
       const treeItem = provider.getTreeItem(item);

--- a/packages/core/src/test/historyTreeProvider.test.ts
+++ b/packages/core/src/test/historyTreeProvider.test.ts
@@ -185,16 +185,16 @@ describe('HistoryTreeProvider', () => {
       expect((treeItem.iconPath as any).id).toBe('archive');
     });
 
-    it('should show "done · group" when Done item has a group', () => {
+    it('should show "group · done" when Done item has a group', () => {
       const item = makeItem({ id: '1', title: 'Done task', state: WorkItemState.Done, group: 'octocat/repo' });
       const treeItem = provider.getTreeItem(item);
-      expect(treeItem.description).toBe('done · octocat/repo');
+      expect(treeItem.description).toBe('octocat/repo · done');
     });
 
-    it('should show "archived · group" when Archived item has a group', () => {
+    it('should show "group · archived" when Archived item has a group', () => {
       const item = makeItem({ id: '1', title: 'Old task', state: WorkItemState.Archived, group: 'octocat/repo' });
       const treeItem = provider.getTreeItem(item);
-      expect(treeItem.description).toBe('archived · octocat/repo');
+      expect(treeItem.description).toBe('octocat/repo · archived');
     });
 
     it('should show state only when group is undefined', () => {

--- a/packages/core/src/test/historyTreeProvider.test.ts
+++ b/packages/core/src/test/historyTreeProvider.test.ts
@@ -197,6 +197,32 @@ describe('HistoryTreeProvider', () => {
       expect(treeItem.description).toBe('octocat/repo · archived');
     });
 
+    it('should show "group · providerLabel · done" when item has group and providerId', () => {
+      const mockRegistry = {
+        getProviderLabel: vi.fn((id: string) => id === 'github' ? 'GitHub Issues' : id),
+        onDidRegisterProvider: new EventEmitter<void>().event,
+        getDiscoveredItems: vi.fn(() => []),
+        onDidChangeDiscoveredItems: new EventEmitter<void>().event,
+      };
+      const providerWithRegistry = new HistoryTreeProvider(workGraph as any, mockRegistry as any);
+      const item = makeItem({ id: '1', title: 'PR fix', state: WorkItemState.Done, group: 'octocat/repo', providerId: 'github' });
+      const treeItem = providerWithRegistry.getTreeItem(item);
+      expect(treeItem.description).toBe('octocat/repo · GitHub Issues · done');
+    });
+
+    it('should show "providerLabel · done" when item has providerId but no group', () => {
+      const mockRegistry = {
+        getProviderLabel: vi.fn((id: string) => id === 'github' ? 'GitHub Issues' : id),
+        onDidRegisterProvider: new EventEmitter<void>().event,
+        getDiscoveredItems: vi.fn(() => []),
+        onDidChangeDiscoveredItems: new EventEmitter<void>().event,
+      };
+      const providerWithRegistry = new HistoryTreeProvider(workGraph as any, mockRegistry as any);
+      const item = makeItem({ id: '1', title: 'Task', state: WorkItemState.Done, providerId: 'github' });
+      const treeItem = providerWithRegistry.getTreeItem(item);
+      expect(treeItem.description).toBe('GitHub Issues · done');
+    });
+
     it('should show state only when group is undefined', () => {
       const item = makeItem({ id: '1', title: 'Task', state: WorkItemState.Done, group: undefined });
       const treeItem = provider.getTreeItem(item);

--- a/packages/core/src/test/historyTreeProvider.test.ts
+++ b/packages/core/src/test/historyTreeProvider.test.ts
@@ -203,6 +203,13 @@ describe('HistoryTreeProvider', () => {
       expect(treeItem.description).toBe('done');
     });
 
+    it('should omit group in tree layout', () => {
+      provider.layout = 'tree';
+      const item = makeItem({ id: '1', title: 'Done task', state: WorkItemState.Done, group: 'octocat/repo' });
+      const treeItem = provider.getTreeItem(item);
+      expect(treeItem.description).toBe('done');
+    });
+
     it('should use circle-outline icon for unexpected state', () => {
       const item = makeItem({ id: '1', title: 'X', state: WorkItemState.InProgress });
       const treeItem = provider.getTreeItem(item);

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -309,13 +309,21 @@ describe('InboxTreeProvider', () => {
       expect((treeItem.iconPath as any).id).toBe('folder');
     });
 
-    it('should set description to group when inbox item has a group', () => {
+    it('should set description to group in flat layout', () => {
+      provider.layout = 'flat';
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug', group: 'octocat/repo' };
       const treeItem = provider.getTreeItem(item);
       expect(treeItem.description).toBe('octocat/repo');
     });
 
+    it('should omit group description in tree layout', () => {
+      const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug', group: 'octocat/repo' };
+      const treeItem = provider.getTreeItem(item);
+      expect(treeItem.description).toBeUndefined();
+    });
+
     it('should set description to undefined when inbox item has no group', () => {
+      provider.layout = 'flat';
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
       const treeItem = provider.getTreeItem(item);
       expect(treeItem.description).toBeUndefined();

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -309,11 +309,11 @@ describe('InboxTreeProvider', () => {
       expect((treeItem.iconPath as any).id).toBe('folder');
     });
 
-    it('should set description to group in flat layout', () => {
+    it('should set description to group and provider label in flat layout', () => {
       provider.layout = 'flat';
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug', group: 'octocat/repo' };
       const treeItem = provider.getTreeItem(item);
-      expect(treeItem.description).toBe('octocat/repo');
+      expect(treeItem.description).toBe('octocat/repo · gh');
     });
 
     it('should omit group description in tree layout', () => {
@@ -322,11 +322,11 @@ describe('InboxTreeProvider', () => {
       expect(treeItem.description).toBeUndefined();
     });
 
-    it('should set description to undefined when inbox item has no group', () => {
+    it('should set description to provider label in flat layout when no group', () => {
       provider.layout = 'flat';
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
       const treeItem = provider.getTreeItem(item);
-      expect(treeItem.description).toBeUndefined();
+      expect(treeItem.description).toBe('gh');
     });
 
     it('should set contextValue with hasUrl when item has url', () => {

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -309,6 +309,18 @@ describe('InboxTreeProvider', () => {
       expect((treeItem.iconPath as any).id).toBe('folder');
     });
 
+    it('should set description to group when inbox item has a group', () => {
+      const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug', group: 'octocat/repo' };
+      const treeItem = provider.getTreeItem(item);
+      expect(treeItem.description).toBe('octocat/repo');
+    });
+
+    it('should set description to undefined when inbox item has no group', () => {
+      const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
+      const treeItem = provider.getTreeItem(item);
+      expect(treeItem.description).toBeUndefined();
+    });
+
     it('should set contextValue with hasUrl when item has url', () => {
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'X', url: 'https://example.com' };
       expect(provider.getTreeItem(item).contextValue).toBe('inboxItem.hasUrl');

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -143,14 +143,16 @@ describe('QueueTreeProvider', () => {
       expect(treeItem.description).toBe('my-org/my-repo');
     });
 
-    it('sets description to undefined in tree layout', async () => {
-      provider.layout = 'tree';
+    it('sets description to provider label in tree layout', async () => {
+      const registry = createMockProviderRegistry();
+      const queueWithRegistry = new QueueTreeProvider(graph, registry as any);
+      queueWithRegistry.layout = 'tree';
       const item = await graph.createItem(
         { title: 'Tree item' },
         { providerId: 'github', externalId: 'ext-tree', group: 'octocat/repo' },
       );
-      const treeItem = provider.getTreeItem(item);
-      expect(treeItem.description).toBeUndefined();
+      const treeItem = queueWithRegistry.getTreeItem(item);
+      expect(treeItem.description).toBe('GitHub Issues');
     });
 
     it('sets contextValue to "queueItem.hasUrl" when item has url', async () => {

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -125,7 +125,7 @@ describe('QueueTreeProvider', () => {
       expect(treeItem.description).toBeUndefined();
     });
 
-    it('sets description to "provider · group" when item has providerId and group', async () => {
+    it('sets description to "group · provider" when item has providerId and group', async () => {
       const registry = createMockProviderRegistry();
       const queueWithRegistry = new QueueTreeProvider(graph, registry as any);
       const item = await graph.createItem(

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -143,7 +143,7 @@ describe('QueueTreeProvider', () => {
       expect(treeItem.description).toBe('my-org/my-repo');
     });
 
-    it('sets description to provider label in tree layout', async () => {
+    it('omits description in tree layout since items are nested under provider group', async () => {
       const registry = createMockProviderRegistry();
       const queueWithRegistry = new QueueTreeProvider(graph, registry as any);
       queueWithRegistry.layout = 'tree';
@@ -152,7 +152,7 @@ describe('QueueTreeProvider', () => {
         { providerId: 'github', externalId: 'ext-tree', group: 'octocat/repo' },
       );
       const treeItem = queueWithRegistry.getTreeItem(item);
-      expect(treeItem.description).toBe('GitHub Issues');
+      expect(treeItem.description).toBeUndefined();
     });
 
     it('sets contextValue to "queueItem.hasUrl" when item has url', async () => {

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -143,6 +143,16 @@ describe('QueueTreeProvider', () => {
       expect(treeItem.description).toBe('my-org/my-repo');
     });
 
+    it('sets description to undefined in tree layout', async () => {
+      provider.layout = 'tree';
+      const item = await graph.createItem(
+        { title: 'Tree item' },
+        { providerId: 'github', externalId: 'ext-tree', group: 'octocat/repo' },
+      );
+      const treeItem = provider.getTreeItem(item);
+      expect(treeItem.description).toBeUndefined();
+    });
+
     it('sets contextValue to "queueItem.hasUrl" when item has url', async () => {
       const item = await graph.createItem(
         { title: 'With URL' },

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -125,6 +125,24 @@ describe('QueueTreeProvider', () => {
       expect(treeItem.description).toBeUndefined();
     });
 
+    it('sets description to "provider · group" when item has providerId and group', async () => {
+      const registry = createMockProviderRegistry();
+      const queueWithRegistry = new QueueTreeProvider(graph, registry as any);
+      const item = await graph.createItem(
+        { title: 'Grouped' },
+        { providerId: 'github', externalId: 'ext-g1', group: 'octocat/repo' },
+      );
+      const treeItem = queueWithRegistry.getTreeItem(item);
+      expect(treeItem.description).toBe('GitHub Issues · octocat/repo');
+    });
+
+    it('sets description to group only when no providerId but group exists', async () => {
+      const item = await graph.createItem({ title: 'Manual grouped' });
+      (item as any).group = 'my-org/my-repo';
+      const treeItem = provider.getTreeItem(item);
+      expect(treeItem.description).toBe('my-org/my-repo');
+    });
+
     it('sets contextValue to "queueItem.hasUrl" when item has url', async () => {
       const item = await graph.createItem(
         { title: 'With URL' },

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -133,7 +133,7 @@ describe('QueueTreeProvider', () => {
         { providerId: 'github', externalId: 'ext-g1', group: 'octocat/repo' },
       );
       const treeItem = queueWithRegistry.getTreeItem(item);
-      expect(treeItem.description).toBe('GitHub Issues · octocat/repo');
+      expect(treeItem.description).toBe('octocat/repo · GitHub Issues');
     });
 
     it('sets description to group only when no providerId but group exists', async () => {

--- a/packages/core/src/test/sourcesTreeProvider.test.ts
+++ b/packages/core/src/test/sourcesTreeProvider.test.ts
@@ -305,6 +305,36 @@ describe('SourcesTreeProvider', () => {
       expect(treeItem.description).toBe('dismissed');
     });
 
+    it('should show provider label in flat layout', () => {
+      registry._setLabel('gh', 'GitHub Issues');
+      provider.layout = 'flat';
+      const node: SourceItemNode = {
+        kind: 'item', providerId: 'gh', externalId: '1', title: 'Item',
+      };
+      const treeItem = provider.getTreeItem(node);
+      expect(treeItem.description).toBe('GitHub Issues');
+    });
+
+    it('should show provider label and dismissed in flat layout', () => {
+      registry._setLabel('gh', 'GitHub Issues');
+      stateStore.getState.mockReturnValue('dismissed');
+      provider.layout = 'flat';
+      const node: SourceItemNode = {
+        kind: 'item', providerId: 'gh', externalId: '1', title: 'Dismissed Item',
+      };
+      const treeItem = provider.getTreeItem(node);
+      expect(treeItem.description).toBe('GitHub Issues · dismissed');
+    });
+
+    it('should omit provider label in tree layout', () => {
+      registry._setLabel('gh', 'GitHub Issues');
+      const node: SourceItemNode = {
+        kind: 'item', providerId: 'gh', externalId: '1', title: 'Item',
+      };
+      const treeItem = provider.getTreeItem(node);
+      expect(treeItem.description).toBeUndefined();
+    });
+
     it('should use distinct icons for accepted, dismissed, and unseen states', () => {
       const node: SourceItemNode = {
         kind: 'item', providerId: 'gh', externalId: '1', title: 'Test Item',

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -47,7 +47,7 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
     treeItem.id = item.id;
     treeItem.description = this.layout === 'tree'
       ? this.buildDescription(this.getStateLabel(item.state))
-      : this.buildDescription(this.getStateLabel(item.state), item.group);
+      : this.buildDescription(item.group, this.getStateLabel(item.state));
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.iconPath = this.getIcon(item.state);
 

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -45,7 +45,7 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
     const title = this.resolveTitle(item);
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = item.id;
-    treeItem.description = this.getStateLabel(item.state);
+    treeItem.description = this.buildDescription(this.getStateLabel(item.state), item.group);
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.iconPath = this.getIcon(item.state);
 

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -45,7 +45,9 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
     const title = this.resolveTitle(item);
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = item.id;
-    treeItem.description = this.buildDescription(this.getStateLabel(item.state), item.group);
+    treeItem.description = this.layout === 'tree'
+      ? this.buildDescription(this.getStateLabel(item.state))
+      : this.buildDescription(this.getStateLabel(item.state), item.group);
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.iconPath = this.getIcon(item.state);
 

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -36,7 +36,7 @@ export class HistoryTreeProvider extends WorkItemViewProvider {
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
     treeItem.description = this.layout === 'tree'
       ? this.buildDescription(this.getStateLabel(item.state))
-      : this.buildDescription(item.group, this.getStateLabel(item.state));
+      : this.buildDescription(item.group, this.getProviderLabel(item.providerId), this.getStateLabel(item.state));
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.iconPath = this.getIcon(item.state);
     let contextBase = 'historyItem';

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -34,7 +34,9 @@ export class HistoryTreeProvider extends WorkItemViewProvider {
   protected createWorkItemTreeItem(item: WorkItem): vscode.TreeItem {
     const title = this.resolveTitle(item);
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
-    treeItem.description = this.buildDescription(this.getStateLabel(item.state), item.group);
+    treeItem.description = this.layout === 'tree'
+      ? this.buildDescription(this.getStateLabel(item.state))
+      : this.buildDescription(this.getStateLabel(item.state), item.group);
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.iconPath = this.getIcon(item.state);
     let contextBase = 'historyItem';

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -34,7 +34,7 @@ export class HistoryTreeProvider extends WorkItemViewProvider {
   protected createWorkItemTreeItem(item: WorkItem): vscode.TreeItem {
     const title = this.resolveTitle(item);
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
-    treeItem.description = this.getStateLabel(item.state);
+    treeItem.description = this.buildDescription(this.getStateLabel(item.state), item.group);
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.iconPath = this.getIcon(item.state);
     let contextBase = 'historyItem';

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -36,7 +36,7 @@ export class HistoryTreeProvider extends WorkItemViewProvider {
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
     treeItem.description = this.layout === 'tree'
       ? this.buildDescription(this.getStateLabel(item.state))
-      : this.buildDescription(this.getStateLabel(item.state), item.group);
+      : this.buildDescription(item.group, this.getStateLabel(item.state));
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.iconPath = this.getIcon(item.state);
     let contextBase = 'historyItem';

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -161,7 +161,9 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
     const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = `inbox::item::${element.providerId}::${element.externalId}`;
-    treeItem.description = this._layoutState.value === 'flat' ? (element.group?.trim() || undefined) : undefined;
+    treeItem.description = this._layoutState.value === 'flat'
+      ? this.buildFlatDescription(element)
+      : undefined;
     treeItem.tooltip = this.buildTooltip(element);
     treeItem.contextValue = element.url ? 'inboxItem.hasUrl' : 'inboxItem';
     treeItem.iconPath = new vscode.ThemeIcon(isSeen ? 'circle-outline' : 'circle-filled');
@@ -320,6 +322,14 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   private formatReason(reason: string): string {
     return reason.replace(/_/g, ' ').replace(/^./, c => c.toUpperCase());
+  }
+
+  private buildFlatDescription(item: InboxItem): string | undefined {
+    const parts = [
+      item.group?.trim(),
+      this.providerRegistry.getProviderLabel(item.providerId),
+    ].filter((p): p is string => p !== undefined && p.length > 0);
+    return parts.length > 0 ? parts.join(' · ') : undefined;
   }
 
   private buildTooltip(item: InboxItem): vscode.MarkdownString {

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -161,7 +161,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
     const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = `inbox::item::${element.providerId}::${element.externalId}`;
-    treeItem.description = element.group;
+    treeItem.description = this._layoutState.value === 'flat' ? element.group : undefined;
     treeItem.tooltip = this.buildTooltip(element);
     treeItem.contextValue = element.url ? 'inboxItem.hasUrl' : 'inboxItem';
     treeItem.iconPath = new vscode.ThemeIcon(isSeen ? 'circle-outline' : 'circle-filled');

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -161,6 +161,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
     const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = `inbox::item::${element.providerId}::${element.externalId}`;
+    treeItem.description = element.group;
     treeItem.tooltip = this.buildTooltip(element);
     treeItem.contextValue = element.url ? 'inboxItem.hasUrl' : 'inboxItem';
     treeItem.iconPath = new vscode.ThemeIcon(isSeen ? 'circle-outline' : 'circle-filled');

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -327,7 +327,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   private buildFlatDescription(item: InboxItem): string | undefined {
     const parts = [
       item.group?.trim(),
-      this.providerRegistry.getProviderLabel(item.providerId),
+      this.providerRegistry.getProviderLabel(item.providerId)?.trim(),
     ].filter((p): p is string => p !== undefined && p.length > 0);
     return parts.length > 0 ? parts.join(' · ') : undefined;
   }

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -161,7 +161,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
     const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = `inbox::item::${element.providerId}::${element.externalId}`;
-    treeItem.description = this._layoutState.value === 'flat' ? element.group : undefined;
+    treeItem.description = this._layoutState.value === 'flat' ? (element.group?.trim() || undefined) : undefined;
     treeItem.tooltip = this.buildTooltip(element);
     treeItem.contextValue = element.url ? 'inboxItem.hasUrl' : 'inboxItem';
     treeItem.iconPath = new vscode.ThemeIcon(isSeen ? 'circle-outline' : 'circle-filled');

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -39,7 +39,7 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
     const title = this.resolveTitle(item);
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = item.id;
-    treeItem.description = this.getProviderLabel(item.providerId);
+    treeItem.description = this.buildDescription(this.getProviderLabel(item.providerId), item.group);
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.contextValue = item.url ? 'queueItem.hasUrl' : 'queueItem';
     treeItem.iconPath = new vscode.ThemeIcon(item.providerId ? 'remote' : 'circle-filled');

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -41,7 +41,7 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
     treeItem.id = item.id;
     treeItem.description = this.layout === 'flat'
       ? this.buildDescription(this.getProviderLabel(item.providerId), item.group)
-      : undefined;
+      : this.buildDescription(this.getProviderLabel(item.providerId));
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.contextValue = item.url ? 'queueItem.hasUrl' : 'queueItem';
     treeItem.iconPath = new vscode.ThemeIcon(item.providerId ? 'remote' : 'circle-filled');

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -41,7 +41,7 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
     treeItem.id = item.id;
     treeItem.description = this.layout === 'flat'
       ? this.buildDescription(item.group, this.getProviderLabel(item.providerId))
-      : this.buildDescription(this.getProviderLabel(item.providerId));
+      : undefined;
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.contextValue = item.url ? 'queueItem.hasUrl' : 'queueItem';
     treeItem.iconPath = new vscode.ThemeIcon(item.providerId ? 'remote' : 'circle-filled');

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -39,7 +39,9 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
     const title = this.resolveTitle(item);
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = item.id;
-    treeItem.description = this.buildDescription(this.getProviderLabel(item.providerId), item.group);
+    treeItem.description = this.layout === 'flat'
+      ? this.buildDescription(this.getProviderLabel(item.providerId), item.group)
+      : undefined;
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.contextValue = item.url ? 'queueItem.hasUrl' : 'queueItem';
     treeItem.iconPath = new vscode.ThemeIcon(item.providerId ? 'remote' : 'circle-filled');

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -40,7 +40,7 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = item.id;
     treeItem.description = this.layout === 'flat'
-      ? this.buildDescription(this.getProviderLabel(item.providerId), item.group)
+      ? this.buildDescription(item.group, this.getProviderLabel(item.providerId))
       : this.buildDescription(this.getProviderLabel(item.providerId));
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.contextValue = item.url ? 'queueItem.hasUrl' : 'queueItem';

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { DiscoveredItem } from '../api/types';
 import { ProviderRegistry } from '../services/providerRegistry';
-import { DiscoveredStateStore } from '../storage/discoveredStateStore';
+import { DiscoveredStateStore, InboxState } from '../storage/discoveredStateStore';
 import { ViewLayout, LayoutState } from './viewLayout';
 
 export type SourcesElement = SourceProviderNode | SourceGroupNode | SourceItemNode;
@@ -79,7 +79,7 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
             break;
         }
         const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
-        treeItem.description = state === 'dismissed' ? 'dismissed' : undefined;
+        treeItem.description = this.buildItemDescription(element.providerId, state);
         treeItem.tooltip = this.buildItemTooltip(element);
         treeItem.contextValue = element.url ? 'sourceItem.hasUrl' : 'sourceItem';
         treeItem.iconPath = new vscode.ThemeIcon(icon);
@@ -179,6 +179,16 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
       url: item.url,
       group: item.group,
     };
+  }
+
+  private buildItemDescription(providerId: string, state: InboxState | undefined): string | undefined {
+    const parts: string[] = [];
+    if (this._layoutState.value === 'flat') {
+      const label = this.providerRegistry.getProviderLabel(providerId);
+      if (label) { parts.push(label); }
+    }
+    if (state === 'dismissed') { parts.push('dismissed'); }
+    return parts.length > 0 ? parts.join(' · ') : undefined;
   }
 
   private buildItemTooltip(item: SourceItemNode): vscode.MarkdownString {

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -184,8 +184,8 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
   private buildItemDescription(providerId: string, state: InboxState | undefined): string | undefined {
     const parts: string[] = [];
     if (this._layoutState.value === 'flat') {
-      const label = this.providerRegistry.getProviderLabel(providerId);
-      if (label) { parts.push(label); }
+      const label = this.providerRegistry.getProviderLabel(providerId)?.trim();
+      if (label && label.length > 0) { parts.push(label); }
     }
     if (state === 'dismissed') { parts.push('dismissed'); }
     return parts.length > 0 ? parts.join(' · ') : undefined;

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -367,7 +367,9 @@ export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<Wo
 
   /** Join non-empty description parts with a separator. */
   protected buildDescription(...parts: (string | undefined)[]): string | undefined {
-    const filtered = parts.filter((p): p is string => !!p);
+    const filtered = parts
+      .map(p => p?.trim())
+      .filter((p): p is string => p !== undefined && p.length > 0);
     return filtered.length > 0 ? filtered.join(' · ') : undefined;
   }
 

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -365,6 +365,12 @@ export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<Wo
     return this.labelResolver?.(normalizedProviderId) ?? normalizedProviderId;
   }
 
+  /** Join non-empty description parts with a separator. */
+  protected buildDescription(...parts: (string | undefined)[]): string | undefined {
+    const filtered = parts.filter((p): p is string => !!p);
+    return filtered.length > 0 ? filtered.join(' · ') : undefined;
+  }
+
   /** Return the WorkItems this view cares about (before sorting). */
   protected abstract getItems(): WorkItem[];
 


### PR DESCRIPTION
## Summary
Items in the Inbox, Queue, Focus, History, and Sources views now display repository/project context (e.g., `contoso/webapp`) and provider labels alongside their title. This helps users working across multiple GitHub repos or ADO projects quickly identify which repo/project an item belongs to.

## Changes

### Inbox view
- In flat layout, description now shows `group · providerLabel` (e.g., `octocat/repo · GitHub Issues`)
- In tree layout, description is omitted (items are nested under provider/group nodes)

### Queue view
- In flat layout, description shows `group · providerLabel` (e.g., `contoso/webapp · GitHub Issues`)
- In tree layout, description is omitted (redundant with provider group nesting)

### Focus view
- In flat layout, description shows `group · state` (e.g., `contoso/webapp · in progress`)
- In tree layout, description shows `state` only

### History view
- In flat layout, description shows `group · providerLabel · state` (e.g., `contoso/webapp · GitHub Issues · done`)
- In tree layout, description shows `state` only

### Sources view
- In flat layout, description shows `providerLabel` (e.g., `GitHub Issues`), or `providerLabel · dismissed` for dismissed items
- In tree layout, shows `dismissed` only when applicable

### Shared infrastructure
- Added `buildDescription()` helper to `WorkItemViewProvider` base class for composing multi-part descriptions with a `·` separator
- Added `buildFlatDescription()` to `InboxTreeProvider` and `buildItemDescription()` to `SourcesTreeProvider` (these don't extend the base class)

### Bug fix
- Fixed `batchAcceptItems` to pass `group` through to `createItem`. The single-accept paths already did this, but multi-select accept was missing it.

## Testing
All tests pass across all packages. New tests added for provider label description behavior in History and Sources views.

Closes #250
