### PR TITLE
Fix logo D shape transparency

### DIFF
--- a/packages/core/resources/devdocket.svg
+++ b/packages/core/resources/devdocket.svg
@@ -1,16 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
-  <defs>
-    <linearGradient id="devdocket-gradient" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#10B981"/>
-      <stop offset="100%" stop-color="#059669"/>
-    </linearGradient>
-  </defs>
-  <!-- Bold D letterform -->
-  <path d="M24 12 L24 116 L70 116 C102 116 116 92 116 64 C116 36 102 12 70 12 Z" fill="url(#devdocket-gradient)"/>
-  <!-- Inner cutout creating D shape -->
-  <path d="M44 32 L44 96 L66 96 C86 96 96 82 96 64 C96 46 86 32 66 32 Z" fill="#FFFFFF"/>
-  <!-- Docket slots - three horizontal lines -->
-  <rect x="50" y="44" width="30" height="7" rx="2" fill="url(#devdocket-gradient)"/>
-  <rect x="50" y="60" width="22" height="7" rx="2" fill="url(#devdocket-gradient)"/>
-  <rect x="50" y="76" width="26" height="7" rx="2" fill="url(#devdocket-gradient)"/>
+  <path fill-rule="evenodd" d="M24 12 L24 116 L70 116 C102 116 116 92 116 64 C116 36 102 12 70 12 Z M44 32 L44 96 L66 96 C86 96 96 82 96 64 C96 46 86 32 66 32 Z" fill="currentColor"/>
+  <rect x="50" y="44" width="30" height="7" rx="2" fill="currentColor"/>
+  <rect x="50" y="60" width="22" height="7" rx="2" fill="currentColor"/>
+  <rect x="50" y="76" width="26" height="7" rx="2" fill="currentColor"/>
 </svg>


### PR DESCRIPTION
Closes #278. Uses compound path with fill-rule=evenodd to make the inner D a true cutout instead of solid white fill. All 6 SVG files updated (devdocket.svg, logo.svg, logo-dark.svg, logo-light.svg, logo-mono.svg, favicon.svg).