### PR TITLE
feat: add inline state transition actions to work item editor

### DIFF
--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getEditorPanelHtml } from '../views/editorPanelHtml';
+import { getEditorPanelHtml, getTransitionActions } from '../views/editorPanelHtml';
 import { WorkItem, WorkItemState } from '../models/workItem';
 
 function makeItem(overrides: Partial<WorkItem> = {}): WorkItem {
@@ -288,5 +288,102 @@ describe('getEditorPanelHtml', () => {
       expect(html).not.toContain('<script>alert(1)</script>');
       expect(html).toContain('&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
     });
+  });
+
+  describe('state action buttons', () => {
+    it('renders Start and Archive buttons for New state', () => {
+      const item = makeItem({ state: WorkItemState.New });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).toContain('class="actions"');
+      expect(html).toContain('data-target-state="InProgress"');
+      expect(html).toContain('>Start<');
+      expect(html).toContain('data-target-state="Archived"');
+      expect(html).toContain('>Archive<');
+    });
+
+    it('renders Complete, Pause, Return to Queue, and Archive for InProgress', () => {
+      const item = makeItem({ state: WorkItemState.InProgress });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).toContain('data-target-state="Done"');
+      expect(html).toContain('>Complete<');
+      expect(html).toContain('data-target-state="Paused"');
+      expect(html).toContain('>Pause<');
+      expect(html).toContain('data-target-state="New"');
+      expect(html).toContain('>Return to Queue<');
+      expect(html).toContain('data-target-state="Archived"');
+    });
+
+    it('renders Resume, Return to Queue, and Archive for Paused', () => {
+      const item = makeItem({ state: WorkItemState.Paused });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).toContain('data-target-state="InProgress"');
+      expect(html).toContain('>Resume<');
+      expect(html).toContain('data-target-state="New"');
+      expect(html).toContain('data-target-state="Archived"');
+    });
+
+    it('renders Archive button for Done state', () => {
+      const item = makeItem({ state: WorkItemState.Done });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).toContain('data-target-state="Archived"');
+      expect(html).toContain('>Archive<');
+    });
+
+    it('renders no action buttons for Archived state', () => {
+      const item = makeItem({ state: WorkItemState.Archived });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).not.toContain('class="actions"');
+    });
+
+    it('uses primary class for the main action button', () => {
+      const item = makeItem({ state: WorkItemState.New });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).toMatch(/<button[^>]*class="primary"[^>]*data-target-state="InProgress"/);
+    });
+
+    it('uses secondary class for non-primary action buttons', () => {
+      const item = makeItem({ state: WorkItemState.New });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).toMatch(/<button[^>]*class="secondary"[^>]*data-target-state="Archived"/);
+    });
+
+    it('includes aria-label on the actions container', () => {
+      const item = makeItem({ state: WorkItemState.InProgress });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).toContain('aria-label="State actions"');
+    });
+  });
+});
+
+describe('getTransitionActions', () => {
+  it('returns correct actions for New state', () => {
+    const actions = getTransitionActions(WorkItemState.New);
+    expect(actions).toHaveLength(2);
+    expect(actions[0]).toEqual({ label: 'Start', targetState: WorkItemState.InProgress, style: 'primary' });
+    expect(actions[1]).toEqual({ label: 'Archive', targetState: WorkItemState.Archived, style: 'secondary' });
+  });
+
+  it('returns correct actions for InProgress state', () => {
+    const actions = getTransitionActions(WorkItemState.InProgress);
+    expect(actions).toHaveLength(4);
+    expect(actions.map(a => a.targetState)).toEqual([
+      WorkItemState.Done, WorkItemState.Paused, WorkItemState.New, WorkItemState.Archived,
+    ]);
+  });
+
+  it('returns correct actions for Paused state', () => {
+    const actions = getTransitionActions(WorkItemState.Paused);
+    expect(actions).toHaveLength(3);
+    expect(actions[0]).toEqual({ label: 'Resume', targetState: WorkItemState.InProgress, style: 'primary' });
+  });
+
+  it('returns correct actions for Done state', () => {
+    const actions = getTransitionActions(WorkItemState.Done);
+    expect(actions).toHaveLength(1);
+    expect(actions[0].targetState).toBe(WorkItemState.Archived);
+  });
+
+  it('returns empty array for Archived state', () => {
+    expect(getTransitionActions(WorkItemState.Archived)).toEqual([]);
   });
 });

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -438,11 +438,14 @@ describe('WorkItemEditorPanel', () => {
       const mock = createMockWebviewPanel();
       openPanel(item, workGraph, mock);
 
+      const initialGetItemCallCount = workGraph.getItem.mock.calls.length;
+
       mock.simulateMessage({ type: 'transitionState', targetState: 'InProgress' });
 
       await vi.waitFor(() => {
         expect(workGraph.transitionState).toHaveBeenCalled();
       });
+      expect(workGraph.getItem.mock.calls.length).toBeGreaterThan(initialGetItemCallCount);
       expect(mock.panel.webview.html).toBeDefined();
       expect(typeof mock.panel.webview.html).toBe('string');
     });

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -53,6 +53,7 @@ function createMockWorkGraph(item?: WorkItem) {
   return {
     getItem: vi.fn((id: string) => (item && item.id === id ? item : undefined)),
     updateItem: vi.fn(async () => {}),
+    transitionState: vi.fn(async () => {}),
   };
 }
 
