### PR TITLE
feat: add provider health indicator on background refresh failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3145,6 +3145,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/timeago.js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/timeago.js/-/timeago.js-4.0.2.tgz",
+      "integrity": "sha512-a7wPxPdVlQL7lqvitHGGRsofhdwtkoSXPGATFuSOA2i1ZNQEPLrGnj68vOp2sOJTCFAQVXPeNMX/GctBaO9L2w==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -3958,7 +3964,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@devdocket/shared": "*"
+        "@devdocket/shared": "*",
+        "timeago.js": "^4.0.2"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,12 @@
       "properties": {
         "devdocket.logLevel": {
           "type": "string",
-          "enum": ["debug", "info", "warn", "error"],
+          "enum": [
+            "debug",
+            "info",
+            "warn",
+            "error"
+          ],
           "default": "info",
           "description": "Log level for DevDocket output channel"
         },
@@ -42,11 +47,46 @@
           "default": {},
           "description": "Per-view layout mode. Keys are view names (inbox, queue, focus, history, sources) and values are 'flat' or 'tree'.",
           "properties": {
-            "inbox": { "type": "string", "enum": ["flat", "tree"], "default": "tree" },
-            "queue": { "type": "string", "enum": ["flat", "tree"], "default": "flat" },
-            "focus": { "type": "string", "enum": ["flat", "tree"], "default": "flat" },
-            "history": { "type": "string", "enum": ["flat", "tree"], "default": "flat" },
-            "sources": { "type": "string", "enum": ["flat", "tree"], "default": "tree" }
+            "inbox": {
+              "type": "string",
+              "enum": [
+                "flat",
+                "tree"
+              ],
+              "default": "tree"
+            },
+            "queue": {
+              "type": "string",
+              "enum": [
+                "flat",
+                "tree"
+              ],
+              "default": "flat"
+            },
+            "focus": {
+              "type": "string",
+              "enum": [
+                "flat",
+                "tree"
+              ],
+              "default": "flat"
+            },
+            "history": {
+              "type": "string",
+              "enum": [
+                "flat",
+                "tree"
+              ],
+              "default": "flat"
+            },
+            "sources": {
+              "type": "string",
+              "enum": [
+                "flat",
+                "tree"
+              ],
+              "default": "tree"
+            }
           },
           "additionalProperties": false
         }
@@ -616,7 +656,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@devdocket/shared": "*"
+    "@devdocket/shared": "*",
+    "timeago.js": "^4.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -41,7 +41,7 @@ export class ProviderRegistry {
   /** Fired when new unseen items are added to the inbox, with the count of new items. */
   readonly onDidAddNewUnseenItems = this._onDidAddNewUnseenItems.event;
   private readonly _onDidChangeProviderHealth = new vscode.EventEmitter<string>();
-  /** Fired when a provider's health status changes, with the provider ID. */
+  /** Fired when a provider's health info changes (status, lastError, or lastRefreshTime), with the provider ID. */
   readonly onDidChangeProviderHealth = this._onDidChangeProviderHealth.event;
   private readonly healthStatus = new Map<string, ProviderHealthStatus>();
   private readonly _loadingProviders = new Set<string>();

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -4,6 +4,16 @@ import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import { ProviderLabelCache } from '../storage/providerLabelCache';
 import { logger } from './logger';
 
+/** Health status of a single provider's most recent refresh attempt. */
+export interface ProviderHealthStatus {
+  /** Whether the last refresh succeeded or failed. */
+  status: 'healthy' | 'unhealthy' | 'unknown';
+  /** When the last successful refresh completed. */
+  lastRefreshTime?: Date;
+  /** Human-readable error message from the last failed refresh, if any. */
+  lastError?: string;
+}
+
 /**
  * Central registry for {@link DevDocketProvider} instances.
  *
@@ -30,6 +40,10 @@ export class ProviderRegistry {
   private readonly _onDidAddNewUnseenItems = new vscode.EventEmitter<number>();
   /** Fired when new unseen items are added to the inbox, with the count of new items. */
   readonly onDidAddNewUnseenItems = this._onDidAddNewUnseenItems.event;
+  private readonly _onDidChangeProviderHealth = new vscode.EventEmitter<string>();
+  /** Fired when a provider's health status changes, with the provider ID. */
+  readonly onDidChangeProviderHealth = this._onDidChangeProviderHealth.event;
+  private readonly healthStatus = new Map<string, ProviderHealthStatus>();
   private readonly _loadingProviders = new Set<string>();
   private readonly _pendingRefreshes = new Map<string, { cts: vscode.CancellationTokenSource; timeoutId: ReturnType<typeof setTimeout> }>();
   private _disposed = false;
