### PR TITLE
Add TypeScript LSP configuration for Copilot CLI

### DIFF
--- a/.github/lsp.json
+++ b/.github/lsp.json
@@ -1,0 +1,12 @@
+{
+  "lspServers": {
+    "typescript": {
+      "command": "typescript-language-server",
+      "args": ["--stdio"],
+      "fileExtensions": {
+        ".ts": "typescript",
+        ".tsx": "typescript"
+      }
+    }
+  }
+}

--- a/.github/lsp.json
+++ b/.github/lsp.json
@@ -5,7 +5,9 @@
       "args": ["--stdio"],
       "fileExtensions": {
         ".ts": "typescript",
-        ".tsx": "typescript"
+        ".tsx": "typescriptreact",
+        ".js": "javascript",
+        ".jsx": "javascriptreact"
       }
     }
   }


### PR DESCRIPTION
## Summary

Adds a `.github/lsp.json` configuration file to enable the TypeScript Language Server for Copilot CLI. This gives Copilot CLI access to type-aware code intelligence (completions, diagnostics, go-to-definition) when working in this repository.

## Changes

- **`.github/lsp.json`** — Configures `typescript-language-server` with `--stdio` transport
  - Maps `.ts` → `typescript`, `.tsx` → `typescriptreact`
  - Maps `.js` → `javascript`, `.jsx` → `javascriptreact`

## Notes

- The `typescript-language-server` binary is expected to be provided by the Copilot CLI runtime environment
- No source code changes; configuration-only addition
