### PR TITLE
Allow moving items from History back to Queue

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -627,6 +627,11 @@
           "group": "1_actions"
         },
         {
+          "command": "devdocket.moveToQueue",
+          "when": "view == devdocket.history && viewItem =~ /^historyItem/",
+          "group": "1_actions"
+        },
+        {
           "command": "devdocket.archiveItem",
           "when": "view == devdocket.history && viewItem =~ /historyItem\\.done/",
           "group": "1_actions"

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -4,11 +4,11 @@
  * Items move through these states following the work-item state machine:
  *
  * ```
- * New → InProgress ⇄ Paused
- * ↑         ↓           ↑
- * │       Done ────────┤
- * │         ↓
- * └───── Archived
+ * New ⇄ InProgress ⇄ Paused
+ *  ↑        ↓
+ *  ↑      Done
+ *  ↑        ↓
+ *  └──── Archived
  * ```
  *
  * Valid transitions:

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -4,13 +4,19 @@
  * Items move through these states following the work-item state machine:
  *
  * ```
- * New → InProgress → Done → Archived
- * ↑         ↕         ↑
- * │       Paused ────┤
- * └──────────┘       │
- * └──────────────────┴─────────────┘
- *           └──────────────────────→ Archived
+ * New → InProgress ⇄ Paused
+ * ↑         ↓
+ * │       Done
+ * │         ↓
+ * └─────Archived
  * ```
+ *
+ * Valid transitions:
+ * - New → InProgress | Archived
+ * - InProgress → Paused | Done | New | Archived
+ * - Paused → InProgress | New | Archived
+ * - Done → Archived | New
+ * - Archived → New
  *
  * InProgress and Paused may transition back to New (returning to Queue).
  * Done and Archived may also transition back to New (for re-work after

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -5,10 +5,10 @@
  *
  * ```
  * New → InProgress ⇄ Paused
- * ↑         ↓
- * │       Done
+ * ↑         ↓           ↑
+ * │       Done ────────┤
  * │         ↓
- * └─────Archived
+ * └───── Archived
  * ```
  *
  * Valid transitions:

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -5,14 +5,17 @@
  *
  * ```
  * New → InProgress → Done → Archived
- * ↑         ↕         ↗
- * │       Paused ────┘
- * └──────────┘
- * └──────────────────────→ Archived
+ * ↑         ↕         ↑
+ * │       Paused ────┤
+ * └──────────┘       │
+ * └──────────────────┴─────────────┘
+ *           └──────────────────────→ Archived
  * ```
  *
  * InProgress and Paused may transition back to New (returning to Queue).
- * Both InProgress and Paused may also transition directly to Archived
+ * Done and Archived may also transition back to New (for re-work after
+ * discovering the item was not actually complete).
+ * InProgress, Paused, and Done may transition directly to Archived
  * (for abandoned or no-longer-relevant work).
  */
 export enum WorkItemState {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -10,8 +10,8 @@ const VALID_TRANSITIONS: ReadonlyMap<WorkItemState, ReadonlySet<WorkItemState>> 
   [WorkItemState.New, new Set([WorkItemState.InProgress, WorkItemState.Archived])],
   [WorkItemState.InProgress, new Set([WorkItemState.Paused, WorkItemState.Done, WorkItemState.New, WorkItemState.Archived])],
   [WorkItemState.Paused, new Set([WorkItemState.InProgress, WorkItemState.New, WorkItemState.Archived])],
-  [WorkItemState.Done, new Set([WorkItemState.Archived])],
-  [WorkItemState.Archived, new Set<WorkItemState>()],
+  [WorkItemState.Done, new Set([WorkItemState.Archived, WorkItemState.New])],
+  [WorkItemState.Archived, new Set([WorkItemState.New])],
 ]);
 
 /**
@@ -234,6 +234,9 @@ export class WorkGraph {
     const updated: WorkItem = { ...item, state: newState, updatedAt: Date.now() };
     // When returning to Queue, assign a fresh sortOrder to avoid collisions
     if (newState === WorkItemState.New) {
+      // Update state first so nextSortOrder can see the item in its new state
+      this.items.set(id, updated);
+      this.invalidateStateCache();
       updated.sortOrder = this.nextSortOrder(WorkItemState.New);
     }
     await this.store.save(updated);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -232,15 +232,10 @@ export class WorkGraph {
       );
     }
     const updated: WorkItem = { ...item, state: newState, updatedAt: Date.now() };
-    // When returning to Queue, assign a fresh sortOrder to avoid collisions
+    // When returning to Queue, assign a fresh sortOrder based on the current Queue contents,
+    // excluding the moving item, to avoid skipping indices.
     if (newState === WorkItemState.New) {
-      const originalItem = this.items.get(id)!;
-      this.items.set(id, updated);
-      this.invalidateStateCache();
       updated.sortOrder = this.nextSortOrder(WorkItemState.New);
-      // Restore original state — the unconditional items.set after save handles the real commit
-      this.items.set(id, originalItem);
-      this.invalidateStateCache();
     }
     await this.store.save(updated);
     this.items.set(id, updated);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -232,8 +232,8 @@ export class WorkGraph {
       );
     }
     const updated: WorkItem = { ...item, state: newState, updatedAt: Date.now() };
-    // When returning to Queue, assign a fresh sortOrder based on the current Queue contents,
-    // excluding the moving item, to avoid skipping indices.
+    // When returning to Queue, assign a fresh sortOrder based on the current pre-transition
+    // Queue contents. This is computed before this.items is updated with the new state.
     if (newState === WorkItemState.New) {
       updated.sortOrder = this.nextSortOrder(WorkItemState.New);
     }

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -233,17 +233,13 @@ export class WorkGraph {
     }
     const updated: WorkItem = { ...item, state: newState, updatedAt: Date.now() };
     // When returning to Queue, assign a fresh sortOrder based on the current pre-transition
-    // Queue contents. This is computed before this.items is updated with the new state.
-    // Also account for the item's own sortOrder if it was previously in Queue, to avoid
-    // reusing the same value when moving back to Queue multiple times.
+    // Queue contents. Reuse nextSortOrder but also account for the item's own sortOrder
+    // to avoid reusing the same value when moving back to Queue multiple times.
     if (newState === WorkItemState.New) {
-      const queueItems = this.getItemsByState(WorkItemState.New);
-      const maxOrder = Math.max(
-        queueItems.length - 1,
-        queueItems.reduce((max, i) => Math.max(max, i.sortOrder ?? -1), -1),
-        item.sortOrder ?? -1  // Include the moving item's current sortOrder
+      updated.sortOrder = Math.max(
+        this.nextSortOrder(WorkItemState.New),
+        (item.sortOrder ?? -1) + 1
       );
-      updated.sortOrder = maxOrder + 1;
     }
     await this.store.save(updated);
     this.items.set(id, updated);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -234,8 +234,16 @@ export class WorkGraph {
     const updated: WorkItem = { ...item, state: newState, updatedAt: Date.now() };
     // When returning to Queue, assign a fresh sortOrder based on the current pre-transition
     // Queue contents. This is computed before this.items is updated with the new state.
+    // Also account for the item's own sortOrder if it was previously in Queue, to avoid
+    // reusing the same value when moving back to Queue multiple times.
     if (newState === WorkItemState.New) {
-      updated.sortOrder = this.nextSortOrder(WorkItemState.New);
+      const queueItems = this.getItemsByState(WorkItemState.New);
+      const maxOrder = Math.max(
+        queueItems.length - 1,
+        queueItems.reduce((max, i) => Math.max(max, i.sortOrder ?? -1), -1),
+        item.sortOrder ?? -1  // Include the moving item's current sortOrder
+      );
+      updated.sortOrder = maxOrder + 1;
     }
     await this.store.save(updated);
     this.items.set(id, updated);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -234,10 +234,13 @@ export class WorkGraph {
     const updated: WorkItem = { ...item, state: newState, updatedAt: Date.now() };
     // When returning to Queue, assign a fresh sortOrder to avoid collisions
     if (newState === WorkItemState.New) {
-      // Update state first so nextSortOrder can see the item in its new state
+      const originalItem = this.items.get(id)!;
       this.items.set(id, updated);
       this.invalidateStateCache();
       updated.sortOrder = this.nextSortOrder(WorkItemState.New);
+      // Restore original state — the unconditional items.set after save handles the real commit
+      this.items.set(id, originalItem);
+      this.invalidateStateCache();
     }
     await this.store.save(updated);
     this.items.set(id, updated);

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -506,15 +506,14 @@ describe('WorkGraph', () => {
       expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
     });
 
-    it('rejects Done → New', async () => {
+    it('allows Done → New (move back to queue)', async () => {
       const item = await graph.createItem({ title: 'Test' });
       await graph.transitionState(item.id, WorkItemState.InProgress);
       await graph.transitionState(item.id, WorkItemState.Done);
       vi.mocked(store.save).mockClear();
-      await expect(graph.transitionState(item.id, WorkItemState.New))
-        .rejects.toThrow('Invalid state transition');
-      expect(store.save).not.toHaveBeenCalled();
-      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Done);
+      await graph.transitionState(item.id, WorkItemState.New);
+      expect(store.save).toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
     });
 
     it('rejects Done → InProgress', async () => {
@@ -528,16 +527,15 @@ describe('WorkGraph', () => {
       expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Done);
     });
 
-    it('rejects Archived → New', async () => {
+    it('allows Archived → New (move back to queue)', async () => {
       const item = await graph.createItem({ title: 'Test' });
       await graph.transitionState(item.id, WorkItemState.InProgress);
       await graph.transitionState(item.id, WorkItemState.Done);
       await graph.transitionState(item.id, WorkItemState.Archived);
       vi.mocked(store.save).mockClear();
-      await expect(graph.transitionState(item.id, WorkItemState.New))
-        .rejects.toThrow('Invalid state transition');
-      expect(store.save).not.toHaveBeenCalled();
-      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Archived);
+      await graph.transitionState(item.id, WorkItemState.New);
+      expect(store.save).toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
     });
 
     it('allows InProgress → New (move to queue)', async () => {
@@ -614,6 +612,162 @@ describe('WorkGraph', () => {
       // Done → Archived
       await graph.transitionState(item.id, WorkItemState.Archived);
       expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Archived);
+    });
+  });
+
+  describe('move from History back to Queue', () => {
+    it('moving Done item back to Queue appears in Queue view', async () => {
+      const item = await graph.createItem({ title: 'Rework item' });
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Done);
+
+      // Verify in History (Done state)
+      const historyItems = graph.getItemsByState(WorkItemState.Done, WorkItemState.Archived);
+      expect(historyItems).toHaveLength(1);
+      expect(historyItems[0].id).toBe(item.id);
+
+      // Move back to Queue
+      await graph.transitionState(item.id, WorkItemState.New);
+
+      // Verify in Queue view
+      const queueItems = graph.getItemsByState(WorkItemState.New);
+      expect(queueItems).toHaveLength(1);
+      expect(queueItems[0].id).toBe(item.id);
+    });
+
+    it('moving Archived item back to Queue appears in Queue view', async () => {
+      const item = await graph.createItem({ title: 'Archived rework' });
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Done);
+      await graph.transitionState(item.id, WorkItemState.Archived);
+
+      // Verify in History (Archived state)
+      const historyItems = graph.getItemsByState(WorkItemState.Done, WorkItemState.Archived);
+      expect(historyItems).toHaveLength(1);
+
+      // Move back to Queue
+      await graph.transitionState(item.id, WorkItemState.New);
+
+      // Verify in Queue view
+      const queueItems = graph.getItemsByState(WorkItemState.New);
+      expect(queueItems).toHaveLength(1);
+      expect(queueItems[0].id).toBe(item.id);
+    });
+
+    it('item no longer appears in History after move to Queue', async () => {
+      const item = await graph.createItem({ title: 'Done item' });
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Done);
+
+      // Move back to Queue
+      await graph.transitionState(item.id, WorkItemState.New);
+
+      // Verify NOT in History
+      const historyItems = graph.getItemsByState(WorkItemState.Done, WorkItemState.Archived);
+      expect(historyItems).toHaveLength(0);
+    });
+
+    it('Done → New assigns fresh sortOrder at end of Queue', async () => {
+      const a = await graph.createItem({ title: 'A' });
+      const b = await graph.createItem({ title: 'B' });
+      const c = await graph.createItem({ title: 'C' });
+      await graph.transitionState(a.id, WorkItemState.InProgress);
+      await graph.transitionState(a.id, WorkItemState.Done);
+
+      // Move Done item back to Queue
+      await graph.transitionState(a.id, WorkItemState.New);
+
+      const queueItems = graph.getItemsByState(WorkItemState.New)
+        .sort((x, y) => (x.sortOrder ?? 0) - (y.sortOrder ?? 0));
+      expect(queueItems.map(i => i.title)).toEqual(['B', 'C', 'A']);
+      expect(graph.getItem(a.id)!.sortOrder).toBeGreaterThan(graph.getItem(c.id)!.sortOrder!);
+    });
+
+    it('Archived → New assigns fresh sortOrder at end of Queue', async () => {
+      const a = await graph.createItem({ title: 'A' });
+      const b = await graph.createItem({ title: 'B' });
+      await graph.transitionState(a.id, WorkItemState.InProgress);
+      await graph.transitionState(a.id, WorkItemState.Done);
+      await graph.transitionState(a.id, WorkItemState.Archived);
+
+      // Move Archived item back to Queue
+      await graph.transitionState(a.id, WorkItemState.New);
+
+      const queueItems = graph.getItemsByState(WorkItemState.New)
+        .sort((x, y) => (x.sortOrder ?? 0) - (y.sortOrder ?? 0));
+      expect(queueItems.map(i => i.title)).toEqual(['B', 'A']);
+      expect(graph.getItem(a.id)!.sortOrder).toBeGreaterThan(graph.getItem(b.id)!.sortOrder!);
+    });
+
+    it('moving same Done item back to Queue twice works', async () => {
+      const other = await graph.createItem({ title: 'Other item' });
+      const item = await graph.createItem({ title: 'Rework twice' });
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Done);
+
+      // First move back to Queue (should be after 'Other item')
+      await graph.transitionState(item.id, WorkItemState.New);
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
+      const firstSortOrder = graph.getItem(item.id)!.sortOrder;
+      expect(firstSortOrder).toBeGreaterThan(graph.getItem(other.id)!.sortOrder!);
+
+      // Complete again
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Done);
+
+      // Second move back to Queue (should get an even higher sortOrder)
+      await graph.transitionState(item.id, WorkItemState.New);
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
+      const secondSortOrder = graph.getItem(item.id)!.sortOrder;
+      expect(secondSortOrder).toBeGreaterThan(firstSortOrder!);
+    });
+
+    it('fires onDidChange when moving History item to Queue', async () => {
+      const item = await graph.createItem({ title: 'Test' });
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Done);
+
+      const listener = vi.fn();
+      graph.onDidChange(listener);
+
+      await graph.transitionState(item.id, WorkItemState.New);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('moving Done item to Queue updates sortOrder only', async () => {
+      const item = await graph.createItem({ title: 'Original title', notes: 'Original notes' });
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Done);
+
+      await graph.transitionState(item.id, WorkItemState.New);
+
+      const updated = graph.getItem(item.id)!;
+      expect(updated.title).toBe('Original title');
+      expect(updated.notes).toBe('Original notes');
+      expect(updated.sortOrder).toBeGreaterThanOrEqual(0);
+    });
+
+    it('multiple Done items moved back to Queue maintain relative order', async () => {
+      const a = await graph.createItem({ title: 'A' });
+      const b = await graph.createItem({ title: 'B' });
+      const c = await graph.createItem({ title: 'C' });
+
+      // Complete all three
+      await graph.transitionState(a.id, WorkItemState.InProgress);
+      await graph.transitionState(a.id, WorkItemState.Done);
+      await graph.transitionState(b.id, WorkItemState.InProgress);
+      await graph.transitionState(b.id, WorkItemState.Done);
+      await graph.transitionState(c.id, WorkItemState.InProgress);
+      await graph.transitionState(c.id, WorkItemState.Done);
+
+      // Move back in order A, then B
+      await graph.transitionState(a.id, WorkItemState.New);
+      await graph.transitionState(b.id, WorkItemState.New);
+
+      const queueItems = graph.getItemsByState(WorkItemState.New)
+        .sort((x, y) => (x.sortOrder ?? 0) - (y.sortOrder ?? 0));
+      expect(queueItems.map(i => i.title)).toEqual(['A', 'B']);
+      expect(graph.getItem(a.id)!.sortOrder).toBeLessThan(graph.getItem(b.id)!.sortOrder!);
     });
   });
 


### PR DESCRIPTION
## Summary
Adds the ability to move work items from History back to Queue. Items in Done or Archived state can now be transitioned back to New state for re-work.

## Changes
- Added `Done → New` and `Archived → New` as valid state transitions in the WorkGraph service
- Added "Move to Queue" context menu entry for History view items
- sortOrder is computed from pre-transition Queue contents before updating the item's state, ensuring the moving item doesn't inflate the computed value
- Updated the state machine diagram in `workItem.ts` to reflect all valid transitions

## Testing
- 11 new/updated test cases covering state transitions, view membership, sortOrder ordering, round-tripping, metadata preservation, event firing, and batch ordering
- All 1071 tests pass

Closes #275
