### PR TITLE
Add un-dismiss action for dismissed items in Sources view

### DIFF
--- a/.squad/decisions/inbox/fenster-218-actions.md
+++ b/.squad/decisions/inbox/fenster-218-actions.md
@@ -1,0 +1,24 @@
+# Decision: Editor State Transitions Use Duplicated Transition Map
+
+**Author:** Fenster (Extension Dev)
+**Date:** 2026-04-14
+**Issue:** #218
+
+## Context
+
+The work item state machine (`VALID_TRANSITIONS`) lives in `workGraph.ts`. The editor panel HTML needs to know which transitions are valid to render buttons. The HTML module (`editorPanelHtml.ts`) is a pure function that generates a string — it doesn't have access to `WorkGraph`.
+
+## Decision
+
+Duplicated the transition-to-button mapping as `getTransitionActions()` in `editorPanelHtml.ts` rather than importing or sharing the `VALID_TRANSITIONS` map. The function returns labeled, styled button definitions per state.
+
+## Rationale
+
+- `editorPanelHtml.ts` is a pure HTML generator with no service dependencies — importing `WorkGraph` would break that boundary
+- The button labels (Start, Resume, Complete, etc.) and primary/secondary styling are UI concerns that don't belong in the state machine
+- The state machine rarely changes; if it does, the HTML tests will catch mismatches since they assert specific buttons per state
+- Exporting `getTransitionActions()` makes it independently testable
+
+## Risk
+
+If new states or transitions are added to `VALID_TRANSITIONS` but not mirrored in `getTransitionActions()`, the editor will be missing buttons. Mitigated by the test suite which covers all states.

--- a/.squad/decisions/inbox/fenster-228-undismiss.md
+++ b/.squad/decisions/inbox/fenster-228-undismiss.md
@@ -1,0 +1,33 @@
+# Un-dismiss Items from Sources (Issue #228)
+
+**Author:** Fenster (Extension Dev)
+**Date:** 2025-07-24
+**Status:** Proposed (PR #262)
+
+## Decision
+
+Added a "Restore to Inbox" action on dismissed items in the Sources view. The action resets inbox state from `dismissed` → `unseen`, causing the item to reappear in Inbox.
+
+## Context
+
+Once a user dismissed an item from Inbox, it was gone forever. The item was visible in Sources with a "dismissed" label but had no recovery action. Accidental dismisses had no undo path.
+
+## Approach
+
+Used composite `contextValue` strings to encode the dismissed state directly into the tree item's context, enabling VS Code's `when`-clause regex matching to conditionally show/hide actions:
+
+- Non-dismissed: `sourceItem` or `sourceItem.hasUrl` → shows Accept + Dismiss
+- Dismissed: `sourceItem.dismissed` or `sourceItem.hasUrl.dismissed` → shows only Restore to Inbox
+
+This avoids needing a separate VS Code context key and keeps the logic self-contained in the tree provider.
+
+## Alternatives Considered
+
+1. **VS Code context key per item** — Would require setting/clearing context keys dynamically as items change state. More complex, no real benefit for a single boolean flag.
+2. **Separate "Dismissed" view** — Overkill for the recovery use case; Sources already shows dismissed items with labels.
+
+## Impact
+
+- No API surface changes (contextValue is internal to the tree provider)
+- Existing tests unaffected — default mock state is `undefined` (unseen), so contextValue tests still pass
+- Follows existing single/batch handler pattern from dismiss command

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -534,17 +534,17 @@
         },
         {
           "command": "workcenter.acceptFromSources",
-          "when": "view == workcenter.sources && viewItem =~ /sourceItem/ && viewItem =~ /^((?!dismissed).)*$/",
+          "when": "view == workcenter.sources && viewItem =~ /^sourceItem(\\.hasUrl)?$/",
           "group": "inline"
         },
         {
           "command": "workcenter.dismissFromSources",
-          "when": "view == workcenter.sources && viewItem =~ /sourceItem/ && viewItem =~ /^((?!dismissed).)*$/",
+          "when": "view == workcenter.sources && viewItem =~ /^sourceItem(\\.hasUrl)?$/",
           "group": "inline"
         },
         {
           "command": "workcenter.dismissFromSources",
-          "when": "view == workcenter.sources && viewItem =~ /sourceItem/ && viewItem =~ /^((?!dismissed).)*$/",
+          "when": "view == workcenter.sources && viewItem =~ /^sourceItem(\\.hasUrl)?$/",
           "group": "1_actions"
         },
         {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,6 +19,7 @@
     "onView:workcenter.history",
     "onCommand:workcenter.refresh",
     "onCommand:workcenter.dismissFromSources",
+    "onCommand:workcenter.undismissFromSources",
     "onCommand:workcenter.deleteItem"
   ],
   "main": "./dist/extension.js",