@@ -414,6 +415,74 @@ describe('WorkItemEditorPanel', () => {
       mock.simulateMessage({ type: 'openUrl', url: 'data:text/html,<h1>hi</h1>' });
 
       expect(vscode.env.openExternal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('message handling (transitionState)', () => {
+    it('should call transitionState on workGraph with valid target state', async () => {
+      const item = makeItem({ state: WorkItemState.New });
+      const workGraph = createMockWorkGraph(item);
+      const mock = createMockWebviewPanel();
+      openPanel(item, workGraph, mock);
+
+      mock.simulateMessage({ type: 'transitionState', targetState: 'InProgress' });
+
+      await vi.waitFor(() => {
+        expect(workGraph.transitionState).toHaveBeenCalledWith('item-1', 'InProgress');
+      });
+    });
+
+    it('should refresh editor HTML after successful transition', async () => {
+      const item = makeItem({ state: WorkItemState.New });
+      const workGraph = createMockWorkGraph(item);
+      const mock = createMockWebviewPanel();
+      openPanel(item, workGraph, mock);
+
+      mock.simulateMessage({ type: 'transitionState', targetState: 'InProgress' });
+
+      await vi.waitFor(() => {
+        expect(workGraph.transitionState).toHaveBeenCalled();
+      });
+      expect(mock.panel.webview.html).toBeDefined();
+      expect(typeof mock.panel.webview.html).toBe('string');
+    });
+
+    it('should show error message when transition fails', async () => {
+      const item = makeItem({ state: WorkItemState.New });
+      const workGraph = createMockWorkGraph(item);
+      workGraph.transitionState.mockRejectedValueOnce(new Error('Invalid state transition'));
+      const mock = createMockWebviewPanel();
+      openPanel(item, workGraph, mock);
+
+      mock.simulateMessage({ type: 'transitionState', targetState: 'Done' });
+
+      await vi.waitFor(() => {
+        expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+          expect.stringContaining('Invalid state transition'),
+        );
+      });
+    });
+
+    it('should ignore transitionState message with invalid target state', async () => {
+      const item = makeItem({ state: WorkItemState.New });
+      const workGraph = createMockWorkGraph(item);
+      const mock = createMockWebviewPanel();
+      openPanel(item, workGraph, mock);
+
+      await mock.simulateMessage({ type: 'transitionState', targetState: 'NotAState' });
+
+      expect(workGraph.transitionState).not.toHaveBeenCalled();
+    });
+
+    it('should ignore transitionState message when targetState is not a string', async () => {
+      const item = makeItem({ state: WorkItemState.New });
+      const workGraph = createMockWorkGraph(item);
+      const mock = createMockWebviewPanel();
+      openPanel(item, workGraph, mock);
+
+      await mock.simulateMessage({ type: 'transitionState', targetState: 42 });
+
+      expect(workGraph.transitionState).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -440,12 +440,12 @@ describe('WorkItemEditorPanel', () => {
 
       const initialGetItemCallCount = workGraph.getItem.mock.calls.length;
 
-      mock.simulateMessage({ type: 'transitionState', targetState: 'InProgress' });
+      await mock.simulateMessage({ type: 'transitionState', targetState: 'InProgress' });
 
       await vi.waitFor(() => {
-        expect(workGraph.transitionState).toHaveBeenCalled();
+        expect(workGraph.transitionState).toHaveBeenCalledWith('item-1', 'InProgress');
+        expect(workGraph.getItem.mock.calls.length).toBeGreaterThan(initialGetItemCallCount);
       });
-      expect(workGraph.getItem.mock.calls.length).toBeGreaterThan(initialGetItemCallCount);
       expect(mock.panel.webview.html).toBeDefined();
       expect(typeof mock.panel.webview.html).toBe('string');
     });

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -321,36 +321,31 @@ interface ActionButton {
   style: 'primary' | 'secondary';
 }
 
+const TRANSITION_ACTIONS: Record<WorkItemState, ActionButton[]> = {
+  [WorkItemState.New]: [
+    { label: 'Start', targetState: WorkItemState.InProgress, style: 'primary' },
+    { label: 'Archive', targetState: WorkItemState.Archived, style: 'secondary' },
+  ],
+  [WorkItemState.InProgress]: [
+    { label: 'Complete', targetState: WorkItemState.Done, style: 'primary' },
+    { label: 'Pause', targetState: WorkItemState.Paused, style: 'secondary' },
+    { label: 'Return to Queue', targetState: WorkItemState.New, style: 'secondary' },
+    { label: 'Archive', targetState: WorkItemState.Archived, style: 'secondary' },
+  ],
+  [WorkItemState.Paused]: [
+    { label: 'Resume', targetState: WorkItemState.InProgress, style: 'primary' },
+    { label: 'Return to Queue', targetState: WorkItemState.New, style: 'secondary' },
+    { label: 'Archive', targetState: WorkItemState.Archived, style: 'secondary' },
+  ],
+  [WorkItemState.Done]: [
+    { label: 'Archive', targetState: WorkItemState.Archived, style: 'secondary' },
+  ],
+  [WorkItemState.Archived]: [],
+};
+
 /** Returns the action buttons available for the given state, derived from the state machine. */
 export function getTransitionActions(state: WorkItemState): ActionButton[] {
-  switch (state) {
-    case WorkItemState.New:
-      return [
-        { label: 'Start', targetState: WorkItemState.InProgress, style: 'primary' },
-        { label: 'Archive', targetState: WorkItemState.Archived, style: 'secondary' },
-      ];
-    case WorkItemState.InProgress:
-      return [
-        { label: 'Complete', targetState: WorkItemState.Done, style: 'primary' },
-        { label: 'Pause', targetState: WorkItemState.Paused, style: 'secondary' },
-        { label: 'Return to Queue', targetState: WorkItemState.New, style: 'secondary' },
-        { label: 'Archive', targetState: WorkItemState.Archived, style: 'secondary' },
-      ];
-    case WorkItemState.Paused:
-      return [
-        { label: 'Resume', targetState: WorkItemState.InProgress, style: 'primary' },
-        { label: 'Return to Queue', targetState: WorkItemState.New, style: 'secondary' },
-        { label: 'Archive', targetState: WorkItemState.Archived, style: 'secondary' },
-      ];
-    case WorkItemState.Done:
-      return [
-        { label: 'Archive', targetState: WorkItemState.Archived, style: 'secondary' },
-      ];
-    case WorkItemState.Archived:
-      return [];
-    default:
-      return [];
-  }
+  return TRANSITION_ACTIONS[state] ?? [];
 }
 
 function getActionsHtml(state: WorkItemState): string {

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -345,7 +345,7 @@ const TRANSITION_ACTIONS: Record<WorkItemState, ActionButton[]> = {
 
 /** Returns the action buttons available for the given state, derived from the state machine. */
 export function getTransitionActions(state: WorkItemState): ActionButton[] {
-  return TRANSITION_ACTIONS[state] ?? [];
+  return [...(TRANSITION_ACTIONS[state] ?? [])];
 }
 
 function getActionsHtml(state: WorkItemState): string {

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -173,6 +173,35 @@ export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDes
       color: var(--vscode-textLink-activeForeground);
       text-decoration: underline;
     }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 16px;
+      margin-bottom: 8px;
+    }
+    button.primary, button.secondary {
+      padding: 6px 14px;
+      border-radius: 3px;
+      font-family: var(--font);
+      font-size: var(--font-size);
+      cursor: pointer;
+      border: 1px solid transparent;
+    }
+    button.primary {
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+    }
+    button.primary:hover {
+      background: var(--vscode-button-hoverBackground);
+    }
+    button.secondary {
+      background: var(--vscode-button-secondaryBackground);
+      color: var(--vscode-button-secondaryForeground);
+    }
+    button.secondary:hover {
+      background: var(--vscode-button-secondaryHoverBackground);
+    }
   </style>
 </head>
 <body>
@@ -190,6 +219,7 @@ ${descriptionSection}
       <textarea id="notes" placeholder="Add notes...">${escapeHtml(item.notes ?? '')}</textarea>
     </div>
   </div>
+${getActionsHtml(item.state)}
   <div class="metadata" aria-label="Item metadata">
     <div class="metadata-heading">Details</div>
     <dl>
@@ -240,6 +270,12 @@ ${item.providerId && providerLabel ? `      <dt>Provider</dt>
         vscode.postMessage({ type: 'openUrl', url: sourceLink.dataset.url });
       });
     }
+
+    document.querySelectorAll('.actions button[data-target-state]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        vscode.postMessage({ type: 'transitionState', targetState: btn.dataset.targetState });
+      });
+    });
   </script>
 </body>
 </html>`;
@@ -277,4 +313,56 @@ function escapeHtml(s: string): string {
 
 function escapeAttr(s: string): string {
   return escapeHtml(s).replace(/"/g, '&quot;');
+}
+
+interface ActionButton {
+  label: string;
+  targetState: WorkItemState;
+  style: 'primary' | 'secondary';
+}
+
+/** Returns the action buttons available for the given state, derived from the state machine. */
+export function getTransitionActions(state: WorkItemState): ActionButton[] {
+  switch (state) {
+    case WorkItemState.New:
+      return [
+        { label: 'Start', targetState: WorkItemState.InProgress, style: 'primary' },
+        { label: 'Archive', targetState: WorkItemState.Archived, style: 'secondary' },
+      ];
+    case WorkItemState.InProgress:
+      return [
+        { label: 'Complete', targetState: WorkItemState.Done, style: 'primary' },
+        { label: 'Pause', targetState: WorkItemState.Paused, style: 'secondary' },
+        { label: 'Return to Queue', targetState: WorkItemState.New, style: 'secondary' },
+        { label: 'Archive', targetState: WorkItemState.Archived, style: 'secondary' },
+      ];
+    case WorkItemState.Paused:
+      return [
+        { label: 'Resume', targetState: WorkItemState.InProgress, style: 'primary' },
+        { label: 'Return to Queue', targetState: WorkItemState.New, style: 'secondary' },
+        { label: 'Archive', targetState: WorkItemState.Archived, style: 'secondary' },
+      ];
+    case WorkItemState.Done:
+      return [
+        { label: 'Archive', targetState: WorkItemState.Archived, style: 'secondary' },
+      ];
+    case WorkItemState.Archived:
+      return [];
+    default:
+      return [];
+  }
+}
+
+function getActionsHtml(state: WorkItemState): string {
+  const actions = getTransitionActions(state);
+  if (actions.length === 0) {
+    return '';
+  }
+  const buttons = actions.map(
+    (a) =>
+      `<button type="button" class="${a.style}" data-target-state="${escapeAttr(a.targetState)}">${escapeHtml(a.label)}</button>`,
+  ).join('\n      ');
+  return `  <div class="actions" aria-label="State actions">
+      ${buttons}
+    </div>`;
 }

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -343,7 +343,7 @@ const TRANSITION_ACTIONS: Record<WorkItemState, ActionButton[]> = {
   [WorkItemState.Archived]: [],
 };
 
-/** Returns the action buttons available for the given state, derived from the state machine. */
+/** Returns the action buttons available for the given state, as defined by the editor's transition action map. */
 export function getTransitionActions(state: WorkItemState): ActionButton[] {
   return [...(TRANSITION_ACTIONS[state] ?? [])];
 }

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -143,16 +143,21 @@ export class WorkItemEditorPanel {
     }
   }
 
-  private async handleTransition(targetState: WorkItemState): Promise<void> {
-    try {
-      await this.workGraph.transitionState(this.itemId, targetState);
-      if (!this.disposed) {
-        this.update();
+  private handleTransition(targetState: WorkItemState): void {
+    // Flush any unsaved edits so they aren't lost when update() regenerates HTML
+    this.flushPendingData();
+    // Serialize through saveQueue to avoid racing with in-flight autosaves
+    this.saveQueue = this.saveQueue.then(async () => {
+      try {
+        await this.workGraph.transitionState(this.itemId, targetState);
+        if (!this.disposed) {
+          this.update();
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        vscode.window.showErrorMessage(`Failed to transition work item: ${message}`);
       }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      vscode.window.showErrorMessage(`Failed to transition work item: ${message}`);
-    }
+    });
   }
 
   private update(): void {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { WorkItem, WorkItemInput } from '../models/workItem';
+import { WorkItem, WorkItemInput, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import { ProviderRegistry } from '../services/providerRegistry';
 import { getEditorPanelHtml } from './editorPanelHtml';
@@ -77,6 +77,13 @@ export class WorkItemEditorPanel {
         }
         return;
       }
+      if (msg?.type === 'transitionState' && typeof msg.targetState === 'string') {
+        const target = msg.targetState as WorkItemState;
+        if (Object.values(WorkItemState).includes(target)) {
+          void this.handleTransition(target);
+        }
+        return;
+      }
       if (msg?.type === 'autosave' && msg.data && typeof msg.data === 'object') {
         this.pendingData = msg.data;
         if (this.debounceTimer) {
@@ -133,6 +140,18 @@ export class WorkItemEditorPanel {
     await this.workGraph.updateItem(this.itemId, patch);
     if (!this.disposed && data.title && !item.providerId) {
       this.panel.title = `Edit: ${data.title}`;
+    }
+  }
+
+  private async handleTransition(targetState: WorkItemState): Promise<void> {
+    try {
+      await this.workGraph.transitionState(this.itemId, targetState);
+      if (!this.disposed) {
+        this.update();
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      vscode.window.showErrorMessage(`Failed to transition work item: ${message}`);
     }
   }
 


### PR DESCRIPTION
## Summary

Adds inline state transition action buttons to the work item editor panel, so users can change an item's lifecycle state without leaving the editor.

Closes #218

## Changes

### `editorPanelHtml.ts`
- Added CSS styles for `.actions`, `button.primary`, and `button.secondary`
- Added `getTransitionActions()` (exported for testing) that maps each `WorkItemState` to its valid transitions with human-friendly labels
- Added `getActionsHtml()` that renders the action buttons section
- Added JS click handlers that post `transitionState` messages to the extension host

### `workItemEditorPanel.ts`
- Added handler for `transitionState` webview messages — validates the target state enum, calls `workGraph.transitionState()`, then refreshes the editor panel
- Shows error notification if the transition fails

### Transition buttons per state

| Current State | Buttons |
|---|---|
| New | **Start** (primary), Archive |
| InProgress | **Complete** (primary), Pause, Return to Queue, Archive |
| Paused | **Resume** (primary), Return to Queue, Archive |
| Done | Archive |
| Archived | *(none)* |

### Tests
- 13 new HTML rendering tests (`editorPanelHtml.test.ts`) covering button presence/absence per state, CSS classes, aria labels, and the `getTransitionActions` API
- 5 new message handler tests (`workItemEditorPanel.test.ts`) covering successful transition, panel refresh, error handling, and invalid state rejection

**All 1521 tests pass across all packages.**