@@ -97,6 +111,7 @@ export class ProviderRegistry {
       this.subscriptions.get(provider.id)?.dispose();
       this.subscriptions.delete(provider.id);
       this.discoveredItems.delete(provider.id);
+      this.healthStatus.delete(provider.id);
       this._loadingProviders.delete(provider.id);
       if (!this._disposed) {
         this._onDidChangeDiscoveredItems.fire();
@@ -122,6 +137,16 @@ export class ProviderRegistry {
    */
   getProviderLabel(providerId: string): string {
     return this.providers.get(providerId)?.label ?? this.labelCache?.get(providerId) ?? providerId;
+  }
+
+  /**
+   * Get the health status for a provider.
+   *
+   * @param providerId - The provider identifier.
+   * @returns The health status, or a default 'unknown' status if not yet tracked.
+   */
+  getProviderHealth(providerId: string): ProviderHealthStatus {
+    return this.healthStatus.get(providerId) ?? { status: 'unknown' };
   }
 
   /**
@@ -168,9 +193,11 @@ export class ProviderRegistry {
   private refreshWithTimeout(provider: DevDocketProvider): Promise<void> {
     this.cancelPendingRefresh(provider.id);
     const cts = new vscode.CancellationTokenSource();
+    let timedOut = false;
     const timeoutId = setTimeout(() => {
       if (this.providers.has(provider.id)) {
         logger.warn(`Provider "${provider.id}" refresh timed out after ${ProviderRegistry.REFRESH_TIMEOUT_MS}ms`);
+        timedOut = true;
       }
       cts.cancel();
     }, ProviderRegistry.REFRESH_TIMEOUT_MS);
@@ -178,14 +205,26 @@ export class ProviderRegistry {
     this._pendingRefreshes.set(provider.id, entry);
 
     const refreshPromise = provider.refresh(cts.token)
+      .then(() => {
+        if (!cts.token.isCancellationRequested) {
+          this.updateHealth(provider.id, 'healthy');
+        }
+      })
       .catch((err: unknown) => {
         if (!cts.token.isCancellationRequested) {
           logger.error(`Provider "${provider.id}" refresh failed`, err);
+          const message = err instanceof Error ? err.message : String(err);
+          this.updateHealth(provider.id, 'unhealthy', message);
         }
       });
 
     const cancelledPromise = new Promise<void>((resolve) => {
-      cts.token.onCancellationRequested(() => resolve());
+      cts.token.onCancellationRequested(() => {
+        if (timedOut) {
+          this.updateHealth(provider.id, 'unhealthy', 'Refresh timed out');
+        }
+        resolve();
+      });
     });
 
     return Promise.race([refreshPromise, cancelledPromise])
@@ -206,6 +245,19 @@ export class ProviderRegistry {
       pending.cts.cancel();
       // CTS is disposed in refreshWithTimeout's finally block
       this._pendingRefreshes.delete(providerId);
+    }
+  }
+
+  private updateHealth(providerId: string, status: 'healthy' | 'unhealthy', lastError?: string): void {
+    const prev = this.healthStatus.get(providerId);
+    const next: ProviderHealthStatus = {
+      status,
+      lastRefreshTime: status === 'healthy' ? new Date() : prev?.lastRefreshTime,
+      lastError: status === 'unhealthy' ? lastError : undefined,
+    };
+    this.healthStatus.set(providerId, next);
+    if (!this._disposed) {
+      this._onDidChangeProviderHealth.fire(providerId);
     }
   }
 
@@ -263,5 +315,6 @@ export class ProviderRegistry {
     this._onDidChangeDiscoveredItems.dispose();
     this._onDidRegisterProvider.dispose();
     this._onDidAddNewUnseenItems.dispose();
+    this._onDidChangeProviderHealth.dispose();
   }
 }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -256,7 +256,14 @@ export class ProviderRegistry {
       lastError: status === 'unhealthy' ? lastError : undefined,
     };
     this.healthStatus.set(providerId, next);
-    if (!this._disposed && (prev?.status !== next.status || prev?.lastError !== next.lastError)) {
+    const prevRefreshTime = prev?.lastRefreshTime?.getTime();
+    const nextRefreshTime = next.lastRefreshTime?.getTime();
+    if (
+      !this._disposed &&
+      (prev?.status !== next.status ||
+        prev?.lastError !== next.lastError ||
+        prevRefreshTime !== nextRefreshTime)
+    ) {
       this._onDidChangeProviderHealth.fire(providerId);
     }
   }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -256,7 +256,7 @@ export class ProviderRegistry {
       lastError: status === 'unhealthy' ? lastError : undefined,
     };
     this.healthStatus.set(providerId, next);
-    if (!this._disposed) {
+    if (!this._disposed && (prev?.status !== next.status || prev?.lastError !== next.lastError)) {
       this._onDidChangeProviderHealth.fire(providerId);
     }
   }

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -17,11 +17,12 @@ class MockEventEmitter {
 }
 
 class MockThemeIcon {
-  constructor(public id: string) {}
+  constructor(public id: string, public color?: any) {}
 }
 
 class MockMarkdownString {
   value = '';
+  supportThemeIcons = false;
   appendMarkdown(text: string) { this.value += text; }
   appendText(text: string) { this.value += text; }
 }
@@ -168,6 +169,10 @@ const workspace = {
   onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
 };
 
+class MockThemeColor {
+  constructor(public id: string) {}
+}
+
 const ConfigurationTarget = {
   Global: 1,
   Workspace: 2,
@@ -177,6 +182,7 @@ const ConfigurationTarget = {
 export {
   MockEventEmitter as EventEmitter,
   MockThemeIcon as ThemeIcon,
+  MockThemeColor as ThemeColor,
   MockMarkdownString as MarkdownString,
   MockTreeItem as TreeItem,
   MockDataTransferItem as DataTransferItem,

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -30,13 +30,16 @@ function createMockProviderRegistry() {
   const items = new Map<string, DiscoveredItem[]>();
   const labels = new Map<string, string>();
   const emitter = new EventEmitter<void>();
+  const healthEmitter = new EventEmitter<string>();
   let _loading = false;
   return {
     get loading() { return _loading; },
     getAllDiscoveredItems: vi.fn(() => items),
     getDiscoveredItems: vi.fn((id: string) => items.get(id) ?? []),
     getProviderLabel: vi.fn((id: string) => labels.get(id) ?? id),
+    getProviderHealth: vi.fn(() => ({ status: 'unknown' as const })),
     onDidChangeDiscoveredItems: emitter.event,
+    onDidChangeProviderHealth: healthEmitter.event,
     _setItems: (providerId: string, discoveredItems: DiscoveredItem[]) => {
       items.set(providerId, discoveredItems);
     },

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -770,4 +770,60 @@ describe('InboxTreeProvider', () => {
       }
     });
   });
+
+  describe('unhealthy provider rendering', () => {
+    it('shows warning icon for unhealthy provider', () => {
+      registry._setItems('gh', [{ externalId: 'issue-1', title: 'Bug' }]);
+      registry.getProviderHealth.mockReturnValue({
+        status: 'unhealthy',
+        lastError: 'network error',
+        lastRefreshTime: new Date(0),
+      });
+
+      const node = providerNode('gh');
+      const treeItem = provider.getTreeItem(node);
+      expect((treeItem.iconPath as any).id).toBe('warning');
+    });
+
+    it('shows plug icon for healthy provider', () => {
+      registry._setItems('gh', [{ externalId: 'issue-1', title: 'Bug' }]);
+      registry.getProviderHealth.mockReturnValue({
+        status: 'healthy',
+        lastRefreshTime: new Date(),
+      });
+
+      const node = providerNode('gh');
+      const treeItem = provider.getTreeItem(node);
+      expect((treeItem.iconPath as any).id).toBe('plug');
+    });
+
+    it('includes error message in tooltip for unhealthy provider', () => {
+      registry._setItems('gh', [{ externalId: 'issue-1', title: 'Bug' }]);
+      registry.getProviderHealth.mockReturnValue({
+        status: 'unhealthy',
+        lastError: 'connection refused',
+        lastRefreshTime: new Date(0),
+      });
+
+      const node = providerNode('gh');
+      const treeItem = provider.getTreeItem(node);
+      expect(treeItem.tooltip).toBeInstanceOf(MarkdownString);
+      const md = treeItem.tooltip as MarkdownString;
+      expect(md.value).toContain('Refresh failed');
+      expect(md.value).toContain('connection refused');
+    });
+
+    it('shows unhealthy provider even with zero unseen items', () => {
+      registry._setItems('gh', [{ externalId: 'issue-1', title: 'Bug' }]);
+      stateStore._set('gh', 'issue-1', 'accepted');
+      registry.getProviderHealth.mockReturnValue({
+        status: 'unhealthy',
+        lastError: 'timeout',
+      });
+
+      const children = provider.getChildren();
+      expect(children).toHaveLength(1);
+      expect((children[0] as InboxProviderNode).providerId).toBe('gh');
+    });
+  });
 });

--- a/packages/core/src/test/inboxTreeProviderLayout.test.ts
+++ b/packages/core/src/test/inboxTreeProviderLayout.test.ts
@@ -31,12 +31,15 @@ function createMockProviderRegistry() {
   const items = new Map<string, DiscoveredItem[]>();
   const labels = new Map<string, string>();
   const emitter = new EventEmitter<void>();
+  const healthEmitter = new EventEmitter<string>();
   return {
     loading: false,
     getAllDiscoveredItems: vi.fn(() => items),
     getDiscoveredItems: vi.fn((id: string) => items.get(id) ?? []),
     getProviderLabel: vi.fn((id: string) => labels.get(id) ?? id),
+    getProviderHealth: vi.fn(() => ({ status: 'unknown' as const })),
     onDidChangeDiscoveredItems: emitter.event,
+    onDidChangeProviderHealth: healthEmitter.event,
     _setItems: (pid: string, list: DiscoveredItem[]) => { items.set(pid, list); },
     _setLabel: (pid: string, label: string) => { labels.set(pid, label); },
     _fire: () => emitter.fire(),

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -1022,7 +1022,7 @@ describe('ProviderRegistry', () => {
       expect(listener).toHaveBeenCalledWith('evented');
     });
 
-    it('does not fire onDidChangeProviderHealth when status is unchanged', async () => {
+    it('fires onDidChangeProviderHealth when lastRefreshTime changes even if status is same', async () => {
       const provider = createMockProvider('stable');
       registry.register(provider);
       // First refresh resolves immediately → healthy
@@ -1032,10 +1032,10 @@ describe('ProviderRegistry', () => {
       registry.onDidChangeProviderHealth(listener);
 
       // Trigger another refresh — also resolves immediately → healthy again
+      // but lastRefreshTime changes, so the event should fire
       await registry.refreshAll();
 
-      // Should not fire because status stayed 'healthy'
-      expect(listener).not.toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledWith('stable');
     });
 
     it('clears health status when provider is unregistered', async () => {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -929,4 +929,143 @@ describe('ProviderRegistry', () => {
       expect(registry.getDiscoveredItems('defensive-copy')).toHaveLength(3);
     });
   });
+
+  describe('health tracking', () => {
+    function nextTick(): Promise<void> {
+      return new Promise(resolve => setTimeout(resolve, 0));
+    }
+
+    function createDeferredProvider(id: string) {
+      let resolveRefresh!: () => void;
+      let rejectRefresh!: (err: Error) => void;
+      const refreshPromise = new Promise<void>((resolve, reject) => {
+        resolveRefresh = resolve;
+        rejectRefresh = reject;
+      });
+      const emitter = new EventEmitter<DiscoveredItem[]>();
+      const provider: DevDocketProvider & { fireItems: (items: DiscoveredItem[]) => void } = {
+        id,
+        label: `Provider ${id}`,
+        onDidDiscoverItems: emitter.event,
+        refresh: vi.fn(() => refreshPromise),
+        fireItems: (items) => emitter.fire(items),
+      };
+      return { provider, resolveRefresh, rejectRefresh };
+    }
+
+    it('reports unknown health before first refresh completes', () => {
+      const { provider } = createDeferredProvider('pending');
+      registry.register(provider);
+      expect(registry.getProviderHealth('pending')).toEqual({ status: 'unknown' });
+    });
+
+    it('sets healthy status after successful refresh', async () => {
+      const { provider, resolveRefresh } = createDeferredProvider('ok');
+      registry.register(provider);
+
+      resolveRefresh();
+      await nextTick();
+
+      const health = registry.getProviderHealth('ok');
+      expect(health.status).toBe('healthy');
+      expect(health.lastRefreshTime).toBeInstanceOf(Date);
+      expect(health.lastError).toBeUndefined();
+    });
+
+    it('sets unhealthy status with error message after failed refresh', async () => {
+      const { provider, rejectRefresh } = createDeferredProvider('fail');
+      registry.register(provider);
+
+      rejectRefresh(new Error('network error'));
+      await nextTick();
+
+      const health = registry.getProviderHealth('fail');
+      expect(health.status).toBe('unhealthy');
+      expect(health.lastError).toBe('network error');
+    });
+
+    it('sets unhealthy status on timeout', async () => {
+      vi.useFakeTimers();
+      try {
+        const neverResolve = new Promise<void>(() => {});
+        const emitter = new EventEmitter<DiscoveredItem[]>();
+        const provider: DevDocketProvider = {
+          id: 'slow',
+          label: 'Slow Provider',
+          onDidDiscoverItems: emitter.event,
+          refresh: vi.fn(() => neverResolve),
+        };
+        registry.register(provider);
+
+        // Advance past the timeout
+        vi.advanceTimersByTime(ProviderRegistry.REFRESH_TIMEOUT_MS + 100);
+        await vi.runAllTimersAsync();
+
+        const health = registry.getProviderHealth('slow');
+        expect(health.status).toBe('unhealthy');
+        expect(health.lastError).toBe('Refresh timed out');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('fires onDidChangeProviderHealth on status change', async () => {
+      const { provider, resolveRefresh } = createDeferredProvider('evented');
+      registry.register(provider);
+
+      const listener = vi.fn();
+      registry.onDidChangeProviderHealth(listener);
+
+      resolveRefresh();
+      await nextTick();
+
+      expect(listener).toHaveBeenCalledWith('evented');
+    });
+
+    it('does not fire onDidChangeProviderHealth when status is unchanged', async () => {
+      const provider = createMockProvider('stable');
+      registry.register(provider);
+      // First refresh resolves immediately → healthy
+      await nextTick();
+
+      const listener = vi.fn();
+      registry.onDidChangeProviderHealth(listener);
+
+      // Trigger another refresh — also resolves immediately → healthy again
+      await registry.refreshAll();
+
+      // Should not fire because status stayed 'healthy'
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('clears health status when provider is unregistered', async () => {
+      const provider = createMockProvider('temp');
+      const disposable = registry.register(provider);
+      await nextTick();
+
+      expect(registry.getProviderHealth('temp').status).toBe('healthy');
+
+      disposable.dispose();
+      expect(registry.getProviderHealth('temp')).toEqual({ status: 'unknown' });
+    });
+
+    it('preserves lastRefreshTime from previous healthy state on failure', async () => {
+      const provider = createMockProvider('flaky');
+      registry.register(provider);
+      await nextTick();
+
+      const healthyTime = registry.getProviderHealth('flaky').lastRefreshTime;
+      expect(healthyTime).toBeInstanceOf(Date);
+
+      // Now trigger a failed refresh
+      vi.mocked(provider.refresh).mockRejectedValueOnce(new Error('oops'));
+      await registry.refreshAll();
+
+      const health = registry.getProviderHealth('flaky');
+      expect(health.status).toBe('unhealthy');
+      expect(health.lastError).toBe('oops');
+      // lastRefreshTime is preserved from the last healthy refresh
+      expect(health.lastRefreshTime).toEqual(healthyTime);
+    });
+  });
 });

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -1031,9 +1031,13 @@ describe('ProviderRegistry', () => {
       const listener = vi.fn();
       registry.onDidChangeProviderHealth(listener);
 
-      // Trigger another refresh — also resolves immediately → healthy again
-      // but lastRefreshTime changes, so the event should fire
-      await registry.refreshAll();
+      // Guarantee a different timestamp on next refresh
+      const spy = vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 1000);
+      try {
+        await registry.refreshAll();
+      } finally {
+        spy.mockRestore();
+      }
 
       expect(listener).toHaveBeenCalledWith('stable');
     });

--- a/packages/core/src/test/sourcesTreeProvider.test.ts
+++ b/packages/core/src/test/sourcesTreeProvider.test.ts
@@ -28,11 +28,14 @@ function createMockProviderRegistry() {
   const items = new Map<string, DiscoveredItem[]>();
   const labels = new Map<string, string>();
   const emitter = new EventEmitter<void>();
+  const healthEmitter = new EventEmitter<string>();
   return {
     getAllDiscoveredItems: vi.fn(() => items),
     getDiscoveredItems: vi.fn((id: string) => items.get(id) ?? []),
     getProviderLabel: vi.fn((id: string) => labels.get(id) ?? id),
+    getProviderHealth: vi.fn(() => ({ status: 'unknown' as const })),
     onDidChangeDiscoveredItems: emitter.event,
+    onDidChangeProviderHealth: healthEmitter.event,
     _setItems: (providerId: string, discoveredItems: DiscoveredItem[]) => {
       items.set(providerId, discoveredItems);
     },

--- a/packages/core/src/test/sourcesTreeProvider.test.ts
+++ b/packages/core/src/test/sourcesTreeProvider.test.ts
@@ -529,4 +529,60 @@ describe('SourcesTreeProvider', () => {
       expect(listener).not.toHaveBeenCalled();
     });
   });
+
+  describe('unhealthy provider rendering', () => {
+    it('shows warning icon for unhealthy provider', () => {
+      registry._setItems('gh', [{ externalId: 'issue-1', title: 'Bug' }]);
+      registry.getProviderHealth.mockReturnValue({
+        status: 'unhealthy',
+        lastError: 'network error',
+        lastRefreshTime: new Date(0),
+      });
+
+      const node: SourceProviderNode = { kind: 'provider', providerId: 'gh', label: 'GitHub' };
+      const treeItem = provider.getTreeItem(node);
+      expect((treeItem.iconPath as any).id).toBe('warning');
+      expect(treeItem.description).toBe('refresh failed');
+    });
+
+    it('shows plug icon for healthy provider', () => {
+      registry._setItems('gh', [{ externalId: 'issue-1', title: 'Bug' }]);
+      registry.getProviderHealth.mockReturnValue({
+        status: 'healthy',
+        lastRefreshTime: new Date(),
+      });
+
+      const node: SourceProviderNode = { kind: 'provider', providerId: 'gh', label: 'GitHub' };
+      const treeItem = provider.getTreeItem(node);
+      expect((treeItem.iconPath as any).id).toBe('plug');
+    });
+
+    it('includes error message in tooltip for unhealthy provider', () => {
+      registry._setItems('gh', [{ externalId: 'issue-1', title: 'Bug' }]);
+      registry.getProviderHealth.mockReturnValue({
+        status: 'unhealthy',
+        lastError: 'connection refused',
+        lastRefreshTime: new Date(0),
+      });
+
+      const node: SourceProviderNode = { kind: 'provider', providerId: 'gh', label: 'GitHub' };
+      const treeItem = provider.getTreeItem(node);
+      expect(treeItem.tooltip).toBeInstanceOf(MarkdownString);
+      const md = treeItem.tooltip as MarkdownString;
+      expect(md.value).toContain('Refresh failed');
+      expect(md.value).toContain('connection refused');
+    });
+
+    it('shows unhealthy provider even with zero items', () => {
+      registry._setItems('gh', []);
+      registry.getProviderHealth.mockReturnValue({
+        status: 'unhealthy',
+        lastError: 'timeout',
+      });
+
+      const children = provider.getChildren();
+      expect(children).toHaveLength(1);
+      expect((children[0] as SourceProviderNode).providerId).toBe('gh');
+    });
+  });
 });

--- a/packages/core/src/test/sourcesTreeProviderLayout.test.ts
+++ b/packages/core/src/test/sourcesTreeProviderLayout.test.ts
@@ -18,11 +18,14 @@ function createMockProviderRegistry() {
   const items = new Map<string, DiscoveredItem[]>();
   const labels = new Map<string, string>();
   const emitter = new EventEmitter<void>();
+  const healthEmitter = new EventEmitter<string>();
   return {
     getAllDiscoveredItems: vi.fn(() => items),
     getDiscoveredItems: vi.fn((id: string) => items.get(id) ?? []),
     getProviderLabel: vi.fn((id: string) => labels.get(id) ?? id),
+    getProviderHealth: vi.fn(() => ({ status: 'unknown' as const })),
     onDidChangeDiscoveredItems: emitter.event,
+    onDidChangeProviderHealth: healthEmitter.event,
     _setItems: (pid: string, list: DiscoveredItem[]) => { items.set(pid, list); },
     _setLabel: (pid: string, label: string) => { labels.set(pid, label); },
     _fire: () => emitter.fire(),

--- a/packages/core/src/test/time.test.ts
+++ b/packages/core/src/test/time.test.ts
@@ -6,33 +6,33 @@ describe('formatRelativeTime', () => {
     vi.useRealTimers();
   });
 
-  it('returns "just now" for very recent dates', () => {
+  it('returns a "now"-style string for very recent dates', () => {
     vi.useFakeTimers({ now: 1000 });
-    expect(formatRelativeTime(new Date(1000))).toBe('just now');
+    expect(formatRelativeTime(new Date(1000))).toMatch(/\bnow\b/i);
   });
 
-  it('returns a relative string for dates in the future', () => {
+  it('returns a "now"-style string for dates in the future', () => {
     vi.useFakeTimers({ now: 1000 });
-    expect(formatRelativeTime(new Date(2000))).toBe('right now');
+    expect(formatRelativeTime(new Date(2000))).toMatch(/\bnow\b/i);
   });
 
-  it('returns "1 minute ago" at exactly 60 seconds', () => {
+  it('returns a 1-minute-ago style string at exactly 60 seconds', () => {
     vi.useFakeTimers({ now: 60_000 });
-    expect(formatRelativeTime(new Date(0))).toBe('1 minute ago');
+    expect(formatRelativeTime(new Date(0))).toMatch(/\b1\b.*\bminute\b.*\bago\b/i);
   });
 
-  it('returns "5 minutes ago" for 5 minutes', () => {
+  it('returns a 5-minutes-ago style string for 5 minutes', () => {
     vi.useFakeTimers({ now: 5 * 60_000 });
-    expect(formatRelativeTime(new Date(0))).toBe('5 minutes ago');
+    expect(formatRelativeTime(new Date(0))).toMatch(/\b5\b.*\bminutes?\b.*\bago\b/i);
   });
 
-  it('returns "1 hour ago" at exactly 60 minutes', () => {
+  it('returns a 1-hour-ago style string at exactly 60 minutes', () => {
     vi.useFakeTimers({ now: 60 * 60_000 });
-    expect(formatRelativeTime(new Date(0))).toBe('1 hour ago');
+    expect(formatRelativeTime(new Date(0))).toMatch(/\b1\b.*\bhour\b.*\bago\b/i);
   });
 
-  it('returns "1 day ago" for 24+ hours', () => {
+  it('returns a 1-day-ago style string for 24+ hours', () => {
     vi.useFakeTimers({ now: 24 * 60 * 60_000 });
-    expect(formatRelativeTime(new Date(0))).toBe('1 day ago');
+    expect(formatRelativeTime(new Date(0))).toMatch(/\b1\b.*\bday\b.*\bago\b/i);
   });
 });

--- a/packages/core/src/test/time.test.ts
+++ b/packages/core/src/test/time.test.ts
@@ -6,14 +6,14 @@ describe('formatRelativeTime', () => {
     vi.useRealTimers();
   });
 
-  it('returns "just now" for dates in the future', () => {
+  it('returns "just now" for very recent dates', () => {
     vi.useFakeTimers({ now: 1000 });
-    expect(formatRelativeTime(new Date(2000))).toBe('just now');
+    expect(formatRelativeTime(new Date(1000))).toBe('just now');
   });
 
-  it('returns "just now" for less than 60 seconds ago', () => {
-    vi.useFakeTimers({ now: 60_000 });
-    expect(formatRelativeTime(new Date(1_000))).toBe('just now');
+  it('returns a relative string for dates in the future', () => {
+    vi.useFakeTimers({ now: 1000 });
+    expect(formatRelativeTime(new Date(2000))).toBe('right now');
   });
 
   it('returns "1 minute ago" at exactly 60 seconds', () => {
@@ -26,24 +26,13 @@ describe('formatRelativeTime', () => {
     expect(formatRelativeTime(new Date(0))).toBe('5 minutes ago');
   });
 
-  it('returns "59 minutes ago" at boundary', () => {
-    vi.useFakeTimers({ now: 59 * 60_000 });
-    expect(formatRelativeTime(new Date(0))).toBe('59 minutes ago');
-  });
-
   it('returns "1 hour ago" at exactly 60 minutes', () => {
     vi.useFakeTimers({ now: 60 * 60_000 });
     expect(formatRelativeTime(new Date(0))).toBe('1 hour ago');
   });
 
-  it('returns "23 hours ago" at boundary', () => {
-    vi.useFakeTimers({ now: 23 * 60 * 60_000 });
-    expect(formatRelativeTime(new Date(0))).toBe('23 hours ago');
-  });
-
-  it('returns locale string for 24+ hours', () => {
+  it('returns "1 day ago" for 24+ hours', () => {
     vi.useFakeTimers({ now: 24 * 60 * 60_000 });
-    const date = new Date(0);
-    expect(formatRelativeTime(date)).toBe(date.toLocaleString());
+    expect(formatRelativeTime(new Date(0))).toBe('1 day ago');
   });
 });

--- a/packages/core/src/test/time.test.ts
+++ b/packages/core/src/test/time.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { formatRelativeTime } from '../utils/time';
+
+describe('formatRelativeTime', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns "just now" for dates in the future', () => {
+    vi.useFakeTimers({ now: 1000 });
+    expect(formatRelativeTime(new Date(2000))).toBe('just now');
+  });
+
+  it('returns "just now" for less than 60 seconds ago', () => {
+    vi.useFakeTimers({ now: 60_000 });
+    expect(formatRelativeTime(new Date(1_000))).toBe('just now');
+  });
+
+  it('returns "1 minute ago" at exactly 60 seconds', () => {
+    vi.useFakeTimers({ now: 60_000 });
+    expect(formatRelativeTime(new Date(0))).toBe('1 minute ago');
+  });
+
+  it('returns "5 minutes ago" for 5 minutes', () => {
+    vi.useFakeTimers({ now: 5 * 60_000 });
+    expect(formatRelativeTime(new Date(0))).toBe('5 minutes ago');
+  });
+
+  it('returns "59 minutes ago" at boundary', () => {
+    vi.useFakeTimers({ now: 59 * 60_000 });
+    expect(formatRelativeTime(new Date(0))).toBe('59 minutes ago');
+  });
+
+  it('returns "1 hour ago" at exactly 60 minutes', () => {
+    vi.useFakeTimers({ now: 60 * 60_000 });
+    expect(formatRelativeTime(new Date(0))).toBe('1 hour ago');
+  });
+
+  it('returns "23 hours ago" at boundary', () => {
+    vi.useFakeTimers({ now: 23 * 60 * 60_000 });
+    expect(formatRelativeTime(new Date(0))).toBe('23 hours ago');
+  });
+
+  it('returns locale string for 24+ hours', () => {
+    vi.useFakeTimers({ now: 24 * 60 * 60_000 });
+    const date = new Date(0);
+    expect(formatRelativeTime(date)).toBe(date.toLocaleString());
+  });
+});

--- a/packages/core/src/utils/time.ts
+++ b/packages/core/src/utils/time.ts
@@ -2,7 +2,7 @@ import { format } from 'timeago.js';
 
 /**
  * Format a Date as a human-readable relative time string (e.g. "5 minutes ago").
- * Delegates to timeago.js for locale-aware relative formatting.
+ * Delegates to timeago.js for relative time formatting.
  */
 export function formatRelativeTime(date: Date): string {
   return format(date);

--- a/packages/core/src/utils/time.ts
+++ b/packages/core/src/utils/time.ts
@@ -1,6 +1,6 @@
 /**
  * Format a Date as a human-readable relative time string (e.g. "2 minutes ago").
- * Falls back to an absolute timestamp for durations longer than 24 hours.
+ * Falls back to an absolute timestamp for durations of 24 hours or more.
  */
 export function formatRelativeTime(date: Date): string {
   const now = Date.now();

--- a/packages/core/src/utils/time.ts
+++ b/packages/core/src/utils/time.ts
@@ -1,29 +1,9 @@
+import { format } from 'timeago.js';
+
 /**
- * Format a Date as a human-readable relative time string (e.g. "2 minutes ago").
- * Falls back to an absolute timestamp for durations of 24 hours or more.
+ * Format a Date as a human-readable relative time string (e.g. "5 minutes ago").
+ * Delegates to timeago.js for locale-aware relative formatting.
  */
 export function formatRelativeTime(date: Date): string {
-  const now = Date.now();
-  const diffMs = now - date.getTime();
-
-  if (diffMs < 0) {
-    return 'just now';
-  }
-
-  const seconds = Math.floor(diffMs / 1000);
-  if (seconds < 60) {
-    return 'just now';
-  }
-
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) {
-    return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
-  }
-
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) {
-    return `${hours} hour${hours === 1 ? '' : 's'} ago`;
-  }
-
-  return date.toLocaleString();
+  return format(date);
 }

--- a/packages/core/src/utils/time.ts
+++ b/packages/core/src/utils/time.ts
@@ -1,0 +1,29 @@
+/**
+ * Format a Date as a human-readable relative time string (e.g. "2 minutes ago").
+ * Falls back to an absolute timestamp for durations longer than 24 hours.
+ */
+export function formatRelativeTime(date: Date): string {
+  const now = Date.now();
+  const diffMs = now - date.getTime();
+
+  if (diffMs < 0) {
+    return 'just now';
+  }
+
+  const seconds = Math.floor(diffMs / 1000);
+  if (seconds < 60) {
+    return 'just now';
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  }
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  }
+
+  return date.toLocaleString();
+}

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -1,11 +1,11 @@
 import * as vscode from 'vscode';
 import { DiscoveredItem } from '../api/types';
-import { ProviderRegistry, ProviderHealthStatus } from '../services/providerRegistry';
+import { ProviderRegistry } from '../services/providerRegistry';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import { ReadStateStore } from '../storage/readStateStore';
 import { logger } from '../services/logger';
 import { ViewLayout, LayoutState } from './viewLayout';
-import { formatRelativeTime } from '../utils/time';
+import { buildProviderTooltip } from './providerTooltip';
 
 export interface InboxProviderNode {
   kind: 'provider';
@@ -151,7 +151,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       } else {
         treeItem.iconPath = new vscode.ThemeIcon('plug');
       }
-      treeItem.tooltip = this.buildProviderTooltip(element.label, health);
+      treeItem.tooltip = buildProviderTooltip(element.label, health);
       return treeItem;
     }
 
@@ -331,23 +331,6 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   private formatReason(reason: string): string {
     return reason.replace(/_/g, ' ').replace(/^./, c => c.toUpperCase());
-  }
-
-  private buildProviderTooltip(label: string, health: ProviderHealthStatus): vscode.MarkdownString {
-    const md = new vscode.MarkdownString();
-    md.appendMarkdown(`**`);
-    md.appendText(label);
-    md.appendMarkdown(`**\n\n`);
-    if (health.lastRefreshTime) {
-      md.appendMarkdown(`Last refreshed: ${formatRelativeTime(health.lastRefreshTime)}\n\n`);
-    }
-    if (health.status === 'unhealthy' && health.lastError) {
-      md.appendMarkdown(`$(warning) **Refresh failed:** `);
-      md.appendText(health.lastError);
-      md.appendMarkdown(`\n\n`);
-    }
-    md.supportThemeIcons = true;
-    return md;
   }
 
   private buildFlatDescription(item: InboxItem): string | undefined {

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -1,10 +1,11 @@
 import * as vscode from 'vscode';
 import { DiscoveredItem } from '../api/types';
-import { ProviderRegistry } from '../services/providerRegistry';
+import { ProviderRegistry, ProviderHealthStatus } from '../services/providerRegistry';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import { ReadStateStore } from '../storage/readStateStore';
 import { logger } from '../services/logger';
 import { ViewLayout, LayoutState } from './viewLayout';
+import { formatRelativeTime } from '../utils/time';
 
 export interface InboxProviderNode {
   kind: 'provider';
@@ -54,6 +55,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     this._layoutState = new LayoutState('tree', () => this._onDidChangeTreeData.fire());
     this.disposables.push(
       providerRegistry.onDidChangeDiscoveredItems(() => this.scheduleRefresh()),
+      providerRegistry.onDidChangeProviderHealth(() => this.scheduleRefresh()),
       stateStore.onDidChange(() => this.scheduleRefresh()),
     );
   }
@@ -139,11 +141,17 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   getTreeItem(element: InboxElement): vscode.TreeItem {
     if (element.kind === 'provider') {
       const count = this.getUnseenCount(element.providerId);
+      const health = this.providerRegistry.getProviderHealth(element.providerId);
       const treeItem = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.Collapsed);
       treeItem.description = `${count}`;
       treeItem.id = `inbox::provider::${element.providerId}`;
       treeItem.contextValue = 'inboxProvider';
-      treeItem.iconPath = new vscode.ThemeIcon('plug');
+      if (health.status === 'unhealthy') {
+        treeItem.iconPath = new vscode.ThemeIcon('warning', new vscode.ThemeColor('problemsWarningIcon.foreground'));
+      } else {
+        treeItem.iconPath = new vscode.ThemeIcon('plug');
+      }
+      treeItem.tooltip = this.buildProviderTooltip(element.label, health);
       return treeItem;
     }
 
@@ -322,6 +330,18 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   private formatReason(reason: string): string {
     return reason.replace(/_/g, ' ').replace(/^./, c => c.toUpperCase());
+  }
+
+  private buildProviderTooltip(label: string, health: ProviderHealthStatus): vscode.MarkdownString {
+    const md = new vscode.MarkdownString();
+    md.appendMarkdown(`**${label}**\n\n`);
+    if (health.lastRefreshTime) {
+      md.appendMarkdown(`Last refreshed: ${formatRelativeTime(health.lastRefreshTime)}\n\n`);
+    }
+    if (health.status === 'unhealthy' && health.lastError) {
+      md.appendMarkdown(`$(warning) **Refresh failed:** ${health.lastError}\n\n`);
+    }
+    return md;
   }
 
   private buildFlatDescription(item: InboxItem): string | undefined {

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -218,7 +218,8 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       const result: InboxProviderNode[] = [];
       const allItems = this.providerRegistry.getAllDiscoveredItems();
       for (const [providerId] of allItems) {
-        if (this.getUnseenCount(providerId) > 0) {
+        const health = this.providerRegistry.getProviderHealth(providerId);
+        if (this.getUnseenCount(providerId) > 0 || health.status === 'unhealthy') {
           result.push({
             kind: 'provider',
             providerId,
@@ -334,7 +335,9 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   private buildProviderTooltip(label: string, health: ProviderHealthStatus): vscode.MarkdownString {
     const md = new vscode.MarkdownString();
-    md.appendMarkdown(`**${label}**\n\n`);
+    md.appendMarkdown(`**`);
+    md.appendText(label);
+    md.appendMarkdown(`**\n\n`);
     if (health.lastRefreshTime) {
       md.appendMarkdown(`Last refreshed: ${formatRelativeTime(health.lastRefreshTime)}\n\n`);
     }

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -339,8 +339,11 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       md.appendMarkdown(`Last refreshed: ${formatRelativeTime(health.lastRefreshTime)}\n\n`);
     }
     if (health.status === 'unhealthy' && health.lastError) {
-      md.appendMarkdown(`$(warning) **Refresh failed:** ${health.lastError}\n\n`);
+      md.appendMarkdown(`$(warning) **Refresh failed:** `);
+      md.appendText(health.lastError);
+      md.appendMarkdown(`\n\n`);
     }
+    md.supportThemeIcons = true;
     return md;
   }
 

--- a/packages/core/src/views/providerTooltip.ts
+++ b/packages/core/src/views/providerTooltip.ts
@@ -1,0 +1,24 @@
+import * as vscode from 'vscode';
+import { ProviderHealthStatus } from '../services/providerRegistry';
+import { formatRelativeTime } from '../utils/time';
+
+/**
+ * Build a tooltip for a provider tree node showing its label and health status.
+ * Shared by Inbox and Sources tree providers to keep tooltip rendering consistent.
+ */
+export function buildProviderTooltip(label: string, health: ProviderHealthStatus): vscode.MarkdownString {
+  const md = new vscode.MarkdownString();
+  md.appendMarkdown(`**`);
+  md.appendText(label);
+  md.appendMarkdown(`**\n\n`);
+  if (health.lastRefreshTime) {
+    md.appendMarkdown(`Last refreshed: ${formatRelativeTime(health.lastRefreshTime)}\n\n`);
+  }
+  if (health.status === 'unhealthy' && health.lastError) {
+    md.appendMarkdown(`$(warning) **Refresh failed:** `);
+    md.appendText(health.lastError);
+    md.appendMarkdown(`\n\n`);
+  }
+  md.supportThemeIcons = true;
+  return md;
+}

--- a/packages/core/src/views/providerTooltip.ts
+++ b/packages/core/src/views/providerTooltip.ts
@@ -12,7 +12,9 @@ export function buildProviderTooltip(label: string, health: ProviderHealthStatus
   md.appendText(label);
   md.appendMarkdown(`**\n\n`);
   if (health.lastRefreshTime) {
-    md.appendMarkdown(`Last refreshed: ${formatRelativeTime(health.lastRefreshTime)}\n\n`);
+    md.appendMarkdown(`Last refreshed: `);
+    md.appendText(formatRelativeTime(health.lastRefreshTime));
+    md.appendMarkdown(`\n\n`);
   }
   if (health.status === 'unhealthy' && health.lastError) {
     md.appendMarkdown(`$(warning) **Refresh failed:** `);

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -1,9 +1,9 @@
 import * as vscode from 'vscode';
 import { DiscoveredItem } from '../api/types';
-import { ProviderRegistry, ProviderHealthStatus } from '../services/providerRegistry';
+import { ProviderRegistry } from '../services/providerRegistry';
 import { DiscoveredStateStore, InboxState } from '../storage/discoveredStateStore';
 import { ViewLayout, LayoutState } from './viewLayout';
-import { formatRelativeTime } from '../utils/time';
+import { buildProviderTooltip } from './providerTooltip';
 
 export type SourcesElement = SourceProviderNode | SourceGroupNode | SourceItemNode;
 
@@ -64,7 +64,7 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
         } else {
           treeItem.iconPath = new vscode.ThemeIcon('plug');
         }
-        treeItem.tooltip = this.buildProviderTooltip(element.label, health);
+        treeItem.tooltip = buildProviderTooltip(element.label, health);
         return treeItem;
       }
       case 'group': {
@@ -189,23 +189,6 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
       url: item.url,
       group: item.group,
     };
-  }
-
-  private buildProviderTooltip(label: string, health: ProviderHealthStatus): vscode.MarkdownString {
-    const md = new vscode.MarkdownString();
-    md.appendMarkdown(`**`);
-    md.appendText(label);
-    md.appendMarkdown(`**\n\n`);
-    if (health.lastRefreshTime) {
-      md.appendMarkdown(`Last refreshed: ${formatRelativeTime(health.lastRefreshTime)}\n\n`);
-    }
-    if (health.status === 'unhealthy' && health.lastError) {
-      md.appendMarkdown(`$(warning) **Refresh failed:** `);
-      md.appendText(health.lastError);
-      md.appendMarkdown(`\n\n`);
-    }
-    md.supportThemeIcons = true;
-    return md;
   }
 
   private buildItemDescription(providerId: string, state: InboxState | undefined): string | undefined {

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -193,7 +193,9 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
 
   private buildProviderTooltip(label: string, health: ProviderHealthStatus): vscode.MarkdownString {
     const md = new vscode.MarkdownString();
-    md.appendMarkdown(`**${label}**\n\n`);
+    md.appendMarkdown(`**`);
+    md.appendText(label);
+    md.appendMarkdown(`**\n\n`);
     if (health.lastRefreshTime) {
       md.appendMarkdown(`Last refreshed: ${formatRelativeTime(health.lastRefreshTime)}\n\n`);
     }

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -198,8 +198,11 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
       md.appendMarkdown(`Last refreshed: ${formatRelativeTime(health.lastRefreshTime)}\n\n`);
     }
     if (health.status === 'unhealthy' && health.lastError) {
-      md.appendMarkdown(`$(warning) **Refresh failed:** ${health.lastError}\n\n`);
+      md.appendMarkdown(`$(warning) **Refresh failed:** `);
+      md.appendText(health.lastError);
+      md.appendMarkdown(`\n\n`);
     }
+    md.supportThemeIcons = true;
     return md;
   }
 

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
 import { DiscoveredItem } from '../api/types';
-import { ProviderRegistry } from '../services/providerRegistry';
+import { ProviderRegistry, ProviderHealthStatus } from '../services/providerRegistry';
 import { DiscoveredStateStore, InboxState } from '../storage/discoveredStateStore';
 import { ViewLayout, LayoutState } from './viewLayout';
+import { formatRelativeTime } from '../utils/time';
 
 export type SourcesElement = SourceProviderNode | SourceGroupNode | SourceItemNode;
 
@@ -44,6 +45,7 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
     this._layoutState = new LayoutState('tree', () => this._onDidChangeTreeData.fire());
     this.disposables.push(
       providerRegistry.onDidChangeDiscoveredItems(() => this._onDidChangeTreeData.fire()),
+      providerRegistry.onDidChangeProviderHealth(() => this._onDidChangeTreeData.fire()),
       stateStore.onDidChange(() => this._onDidChangeTreeData.fire())
     );
   }
@@ -53,9 +55,16 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
   getTreeItem(element: SourcesElement): vscode.TreeItem {
     switch (element.kind) {
       case 'provider': {
+        const health = this.providerRegistry.getProviderHealth(element.providerId);
         const treeItem = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.Collapsed);
         treeItem.contextValue = 'sourceProvider';
-        treeItem.iconPath = new vscode.ThemeIcon('plug');
+        if (health.status === 'unhealthy') {
+          treeItem.iconPath = new vscode.ThemeIcon('warning', new vscode.ThemeColor('problemsWarningIcon.foreground'));
+          treeItem.description = 'refresh failed';
+        } else {
+          treeItem.iconPath = new vscode.ThemeIcon('plug');
+        }
+        treeItem.tooltip = this.buildProviderTooltip(element.label, health);
         return treeItem;
       }
       case 'group': {
@@ -96,7 +105,8 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
       const result: SourceProviderNode[] = [];
       const allItems = this.providerRegistry.getAllDiscoveredItems();
       for (const [providerId, items] of allItems) {
-        if (items.length > 0) {
+        const health = this.providerRegistry.getProviderHealth(providerId);
+        if (items.length > 0 || health.status === 'unhealthy') {
           result.push({
             kind: 'provider',
             providerId,
@@ -179,6 +189,18 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
       url: item.url,
       group: item.group,
     };
+  }
+
+  private buildProviderTooltip(label: string, health: ProviderHealthStatus): vscode.MarkdownString {
+    const md = new vscode.MarkdownString();
+    md.appendMarkdown(`**${label}**\n\n`);
+    if (health.lastRefreshTime) {
+      md.appendMarkdown(`Last refreshed: ${formatRelativeTime(health.lastRefreshTime)}\n\n`);
+    }
+    if (health.status === 'unhealthy' && health.lastError) {
+      md.appendMarkdown(`$(warning) **Refresh failed:** ${health.lastError}\n\n`);
+    }
+    return md;
   }
 
   private buildItemDescription(providerId: string, state: InboxState | undefined): string | undefined {


### PR DESCRIPTION
Closes #233

## Summary

Adds provider health tracking so users can see when a provider's background refresh fails or times out. Unhealthy providers show a warning icon in the Inbox and Sources tree views, with diagnostic details in tooltips.

## Changes

### Core health tracking (`providerRegistry.ts`)
- New `ProviderHealthStatus` interface with `status`, `lastRefreshTime`, and `lastError`
- `updateHealth()` sets healthy/unhealthy status after refresh completes or fails
- Timeout-based unhealthy detection via existing `refreshWithTimeout` cancellation
- `onDidChangeProviderHealth` event fires when any part of the health state changes (status, lastError, or lastRefreshTime)
- Health state cleaned up on provider unregister

### Tree views (`inboxTreeProvider.ts`, `sourcesTreeProvider.ts`)
- Provider nodes show warning icon (`ThemeIcon('warning')`) when unhealthy
- Tooltip displays last refresh time and error message for unhealthy providers
- Provider labels and error messages are sanitized via `appendText()` to prevent Markdown injection
- Unhealthy providers shown in both Inbox and Sources even with zero items
- `supportThemeIcons` enabled for tooltip icon rendering

### Utility (`utils/time.ts`)
- `formatRelativeTime()` delegates to `timeago.js` for human-readable relative timestamps in tooltips

### Tests
- 8 new unit tests covering health transitions: healthy, unhealthy, timeout, event firing, deduplication, cleanup, and `lastRefreshTime` preservation
- 6 unit tests for `formatRelativeTime` covering key time ranges with regex-based assertions for resilience to upstream wording changes
- Mock updates across 4 test files for new `getProviderHealth` interface

## Testing

- All test files pass across all packages
- Build succeeds across all packages
