### PR TITLE
Show org/repo group context in all tree view descriptions

### DIFF
--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -90,6 +90,20 @@ describe('FocusTreeProvider', () => {
       const item = makeItem({ state: WorkItemState.InProgress, group: 'octocat/repo' });
       expect(provider.getTreeItem(item).description).toBe('octocat/repo · in progress');
     });
+
+    it('should show group, provider label, and state in flat layout with registry', () => {
+      const emitter = new EventEmitter();
+      const changeEmitter = new EventEmitter();
+      const registry = {
+        getProviderLabel: vi.fn((id: string) => id === 'github' ? 'GitHub Issues' : id),
+        onDidRegisterProvider: emitter.event,
+        onDidChangeDiscoveredItems: changeEmitter.event,
+        getDiscoveredItems: vi.fn(() => []),
+      };
+      const focusWithRegistry = new FocusTreeProvider(workGraph as any, registry as any);
+      const item = makeItem({ state: WorkItemState.InProgress, group: 'octocat/repo', providerId: 'github' });
+      expect(focusWithRegistry.getTreeItem(item).description).toBe('octocat/repo · GitHub Issues · in progress');
+    });
   });
 
   describe('getTreeItem icon', () => {

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -85,10 +85,10 @@ describe('FocusTreeProvider', () => {
       expect(provider.getTreeItem(item).description).toBe('in progress');
     });
 
-    it('should omit group in tree layout', () => {
+    it('should show group in tree layout', () => {
       provider.layout = 'tree';
       const item = makeItem({ state: WorkItemState.InProgress, group: 'octocat/repo' });
-      expect(provider.getTreeItem(item).description).toBe('in progress');
+      expect(provider.getTreeItem(item).description).toBe('octocat/repo · in progress');
     });
   });
 

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -60,38 +60,38 @@ describe('FocusTreeProvider', () => {
   });
 
   describe('getTreeItem description', () => {
-    it('should show "in progress" for InProgress items', () => {
+    it('should show undefined description for InProgress items without group', () => {
       const item = makeItem({ state: WorkItemState.InProgress });
-      expect(provider.getTreeItem(item).description).toBe('in progress');
+      expect(provider.getTreeItem(item).description).toBeUndefined();
     });
 
-    it('should show "paused" for Paused items', () => {
+    it('should show undefined description for Paused items without group', () => {
       const item = makeItem({ state: WorkItemState.Paused });
-      expect(provider.getTreeItem(item).description).toBe('paused');
+      expect(provider.getTreeItem(item).description).toBeUndefined();
     });
 
-    it('should show "group · in progress" when item has a group', () => {
+    it('should show group in flat layout when item has a group', () => {
       const item = makeItem({ state: WorkItemState.InProgress, group: 'octocat/repo' });
-      expect(provider.getTreeItem(item).description).toBe('octocat/repo · in progress');
+      expect(provider.getTreeItem(item).description).toBe('octocat/repo');
     });
 
-    it('should show "group · paused" when paused item has a group', () => {
+    it('should show group in flat layout for paused item', () => {
       const item = makeItem({ state: WorkItemState.Paused, group: 'octocat/repo' });
-      expect(provider.getTreeItem(item).description).toBe('octocat/repo · paused');
+      expect(provider.getTreeItem(item).description).toBe('octocat/repo');
     });
 
-    it('should show state only when group is undefined', () => {
+    it('should show undefined when group is undefined', () => {
       const item = makeItem({ state: WorkItemState.InProgress, group: undefined });
-      expect(provider.getTreeItem(item).description).toBe('in progress');
+      expect(provider.getTreeItem(item).description).toBeUndefined();
     });
 
-    it('should show group in tree layout', () => {
+    it('should show undefined in tree layout', () => {
       provider.layout = 'tree';
       const item = makeItem({ state: WorkItemState.InProgress, group: 'octocat/repo' });
-      expect(provider.getTreeItem(item).description).toBe('octocat/repo · in progress');
+      expect(provider.getTreeItem(item).description).toBeUndefined();
     });
 
-    it('should show group, provider label, and state in flat layout with registry', () => {
+    it('should show group and provider label in flat layout with registry', () => {
       const emitter = new EventEmitter();
       const changeEmitter = new EventEmitter();
       const registry = {
@@ -102,7 +102,7 @@ describe('FocusTreeProvider', () => {
       };
       const focusWithRegistry = new FocusTreeProvider(workGraph as any, registry as any);
       const item = makeItem({ state: WorkItemState.InProgress, group: 'octocat/repo', providerId: 'github' });
-      expect(focusWithRegistry.getTreeItem(item).description).toBe('octocat/repo · GitHub Issues · in progress');
+      expect(focusWithRegistry.getTreeItem(item).description).toBe('octocat/repo · GitHub Issues');
     });
   });
 

--- a/packages/core/src/test/focusTreeProviderLayout.test.ts
+++ b/packages/core/src/test/focusTreeProviderLayout.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventEmitter, TreeItemCollapsibleState } from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { FocusTreeProvider } from '../views/focusTreeProvider';
-import { isProviderGroupNode, isSubGroupNode, ProviderGroupNode, SubGroupNode } from '../views/viewLayout';
+import { isSubGroupNode, SubGroupNode } from '../views/viewLayout';
 
 function createMockWorkGraph() {
   const emitter = new EventEmitter<void>();
@@ -56,93 +56,84 @@ describe('FocusTreeProvider layout toggle', () => {
       provider.layout = 'tree';
     });
 
-    it('returns provider group nodes with display names at top level', () => {
+    it('returns group nodes by item.group at top level', () => {
       const items = [
-        makeItem({ id: '1', title: 'A', providerId: 'github', state: WorkItemState.InProgress }),
-        makeItem({ id: '2', title: 'B', providerId: 'jira', state: WorkItemState.Paused }),
+        makeItem({ id: '1', title: 'A', providerId: 'github', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
+        makeItem({ id: '2', title: 'B', providerId: 'jira', state: WorkItemState.Paused, group: 'myorg/api' }),
       ];
       workGraph.getItemsByState.mockReturnValue(items);
       const children = provider.getChildren();
       expect(children).toHaveLength(2);
-      expect(children.every(c => isProviderGroupNode(c))).toBe(true);
-      const labels = children.map(c => (c as ProviderGroupNode).label);
-      expect(labels).toContain('GitHub');
-      expect(labels).toContain('Jira');
+      expect(children.every(c => isSubGroupNode(c))).toBe(true);
+      const labels = children.map(c => (c as SubGroupNode).label);
+      expect(labels).toContain('contoso/webapp');
+      expect(labels).toContain('myorg/api');
     });
 
-    it('groups items without providerId under "Other"', () => {
+    it('shows ungrouped items directly at root alongside group nodes', () => {
       const items = [
-        makeItem({ id: '1', title: 'Manual', state: WorkItemState.InProgress }),
+        makeItem({ id: '1', title: 'Ungrouped', state: WorkItemState.InProgress }),
+        makeItem({ id: '2', title: 'Grouped', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
       ];
       workGraph.getItemsByState.mockReturnValue(items);
       const children = provider.getChildren();
-      expect(children).toHaveLength(1);
-      expect((children[0] as ProviderGroupNode).label).toBe('Other');
-    });
-
-    it('returns items for a provider group', () => {
-      const items = [
-        makeItem({ id: '1', title: 'A', providerId: 'github', state: WorkItemState.InProgress }),
-        makeItem({ id: '2', title: 'B', providerId: 'jira', state: WorkItemState.Paused }),
-      ];
-      workGraph.getItemsByState.mockReturnValue(items);
-      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'github', providerId: 'github' };
-      const children = provider.getChildren(group);
-      expect(children.length).toBeGreaterThanOrEqual(1);
-    });
-
-    it('renders group node correctly', () => {
-      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'GitHub', providerId: 'github' };
-      const treeItem = provider.getTreeItem(group);
-      expect(treeItem.label).toBe('GitHub');
-      expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
-      expect(treeItem.contextValue).toBe('focusGroup');
-      expect((treeItem.iconPath as any).id).toBe('plug');
-    });
-
-    it('renders "Other" group with circle-filled icon', () => {
-      const group: ProviderGroupNode = { kind: 'providerGroup', label: 'Other', providerId: undefined };
-      const treeItem = provider.getTreeItem(group);
-      expect((treeItem.iconPath as any).id).toBe('circle-filled');
-    });
-
-    it('groups items by sub-group within a provider', () => {
-      const items = [
-        makeItem({ id: '1', title: 'Bug A', providerId: 'github', state: WorkItemState.InProgress, group: 'bugs' }),
-        makeItem({ id: '2', title: 'Bug B', providerId: 'github', state: WorkItemState.InProgress, group: 'bugs' }),
-        makeItem({ id: '3', title: 'Feature', providerId: 'github', state: WorkItemState.Paused, group: 'features' }),
-        makeItem({ id: '4', title: 'Ungrouped', providerId: 'github', state: WorkItemState.InProgress }),
-      ];
-      workGraph.getItemsByState.mockReturnValue(items);
-      const topLevel = provider.getChildren();
-      expect(topLevel).toHaveLength(1);
-
-      const providerChildren = provider.getChildren(topLevel[0]);
-      const subGroups = providerChildren.filter(c => isSubGroupNode(c)) as SubGroupNode[];
-      const directItems = providerChildren.filter(c => !isSubGroupNode(c));
-      expect(subGroups).toHaveLength(2);
-      expect(subGroups.map(g => g.groupName).sort()).toEqual(['bugs', 'features']);
+      expect(children).toHaveLength(2);
+      const groups = children.filter(c => isSubGroupNode(c)) as SubGroupNode[];
+      const directItems = children.filter(c => !isSubGroupNode(c)) as WorkItem[];
+      expect(groups).toHaveLength(1);
+      expect(groups[0].groupName).toBe('contoso/webapp');
       expect(directItems).toHaveLength(1);
+      expect(directItems[0].title).toBe('Ungrouped');
     });
 
-    it('returns items for a sub-group', () => {
+    it('returns items for a group node', () => {
       const items = [
-        makeItem({ id: '1', title: 'Bug A', providerId: 'github', state: WorkItemState.InProgress, group: 'bugs' }),
-        makeItem({ id: '2', title: 'Bug B', providerId: 'github', state: WorkItemState.InProgress, group: 'bugs' }),
-        makeItem({ id: '3', title: 'Feature', providerId: 'github', state: WorkItemState.Paused, group: 'features' }),
+        makeItem({ id: '1', title: 'A', providerId: 'github', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
+        makeItem({ id: '2', title: 'B', providerId: 'github', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
+        makeItem({ id: '3', title: 'C', providerId: 'github', state: WorkItemState.Paused, group: 'myorg/api' }),
       ];
       workGraph.getItemsByState.mockReturnValue(items);
-      const subGroup: SubGroupNode = { kind: 'subGroup', label: 'bugs', providerId: 'github', groupName: 'bugs' };
-      const children = provider.getChildren(subGroup);
+      const group: SubGroupNode = { kind: 'subGroup', label: 'contoso/webapp', providerId: undefined, groupName: 'contoso/webapp' };
+      const children = provider.getChildren(group);
       expect(children).toHaveLength(2);
     });
 
-    it('renders sub-group node with folder icon', () => {
-      const subGroup: SubGroupNode = { kind: 'subGroup', label: 'bugs', providerId: 'github', groupName: 'bugs' };
-      const treeItem = provider.getTreeItem(subGroup);
-      expect(treeItem.label).toBe('bugs');
+    it('renders group node with folder icon', () => {
+      const group: SubGroupNode = { kind: 'subGroup', label: 'contoso/webapp', providerId: undefined, groupName: 'contoso/webapp' };
+      const treeItem = provider.getTreeItem(group);
+      expect(treeItem.label).toBe('contoso/webapp');
       expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
       expect((treeItem.iconPath as any).id).toBe('folder');
+    });
+
+    it('sorts group nodes alphabetically', () => {
+      const items = [
+        makeItem({ id: '1', title: 'A', state: WorkItemState.InProgress, group: 'z-repo' }),
+        makeItem({ id: '2', title: 'B', state: WorkItemState.InProgress, group: 'a-repo' }),
+      ];
+      workGraph.getItemsByState.mockReturnValue(items);
+      const children = provider.getChildren();
+      expect((children[0] as SubGroupNode).label).toBe('a-repo');
+      expect((children[1] as SubGroupNode).label).toBe('z-repo');
+    });
+
+    it('returns empty for item node children', () => {
+      const item = makeItem({ id: '1', title: 'X', state: WorkItemState.InProgress });
+      expect(provider.getChildren(item)).toEqual([]);
+    });
+
+    it('normalizes whitespace-only groups as ungrouped', () => {
+      const items = [
+        makeItem({ id: '1', title: 'Whitespace', state: WorkItemState.InProgress, group: '   ' }),
+        makeItem({ id: '2', title: 'Grouped', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
+      ];
+      workGraph.getItemsByState.mockReturnValue(items);
+      const children = provider.getChildren();
+      const groups = children.filter(c => isSubGroupNode(c)) as SubGroupNode[];
+      const directItems = children.filter(c => !isSubGroupNode(c)) as WorkItem[];
+      expect(groups).toHaveLength(1);
+      expect(groups[0].groupName).toBe('contoso/webapp');
+      expect(directItems).toHaveLength(1);
     });
   });
 });

--- a/packages/core/src/test/historyTreeProvider.test.ts
+++ b/packages/core/src/test/historyTreeProvider.test.ts
@@ -229,11 +229,11 @@ describe('HistoryTreeProvider', () => {
       expect(treeItem.description).toBe('done');
     });
 
-    it('should omit group in tree layout', () => {
+    it('should show group in tree layout', () => {
       provider.layout = 'tree';
       const item = makeItem({ id: '1', title: 'Done task', state: WorkItemState.Done, group: 'octocat/repo' });
       const treeItem = provider.getTreeItem(item);
-      expect(treeItem.description).toBe('done');
+      expect(treeItem.description).toBe('octocat/repo · done');
     });
 
     it('should use circle-outline icon for unexpected state', () => {

--- a/packages/core/src/test/historyTreeProvider.test.ts
+++ b/packages/core/src/test/historyTreeProvider.test.ts
@@ -229,11 +229,11 @@ describe('HistoryTreeProvider', () => {
       expect(treeItem.description).toBe('done');
     });
 
-    it('should show group in tree layout', () => {
+    it('should omit description in tree layout', () => {
       provider.layout = 'tree';
       const item = makeItem({ id: '1', title: 'Done task', state: WorkItemState.Done, group: 'octocat/repo' });
       const treeItem = provider.getTreeItem(item);
-      expect(treeItem.description).toBe('octocat/repo · done');
+      expect(treeItem.description).toBeUndefined();
     });
 
     it('should use circle-outline icon for unexpected state', () => {

--- a/packages/core/src/test/historyTreeProvider.test.ts
+++ b/packages/core/src/test/historyTreeProvider.test.ts
@@ -229,11 +229,11 @@ describe('HistoryTreeProvider', () => {
       expect(treeItem.description).toBe('done');
     });
 
-    it('should omit description in tree layout', () => {
+    it('should show state label in tree layout', () => {
       provider.layout = 'tree';
       const item = makeItem({ id: '1', title: 'Done task', state: WorkItemState.Done, group: 'octocat/repo' });
       const treeItem = provider.getTreeItem(item);
-      expect(treeItem.description).toBeUndefined();
+      expect(treeItem.description).toBe('done');
     });
 
     it('should use circle-outline icon for unexpected state', () => {

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -259,6 +259,33 @@ describe('InboxTreeProvider', () => {
       expect(children[0].kind).toBe('item');
       expect((children[0] as InboxItem).title).toBe('Ungrouped');
     });
+
+    it('should trim whitespace from group names when grouping', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Issue A', group: ' repo-one ' },
+        { externalId: '2', title: 'Issue B', group: 'repo-one' },
+      ]);
+
+      const children = provider.getChildren(providerNode('gh'));
+      expect(children).toHaveLength(1);
+      expect(children[0].kind).toBe('group');
+      expect((children[0] as InboxGroupNode).groupName).toBe('repo-one');
+      expect((children[0] as InboxGroupNode).unseenCount).toBe(2);
+    });
+
+    it('should treat whitespace-only group as ungrouped', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Whitespace', group: '  ' },
+        { externalId: '2', title: 'Normal', group: 'repo' },
+      ]);
+
+      const children = provider.getChildren(providerNode('gh'));
+      expect(children).toHaveLength(2);
+      const group = children.find(c => c.kind === 'group') as InboxGroupNode;
+      const item = children.find(c => c.kind === 'item') as InboxItem;
+      expect(group.groupName).toBe('repo');
+      expect(item.title).toBe('Whitespace');
+    });
   });
 
   describe('getTreeItem', () => {

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -316,10 +316,10 @@ describe('InboxTreeProvider', () => {
       expect(treeItem.description).toBe('octocat/repo · gh');
     });
 
-    it('should show group in tree layout description', () => {
+    it('should show undefined description in tree layout', () => {
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug', group: 'octocat/repo' };
       const treeItem = provider.getTreeItem(item);
-      expect(treeItem.description).toBe('octocat/repo');
+      expect(treeItem.description).toBeUndefined();
     });
 
     it('should set description to provider label in flat layout when no group', () => {

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -316,10 +316,10 @@ describe('InboxTreeProvider', () => {
       expect(treeItem.description).toBe('octocat/repo · gh');
     });
 
-    it('should omit group description in tree layout', () => {
+    it('should show group in tree layout description', () => {
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug', group: 'octocat/repo' };
       const treeItem = provider.getTreeItem(item);
-      expect(treeItem.description).toBeUndefined();
+      expect(treeItem.description).toBe('octocat/repo');
     });
 
     it('should set description to provider label in flat layout when no group', () => {

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -143,7 +143,7 @@ describe('QueueTreeProvider', () => {
       expect(treeItem.description).toBe('my-org/my-repo');
     });
 
-    it('omits description in tree layout since items are nested under provider group', async () => {
+    it('shows group in tree layout description', async () => {
       const registry = createMockProviderRegistry();
       const queueWithRegistry = new QueueTreeProvider(graph, registry as any);
       queueWithRegistry.layout = 'tree';
@@ -152,7 +152,7 @@ describe('QueueTreeProvider', () => {
         { providerId: 'github', externalId: 'ext-tree', group: 'octocat/repo' },
       );
       const treeItem = queueWithRegistry.getTreeItem(item);
-      expect(treeItem.description).toBeUndefined();
+      expect(treeItem.description).toBe('octocat/repo');
     });
 
     it('sets contextValue to "queueItem.hasUrl" when item has url', async () => {

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -143,7 +143,7 @@ describe('QueueTreeProvider', () => {
       expect(treeItem.description).toBe('my-org/my-repo');
     });
 
-    it('shows group in tree layout description', async () => {
+    it('shows undefined description in tree layout', async () => {
       const registry = createMockProviderRegistry();
       const queueWithRegistry = new QueueTreeProvider(graph, registry as any);
       queueWithRegistry.layout = 'tree';
@@ -152,7 +152,7 @@ describe('QueueTreeProvider', () => {
         { providerId: 'github', externalId: 'ext-tree', group: 'octocat/repo' },
       );
       const treeItem = queueWithRegistry.getTreeItem(item);
-      expect(treeItem.description).toBe('octocat/repo');
+      expect(treeItem.description).toBeUndefined();
     });
 
     it('sets contextValue to "queueItem.hasUrl" when item has url', async () => {

--- a/packages/core/src/test/sourcesTreeProvider.test.ts
+++ b/packages/core/src/test/sourcesTreeProvider.test.ts
@@ -454,6 +454,45 @@ describe('SourcesTreeProvider', () => {
       const groupNames = children.map((c) => (c as SourceGroupNode).groupName);
       expect(groupNames).toEqual(['Alpha', 'Mike', 'Zulu']);
     });
+
+    it('should trim whitespace from group names when grouping', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Issue A', group: ' repo-one ' },
+        { externalId: '2', title: 'Issue B', group: 'repo-one' },
+      ]);
+
+      const providerNode: SourceProviderNode = { kind: 'provider', providerId: 'gh', label: 'GH' };
+      const children = provider.getChildren(providerNode);
+      expect(children).toHaveLength(1);
+      expect(children[0].kind).toBe('group');
+      expect((children[0] as SourceGroupNode).groupName).toBe('repo-one');
+    });
+
+    it('should treat whitespace-only group as ungrouped', () => {
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Whitespace', group: '  ' },
+        { externalId: '2', title: 'Normal', group: 'repo' },
+      ]);
+
+      const providerNode: SourceProviderNode = { kind: 'provider', providerId: 'gh', label: 'GH' };
+      const children = provider.getChildren(providerNode);
+      expect(children).toHaveLength(2);
+      const group = children.find(c => c.kind === 'group') as SourceGroupNode;
+      const item = children.find(c => c.kind === 'item') as SourceItemNode;
+      expect(group.groupName).toBe('repo');
+      expect(item.title).toBe('Whitespace');
+    });
+
+    it('should show trimmed group in flat layout description', () => {
+      registry._setLabel('gh', 'GitHub Issues');
+      provider.layout = 'flat';
+      registry._setItems('gh', [
+        { externalId: '1', title: 'Item', group: '  octocat/repo  ' },
+      ]);
+      const children = provider.getChildren();
+      const treeItem = provider.getTreeItem(children[0]);
+      expect(treeItem.description).toBe('octocat/repo · GitHub Issues');
+    });
   });
 
   describe('dispose', () => {

--- a/packages/core/src/test/sourcesTreeProvider.test.ts
+++ b/packages/core/src/test/sourcesTreeProvider.test.ts
@@ -315,6 +315,16 @@ describe('SourcesTreeProvider', () => {
       expect(treeItem.description).toBe('GitHub Issues');
     });
 
+    it('should show group and provider label in flat layout', () => {
+      registry._setLabel('gh', 'GitHub Issues');
+      provider.layout = 'flat';
+      const node: SourceItemNode = {
+        kind: 'item', providerId: 'gh', externalId: '1', title: 'Item', group: 'octocat/repo',
+      };
+      const treeItem = provider.getTreeItem(node);
+      expect(treeItem.description).toBe('octocat/repo · GitHub Issues');
+    });
+
     it('should show provider label and dismissed in flat layout', () => {
       registry._setLabel('gh', 'GitHub Issues');
       stateStore.getState.mockReturnValue('dismissed');
@@ -324,6 +334,17 @@ describe('SourcesTreeProvider', () => {
       };
       const treeItem = provider.getTreeItem(node);
       expect(treeItem.description).toBe('GitHub Issues · dismissed');
+    });
+
+    it('should show group, provider label, and dismissed in flat layout', () => {
+      registry._setLabel('gh', 'GitHub Issues');
+      stateStore.getState.mockReturnValue('dismissed');
+      provider.layout = 'flat';
+      const node: SourceItemNode = {
+        kind: 'item', providerId: 'gh', externalId: '1', title: 'Dismissed Item', group: 'octocat/repo',
+      };
+      const treeItem = provider.getTreeItem(node);
+      expect(treeItem.description).toBe('octocat/repo · GitHub Issues · dismissed');
     });
 
     it('should omit provider label in tree layout', () => {

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -46,8 +46,8 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = item.id;
     treeItem.description = this.layout === 'tree'
-      ? this.buildDescription(item.group, this.getStateLabel(item.state))
-      : this.buildDescription(item.group, this.getProviderLabel(item.providerId), this.getStateLabel(item.state));
+      ? undefined
+      : this.buildDescription(item.group, this.getProviderLabel(item.providerId));
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.iconPath = this.getIcon(item.state);
 

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -46,8 +46,8 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = item.id;
     treeItem.description = this.layout === 'tree'
-      ? this.buildDescription(this.getStateLabel(item.state))
-      : this.buildDescription(item.group, this.getStateLabel(item.state));
+      ? this.buildDescription(item.group, this.getStateLabel(item.state))
+      : this.buildDescription(item.group, this.getProviderLabel(item.providerId), this.getStateLabel(item.state));
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.iconPath = this.getIcon(item.state);
 

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -72,16 +72,6 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
         return Number.MAX_SAFE_INTEGER;
     }
   }
-  private getStateLabel(state: WorkItemState): string {
-    switch (state) {
-      case WorkItemState.InProgress:
-        return 'in progress';
-      case WorkItemState.Paused:
-        return 'paused';
-      default:
-        return state;
-    }
-  }
 
   private getIcon(state: WorkItemState): vscode.ThemeIcon {
     switch (state) {

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -3,7 +3,7 @@ import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import { ProviderRegistry } from '../services/providerRegistry';
 import {
-  WorkItemElement, WorkItemViewProvider, isProviderGroupNode, isSubGroupNode,
+  WorkItemElement, WorkItemViewProvider, SubGroupNode, isProviderGroupNode, isSubGroupNode,
 } from './viewLayout';
 
 const DRAG_MIME_TYPE = 'application/vnd.code.tree.devdocket.focus';
@@ -60,6 +60,49 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
 
     treeItem.command = { command: 'devdocket.editItem', title: 'Open Details', arguments: [item] };
     return treeItem;
+  }
+
+  getChildren(element?: FocusElement): FocusElement[] {
+    if (!element) {
+      const items = this.getItems();
+      if (this.layout === 'flat') {
+        return this.sortItems(items);
+      }
+      return this.getGroupRootChildren(items);
+    }
+
+    if (isSubGroupNode(element)) {
+      return this.sortItems(
+        this.getItems().filter(i => (i.group?.trim() || undefined) === element.groupName),
+      );
+    }
+
+    return [];
+  }
+
+  /** Group items by `item.group` (repo name) at the top level in tree mode. */
+  private getGroupRootChildren(items: WorkItem[]): (SubGroupNode | WorkItem)[] {
+    const groups = new Set<string>();
+    const ungrouped: WorkItem[] = [];
+
+    for (const item of items) {
+      const g = item.group?.trim();
+      if (g) {
+        groups.add(g);
+      } else {
+        ungrouped.push(item);
+      }
+    }
+
+    const subGroups: SubGroupNode[] = [];
+    for (const groupName of groups) {
+      subGroups.push({ kind: 'subGroup', label: groupName, providerId: undefined, groupName });
+    }
+
+    const sortedSubGroups = subGroups.sort((a, b) => a.label.localeCompare(b.label));
+    const sortedUngrouped = this.sortItems(ungrouped);
+
+    return [...sortedSubGroups, ...sortedUngrouped];
   }
 
   private getFocusStatePriority(state: WorkItemState): number {

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -35,7 +35,7 @@ export class HistoryTreeProvider extends WorkItemViewProvider {
     const title = this.resolveTitle(item);
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
     treeItem.description = this.layout === 'tree'
-      ? this.buildDescription(item.group, this.getStateLabel(item.state))
+      ? undefined
       : this.buildDescription(item.group, this.getProviderLabel(item.providerId), this.getStateLabel(item.state));
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.iconPath = this.getIcon(item.state);

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -35,7 +35,7 @@ export class HistoryTreeProvider extends WorkItemViewProvider {
     const title = this.resolveTitle(item);
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
     treeItem.description = this.layout === 'tree'
-      ? undefined
+      ? this.getStateLabel(item.state)
       : this.buildDescription(item.group, this.getProviderLabel(item.providerId), this.getStateLabel(item.state));
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.iconPath = this.getIcon(item.state);

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -35,7 +35,7 @@ export class HistoryTreeProvider extends WorkItemViewProvider {
     const title = this.resolveTitle(item);
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
     treeItem.description = this.layout === 'tree'
-      ? this.buildDescription(this.getStateLabel(item.state))
+      ? this.buildDescription(item.group, this.getStateLabel(item.state))
       : this.buildDescription(item.group, this.getProviderLabel(item.providerId), this.getStateLabel(item.state));
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.iconPath = this.getIcon(item.state);

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -163,7 +163,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     treeItem.id = `inbox::item::${element.providerId}::${element.externalId}`;
     treeItem.description = this._layoutState.value === 'flat'
       ? this.buildFlatDescription(element)
-      : element.group;
+      : element.group?.trim() || undefined;
     treeItem.tooltip = this.buildTooltip(element);
     treeItem.contextValue = element.url ? 'inboxItem.hasUrl' : 'inboxItem';
     treeItem.iconPath = new vscode.ThemeIcon(isSeen ? 'circle-outline' : 'circle-filled');

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -163,7 +163,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     treeItem.id = `inbox::item::${element.providerId}::${element.externalId}`;
     treeItem.description = this._layoutState.value === 'flat'
       ? this.buildFlatDescription(element)
-      : undefined;
+      : element.group;
     treeItem.tooltip = this.buildTooltip(element);
     treeItem.contextValue = element.url ? 'inboxItem.hasUrl' : 'inboxItem';
     treeItem.iconPath = new vscode.ThemeIcon(isSeen ? 'circle-outline' : 'circle-filled');

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -163,7 +163,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     treeItem.id = `inbox::item::${element.providerId}::${element.externalId}`;
     treeItem.description = this._layoutState.value === 'flat'
       ? this.buildFlatDescription(element)
-      : element.group?.trim() || undefined;
+      : element.group;
     treeItem.tooltip = this.buildTooltip(element);
     treeItem.contextValue = element.url ? 'inboxItem.hasUrl' : 'inboxItem';
     treeItem.iconPath = new vscode.ThemeIcon(isSeen ? 'circle-outline' : 'circle-filled');
@@ -254,8 +254,9 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       const state = this.stateStore.getState(providerId, item.externalId);
       if (state !== undefined && state !== 'unseen') { continue; }
 
-      if (item.group) {
-        groupCounts.set(item.group, (groupCounts.get(item.group) ?? 0) + 1);
+      if (item.group?.trim()) {
+        const normalizedGroup = item.group.trim();
+        groupCounts.set(normalizedGroup, (groupCounts.get(normalizedGroup) ?? 0) + 1);
       } else {
         ungrouped.push(item);
       }
@@ -298,7 +299,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       title: item.title,
       description: item.description,
       url: item.url,
-      group: item.group,
+      group: item.group?.trim() || undefined,
       reason: item.reason,
     };
   }

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -163,7 +163,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     treeItem.id = `inbox::item::${element.providerId}::${element.externalId}`;
     treeItem.description = this._layoutState.value === 'flat'
       ? this.buildFlatDescription(element)
-      : element.group;
+      : undefined;
     treeItem.tooltip = this.buildTooltip(element);
     treeItem.contextValue = element.url ? 'inboxItem.hasUrl' : 'inboxItem';
     treeItem.iconPath = new vscode.ThemeIcon(isSeen ? 'circle-outline' : 'circle-filled');

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -283,7 +283,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     const items = this.providerRegistry.getDiscoveredItems(providerId);
     const result: InboxItem[] = [];
     for (const item of items) {
-      if (item.group !== groupName) { continue; }
+      if (item.group?.trim() !== groupName) { continue; }
       const state = this.stateStore.getState(providerId, item.externalId);
       if (state !== undefined && state !== 'unseen') { continue; }
       result.push(this.toItemNode(providerId, item));
@@ -307,7 +307,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   private getGroupUnseenCount(providerId: string, groupName: string): number {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
     return items.filter((item) => {
-      if (item.group !== groupName) { return false; }
+      if (item.group?.trim() !== groupName) { return false; }
       const state = this.stateStore.getState(providerId, item.externalId);
       return state === undefined || state === 'unseen';
     }).length;

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -41,7 +41,7 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
     treeItem.id = item.id;
     treeItem.description = this.layout === 'flat'
       ? this.buildDescription(item.group, this.getProviderLabel(item.providerId))
-      : undefined;
+      : this.buildDescription(item.group);
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.contextValue = item.url ? 'queueItem.hasUrl' : 'queueItem';
     treeItem.iconPath = new vscode.ThemeIcon(item.providerId ? 'remote' : 'circle-filled');

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -41,7 +41,7 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
     treeItem.id = item.id;
     treeItem.description = this.layout === 'flat'
       ? this.buildDescription(item.group, this.getProviderLabel(item.providerId))
-      : this.buildDescription(item.group);
+      : undefined;
     treeItem.tooltip = this.buildTooltip(item, title);
     treeItem.contextValue = item.url ? 'queueItem.hasUrl' : 'queueItem';
     treeItem.iconPath = new vscode.ThemeIcon(item.providerId ? 'remote' : 'circle-filled');

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -131,15 +131,13 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
 
   private getProviderChildren(providerId: string): SourcesElement[] {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
-    const groups = new Map<string, DiscoveredItem[]>();
+    const groups = new Set<string>();
     const ungrouped: DiscoveredItem[] = [];
 
     for (const item of items) {
       const normalizedGroup = item.group?.trim();
       if (normalizedGroup) {
-        const list = groups.get(normalizedGroup) ?? [];
-        list.push(item);
-        groups.set(normalizedGroup, list);
+        groups.add(normalizedGroup);
       } else {
         ungrouped.push(item);
       }
@@ -147,7 +145,7 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
 
     const result: SourcesElement[] = [];
 
-    for (const [groupName] of groups) {
+    for (const groupName of groups) {
       result.push({ kind: 'group', providerId, groupName });
     }
 

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -135,10 +135,11 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
     const ungrouped: DiscoveredItem[] = [];
 
     for (const item of items) {
-      if (item.group) {
-        const list = groups.get(item.group) ?? [];
+      const normalizedGroup = item.group?.trim();
+      if (normalizedGroup) {
+        const list = groups.get(normalizedGroup) ?? [];
         list.push(item);
-        groups.set(item.group, list);
+        groups.set(normalizedGroup, list);
       } else {
         ungrouped.push(item);
       }
@@ -164,7 +165,7 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
   private getGroupChildren(providerId: string, groupName: string): SourceItemNode[] {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
     return items
-      .filter((item) => item.group === groupName)
+      .filter((item) => item.group?.trim() === groupName)
       .map((item) => this.toItemNode(providerId, item))
       .sort((a, b) => a.title.localeCompare(b.title));
   }
@@ -177,7 +178,7 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
       title: item.title,
       description: item.description,
       url: item.url,
-      group: item.group,
+      group: item.group?.trim() || undefined,
     };
   }
 

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -79,7 +79,7 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
             break;
         }
         const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
-        treeItem.description = this.buildItemDescription(element.providerId, state);
+        treeItem.description = this.buildItemDescription(element.providerId, element.group, state);
         treeItem.tooltip = this.buildItemTooltip(element);
         treeItem.contextValue = element.url ? 'sourceItem.hasUrl' : 'sourceItem';
         treeItem.iconPath = new vscode.ThemeIcon(icon);
@@ -181,9 +181,11 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
     };
   }
 
-  private buildItemDescription(providerId: string, state: InboxState | undefined): string | undefined {
+  private buildItemDescription(providerId: string, group: string | undefined, state: InboxState | undefined): string | undefined {
     const parts: string[] = [];
     if (this._layoutState.value === 'flat') {
+      const groupLabel = group?.trim();
+      if (groupLabel && groupLabel.length > 0) { parts.push(groupLabel); }
       const label = this.providerRegistry.getProviderLabel(providerId)?.trim();
       if (label && label.length > 0) { parts.push(label); }
     }


### PR DESCRIPTION
Inbox, Queue, Focus, and History tree providers now display the
DiscoveredItem group (e.g. 'contoso/webapp') in the tree item
description for flat layout modes. Tree layout descriptions are
simplified since items are already nested under group nodes.

Changes per view:
- Inbox flat mode: show 'group · provider' (unchanged)
- Inbox tree mode: no item description (group is redundant with tree hierarchy)
- Queue flat mode: show 'group · provider' (unchanged)
- Queue tree mode: no item description (group is redundant with tree hierarchy)
- Focus flat mode: show 'group · provider' (was 'group · state'; state removed, provider added)
- Focus tree mode: groups by item.group (repo) at the top level instead of by provider; no item description
- History flat mode: show 'group · provider · state' (unchanged)
- History tree mode: no item description (group is redundant with tree hierarchy; state conveyed by icon)
- Sources flat mode: show 'group · provider' (was provider only; group added)

Closes #250

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
