### PR TITLE
feat: add Accept to Focus action on Inbox items

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -527,11 +527,6 @@
           "group": "1_actions"
         },
         {
-          "command": "workcenter.acceptToFocusFromInbox",
-          "when": "view == workcenter.inbox && viewItem =~ /inboxItem/",
-          "group": "inline"
-        },
-        {
           "command": "workcenter.dismissFromInbox",
           "when": "view == workcenter.inbox && viewItem =~ /inboxItem/",
           "group": "inline"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -193,6 +193,12 @@
         "icon": "$(arrow-right)"
       },
       {
+        "command": "workcenter.acceptToFocusFromInbox",
+        "title": "Accept to Focus",
+        "category": "WorkCenter",
+        "icon": "$(rocket)"
+      },
+      {
         "command": "workcenter.dismissFromInbox",
         "title": "Dismiss",
         "category": "WorkCenter",
@@ -516,12 +522,22 @@
           "group": "inline"
         },
         {
+          "command": "workcenter.acceptToFocusFromInbox",
+          "when": "view == workcenter.inbox && viewItem =~ /inboxItem/",
+          "group": "inline"
+        },
+        {
           "command": "workcenter.dismissFromInbox",
           "when": "view == workcenter.inbox && viewItem =~ /inboxItem/",
           "group": "inline"
         },
         {
           "command": "workcenter.dismissFromInbox",
+          "when": "view == workcenter.inbox && viewItem =~ /inboxItem/",
+          "group": "1_actions"
+        },
+        {
+          "command": "workcenter.acceptToFocusFromInbox",
           "when": "view == workcenter.inbox && viewItem =~ /inboxItem/",
           "group": "1_actions"
         },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -522,6 +522,11 @@
           "group": "inline"
         },
         {
+          "command": "workcenter.acceptFromInbox",
+          "when": "view == workcenter.inbox && viewItem =~ /inboxItem/",
+          "group": "1_actions"
+        },
+        {
           "command": "workcenter.acceptToFocusFromInbox",
           "when": "view == workcenter.inbox && viewItem =~ /inboxItem/",
           "group": "inline"

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -723,11 +723,12 @@ async function acceptSingleSourceItem(
     );
     return;
   }
+  const group = item.group?.trim();
   let createdItem: Awaited<ReturnType<typeof workGraph.createItem>>;
   try {
     createdItem = await workGraph.createItem(
       { title: formatItemTitle(item) },
-      { providerId: item.providerId, externalId: item.externalId, url: item.url, ...(item.group ? { group: item.group } : {}) },
+      { providerId: item.providerId, externalId: item.externalId, url: item.url, ...(group ? { group } : {}) },
     );
   } catch (err: unknown) {
     handleCommandError('Failed to accept sources item', err);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -446,11 +446,12 @@ async function acceptSingleInboxItem(
     }
     return;
   }
