### PR TITLE
Add Clear Old History command with configurable age threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Your active work. Items here are things you're actively working on or paused. Th
 
 ### History
 
-Completed and archived items. The History view gives you a record of finished work — useful for standups, status updates, and recalling what you've done. Use the **Clear Old History** command (in the History title bar) to remove items older than a configurable threshold — see the `devdocket.historyClearDays` setting.
+Completed and archived items. The History view gives you a record of finished work — useful for standups, status updates, and recalling what you've done.
 
 ### Sources
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Your active work. Items here are things you're actively working on or paused. Th
 
 ### History
 
-Completed and archived items. The History view gives you a record of finished work — useful for standups, status updates, and recalling what you've done.
+Completed and archived items. The History view gives you a record of finished work — useful for standups, status updates, and recalling what you've done. Use the **Clear Old History** command (in the History title bar) to remove items older than a configurable threshold — see the `devdocket.historyClearDays` setting.
 
 ### Sources
 

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -106,9 +106,9 @@ Clicking a History item opens the editor panel to view its details.
 
 #### Clear Old History
 
-The **Clear Old History** command (available from the History view title bar) bulk-removes history items that have been in a terminal state longer than a configurable number of days. A confirmation dialog shows the threshold before proceeding.
+The **Clear Old History** command (available from the History view title bar) bulk-removes history items that have not been updated within a configurable number of days. A confirmation dialog shows the threshold before proceeding.
 
-The age threshold is controlled by the `devdocket.historyClearDays` setting (default: **30** days). Only items whose last state change is older than the threshold are removed.
+The age threshold is controlled by the `devdocket.historyClearDays` setting (default: **30** days). Only items whose last modification is older than the threshold are removed.
 
 > **Note:** History items are in terminal states, so no state-changing commands are available beyond clearing old items.
 

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -101,9 +101,16 @@ Clicking a History item opens the editor panel to view its details.
 
 | Action | Description |
 |--------|-------------|
+| **Clear Old History** | Removes history items older than a configurable threshold (title bar button) |
 | **Open in Browser** | Opens the item's URL in your default browser (if the item has a URL) |
 
-> **Note:** History items are in terminal states, so no state-changing commands are available.
+#### Clear Old History
+
+The **Clear Old History** command (available from the History view title bar) bulk-removes history items that have been in a terminal state longer than a configurable number of days. A confirmation dialog shows the threshold before proceeding.
+
+The age threshold is controlled by the `devdocket.historyClearDays` setting (default: **30** days). Only items whose last state change is older than the threshold are removed.
+
+> **Note:** History items are in terminal states, so no state-changing commands are available beyond clearing old items.
 
 ## Data Flow
 
@@ -197,6 +204,7 @@ Registers an **AI Code Review** action that can be run on any work item whose UR
 |---------|------|---------|-------------|
 | `devdocket.logLevel` | `string` | `"info"` | Log level for the DevDocket output channel. Valid values: `debug`, `info`, `warn`, `error`. |
 | `devdocket.showInboxNotifications` | `boolean` | `true` | Show a notification when new items arrive in the Inbox. |
+| `devdocket.historyClearDays` | `integer` | `30` | Age threshold in days for the **Clear Old History** command. Items in History whose last state change is older than this many days are removed. Minimum: 1. |
 
 ## Keyboard Shortcuts
 

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -204,7 +204,7 @@ Registers an **AI Code Review** action that can be run on any work item whose UR
 |---------|------|---------|-------------|
 | `devdocket.logLevel` | `string` | `"info"` | Log level for the DevDocket output channel. Valid values: `debug`, `info`, `warn`, `error`. |
 | `devdocket.showInboxNotifications` | `boolean` | `true` | Show a notification when new items arrive in the Inbox. |
-| `devdocket.historyClearDays` | `integer` | `30` | Age threshold in days for the **Clear Old History** command. Items in History whose last state change is older than this many days are removed. Minimum: 1. |
+| `devdocket.historyClearDays` | `integer` | `30` | Age threshold in days for the **Clear Old History** command. Items in History whose last modification is older than this many days are removed. Minimum: 1. |
 
 ## Keyboard Shortcuts
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,12 @@
             "sources": { "type": "string", "enum": ["flat", "tree"], "default": "tree" }
           },
           "additionalProperties": false
+        },
+        "devdocket.historyClearDays": {
+          "type": "number",
+          "default": 30,
+          "minimum": 1,
+          "description": "Age threshold in days for the Clear Old History command. Items older than this are removed."
         }
       }
     },
