### PR TITLE
Add keyboard shortcuts with Ctrl+Alt+D chord prefix

### DIFF
--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -201,7 +201,7 @@ Registers an **AI Code Review** action that can be run on any work item whose UR
 
 ## Keyboard Shortcuts
 
-DevDocket provides chorded keyboard shortcuts using the **Ctrl+Alt+D** prefix. All shortcuts are scoped to DevDocket views — they only activate when a DevDocket view has focus.
+WorkCenter provides chorded keyboard shortcuts using the **Ctrl+Alt+D** prefix. All shortcuts are scoped to WorkCenter views — they only activate when a WorkCenter view has focus.
 
 To use a shortcut, press **Ctrl+Alt+D**, release, then press the second key.
 

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -198,3 +198,19 @@ Registers an **AI Code Review** action that can be run on any work item whose UR
 |---------|------|---------|-------------|
 | `workcenter.logLevel` | `string` | `"info"` | Log level for the WorkCenter output channel. Valid values: `debug`, `info`, `warn`, `error`. |
 | `workcenter.showInboxNotifications` | `boolean` | `true` | Show a notification when new items arrive in the Inbox. |
+
+## Keyboard Shortcuts
+
+DevDocket provides chorded keyboard shortcuts using the **Ctrl+Alt+D** prefix. All shortcuts are scoped to DevDocket views — they only activate when a DevDocket view has focus.
+
+To use a shortcut, press **Ctrl+Alt+D**, release, then press the second key.
+
+| Shortcut | Action | Description |
+|----------|--------|-------------|
+| `Ctrl+Alt+D`, `N` | Create Work Item | Opens the input box to create a new item in the Queue |
+| `Ctrl+Alt+D`, `D` | Complete Item | Marks the focused item as **Done** and moves it to History |
+| `Ctrl+Alt+D`, `P` | Pause Item | Pauses an active (in progress) item in Focus |
+| `Ctrl+Alt+D`, `U` | Resume Item | Resumes a paused item in Focus |
+| `Ctrl+Alt+D`, `F` | Accept to Focus | Accepts an Inbox item directly to Focus (skipping Queue) |
+| `Ctrl+Alt+D`, `Q` | Move to Queue | Moves an item to the Queue |
+| `Ctrl+Alt+D`, `R` | Refresh | Refreshes all provider data |

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -211,6 +211,6 @@ To use a shortcut, press **Ctrl+Alt+D**, release, then press the second key.
 | `Ctrl+Alt+D`, `D` | Complete Item | Marks the focused item as **Done** and moves it to History |
 | `Ctrl+Alt+D`, `P` | Pause Item | Pauses an active (in progress) item in Focus |
 | `Ctrl+Alt+D`, `U` | Resume Item | Resumes a paused item in Focus |
-| `Ctrl+Alt+D`, `F` | Accept to Focus | Accepts an Inbox item directly to Focus (skipping Queue) |
+| `Ctrl+Alt+D`, `F` | Move to Focus | Moves the selected work item to Focus (**In Progress**) |
 | `Ctrl+Alt+D`, `Q` | Move to Queue | Moves an item to the Queue |
 | `Ctrl+Alt+D`, `R` | Refresh | Refreshes all provider data |

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -555,37 +555,37 @@
     "keybindings": [
       {
         "command": "workcenter.createItem",
-        "key": "ctrl+alt+w n",
+        "key": "ctrl+alt+d n",
         "when": "focusedView =~ /workcenter/"
       },
       {
         "command": "workcenter.completeItem",
-        "key": "ctrl+alt+w d",
+        "key": "ctrl+alt+d d",
         "when": "focusedView =~ /workcenter/"
       },
       {
         "command": "workcenter.pauseItem",
-        "key": "ctrl+alt+w p",
+        "key": "ctrl+alt+d p",
         "when": "focusedView =~ /workcenter/"
       },
       {
         "command": "workcenter.resumeItem",
-        "key": "ctrl+alt+w u",
+        "key": "ctrl+alt+d u",
         "when": "focusedView =~ /workcenter/"
       },
       {
         "command": "workcenter.acceptToFocus",
-        "key": "ctrl+alt+w f",
+        "key": "ctrl+alt+d f",
         "when": "focusedView =~ /workcenter/"
       },
       {
         "command": "workcenter.moveToQueue",
-        "key": "ctrl+alt+w q",
+        "key": "ctrl+alt+d q",
         "when": "focusedView =~ /workcenter/"
       },
       {
         "command": "workcenter.refresh",
-        "key": "ctrl+alt+w r",
+        "key": "ctrl+alt+d r",
         "when": "focusedView =~ /workcenter/"
       }
     ]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -551,7 +551,44 @@
           "group": "1_actions"
         }
       ]
-    }
+    },
+    "keybindings": [
+      {
+        "command": "workcenter.createItem",
+        "key": "ctrl+alt+w n",
+        "when": "focusedView =~ /workcenter/"
+      },
+      {
+        "command": "workcenter.completeItem",
+        "key": "ctrl+alt+w d",
+        "when": "focusedView =~ /workcenter/"
+      },
+      {
+        "command": "workcenter.pauseItem",
+        "key": "ctrl+alt+w p",
+        "when": "focusedView =~ /workcenter/"
+      },
+      {
+        "command": "workcenter.resumeItem",
+        "key": "ctrl+alt+w u",
+        "when": "focusedView =~ /workcenter/"
+      },
+      {
+        "command": "workcenter.acceptToFocus",
+        "key": "ctrl+alt+w f",
+        "when": "focusedView =~ /workcenter/"
+      },
+      {
+        "command": "workcenter.moveToQueue",
+        "key": "ctrl+alt+w q",
+        "when": "focusedView =~ /workcenter/"
+      },
+      {
+        "command": "workcenter.refresh",
+        "key": "ctrl+alt+w r",
+        "when": "focusedView =~ /workcenter/"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run build:prod",


### PR DESCRIPTION
## Summary

Adds keyboard shortcuts for common DevDocket actions, using a chorded keybinding prefix of `Ctrl+Alt+D` (D for DevDocket). Also includes UX guide documentation for the new shortcuts.

Closes #226

## Keyboard Shortcuts

All shortcuts use a two-key chord starting with `Ctrl+Alt+D`, followed by a mnemonic letter. They are active when any WorkCenter view has focus (`focusedView =~ /workcenter/`).

| Shortcut | Command | Description |
|---|---|---|
| `Ctrl+Alt+D`, `N` | `workcenter.createItem` | Create a **N**ew work item |
| `Ctrl+Alt+D`, `D` | `workcenter.completeItem` | Mark item as **D**one |
| `Ctrl+Alt+D`, `P` | `workcenter.pauseItem` | **P**ause the current item |
| `Ctrl+Alt+D`, `U` | `workcenter.resumeItem` | Res**u**me a paused item |
| `Ctrl+Alt+D`, `F` | `workcenter.acceptToFocus` | Move selected item to **F**ocus (In Progress) |
| `Ctrl+Alt+D`, `Q` | `workcenter.moveToQueue` | Move item to **Q**ueue |
| `Ctrl+Alt+D`, `R` | `workcenter.refresh` | **R**efresh all views |

## Chord Prefix Change

The chord prefix was originally `Ctrl+Alt+W` (W for WorkCenter) but has been updated to `Ctrl+Alt+D` (D for DevDocket) to align with the DevDocket rebrand.

## UX Guide Documentation

Added a new "Keyboard Shortcuts" section to `docs/ux-guide.md` documenting all chorded keybindings, their actions, and usage instructions.