+  const group = item.group?.trim();
   let createdItem: Awaited<ReturnType<typeof workGraph.createItem>>;
   try {
     createdItem = await workGraph.createItem(
       { title: formatItemTitle(item) },
-      { providerId: item.providerId, externalId: item.externalId, url: item.url, ...(item.group ? { group: item.group } : {}) },
+      { providerId: item.providerId, externalId: item.externalId, url: item.url, ...(group ? { group } : {}) },
     );
   } catch (err: unknown) {
     handleCommandError('Failed to accept inbox item', err);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -508,11 +508,12 @@ async function acceptToFocusSingleInboxItem(
       return;
     }
   } else {
+    const group = item.group?.trim();
     let createdItem: Awaited<ReturnType<typeof workGraph.createItem>>;
     try {
       createdItem = await workGraph.createItem(
         { title: formatItemTitle(item) },
-        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group },
+        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: group || undefined },
       );
     } catch (err: unknown) {
       handleCommandError('Failed to accept inbox item', err);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -478,6 +478,22 @@ async function acceptToFocusSingleInboxItem(
   let workItemId: string;
   const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
   if (existing) {
+    if (existing.state === WorkItemState.InProgress) {
+      try {
+        await stateStore.setState(item.providerId, item.externalId, 'accepted');
+      } catch { /* best-effort */ }
+      void vscode.window.showInformationMessage('WorkCenter: Item is already in Focus');
+      return;
+    }
+    if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+      try {
+        await stateStore.setState(item.providerId, item.externalId, 'accepted');
+      } catch { /* best-effort */ }
+      void vscode.window.showWarningMessage(
+        `WorkCenter: Item is ${existing.state} and cannot be moved to Focus`,
+      );
+      return;
+    }
     workItemId = existing.id;
     try {
       await stateStore.setState(item.providerId, item.externalId, 'accepted');
@@ -509,7 +525,11 @@ async function acceptToFocusSingleInboxItem(
     }
     workItemId = createdItem.id;
   }
-  await workGraph.transitionState(workItemId, WorkItemState.InProgress);
+  try {
+    await workGraph.transitionState(workItemId, WorkItemState.InProgress);
+  } catch (err: unknown) {
+    handleCommandError('Failed to move item to Focus', err);
+  }
 }
 
 async function batchAcceptToFocusItems(
@@ -521,10 +541,23 @@ async function batchAcceptToFocusItems(
   const createdIds: string[] = [];
   const allIds: string[] = [];
   let failed = 0;
+  let skipped = 0;
 
   for (const item of items) {
     const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
     if (existing) {
+      if (existing.state === WorkItemState.InProgress) {
+        logger.info(`Skipping "${item.title}" — already in Focus`);
+        stateUpdates.push({ providerId: item.providerId, externalId: item.externalId, state: 'accepted' });
+        skipped++;
+        continue;
+      }
+      if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+        logger.info(`Skipping "${item.title}" — item is ${existing.state} and cannot be moved to Focus`);
+        stateUpdates.push({ providerId: item.providerId, externalId: item.externalId, state: 'accepted' });
+        skipped++;
+        continue;
+      }
       stateUpdates.push({ providerId: item.providerId, externalId: item.externalId, state: 'accepted' });
       allIds.push(existing.id);
       continue;
@@ -568,11 +601,18 @@ async function batchAcceptToFocusItems(
     }
   }
 
-  const total = allIds.length;
-  if (total > 0) {
+  const succeeded = allIds.length - transitionFailed;
+  if (succeeded > 0 || skipped > 0) {
+    const parts: string[] = [];
+    if (succeeded > 0) {
+      parts.push(`Accepted ${succeeded} item${succeeded === 1 ? '' : 's'} to Focus`);
+    }
+    if (skipped > 0) {
+      parts.push(`${skipped} already in Focus or cannot be moved`);
+    }
     const msg = (failed > 0 || transitionFailed > 0)
-      ? `Accepted ${total} of ${total + failed} items to Focus`
-      : `Accepted ${total} item${total === 1 ? '' : 's'} to Focus`;
+      ? `${parts.join('; ')} (${failed + transitionFailed} failed)`
+      : parts.join('; ');
     void vscode.window.showInformationMessage(msg);
   }
   if (failed > 0 || transitionFailed > 0) {

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -553,7 +553,7 @@ async function batchAcceptToFocusItems(
   for (const item of items) {
     const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
     if (existing) {
-      if (existing.state === WorkItemState.InProgress) {
+      if (existing.state === WorkItemState.InProgress || existing.state === WorkItemState.Paused) {
         logger.info(`Skipping "${item.title}" — already in Focus`);
         stateUpdates.push({ providerId: item.providerId, externalId: item.externalId, state: 'accepted' });
         skipped++;

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -517,7 +517,7 @@ async function acceptToFocusSingleInboxItem(
         { providerId: item.providerId, externalId: item.externalId, url: item.url, ...(group ? { group } : {}) },
       );
     } catch (err: unknown) {
-      handleCommandError('Failed to accept inbox item', err);
+      handleCommandError('Failed to accept inbox item to Focus', err);
       return;
     }
     try {

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -482,7 +482,7 @@ async function acceptToFocusSingleInboxItem(
       try {
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {
-        handleCommandError('Failed to update state for existing in-progress item', err);
+        handleCommandError('Failed to update state for existing focus item', err);
         return;
       }
       void vscode.window.showInformationMessage('WorkCenter: Item is already in Focus');

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -469,6 +469,136 @@ async function acceptSingleInboxItem(
   }
 }
 
+async function acceptToFocusSingleInboxItem(
+  workGraph: WorkGraph,
+  stateStore: DiscoveredStateStore,
+  item: InboxItem,
+): Promise<void> {
+  logger.info(`Accepting inbox item to Focus: ${item.externalId} from ${item.providerId}`);
+  let workItemId: string;
+  const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
+  if (existing) {
+    workItemId = existing.id;
+    try {
+      await stateStore.setState(item.providerId, item.externalId, 'accepted');
+    } catch (err: unknown) {
+      handleCommandError('Failed to update state for existing accepted item', err);
+      return;
+    }
+  } else {
+    let createdItem: Awaited<ReturnType<typeof workGraph.createItem>>;
+    try {
+      createdItem = await workGraph.createItem(
+        { title: formatItemTitle(item) },
+        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group },
+      );
+    } catch (err: unknown) {
+      handleCommandError('Failed to accept inbox item', err);
+      return;
+    }
+    try {
+      await stateStore.setState(item.providerId, item.externalId, 'accepted');
+    } catch (err: unknown) {
+      try {
+        await workGraph.deleteItem(createdItem.id);
+      } catch (rollbackErr: unknown) {
+        logger.error('Failed to roll back created item after setState failure', rollbackErr);
+      }
+      handleCommandError('Failed to update state after accepting item', err);
+      return;
+    }
+    workItemId = createdItem.id;
+  }
+  await workGraph.transitionState(workItemId, WorkItemState.InProgress);
+}
+
+async function batchAcceptToFocusItems(
+  workGraph: WorkGraph,
+  stateStore: DiscoveredStateStore,
+  items: InboxItem[],
+): Promise<void> {
+  const stateUpdates: Array<{ providerId: string; externalId: string; state: InboxState }> = [];
+  const createdIds: string[] = [];
+  const allIds: string[] = [];
+  let failed = 0;
+
+  for (const item of items) {
+    const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
+    if (existing) {
+      stateUpdates.push({ providerId: item.providerId, externalId: item.externalId, state: 'accepted' });
+      allIds.push(existing.id);
+      continue;
+    }
+    try {
+      const createdItem = await workGraph.createItem(
+        { title: formatItemTitle(item) },
+        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group },
+      );
+      createdIds.push(createdItem.id);
+      allIds.push(createdItem.id);
+      stateUpdates.push({ providerId: item.providerId, externalId: item.externalId, state: 'accepted' });
+    } catch (err: unknown) {
+      failed++;
+      logger.error(`Failed to accept inbox item to Focus "${item.title}"`, err);
+    }
+  }
+
+  if (stateUpdates.length > 0) {
+    try {
+      await stateStore.setStates(stateUpdates);
+    } catch (err: unknown) {
+      for (const id of createdIds) {
+        try { await workGraph.deleteItem(id); } catch (rollbackErr: unknown) {
+          logger.error('Failed to roll back created item after batch setStates failure', rollbackErr);
+        }
+      }
+      handleCommandError('Failed to update states after accepting items', err);
+      return;
+    }
+  }
+
+  // Transition all successfully accepted items to InProgress
+  let transitionFailed = 0;
+  for (const id of allIds) {
+    try {
+      await workGraph.transitionState(id, WorkItemState.InProgress);
+    } catch (err: unknown) {
+      transitionFailed++;
+      logger.error(`Failed to transition item ${id} to Focus`, err);
+    }
+  }
+
+  const total = allIds.length;
+  if (total > 0) {
+    const msg = (failed > 0 || transitionFailed > 0)
+      ? `Accepted ${total} of ${total + failed} items to Focus`
+      : `Accepted ${total} item${total === 1 ? '' : 's'} to Focus`;
+    void vscode.window.showInformationMessage(msg);
+  }
+  if (failed > 0 || transitionFailed > 0) {
+    void vscode.window.showErrorMessage(
+      `WorkCenter: Failed to process ${failed + transitionFailed} item(s); see Output for details`,
+    );
+  }
+}
+
+async function handleAcceptToFocusFromInbox(
+  workGraph: WorkGraph,
+  stateStore: DiscoveredStateStore,
+  item?: InboxElement,
+  selectedItems?: InboxElement[],
+): Promise<void> {
+  const items = resolveInboxItems(item, selectedItems);
+  if (items.length === 0) { return; }
+
+  if (items.length === 1) {
+    await acceptToFocusSingleInboxItem(workGraph, stateStore, items[0]);
+    return;
+  }
+
+  await batchAcceptToFocusItems(workGraph, stateStore, items);
+}
+
 async function handleDismissFromInbox(
   stateStore: DiscoveredStateStore,
   item?: InboxElement,
@@ -642,6 +772,8 @@ export function registerCommands(
       wrapCommand('Failed to move item to queue', (item, selectedItems) => handleMoveToQueue(workGraph, item, selectedItems))),
     vscode.commands.registerCommand('workcenter.acceptFromInbox',
       wrapCommand('Failed to accept from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleAcceptFromInbox(workGraph, stateStore, item, selectedItems))),
+    vscode.commands.registerCommand('workcenter.acceptToFocusFromInbox',
+      wrapCommand('Failed to accept to focus from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleAcceptToFocusFromInbox(workGraph, stateStore, item, selectedItems))),
     vscode.commands.registerCommand('workcenter.dismissFromInbox',
       wrapCommand('Failed to dismiss from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleDismissFromInbox(stateStore, item, selectedItems))),
     vscode.commands.registerCommand('workcenter.acceptFromSources',

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -450,7 +450,7 @@ async function acceptSingleInboxItem(
   try {
     createdItem = await workGraph.createItem(
       { title: formatItemTitle(item) },
-      { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group },
+      { providerId: item.providerId, externalId: item.externalId, url: item.url, ...(item.group ? { group: item.group } : {}) },
     );
   } catch (err: unknown) {
     handleCommandError('Failed to accept inbox item', err);
@@ -513,7 +513,7 @@ async function acceptToFocusSingleInboxItem(
     try {
       createdItem = await workGraph.createItem(
         { title: formatItemTitle(item) },
-        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: group || undefined },
+        { providerId: item.providerId, externalId: item.externalId, url: item.url, ...(group ? { group } : {}) },
       );
     } catch (err: unknown) {
       handleCommandError('Failed to accept inbox item', err);
@@ -573,7 +573,7 @@ async function batchAcceptToFocusItems(
     try {
       const createdItem = await workGraph.createItem(
         { title: formatItemTitle(item) },
-        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: group || undefined },
+        { providerId: item.providerId, externalId: item.externalId, url: item.url, ...(group ? { group } : {}) },
       );
       createdIds.push(createdItem.id);
       allIds.push(createdItem.id);
@@ -726,7 +726,7 @@ async function acceptSingleSourceItem(
   try {
     createdItem = await workGraph.createItem(
       { title: formatItemTitle(item) },
-      { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group },
+      { providerId: item.providerId, externalId: item.externalId, url: item.url, ...(item.group ? { group: item.group } : {}) },
     );
   } catch (err: unknown) {
     handleCommandError('Failed to accept sources item', err);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -451,7 +451,12 @@ async function acceptSingleInboxItem(
   try {
     createdItem = await workGraph.createItem(
       { title: formatItemTitle(item) },
-      { providerId: item.providerId, externalId: item.externalId, url: item.url, group: group || undefined },
+      {
+        providerId: item.providerId,
+        externalId: item.externalId,
+        url: item.url,
+        ...(group ? { group } : {}),
+      },
     );
   } catch (err: unknown) {
     handleCommandError('Failed to accept inbox item', err);
@@ -514,7 +519,12 @@ async function acceptToFocusSingleInboxItem(
     try {
       createdItem = await workGraph.createItem(
         { title: formatItemTitle(item) },
-        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: group || undefined },
+        {
+          providerId: item.providerId,
+          externalId: item.externalId,
+          url: item.url,
+          ...(group ? { group } : {}),
+        },
       );
     } catch (err: unknown) {
       handleCommandError('Failed to accept inbox item to Focus', err);
@@ -574,7 +584,12 @@ async function batchAcceptToFocusItems(
     try {
       const createdItem = await workGraph.createItem(
         { title: formatItemTitle(item) },
-        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: group || undefined },
+        {
+          providerId: item.providerId,
+          externalId: item.externalId,
+          url: item.url,
+          ...(group ? { group } : {}),
+        },
       );
       createdIds.push(createdItem.id);
       allIds.push(createdItem.id);
@@ -728,7 +743,12 @@ async function acceptSingleSourceItem(
   try {
     createdItem = await workGraph.createItem(
       { title: formatItemTitle(item) },
-      { providerId: item.providerId, externalId: item.externalId, url: item.url, group: group || undefined },
+      {
+        providerId: item.providerId,
+        externalId: item.externalId,
+        url: item.url,
+        ...(group ? { group } : {}),
+      },
     );
   } catch (err: unknown) {
     handleCommandError('Failed to accept sources item', err);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -569,10 +569,11 @@ async function batchAcceptToFocusItems(
       allIds.push(existing.id);
       continue;
     }
+    const group = item.group?.trim();
     try {
       const createdItem = await workGraph.createItem(
         { title: formatItemTitle(item) },
-        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group },
+        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: group || undefined },
       );
       createdIds.push(createdItem.id);
       allIds.push(createdItem.id);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -451,7 +451,7 @@ async function acceptSingleInboxItem(
   try {
     createdItem = await workGraph.createItem(
       { title: formatItemTitle(item) },
-      { providerId: item.providerId, externalId: item.externalId, url: item.url, ...(group ? { group } : {}) },
+      { providerId: item.providerId, externalId: item.externalId, url: item.url, group: group || undefined },
     );
   } catch (err: unknown) {
     handleCommandError('Failed to accept inbox item', err);
@@ -514,7 +514,7 @@ async function acceptToFocusSingleInboxItem(
     try {
       createdItem = await workGraph.createItem(
         { title: formatItemTitle(item) },
-        { providerId: item.providerId, externalId: item.externalId, url: item.url, ...(group ? { group } : {}) },
+        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: group || undefined },
       );
     } catch (err: unknown) {
       handleCommandError('Failed to accept inbox item to Focus', err);
@@ -574,7 +574,7 @@ async function batchAcceptToFocusItems(
     try {
       const createdItem = await workGraph.createItem(
         { title: formatItemTitle(item) },
-        { providerId: item.providerId, externalId: item.externalId, url: item.url, ...(group ? { group } : {}) },
+        { providerId: item.providerId, externalId: item.externalId, url: item.url, group: group || undefined },
       );
       createdIds.push(createdItem.id);
       allIds.push(createdItem.id);
@@ -728,7 +728,7 @@ async function acceptSingleSourceItem(
   try {
     createdItem = await workGraph.createItem(
       { title: formatItemTitle(item) },
-      { providerId: item.providerId, externalId: item.externalId, url: item.url, ...(group ? { group } : {}) },
+      { providerId: item.providerId, externalId: item.externalId, url: item.url, group: group || undefined },
     );
   } catch (err: unknown) {
     handleCommandError('Failed to accept sources item', err);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -632,7 +632,7 @@ async function batchAcceptToFocusItems(
       parts.push(`Accepted ${succeeded} item${succeeded === 1 ? '' : 's'} to Focus`);
     }
     if (skipped > 0) {
-      parts.push(`${skipped} already in Focus or cannot be moved`);
+      parts.push(`${skipped} item${skipped === 1 ? '' : 's'} already in Focus or cannot be moved`);
     }
     const msg = (failed > 0 || transitionFailed > 0)
       ? `${parts.join('; ')} (${failed + transitionFailed} failed)`

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -481,14 +481,20 @@ async function acceptToFocusSingleInboxItem(
     if (existing.state === WorkItemState.InProgress) {
       try {
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
-      } catch { /* best-effort */ }
+      } catch (err: unknown) {
+        handleCommandError('Failed to update state for existing in-progress item', err);
+        return;
+      }
       void vscode.window.showInformationMessage('WorkCenter: Item is already in Focus');
       return;
     }
     if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
       try {
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
-      } catch { /* best-effort */ }
+      } catch (err: unknown) {
+        handleCommandError('Failed to update state for existing completed item', err);
+        return;
+      }
       void vscode.window.showWarningMessage(
         `WorkCenter: Item is ${existing.state} and cannot be moved to Focus`,
       );

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -478,7 +478,7 @@ async function acceptToFocusSingleInboxItem(
   let workItemId: string;
   const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
   if (existing) {
-    if (existing.state === WorkItemState.InProgress) {
+    if (existing.state === WorkItemState.InProgress || existing.state === WorkItemState.Paused) {
       try {
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -1183,7 +1183,7 @@ describe('registerCommands', () => {
       await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
 
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-        'WorkCenter: Failed to update state for existing in-progress item — state error',
+        'WorkCenter: Failed to update state for existing focus item — state error',
       );
       expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
       expect(workGraph.transitionState).not.toHaveBeenCalled();

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -1085,6 +1085,137 @@ describe('registerCommands', () => {
       expect(stateStore.setState).not.toHaveBeenCalled();
       expect(workGraph.transitionState).not.toHaveBeenCalled();
     });
+
+    // ── failure / rollback paths ──────────────────────────────────────
+
+    it('surfaces error and makes no state changes when createItem throws', async () => {
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem.mockRejectedValue(new Error('disk full'));
+
+      await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
+
+      expect(stateStore.setState).not.toHaveBeenCalled();
+      expect(workGraph.transitionState).not.toHaveBeenCalled();
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to accept inbox item — disk full',
+      );
+    });
+
+    it('rolls back created item via deleteItem when setState fails after createItem', async () => {
+      const created = createWorkItem({ id: 'wc-rollback' });
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem.mockResolvedValue(created);
+      stateStore.setState.mockRejectedValue(new Error('state write failed'));
+
+      await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
+
+      expect(workGraph.deleteItem).toHaveBeenCalledWith('wc-rollback');
+      expect(workGraph.transitionState).not.toHaveBeenCalled();
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to update state after accepting item — state write failed',
+      );
+    });
+
+    it('logs rollback failure but still surfaces original setState error', async () => {
+      const created = createWorkItem({ id: 'wc-rollback-fail' });
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem.mockResolvedValue(created);
+      stateStore.setState.mockRejectedValue(new Error('state write failed'));
+      workGraph.deleteItem.mockRejectedValue(new Error('delete also failed'));
+
+      await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
+
+      expect(workGraph.deleteItem).toHaveBeenCalledWith('wc-rollback-fail');
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to roll back created item after setState failure',
+        expect.any(Error),
+      );
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to update state after accepting item — state write failed',
+      );
+    });
+
+    it('surfaces error when transitionState fails for a new item', async () => {
+      const created = createWorkItem({ id: 'wc-trans-fail' });
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem.mockResolvedValue(created);
+      workGraph.transitionState.mockRejectedValue(new Error('bad transition'));
+
+      await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
+
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to move item to Focus — bad transition',
+      );
+    });
+
+    it('surfaces error when transitionState fails for an existing New item', async () => {
+      const existing = createWorkItem({ id: 'wc-exist-trans', state: WorkItemState.New });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+      workGraph.transitionState.mockRejectedValue(new Error('transition error'));
+
+      await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
+
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to move item to Focus — transition error',
+      );
+    });
+
+    it('returns early with error when setState fails for InProgress item', async () => {
+      const existing = createWorkItem({ id: 'wc-ip', state: WorkItemState.InProgress });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+      stateStore.setState.mockRejectedValue(new Error('state error'));
+
+      await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to update state for existing in-progress item — state error',
+      );
+      expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+      expect(workGraph.transitionState).not.toHaveBeenCalled();
+    });
+
+    it('returns early with error when setState fails for Done item', async () => {
+      const existing = createWorkItem({ id: 'wc-done-err', state: WorkItemState.Done });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+      stateStore.setState.mockRejectedValue(new Error('state error'));
+
+      await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to update state for existing completed item — state error',
+      );
+      expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+      expect(workGraph.transitionState).not.toHaveBeenCalled();
+    });
+
+    it('returns early with error when setState fails for Archived item', async () => {
+      const existing = createWorkItem({ id: 'wc-arch-err', state: WorkItemState.Archived });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+      stateStore.setState.mockRejectedValue(new Error('state error'));
+
+      await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to update state for existing completed item — state error',
+      );
+      expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+      expect(workGraph.transitionState).not.toHaveBeenCalled();
+    });
+
+    it('returns early with error when setState fails for existing New item', async () => {
+      const existing = createWorkItem({ id: 'wc-new-err', state: WorkItemState.New });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+      stateStore.setState.mockRejectedValue(new Error('state error'));
+
+      await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to update state for existing accepted item — state error',
+      );
+      expect(workGraph.transitionState).not.toHaveBeenCalled();
+    });
   });
 
   // ── batch acceptToFocusFromInbox (multi-select) ───────────────────

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -908,10 +908,9 @@ describe('registerCommands', () => {
 
       await invoke('workcenter.acceptFromInbox', items[0], items);
 
-      expect(workGraph.createItem).toHaveBeenCalledWith(
-        { title: 'Whitespace' },
-        expect.not.objectContaining({ group: expect.anything() }),
-      );
+      expect(workGraph.createItem).toHaveBeenCalledTimes(1);
+      const provenance = workGraph.createItem.mock.calls[0][1];
+      expect(provenance).not.toHaveProperty('group');
     });
   });
 

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -179,6 +179,7 @@ describe('registerCommands', () => {
       'workcenter.focusMoveDown',
       'workcenter.moveToQueue',
       'workcenter.acceptFromInbox',
+      'workcenter.acceptToFocusFromInbox',
       'workcenter.dismissFromInbox',
       'workcenter.acceptFromSources',
       'workcenter.dismissFromSources',
@@ -1006,6 +1007,212 @@ describe('registerCommands', () => {
 
       expect(workGraph.transitionState).toHaveBeenCalledWith('wc-ctx', WorkItemState.InProgress);
       expect(workGraph.transitionState).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── acceptToFocusFromInbox (single item) ───────────────────────────
+
+  describe('workcenter.acceptToFocusFromInbox', () => {
+    it('creates WorkItem, sets state to accepted, and transitions to InProgress for a new item', async () => {
+      const inboxItem = makeInboxItem();
+      const created = createWorkItem({ id: 'wc-new-1' });
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem.mockResolvedValue(created);
+
+      await invoke('workcenter.acceptToFocusFromInbox', inboxItem);
+
+      expect(workGraph.createItem).toHaveBeenCalledWith(
+        { title: 'Inbox Issue' },
+        { providerId: 'github', externalId: 'ext-1', url: 'https://github.com/org/repo/issues/1' },
+      );
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-new-1', WorkItemState.InProgress);
+    });
+
+    it('sets state to accepted and transitions existing New item to InProgress', async () => {
+      const existing = createWorkItem({ id: 'wc-exist', state: WorkItemState.New });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+
+      await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
+
+      expect(workGraph.createItem).not.toHaveBeenCalled();
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-exist', WorkItemState.InProgress);
+    });
+
+    it('shows info message and does not transition when item is already InProgress', async () => {
+      const existing = createWorkItem({ id: 'wc-focus', state: WorkItemState.InProgress });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+
+      await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
+
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'WorkCenter: Item is already in Focus',
+      );
+      expect(workGraph.transitionState).not.toHaveBeenCalled();
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
+    });
+
+    it('shows warning and does not transition when item is Done', async () => {
+      const existing = createWorkItem({ id: 'wc-done', state: WorkItemState.Done });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+
+      await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
+
+      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+        'WorkCenter: Item is Done and cannot be moved to Focus',
+      );
+      expect(workGraph.transitionState).not.toHaveBeenCalled();
+    });
+
+    it('shows warning and does not transition when item is Archived', async () => {
+      const existing = createWorkItem({ id: 'wc-arch', state: WorkItemState.Archived });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+
+      await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
+
+      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+        'WorkCenter: Item is Archived and cannot be moved to Focus',
+      );
+      expect(workGraph.transitionState).not.toHaveBeenCalled();
+    });
+
+    it('returns early with no errors for empty selection', async () => {
+      await invoke('workcenter.acceptToFocusFromInbox', undefined);
+
+      expect(workGraph.findItemByProvenance).not.toHaveBeenCalled();
+      expect(workGraph.createItem).not.toHaveBeenCalled();
+      expect(stateStore.setState).not.toHaveBeenCalled();
+      expect(workGraph.transitionState).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── batch acceptToFocusFromInbox (multi-select) ───────────────────
+
+  describe('workcenter.acceptToFocusFromInbox (multi-select)', () => {
+    it('batch-accepts items: creates, sets states, and transitions all to InProgress', async () => {
+      const items = [
+        makeInboxItem({ externalId: 'ext-1', title: 'Issue 1' }),
+        makeInboxItem({ externalId: 'ext-2', title: 'Issue 2' }),
+      ];
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem
+        .mockResolvedValueOnce(createWorkItem({ id: 'wc-1' }))
+        .mockResolvedValueOnce(createWorkItem({ id: 'wc-2' }));
+
+      await invoke('workcenter.acceptToFocusFromInbox', items[0], items);
+
+      expect(workGraph.createItem).toHaveBeenCalledTimes(2);
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'github', externalId: 'ext-1', state: 'accepted' },
+        { providerId: 'github', externalId: 'ext-2', state: 'accepted' },
+      ]);
+      expect(workGraph.transitionState).toHaveBeenCalledTimes(2);
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-1', WorkItemState.InProgress);
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-2', WorkItemState.InProgress);
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'Accepted 2 items to Focus',
+      );
+    });
+
+    it('continues processing when some createItem calls fail', async () => {
+      const items = [
+        makeInboxItem({ externalId: 'ext-1', title: 'Issue 1' }),
+        makeInboxItem({ externalId: 'ext-2', title: 'Issue 2' }),
+        makeInboxItem({ externalId: 'ext-3', title: 'Issue 3' }),
+      ];
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem
+        .mockResolvedValueOnce(createWorkItem({ id: 'wc-1' }))
+        .mockRejectedValueOnce(new Error('create failed'))
+        .mockResolvedValueOnce(createWorkItem({ id: 'wc-3' }));
+
+      await invoke('workcenter.acceptToFocusFromInbox', items[0], items);
+
+      expect(workGraph.createItem).toHaveBeenCalledTimes(3);
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'github', externalId: 'ext-1', state: 'accepted' },
+        { providerId: 'github', externalId: 'ext-3', state: 'accepted' },
+      ]);
+      expect(workGraph.transitionState).toHaveBeenCalledTimes(2);
+      expect(logger.error).toHaveBeenCalledWith(
+        'Failed to accept inbox item to Focus "Issue 2"',
+        expect.any(Error),
+      );
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to process 1 item(s); see Output for details',
+      );
+    });
+
+    it('rolls back createdIds when batch setStates fails', async () => {
+      const items = [
+        makeInboxItem({ externalId: 'ext-1', title: 'Issue 1' }),
+        makeInboxItem({ externalId: 'ext-2', title: 'Issue 2' }),
+      ];
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem
+        .mockResolvedValueOnce(createWorkItem({ id: 'wc-1' }))
+        .mockResolvedValueOnce(createWorkItem({ id: 'wc-2' }));
+      stateStore.setStates.mockRejectedValue(new Error('disk full'));
+
+      await invoke('workcenter.acceptToFocusFromInbox', items[0], items);
+
+      expect(workGraph.deleteItem).toHaveBeenCalledWith('wc-1');
+      expect(workGraph.deleteItem).toHaveBeenCalledWith('wc-2');
+      expect(workGraph.transitionState).not.toHaveBeenCalled();
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to update states after accepting items — disk full',
+      );
+    });
+
+    it('shows correct counts when some transitions fail', async () => {
+      const items = [
+        makeInboxItem({ externalId: 'ext-1', title: 'Issue 1' }),
+        makeInboxItem({ externalId: 'ext-2', title: 'Issue 2' }),
+        makeInboxItem({ externalId: 'ext-3', title: 'Issue 3' }),
+      ];
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem
+        .mockResolvedValueOnce(createWorkItem({ id: 'wc-1' }))
+        .mockResolvedValueOnce(createWorkItem({ id: 'wc-2' }))
+        .mockResolvedValueOnce(createWorkItem({ id: 'wc-3' }));
+      workGraph.transitionState
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('bad state'))
+        .mockResolvedValueOnce(undefined);
+
+      await invoke('workcenter.acceptToFocusFromInbox', items[0], items);
+
+      expect(workGraph.transitionState).toHaveBeenCalledTimes(3);
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'Accepted 2 items to Focus (1 failed)',
+      );
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to process 1 item(s); see Output for details',
+      );
+    });
+
+    it('skips existing items in non-transitionable states', async () => {
+      const items = [
+        makeInboxItem({ externalId: 'ext-1', title: 'Issue 1' }),
+        makeInboxItem({ externalId: 'ext-2', title: 'Issue 2' }),
+        makeInboxItem({ externalId: 'ext-3', title: 'Issue 3' }),
+      ];
+      workGraph.findItemByProvenance
+        .mockReturnValueOnce(createWorkItem({ id: 'wc-1', state: WorkItemState.InProgress }))
+        .mockReturnValueOnce(createWorkItem({ id: 'wc-2', state: WorkItemState.Done }))
+        .mockReturnValueOnce(undefined);
+      workGraph.createItem.mockResolvedValueOnce(createWorkItem({ id: 'wc-3' }));
+
+      await invoke('workcenter.acceptToFocusFromInbox', items[0], items);
+
+      expect(workGraph.createItem).toHaveBeenCalledTimes(1);
+      // Only wc-3 should be transitioned; wc-1 (InProgress) and wc-2 (Done) are skipped
+      expect(workGraph.transitionState).toHaveBeenCalledTimes(1);
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-3', WorkItemState.InProgress);
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'Accepted 1 item to Focus; 2 already in Focus or cannot be moved',
+      );
     });
   });
 

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -910,7 +910,7 @@ describe('registerCommands', () => {
 
       expect(workGraph.createItem).toHaveBeenCalledWith(
         { title: 'Whitespace' },
-        expect.objectContaining({ group: undefined }),
+        expect.not.objectContaining({ group: expect.anything() }),
       );
     });
   });

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -1053,6 +1053,19 @@ describe('registerCommands', () => {
       expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
     });
 
+    it('shows info message and does not transition when item is Paused', async () => {
+      const existing = createWorkItem({ id: 'wc-paused', state: WorkItemState.Paused });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+
+      await invoke('workcenter.acceptToFocusFromInbox', makeInboxItem());
+
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'WorkCenter: Item is already in Focus',
+      );
+      expect(workGraph.transitionState).not.toHaveBeenCalled();
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
+    });
+
     it('shows warning and does not transition when item is Done', async () => {
       const existing = createWorkItem({ id: 'wc-done', state: WorkItemState.Done });
       workGraph.findItemByProvenance.mockReturnValue(existing);

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -1110,7 +1110,7 @@ describe('registerCommands', () => {
       expect(stateStore.setState).not.toHaveBeenCalled();
       expect(workGraph.transitionState).not.toHaveBeenCalled();
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-        'WorkCenter: Failed to accept inbox item — disk full',
+        'WorkCenter: Failed to accept inbox item to Focus — disk full',
       );
     });
 

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -1389,7 +1389,7 @@ describe('registerCommands', () => {
       expect(workGraph.transitionState).toHaveBeenCalledTimes(1);
       expect(workGraph.transitionState).toHaveBeenCalledWith('wc-3', WorkItemState.InProgress);
       expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
-        'Accepted 1 item to Focus; 2 already in Focus or cannot be moved',
+        'Accepted 1 item to Focus; 2 items already in Focus or cannot be moved',
       );
     });
   });


### PR DESCRIPTION
## Summary
Adds an "Accept to Focus" action on Inbox items that combines accepting a discovered item and transitioning it directly to `InProgress` state, bypassing Queue entirely. Closes #249.

## What changed

### `packages/core/src/commands/commands.ts`
- `acceptToFocusSingleInboxItem()` — accepts a single inbox item (creates WorkItem + sets state to `accepted`) then transitions to `InProgress`. Includes full rollback if `setState` fails.
- `batchAcceptToFocusItems()` — batch version for multi-select: creates WorkItems, sets states, then transitions all to `InProgress`. Continues on individual failures and shows a summary.
- `handleAcceptToFocusFromInbox()` — entry point that resolves inbox items from VS Code selection args, dispatches to single or batch path.
- Registered as `workcenter.acceptToFocusFromInbox` command.

### `packages/core/package.json`
- New command definition: `workcenter.acceptToFocusFromInbox` ("Accept to Focus", rocket icon)
- Context menu entry in `1_actions` group (no inline button — intentional design choice to keep the inline button row uncluttered)

## Testing
- All 927 core tests pass
- Full build succeeds across all packages