@@ -308,6 +314,12 @@
         "icon": "$(trash)"
       },
       {
+        "command": "devdocket.clearHistory",
+        "title": "Clear Old History",
+        "category": "DevDocket",
+        "icon": "$(clear-all)"
+      },
+      {
         "command": "devdocket.moveToQueue",
         "title": "Move to Queue",
         "category": "DevDocket",
@@ -365,6 +377,11 @@
         {
           "command": "devdocket.switchHistoryToFlat",
           "when": "view == devdocket.history && devdocket.historyLayout == tree",
+          "group": "navigation"
+        },
+        {
+          "command": "devdocket.clearHistory",
+          "when": "view == devdocket.history",
           "group": "navigation"
         },
         {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,7 +51,7 @@
           "additionalProperties": false
         },
         "devdocket.historyClearDays": {
-          "type": "number",
+          "type": "integer",
           "default": 30,
           "minimum": 1,
           "description": "Age threshold in days for the Clear Old History command. Items older than this are removed."

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,8 @@
     "onView:devdocket.history",
     "onCommand:devdocket.refresh",
     "onCommand:devdocket.dismissFromSources",
-    "onCommand:devdocket.deleteItem"
+    "onCommand:devdocket.deleteItem",
+    "onCommand:devdocket.clearHistory"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -397,7 +397,8 @@ async function handleDeleteItem(workGraph: WorkGraph, item?: { id?: string }, se
 
 async function handleClearHistory(workGraph: WorkGraph): Promise<void> {
   const config = vscode.workspace.getConfiguration('devdocket');
-  const maxAgeDays = config.get<number>('historyClearDays', 30);
+  const raw = config.get<number>('historyClearDays', 30);
+  const maxAgeDays = Number.isFinite(raw) && raw >= 1 ? Math.round(raw) : 30;
 
   const confirm = await vscode.window.showWarningMessage(
     `Delete all history items older than ${maxAgeDays} day${maxAgeDays === 1 ? '' : 's'}?`,

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -401,7 +401,7 @@ async function handleClearHistory(workGraph: WorkGraph): Promise<void> {
   const maxAgeDays = Number.isFinite(raw) && raw >= 1 ? Math.ceil(raw) : 30;
 
   const confirm = await vscode.window.showWarningMessage(
-    `Delete all history items older than ${maxAgeDays} day${maxAgeDays === 1 ? '' : 's'}?`,
+    `Delete all history items older than ${maxAgeDays} day${maxAgeDays === 1 ? '' : 's'}? This cannot be undone.`,
     { modal: true },
     'Delete',
   );

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -395,6 +395,25 @@ async function handleDeleteItem(workGraph: WorkGraph, item?: { id?: string }, se
   }
 }
 
+async function handleClearHistory(workGraph: WorkGraph): Promise<void> {
+  const config = vscode.workspace.getConfiguration('devdocket');
+  const maxAgeDays = config.get<number>('historyClearDays', 30);
+
+  const confirm = await vscode.window.showWarningMessage(
+    `Delete all history items older than ${maxAgeDays} day${maxAgeDays === 1 ? '' : 's'}?`,
+    { modal: true },
+    'Delete',
+  );
+  if (confirm !== 'Delete') { return; }
+
+  const deleted = await workGraph.clearOldHistory(maxAgeDays);
+  if (deleted > 0) {
+    void vscode.window.showInformationMessage(`DevDocket: Cleared ${deleted} old history item${deleted === 1 ? '' : 's'}`);
+  } else {
+    void vscode.window.showInformationMessage('DevDocket: No history items older than the threshold');
+  }
+}
+
 async function handleFocusMoveUp(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
   if (!item?.id) {
     void vscode.window.showInformationMessage('DevDocket: Select an item in Focus to move.');
@@ -824,6 +843,8 @@ export function registerCommands(
       wrapCommand('Failed to resume item', (item, selectedItems) => handleResumeItem(workGraph, item, selectedItems))),
     vscode.commands.registerCommand('devdocket.deleteItem',
       wrapCommand('Failed to delete item', (item, selectedItems) => handleDeleteItem(workGraph, item, selectedItems))),
+    vscode.commands.registerCommand('devdocket.clearHistory',
+      wrapCommand('Failed to clear history', () => handleClearHistory(workGraph))),
     vscode.commands.registerCommand('devdocket.editItem',
       wrapCommand('Failed to open editor', (item) => handleEditItem(context, workGraph, providerRegistry, labelCache, item))),
     vscode.commands.registerCommand('devdocket.openInBrowser',

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -398,7 +398,7 @@ async function handleDeleteItem(workGraph: WorkGraph, item?: { id?: string }, se
 async function handleClearHistory(workGraph: WorkGraph): Promise<void> {
   const config = vscode.workspace.getConfiguration('devdocket');
   const raw = config.get<number>('historyClearDays', 30);
-  const maxAgeDays = Number.isFinite(raw) && raw >= 1 ? Math.round(raw) : 30;
+  const maxAgeDays = Number.isFinite(raw) && raw >= 1 ? Math.ceil(raw) : 30;
 
   const confirm = await vscode.window.showWarningMessage(
     `Delete all history items older than ${maxAgeDays} day${maxAgeDays === 1 ? '' : 's'}?`,

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -407,10 +407,15 @@ async function handleClearHistory(workGraph: WorkGraph): Promise<void> {
   );
   if (confirm !== 'Delete') { return; }
 
-  const deleted = await workGraph.clearOldHistory(maxAgeDays);
-  if (deleted > 0) {
-    void vscode.window.showInformationMessage(`DevDocket: Cleared ${deleted} old history item${deleted === 1 ? '' : 's'}`);
-  } else {
+  const result = await workGraph.clearOldHistory(maxAgeDays);
+  if (result.failed > 0) {
+    void vscode.window.showErrorMessage(
+      `DevDocket: Failed to delete ${result.failed} item(s); see Output for details`,
+    );
+  }
+  if (result.deleted > 0) {
+    void vscode.window.showInformationMessage(`DevDocket: Cleared ${result.deleted} old history item${result.deleted === 1 ? '' : 's'}`);
+  } else if (result.failed === 0) {
     void vscode.window.showInformationMessage('DevDocket: No history items older than the threshold');
   }
 }

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -377,9 +377,9 @@ export class WorkGraph {
    * Delete all history items (Done and Archived) whose `updatedAt` is older than the given age in days.
    * Returns the number of items deleted.
    */
-  async clearOldHistory(maxAgeDays: number): Promise<number> {
+  async clearOldHistory(maxAgeDays: number): Promise<{ deleted: number; failed: number }> {
     if (!Number.isFinite(maxAgeDays) || maxAgeDays < 1) {
-      return 0;
+      return { deleted: 0, failed: 0 };
     }
     const days = Math.ceil(maxAgeDays);
     const cutoff = Date.now() - days * DAY_MS;
@@ -387,16 +387,18 @@ export class WorkGraph {
       .filter(item => item.updatedAt < cutoff);
 
     if (toDelete.length === 0) {
-      return 0;
+      return { deleted: 0, failed: 0 };
     }
 
     let deleted = 0;
+    let failed = 0;
     try {
       for (const item of toDelete) {
         try {
           await this.deleteItem(item.id, { silent: true });
           deleted++;
         } catch (err) {
+          failed++;
           logger.warn(`Failed to delete history item ${item.id}, skipping: ${err instanceof Error ? err.message : String(err)}`);
         }
       }
@@ -406,7 +408,7 @@ export class WorkGraph {
       }
     }
 
-    return deleted;
+    return { deleted, failed };
   }
 
   /** Permanently delete a work item from the store. */

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -375,7 +375,8 @@ export class WorkGraph {
 
   /**
    * Delete all history items (Done and Archived) whose `updatedAt` is older than the given age in days.
-   * Returns the number of items deleted.
+   * @returns `deleted` — number of items successfully removed; `failed` — number of items that
+   * could not be deleted (individual errors are logged and do not abort the batch).
    */
   async clearOldHistory(maxAgeDays: number): Promise<{ deleted: number; failed: number }> {
     if (!Number.isFinite(maxAgeDays) || maxAgeDays < 1) {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -395,7 +395,7 @@ export class WorkGraph {
           await this.deleteItem(item.id, { silent: true });
           deleted++;
         } catch (err) {
-          logger.warn(`Failed to delete history item ${item.id}, skipping`);
+          logger.warn(`Failed to delete history item ${item.id}, skipping: ${err instanceof Error ? err.message : String(err)}`);
         }
       }
     } finally {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -411,7 +411,10 @@ export class WorkGraph {
     return { deleted, failed };
   }
 
-  /** Permanently delete a work item from the store. */
+  /**
+   * Permanently delete a work item from the store.
+   * @param options.silent When true, suppresses the `onDidChange` event (used for batch operations).
+   */
   async deleteItem(id: string, options?: { silent?: boolean }): Promise<void> {
     const item = this.items.get(id);
     await this.store.delete(id);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -381,7 +381,7 @@ export class WorkGraph {
     if (!Number.isFinite(maxAgeDays) || maxAgeDays < 1) {
       return 0;
     }
-    const days = Math.round(maxAgeDays);
+    const days = Math.ceil(maxAgeDays);
     const cutoff = Date.now() - days * DAY_MS;
     const toDelete = this.getItemsByState(WorkItemState.Done, WorkItemState.Archived)
       .filter(item => item.updatedAt < cutoff);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -371,6 +371,26 @@ export class WorkGraph {
     }
   }
 
+  /**
+   * Delete all history items (Done and Archived) whose `updatedAt` is older than the given age in days.
+   * Returns the number of items deleted.
+   */
+  async clearOldHistory(maxAgeDays: number): Promise<number> {
+    const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+    const toDelete = this.getItemsByState(WorkItemState.Done, WorkItemState.Archived)
+      .filter(item => item.updatedAt < cutoff);
+
+    if (toDelete.length === 0) {
+      return 0;
+    }
+
+    for (const item of toDelete) {
+      await this.deleteItem(item.id);
+    }
+
+    return toDelete.length;
+  }
+
   /** Permanently delete a work item from the store. */
   async deleteItem(id: string): Promise<void> {
     const item = this.items.get(id);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -25,7 +25,6 @@ export class WorkGraph {
   /** Lazily-built index of items grouped by state; nulled on any mutation to {@link items}. */
   private stateCache: Map<WorkItemState, WorkItem[]> | null = null;
   private readonly _onDidChange = new vscode.EventEmitter<void>();
-  private _suppressChangeEvents = false;
   /**
    * Fires when this graph changes through public mutation operations exposed by {@link WorkGraph},
    * except for internal maintenance or normalization work that may update items without emitting
@@ -386,18 +385,16 @@ export class WorkGraph {
     }
 
     let deleted = 0;
-    this._suppressChangeEvents = true;
     try {
       for (const item of toDelete) {
         try {
-          await this.deleteItem(item.id);
+          await this.deleteItem(item.id, { silent: true });
           deleted++;
         } catch (err) {
           logger.warn(`Failed to delete history item ${item.id}, skipping`);
         }
       }
     } finally {
-      this._suppressChangeEvents = false;
       if (deleted > 0) {
         this._onDidChange.fire();
       }
@@ -407,7 +404,7 @@ export class WorkGraph {
   }
 
   /** Permanently delete a work item from the store. */
-  async deleteItem(id: string): Promise<void> {
+  async deleteItem(id: string, options?: { silent?: boolean }): Promise<void> {
     const item = this.items.get(id);
     await this.store.delete(id);
     if (item?.providerId && item?.externalId) {
@@ -444,7 +441,7 @@ export class WorkGraph {
     }
     this.items.delete(id);
     this.invalidateStateCache();
-    if (!this._suppressChangeEvents) {
+    if (!options?.silent) {
       this._onDidChange.fire();
     }
     logger.info(`Deleted work item: ${id}`);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -4,6 +4,8 @@ import { WorkItem, WorkItemInput, WorkItemState } from '../models/workItem';
 import { ITaskStore } from '../storage/taskStore';
 import { logger } from './logger';
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 const VALID_TRANSITIONS: ReadonlyMap<WorkItemState, ReadonlySet<WorkItemState>> = new Map([
   [WorkItemState.New, new Set([WorkItemState.InProgress, WorkItemState.Archived])],
   [WorkItemState.InProgress, new Set([WorkItemState.Paused, WorkItemState.Done, WorkItemState.New, WorkItemState.Archived])],
@@ -380,7 +382,7 @@ export class WorkGraph {
       return 0;
     }
     const days = Math.round(maxAgeDays);
-    const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
+    const cutoff = Date.now() - days * DAY_MS;
     const toDelete = this.getItemsByState(WorkItemState.Done, WorkItemState.Archived)
       .filter(item => item.updatedAt < cutoff);
 

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -25,6 +25,7 @@ export class WorkGraph {
   /** Lazily-built index of items grouped by state; nulled on any mutation to {@link items}. */
   private stateCache: Map<WorkItemState, WorkItem[]> | null = null;
   private readonly _onDidChange = new vscode.EventEmitter<void>();
+  private _suppressChangeEvents = false;
   /**
    * Fires when this graph changes through public mutation operations exposed by {@link WorkGraph},
    * except for internal maintenance or normalization work that may update items without emitting
@@ -384,11 +385,25 @@ export class WorkGraph {
       return 0;
     }
 
-    for (const item of toDelete) {
-      await this.deleteItem(item.id);
+    let deleted = 0;
+    this._suppressChangeEvents = true;
+    try {
+      for (const item of toDelete) {
+        try {
+          await this.deleteItem(item.id);
+          deleted++;
+        } catch (err) {
+          logger.warn(`Failed to delete history item ${item.id}, skipping`);
+        }
+      }
+    } finally {
+      this._suppressChangeEvents = false;
+      if (deleted > 0) {
+        this._onDidChange.fire();
+      }
     }
 
-    return toDelete.length;
+    return deleted;
   }
 
   /** Permanently delete a work item from the store. */
@@ -429,7 +444,9 @@ export class WorkGraph {
     }
     this.items.delete(id);
     this.invalidateStateCache();
-    this._onDidChange.fire();
+    if (!this._suppressChangeEvents) {
+      this._onDidChange.fire();
+    }
     logger.info(`Deleted work item: ${id}`);
   }
 

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -376,7 +376,11 @@ export class WorkGraph {
    * Returns the number of items deleted.
    */
   async clearOldHistory(maxAgeDays: number): Promise<number> {
-    const cutoff = Date.now() - maxAgeDays * 24 * 60 * 60 * 1000;
+    if (!Number.isFinite(maxAgeDays) || maxAgeDays < 1) {
+      return 0;
+    }
+    const days = Math.round(maxAgeDays);
+    const cutoff = Date.now() - days * 24 * 60 * 60 * 1000;
     const toDelete = this.getItemsByState(WorkItemState.Done, WorkItemState.Archived)
       .filter(item => item.updatedAt < cutoff);
 

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -57,7 +57,7 @@ function makeSourceItem(overrides: Partial<SourceItemNode> = {}): SourceItemNode
 
 type UsedWorkGraphMethods = Pick<
   WorkGraph,
-  'transitionState' | 'getItem' | 'createItem' | 'findItemByProvenance' | 'moveItem' | 'deleteItem'
+  'transitionState' | 'getItem' | 'createItem' | 'findItemByProvenance' | 'moveItem' | 'deleteItem' | 'clearOldHistory'
 >;
 
 function createMockWorkGraph(): { [K in keyof UsedWorkGraphMethods]: Mock } {
@@ -68,6 +68,7 @@ function createMockWorkGraph(): { [K in keyof UsedWorkGraphMethods]: Mock } {
     findItemByProvenance: vi.fn(),
     moveItem: vi.fn(),
     deleteItem: vi.fn(),
+    clearOldHistory: vi.fn(async () => 0),
   };
 }
 
@@ -183,6 +184,7 @@ describe('registerCommands', () => {
       'devdocket.dismissFromInbox',
       'devdocket.acceptFromSources',
       'devdocket.dismissFromSources',
+      'devdocket.clearHistory',
     ];
     for (const cmd of expected) {
       expect(commandHandlers.has(cmd), `missing command: ${cmd}`).toBe(true);
@@ -1909,9 +1911,83 @@ describe('registerCommands', () => {
       );
     });
   });
-});
 
-// ── isSafeUrl (unit tests) ───────────────────────────────────────────
+  describe('devdocket.clearHistory', () => {
+    function mockConfig(value: any = 30) {
+      (vscode.workspace.getConfiguration as Mock).mockReturnValue({
+        get: vi.fn((_key: string, _def?: any) => value),
+        update: vi.fn(),
+        inspect: vi.fn(),
+      });
+    }
+
+    it('shows confirmation dialog and clears old history', async () => {
+      mockConfig(30);
+      (vscode.window.showWarningMessage as Mock).mockResolvedValue('Delete');
+      workGraph.clearOldHistory.mockResolvedValue(5);
+
+      await invoke('devdocket.clearHistory');
+
+      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('older than 30 day'),
+        { modal: true },
+        'Delete',
+      );
+      expect(workGraph.clearOldHistory).toHaveBeenCalledWith(30);
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining('5 old history items'),
+      );
+    });
+
+    it('does nothing when user cancels confirmation', async () => {
+      mockConfig(30);
+      (vscode.window.showWarningMessage as Mock).mockResolvedValue(undefined);
+
+      await invoke('devdocket.clearHistory');
+
+      expect(workGraph.clearOldHistory).not.toHaveBeenCalled();
+    });
+
+    it('shows no-items message when nothing to clear', async () => {
+      mockConfig(30);
+      (vscode.window.showWarningMessage as Mock).mockResolvedValue('Delete');
+      workGraph.clearOldHistory.mockResolvedValue(0);
+
+      await invoke('devdocket.clearHistory');
+
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining('No history items older'),
+      );
+    });
+
+    it('uses singular form for 1 day threshold', async () => {
+      mockConfig(1);
+      (vscode.window.showWarningMessage as Mock).mockResolvedValue('Delete');
+      workGraph.clearOldHistory.mockResolvedValue(1);
+
+      await invoke('devdocket.clearHistory');
+
+      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('older than 1 day?'),
+        { modal: true },
+        'Delete',
+      );
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining('1 old history item'),
+      );
+    });
+
+    it('falls back to default 30 for invalid config values', async () => {
+      mockConfig(NaN);
+      (vscode.window.showWarningMessage as Mock).mockResolvedValue('Delete');
+      workGraph.clearOldHistory.mockResolvedValue(0);
+
+      await invoke('devdocket.clearHistory');
+
+      expect(workGraph.clearOldHistory).toHaveBeenCalledWith(30);
+    });
+  });
+});
 
 describe('isSafeUrl', () => {
   it('accepts http:// URLs', () => {

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -1968,7 +1968,7 @@ describe('registerCommands', () => {
       await invoke('devdocket.clearHistory');
 
       expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
-        expect.stringContaining('older than 1 day?'),
+        expect.stringContaining('older than 1 day'),
         { modal: true },
         'Delete',
       );

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -68,7 +68,7 @@ function createMockWorkGraph(): { [K in keyof UsedWorkGraphMethods]: Mock } {
     findItemByProvenance: vi.fn(),
     moveItem: vi.fn(),
     deleteItem: vi.fn(),
-    clearOldHistory: vi.fn(async () => 0),
+    clearOldHistory: vi.fn(async () => ({ deleted: 0, failed: 0 })),
   };
 }
 
@@ -1924,7 +1924,7 @@ describe('registerCommands', () => {
     it('shows confirmation dialog and clears old history', async () => {
       mockConfig(30);
       (vscode.window.showWarningMessage as Mock).mockResolvedValue('Delete');
-      workGraph.clearOldHistory.mockResolvedValue(5);
+      workGraph.clearOldHistory.mockResolvedValue({ deleted: 5, failed: 0 });
 
       await invoke('devdocket.clearHistory');
 
@@ -1951,7 +1951,7 @@ describe('registerCommands', () => {
     it('shows no-items message when nothing to clear', async () => {
       mockConfig(30);
       (vscode.window.showWarningMessage as Mock).mockResolvedValue('Delete');
-      workGraph.clearOldHistory.mockResolvedValue(0);
+      workGraph.clearOldHistory.mockResolvedValue({ deleted: 0, failed: 0 });
 
       await invoke('devdocket.clearHistory');
 
@@ -1963,7 +1963,7 @@ describe('registerCommands', () => {
     it('uses singular form for 1 day threshold', async () => {
       mockConfig(1);
       (vscode.window.showWarningMessage as Mock).mockResolvedValue('Delete');
-      workGraph.clearOldHistory.mockResolvedValue(1);
+      workGraph.clearOldHistory.mockResolvedValue({ deleted: 1, failed: 0 });
 
       await invoke('devdocket.clearHistory');
 
@@ -1980,7 +1980,7 @@ describe('registerCommands', () => {
     it('falls back to default 30 for invalid config values', async () => {
       mockConfig(NaN);
       (vscode.window.showWarningMessage as Mock).mockResolvedValue('Delete');
-      workGraph.clearOldHistory.mockResolvedValue(0);
+      workGraph.clearOldHistory.mockResolvedValue({ deleted: 0, failed: 0 });
 
       await invoke('devdocket.clearHistory');
 

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -712,15 +712,14 @@ describe('WorkGraph', () => {
       const old1 = await createDoneItem(graph, 'Old1', 60);
       await createDoneItem(graph, 'Old2', 60);
 
-      // Make store.delete fail for the first item
+      const origImpl = (store.delete as ReturnType<typeof vi.fn>).getMockImplementation()!;
       let callCount = 0;
-      const origDelete = store.delete as ReturnType<typeof vi.fn>;
-      origDelete.mockImplementation(async (id: string) => {
+      (store.delete as ReturnType<typeof vi.fn>).mockImplementation(async (id: string) => {
         callCount++;
         if (id === old1.id) {
           throw new Error('disk full');
         }
-        // Default: succeed (item already removed from mock store by WorkGraph)
+        return origImpl(id);
       });
 
       const deleted = await graph.clearOldHistory(30);

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -692,14 +692,20 @@ describe('WorkGraph', () => {
     });
 
     it('handles boundary: item exactly at cutoff is not deleted', async () => {
-      const item = await createDoneItem(graph, 'Boundary', 30);
-      // Set updatedAt to exactly the cutoff (not strictly less than)
-      (item as any).updatedAt = Date.now() - 30 * DAY_MS;
+      vi.useFakeTimers();
+      const now = new Date('2025-06-15T12:00:00Z').getTime();
+      vi.setSystemTime(now);
+      try {
+        const item = await createDoneItem(graph, 'Boundary', 30);
+        (item as any).updatedAt = now - 30 * DAY_MS;
 
-      const deleted = await graph.clearOldHistory(30);
+        const deleted = await graph.clearOldHistory(30);
 
-      // At exactly the cutoff, updatedAt === cutoff, filter is <, so not deleted
-      expect(deleted).toBe(0);
+        // At exactly the cutoff, updatedAt === cutoff, filter is <, so not deleted
+        expect(deleted).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('continues deleting after a single item fails', async () => {

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -616,4 +616,127 @@ describe('WorkGraph', () => {
       expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Archived);
     });
   });
+
+  describe('clearOldHistory', () => {
+    const DAY_MS = 24 * 60 * 60 * 1000;
+
+    async function createDoneItem(g: WorkGraph, title: string, daysAgo: number) {
+      const item = await g.createItem({ title });
+      await g.transitionState(item.id, WorkItemState.InProgress);
+      await g.transitionState(item.id, WorkItemState.Done);
+      // Backdated updatedAt to simulate age
+      const updated = g.getItem(item.id)!;
+      (updated as any).updatedAt = Date.now() - daysAgo * DAY_MS;
+      return updated;
+    }
+
+    async function createArchivedItem(g: WorkGraph, title: string, daysAgo: number) {
+      const item = await createDoneItem(g, title, daysAgo);
+      await g.transitionState(item.id, WorkItemState.Archived);
+      const updated = g.getItem(item.id)!;
+      (updated as any).updatedAt = Date.now() - daysAgo * DAY_MS;
+      return updated;
+    }
+
+    it('deletes items older than threshold', async () => {
+      await createDoneItem(graph, 'Old', 60);
+      await createDoneItem(graph, 'Recent', 5);
+
+      const deleted = await graph.clearOldHistory(30);
+
+      expect(deleted).toBe(1);
+      expect(graph.getItemsByState(WorkItemState.Done)).toHaveLength(1);
+      expect(graph.getItemsByState(WorkItemState.Done)[0].title).toBe('Recent');
+    });
+
+    it('deletes Archived items older than threshold', async () => {
+      await createArchivedItem(graph, 'Old archived', 90);
+      await createDoneItem(graph, 'Recent done', 5);
+
+      const deleted = await graph.clearOldHistory(30);
+
+      expect(deleted).toBe(1);
+      expect(graph.getItemsByState(WorkItemState.Archived)).toHaveLength(0);
+    });
+
+    it('does not affect InProgress or New items', async () => {
+      const item = await graph.createItem({ title: 'New item' });
+      (item as any).updatedAt = Date.now() - 60 * DAY_MS;
+      const ip = await graph.createItem({ title: 'In progress' });
+      await graph.transitionState(ip.id, WorkItemState.InProgress);
+      (graph.getItem(ip.id)! as any).updatedAt = Date.now() - 60 * DAY_MS;
+
+      const deleted = await graph.clearOldHistory(30);
+
+      expect(deleted).toBe(0);
+      expect(graph.getItem(item.id)).toBeDefined();
+      expect(graph.getItem(ip.id)).toBeDefined();
+    });
+
+    it('uses updatedAt not createdAt for cutoff', async () => {
+      const item = await graph.createItem({ title: 'Old created, recently updated' });
+      (item as any).createdAt = Date.now() - 90 * DAY_MS;
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Done);
+      // updatedAt is recent (just transitioned)
+
+      const deleted = await graph.clearOldHistory(30);
+
+      expect(deleted).toBe(0);
+      expect(graph.getItem(item.id)).toBeDefined();
+    });
+
+    it('returns 0 when no history items exist', async () => {
+      const deleted = await graph.clearOldHistory(30);
+      expect(deleted).toBe(0);
+    });
+
+    it('handles boundary: item exactly at cutoff is not deleted', async () => {
+      const item = await createDoneItem(graph, 'Boundary', 30);
+      // Set updatedAt to exactly the cutoff (not strictly less than)
+      (item as any).updatedAt = Date.now() - 30 * DAY_MS;
+
+      const deleted = await graph.clearOldHistory(30);
+
+      // At exactly the cutoff, updatedAt === cutoff, filter is <, so not deleted
+      expect(deleted).toBe(0);
+    });
+
+    it('continues deleting after a single item fails', async () => {
+      const old1 = await createDoneItem(graph, 'Old1', 60);
+      await createDoneItem(graph, 'Old2', 60);
+
+      // Make store.delete fail for the first item
+      let callCount = 0;
+      const origDelete = store.delete as ReturnType<typeof vi.fn>;
+      origDelete.mockImplementation(async (id: string) => {
+        callCount++;
+        if (id === old1.id) {
+          throw new Error('disk full');
+        }
+        // Default: succeed (item already removed from mock store by WorkGraph)
+      });
+
+      const deleted = await graph.clearOldHistory(30);
+
+      expect(deleted).toBe(1);
+      // Old1 should still exist (delete failed and store.delete rolled back)
+      // Old2 should be deleted
+      expect(callCount).toBe(2);
+    });
+
+    it('fires onDidChange only once for batch deletion', async () => {
+      await createDoneItem(graph, 'Old1', 60);
+      await createDoneItem(graph, 'Old2', 60);
+      await createDoneItem(graph, 'Old3', 60);
+
+      const changeSpy = vi.fn();
+      graph.onDidChange(changeSpy);
+      changeSpy.mockClear();
+
+      await graph.clearOldHistory(30);
+
+      expect(changeSpy).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -726,9 +726,12 @@ describe('WorkGraph', () => {
       const deleted = await graph.clearOldHistory(30);
 
       expect(deleted).toBe(1);
-      // Old1 should still exist (delete failed and store.delete rolled back)
-      // Old2 should be deleted
       expect(callCount).toBe(2);
+      // Old1 should still exist (delete failed before items.delete ran)
+      expect(graph.getItem(old1.id)).toBeDefined();
+      // Old2 should be deleted
+      expect(graph.getItemsByState(WorkItemState.Done)).toHaveLength(1);
+      expect(graph.getItemsByState(WorkItemState.Done)[0].id).toBe(old1.id);
     });
 
     it('fires onDidChange only once for batch deletion', async () => {

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -642,9 +642,9 @@ describe('WorkGraph', () => {
       await createDoneItem(graph, 'Old', 60);
       await createDoneItem(graph, 'Recent', 5);
 
-      const deleted = await graph.clearOldHistory(30);
+      const result = await graph.clearOldHistory(30);
 
-      expect(deleted).toBe(1);
+      expect(result.deleted).toBe(1);
       expect(graph.getItemsByState(WorkItemState.Done)).toHaveLength(1);
       expect(graph.getItemsByState(WorkItemState.Done)[0].title).toBe('Recent');
     });
@@ -653,9 +653,9 @@ describe('WorkGraph', () => {
       await createArchivedItem(graph, 'Old archived', 90);
       await createDoneItem(graph, 'Recent done', 5);
 
-      const deleted = await graph.clearOldHistory(30);
+      const result = await graph.clearOldHistory(30);
 
-      expect(deleted).toBe(1);
+      expect(result.deleted).toBe(1);
       expect(graph.getItemsByState(WorkItemState.Archived)).toHaveLength(0);
     });
 
@@ -666,9 +666,9 @@ describe('WorkGraph', () => {
       await graph.transitionState(ip.id, WorkItemState.InProgress);
       (graph.getItem(ip.id)! as any).updatedAt = Date.now() - 60 * DAY_MS;
 
-      const deleted = await graph.clearOldHistory(30);
+      const result = await graph.clearOldHistory(30);
 
-      expect(deleted).toBe(0);
+      expect(result.deleted).toBe(0);
       expect(graph.getItem(item.id)).toBeDefined();
       expect(graph.getItem(ip.id)).toBeDefined();
     });
@@ -680,15 +680,15 @@ describe('WorkGraph', () => {
       await graph.transitionState(item.id, WorkItemState.Done);
       // updatedAt is recent (just transitioned)
 
-      const deleted = await graph.clearOldHistory(30);
+      const result = await graph.clearOldHistory(30);
 
-      expect(deleted).toBe(0);
+      expect(result.deleted).toBe(0);
       expect(graph.getItem(item.id)).toBeDefined();
     });
 
     it('returns 0 when no history items exist', async () => {
-      const deleted = await graph.clearOldHistory(30);
-      expect(deleted).toBe(0);
+      const result = await graph.clearOldHistory(30);
+      expect(result.deleted).toBe(0);
     });
 
     it('handles boundary: item exactly at cutoff is not deleted', async () => {
@@ -699,10 +699,10 @@ describe('WorkGraph', () => {
         const item = await createDoneItem(graph, 'Boundary', 30);
         (item as any).updatedAt = now - 30 * DAY_MS;
 
-        const deleted = await graph.clearOldHistory(30);
+        const result = await graph.clearOldHistory(30);
 
         // At exactly the cutoff, updatedAt === cutoff, filter is <, so not deleted
-        expect(deleted).toBe(0);
+        expect(result.deleted).toBe(0);
       } finally {
         vi.useRealTimers();
       }
@@ -722,9 +722,10 @@ describe('WorkGraph', () => {
         return origImpl(id);
       });
 
-      const deleted = await graph.clearOldHistory(30);
+      const result = await graph.clearOldHistory(30);
 
-      expect(deleted).toBe(1);
+      expect(result.deleted).toBe(1);
+      expect(result.failed).toBe(1);
       expect(callCount).toBe(2);
       // Old1 should still exist (delete failed before items.delete ran)
       expect(graph.getItem(old1.id)).toBeDefined();


### PR DESCRIPTION
Add Clear Old History command with configurable age threshold (`devdocket.historyClearDays`, default 30 days). Includes modal confirmation dialog, batch deletion with partial failure resilience, suppressed change events during batch ops, and 8 new tests.

Closes #232