@@ -296,6 +297,12 @@
         "icon": "$(close)"
       },
       {
+        "command": "workcenter.undismissFromSources",
+        "title": "Restore to Inbox",
+        "category": "WorkCenter",
+        "icon": "$(inbox)"
+      },
+      {
         "command": "workcenter.deleteItem",
         "title": "Delete",
         "category": "WorkCenter",
@@ -527,17 +534,27 @@
         },
         {
           "command": "workcenter.acceptFromSources",
-          "when": "view == workcenter.sources && viewItem =~ /sourceItem/",
+          "when": "view == workcenter.sources && viewItem =~ /sourceItem/ && viewItem =~ /^((?!dismissed).)*$/",
           "group": "inline"
         },
         {
           "command": "workcenter.dismissFromSources",
-          "when": "view == workcenter.sources && viewItem =~ /sourceItem/",
+          "when": "view == workcenter.sources && viewItem =~ /sourceItem/ && viewItem =~ /^((?!dismissed).)*$/",
           "group": "inline"
         },
         {
           "command": "workcenter.dismissFromSources",
-          "when": "view == workcenter.sources && viewItem =~ /sourceItem/",
+          "when": "view == workcenter.sources && viewItem =~ /sourceItem/ && viewItem =~ /^((?!dismissed).)*$/",
+          "group": "1_actions"
+        },
+        {
+          "command": "workcenter.undismissFromSources",
+          "when": "view == workcenter.sources && viewItem =~ /sourceItem/ && viewItem =~ /dismissed/",
+          "group": "inline"
+        },
+        {
+          "command": "workcenter.undismissFromSources",
+          "when": "view == workcenter.sources && viewItem =~ /sourceItem/ && viewItem =~ /dismissed/",
           "group": "1_actions"
         },
         {

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -622,7 +622,7 @@ async function handleUndismissFromSources(
     await stateStore.setStates(
       dismissedItems.map(i => ({ providerId: i.providerId, externalId: i.externalId, state: 'unseen' as const }))
     );
-    void vscode.window.showInformationMessage(`Restored ${dismissedItems.length} items to inbox`);
+    void vscode.window.showInformationMessage(`Restored ${dismissedItems.length} items to Inbox`);
   } catch (err: unknown) {
     handleCommandError('Failed to restore items to Inbox', err);
   }
@@ -705,7 +705,7 @@ export function registerCommands(
       wrapCommand('Failed to switch sources layout', () => setViewLayout('sources', 'flat'))),
     // Backward-compatible aliases for old toggle commands (preserves existing keybindings)
     vscode.commands.registerCommand('workcenter.toggleInboxLayout',
-      wrapCommand('Failed to switch Inbox layout', () => toggleViewLayout('inbox'))),
+      wrapCommand('Failed to switch inbox layout', () => toggleViewLayout('inbox'))),
     vscode.commands.registerCommand('workcenter.toggleQueueLayout',
       wrapCommand('Failed to switch queue layout', () => toggleViewLayout('queue'))),
     vscode.commands.registerCommand('workcenter.toggleFocusLayout',

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -682,7 +682,7 @@ export function registerCommands(
     vscode.commands.registerCommand('workcenter.dismissFromSources',
       wrapCommand('Failed to dismiss from sources', (item: SourcesElement, selectedItems?: SourcesElement[]) => handleDismissFromSources(stateStore, item, selectedItems))),
     vscode.commands.registerCommand('workcenter.undismissFromSources',
-      wrapCommand('Failed to un-dismiss from sources', (item: SourcesElement, selectedItems?: SourcesElement[]) => handleUndismissFromSources(stateStore, item, selectedItems))),
+      wrapCommand('Failed to restore from sources', (item: SourcesElement, selectedItems?: SourcesElement[]) => handleUndismissFromSources(stateStore, item, selectedItems))),
     vscode.commands.registerCommand('workcenter.switchInboxToTree',
       wrapCommand('Failed to switch inbox layout', () => setViewLayout('inbox', 'tree'))),
     vscode.commands.registerCommand('workcenter.switchInboxToFlat',
@@ -705,7 +705,7 @@ export function registerCommands(
       wrapCommand('Failed to switch sources layout', () => setViewLayout('sources', 'flat'))),
     // Backward-compatible aliases for old toggle commands (preserves existing keybindings)
     vscode.commands.registerCommand('workcenter.toggleInboxLayout',
-      wrapCommand('Failed to switch inbox layout', () => toggleViewLayout('inbox'))),
+      wrapCommand('Failed to switch Inbox layout', () => toggleViewLayout('inbox'))),
     vscode.commands.registerCommand('workcenter.toggleQueueLayout',
       wrapCommand('Failed to switch queue layout', () => toggleViewLayout('queue'))),
     vscode.commands.registerCommand('workcenter.toggleFocusLayout',

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -603,10 +603,14 @@ async function handleUndismissFromSources(
   const items = resolveSourceItems(item, selectedItems);
   if (items.length === 0) { return; }
 
-  if (items.length === 1) {
+  // Filter to only items that are currently dismissed
+  const dismissedItems = items.filter(i => stateStore.getState(i.providerId, i.externalId) === 'dismissed');
+  if (dismissedItems.length === 0) { return; }
+
+  if (dismissedItems.length === 1) {
     try {
-      logger.info(`Restoring source item to inbox: ${items[0].externalId}`);
-      await stateStore.setState(items[0].providerId, items[0].externalId, 'unseen');
+      logger.info(`Restoring source item to inbox: ${dismissedItems[0].externalId}`);
+      await stateStore.setState(dismissedItems[0].providerId, dismissedItems[0].externalId, 'unseen');
     } catch (err: unknown) {
       handleCommandError('Failed to restore item to Inbox', err);
     }
@@ -614,11 +618,11 @@ async function handleUndismissFromSources(
   }
 
   try {
-    logger.info(`Batch restoring ${items.length} source items to inbox`);
+    logger.info(`Batch restoring ${dismissedItems.length} source items to inbox`);
     await stateStore.setStates(
-      items.map(i => ({ providerId: i.providerId, externalId: i.externalId, state: 'unseen' as const }))
+      dismissedItems.map(i => ({ providerId: i.providerId, externalId: i.externalId, state: 'unseen' as const }))
     );
-    void vscode.window.showInformationMessage(`Restored ${items.length} items to inbox`);
+    void vscode.window.showInformationMessage(`Restored ${dismissedItems.length} items to inbox`);
   } catch (err: unknown) {
     handleCommandError('Failed to restore items to Inbox', err);
   }

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -605,22 +605,22 @@ async function handleUndismissFromSources(
 
   if (items.length === 1) {
     try {
-      logger.info(`Un-dismissing source item: ${items[0].externalId}`);
+      logger.info(`Restoring source item to inbox: ${items[0].externalId}`);
       await stateStore.setState(items[0].providerId, items[0].externalId, 'unseen');
     } catch (err: unknown) {
-      handleCommandError('Failed to un-dismiss item', err);
+      handleCommandError('Failed to restore item to Inbox', err);
     }
     return;
   }
 
   try {
-    logger.info(`Batch un-dismissing ${items.length} source items`);
+    logger.info(`Batch restoring ${items.length} source items to inbox`);
     await stateStore.setStates(
       items.map(i => ({ providerId: i.providerId, externalId: i.externalId, state: 'unseen' as const }))
     );
     void vscode.window.showInformationMessage(`Restored ${items.length} items to inbox`);
   } catch (err: unknown) {
-    handleCommandError('Failed to un-dismiss items', err);
+    handleCommandError('Failed to restore items to Inbox', err);
   }
 }
 

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -595,6 +595,35 @@ async function handleDismissFromSources(
   }
 }
 
+async function handleUndismissFromSources(
+  stateStore: DiscoveredStateStore,
+  item?: SourcesElement,
+  selectedItems?: SourcesElement[],
+): Promise<void> {
+  const items = resolveSourceItems(item, selectedItems);
+  if (items.length === 0) { return; }
+
+  if (items.length === 1) {
+    try {
+      logger.info(`Un-dismissing source item: ${items[0].externalId}`);
+      await stateStore.setState(items[0].providerId, items[0].externalId, 'unseen');
+    } catch (err: unknown) {
+      handleCommandError('Failed to un-dismiss item', err);
+    }
+    return;
+  }
+
+  try {
+    logger.info(`Batch un-dismissing ${items.length} source items`);
+    await stateStore.setStates(
+      items.map(i => ({ providerId: i.providerId, externalId: i.externalId, state: 'unseen' as const }))
+    );
+    void vscode.window.showInformationMessage(`Restored ${items.length} items to inbox`);
+  } catch (err: unknown) {
+    handleCommandError('Failed to un-dismiss items', err);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Registration
 // ---------------------------------------------------------------------------
@@ -648,6 +677,8 @@ export function registerCommands(
       wrapCommand('Failed to accept from sources', (item: SourcesElement, selectedItems?: SourcesElement[]) => handleAcceptFromSources(workGraph, stateStore, item, selectedItems))),
     vscode.commands.registerCommand('workcenter.dismissFromSources',
       wrapCommand('Failed to dismiss from sources', (item: SourcesElement, selectedItems?: SourcesElement[]) => handleDismissFromSources(stateStore, item, selectedItems))),
+    vscode.commands.registerCommand('workcenter.undismissFromSources',
+      wrapCommand('Failed to un-dismiss from sources', (item: SourcesElement, selectedItems?: SourcesElement[]) => handleUndismissFromSources(stateStore, item, selectedItems))),
     vscode.commands.registerCommand('workcenter.switchInboxToTree',
       wrapCommand('Failed to switch inbox layout', () => setViewLayout('inbox', 'tree'))),
     vscode.commands.registerCommand('workcenter.switchInboxToFlat',

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -86,7 +86,7 @@ function createMockStateStore(): { [K in keyof UsedStateStoreMethods]: Mock } {
   return {
     setState: vi.fn(),
     setStates: vi.fn(),
-    getState: vi.fn().mockReturnValue('dismissed'),
+    getState: vi.fn(),
   };
 }
 
@@ -1429,6 +1429,10 @@ describe('registerCommands', () => {
   // ── undismissFromSources─────────────────────────────────────────
 
   describe('workcenter.undismissFromSources', () => {
+    beforeEach(() => {
+      stateStore.getState.mockReturnValue('dismissed');
+    });
+
     it('restores a single dismissed source item to inbox', async () => {
       await invoke('workcenter.undismissFromSources', makeSourceItem());
 

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -80,12 +80,13 @@ function createMockActionRegistry(): { [K in keyof UsedActionRegistryMethods]: M
   };
 }
 
-type UsedStateStoreMethods = Pick<DiscoveredStateStore, 'setState' | 'setStates'>;
+type UsedStateStoreMethods = Pick<DiscoveredStateStore, 'setState' | 'setStates' | 'getState'>;
 
 function createMockStateStore(): { [K in keyof UsedStateStoreMethods]: Mock } {
   return {
     setState: vi.fn(),
     setStates: vi.fn(),
+    getState: vi.fn().mockReturnValue('dismissed'),
   };
 }
 

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -1461,7 +1461,7 @@ describe('registerCommands', () => {
         { providerId: 'github', externalId: 'ext-1', state: 'unseen' },
         { providerId: 'github', externalId: 'ext-2', state: 'unseen' },
       ]);
-      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Restored 2 items to inbox');
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Restored 2 items to Inbox');
     });
 
     it('shows error when batch setStates fails', async () => {

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -182,6 +182,7 @@ describe('registerCommands', () => {
       'workcenter.dismissFromInbox',
       'workcenter.acceptFromSources',
       'workcenter.dismissFromSources',
+      'workcenter.undismissFromSources',
     ];
     for (const cmd of expected) {
       expect(commandHandlers.has(cmd), `missing command: ${cmd}`).toBe(true);
@@ -1420,6 +1421,95 @@ describe('registerCommands', () => {
       await invoke('workcenter.dismissFromSources', contextItem, [selectedItem]);
 
       expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-ctx', 'dismissed');
+      expect(stateStore.setStates).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── undismissFromSources─────────────────────────────────────────
+
+  describe('workcenter.undismissFromSources', () => {
+    it('restores a single dismissed source item to inbox', async () => {
+      await invoke('workcenter.undismissFromSources', makeSourceItem());
+
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-2', 'unseen');
+    });
+
+    it('shows error when single restore fails', async () => {
+      stateStore.setState.mockRejectedValue(new Error('io error'));
+
+      await invoke('workcenter.undismissFromSources', makeSourceItem());
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to restore item to Inbox — io error',
+      );
+    });
+
+    it('batch-restores multiple dismissed source items', async () => {
+      const items = [
+        makeSourceItem({ externalId: 'ext-1' }),
+        makeSourceItem({ externalId: 'ext-2' }),
+      ];
+
+      await invoke('workcenter.undismissFromSources', items[0], items);
+
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'github', externalId: 'ext-1', state: 'unseen' },
+        { providerId: 'github', externalId: 'ext-2', state: 'unseen' },
+      ]);
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Restored 2 items to inbox');
+    });
+
+    it('shows error when batch setStates fails', async () => {
+      const items = [
+        makeSourceItem({ externalId: 'ext-1' }),
+        makeSourceItem({ externalId: 'ext-2' }),
+      ];
+      stateStore.setStates.mockRejectedValue(new Error('io error'));
+
+      await invoke('workcenter.undismissFromSources', items[0], items);
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'WorkCenter: Failed to restore items to Inbox — io error',
+      );
+    });
+
+    it('uses single-item path when selectedItems has one item', async () => {
+      const item = makeSourceItem();
+
+      await invoke('workcenter.undismissFromSources', item, [item]);
+
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-2', 'unseen');
+      expect(stateStore.setStates).not.toHaveBeenCalled();
+    });
+
+    it('filters out non-item nodes from selectedItems', async () => {
+      const providerNode: SourceProviderNode = { kind: 'provider', providerId: 'github', label: 'GitHub' };
+      const groupNode: SourceGroupNode = { kind: 'group', providerId: 'github', groupName: 'org/repo' };
+      const sourceItem = makeSourceItem({ externalId: 'ext-1' });
+
+      await invoke('workcenter.undismissFromSources', providerNode, [providerNode, groupNode, sourceItem]);
+
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'unseen');
+      expect(stateStore.setStates).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when selectedItems contains only non-item nodes', async () => {
+      const providerNode: SourceProviderNode = { kind: 'provider', providerId: 'github', label: 'GitHub' };
+      const groupNode: SourceGroupNode = { kind: 'group', providerId: 'github', groupName: 'org/repo' };
+
+      await invoke('workcenter.undismissFromSources', providerNode, [providerNode, groupNode]);
+
+      expect(stateStore.setState).not.toHaveBeenCalled();
+      expect(stateStore.setStates).not.toHaveBeenCalled();
+    });
+
+    it('falls back to context item when it is not in the selection', async () => {
+      const contextItem = makeSourceItem({ externalId: 'ext-ctx' });
+      const selectedItem = makeSourceItem({ externalId: 'ext-other' });
+
+      await invoke('workcenter.undismissFromSources', contextItem, [selectedItem]);
+
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-ctx', 'unseen');
       expect(stateStore.setStates).not.toHaveBeenCalled();
     });
   });

--- a/packages/core/src/test/sourcesTreeProvider.test.ts
+++ b/packages/core/src/test/sourcesTreeProvider.test.ts
@@ -338,6 +338,24 @@ describe('SourcesTreeProvider', () => {
       const treeItem = provider.getTreeItem(node);
       expect(treeItem.contextValue).toBe('sourceItem');
     });
+
+    it('should set contextValue with dismissed suffix for dismissed items', () => {
+      stateStore.getState.mockReturnValue('dismissed');
+      const node: SourceItemNode = {
+        kind: 'item', providerId: 'gh', externalId: '1', title: 'Item',
+      };
+      const treeItem = provider.getTreeItem(node);
+      expect(treeItem.contextValue).toBe('sourceItem.dismissed');
+    });
+
+    it('should set contextValue with hasUrl and dismissed suffix', () => {
+      stateStore.getState.mockReturnValue('dismissed');
+      const node: SourceItemNode = {
+        kind: 'item', providerId: 'gh', externalId: '1', title: 'Item', url: 'https://example.com',
+      };
+      const treeItem = provider.getTreeItem(node);
+      expect(treeItem.contextValue).toBe('sourceItem.hasUrl.dismissed');
+    });
   });
 
   describe('getTreeItem tooltip', () => {

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -81,7 +81,10 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
         const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
         treeItem.description = state === 'dismissed' ? 'dismissed' : undefined;
         treeItem.tooltip = this.buildItemTooltip(element);
-        treeItem.contextValue = element.url ? 'sourceItem.hasUrl' : 'sourceItem';
+        const parts = ['sourceItem'];
+        if (element.url) { parts.push('hasUrl'); }
+        if (state === 'dismissed') { parts.push('dismissed'); }
+        treeItem.contextValue = parts.join('.');
         treeItem.iconPath = new vscode.ThemeIcon(icon);
         return treeItem;
       }


### PR DESCRIPTION
## Summary

Adds an "Un-dismiss" (Restore to Inbox) action for dismissed items in the Sources view. Previously, once an item was dismissed from Inbox, there was no way to recover it — the user had to wait for the provider to re-discover it (which never happened since dismissed items are sticky). Now, dismissed items in Sources show a `Restore to Inbox` button that resets their state from `dismissed` back to `unseen`, causing them to reappear in the Inbox.

## Changes

- **`sourcesTreeProvider.ts`** — Updated `contextValue` to include `.dismissed` suffix for dismissed items (e.g., `sourceItem.dismissed`, `sourceItem.hasUrl.dismissed`), enabling per-state menu visibility
- **`commands.ts`** — Added `handleUndismissFromSources()` handler with single-item and batch support, registered as `workcenter.undismissFromSources` command
- **`package.json`** — Added command definition with `$(inbox)` icon, menu entries showing "Restore to Inbox" only on dismissed items, and `when`-clause regex to hide dismiss/accept on already-dismissed items

## Testing

- All 137 core tests pass (including 38 sourcesTreeProvider tests)
- All 133 ADO tests pass
- All 34 GitHub/start-git-work tests pass
- Build succeeds across all packages

Fixes #228
