### PR TITLE
Make editor panel title a clickable hyperlink

### DIFF
--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -288,5 +288,19 @@ describe('getEditorPanelHtml', () => {
       expect(html).not.toContain('<script>alert(1)</script>');
       expect(html).toContain('&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
     });
+
+    it('does not render a hyperlink for javascript: URLs', () => {
+      const item = makeItem({ url: 'javascript:alert(1)' });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).not.toContain('id="title-link"');
+      expect(html).not.toContain('href=');
+    });
+
+    it('does not render a hyperlink for data: URLs', () => {
+      const item = makeItem({ url: 'data:text/html,<h1>hi</h1>' });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).not.toContain('id="title-link"');
+      expect(html).not.toContain('href=');
+    });
   });
 });

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -271,8 +271,9 @@ describe('getEditorPanelHtml', () => {
       const item = makeItem({ url: 'https://github.com/org/repo/issues/42' });
       const html = getEditorPanelHtml({ cspSource, item });
       expect(html).toContain('id="title-link"');
-      expect(html).toMatch(/<a\s[^>]*data-url="https:\/\/github\.com\/org\/repo\/issues\/42"/);
-      expect(html).not.toContain('Open in browser');
+      expect(html).toMatch(/<a\s[^>]*href="#"[^>]*data-url="https:\/\/github\.com\/org\/repo\/issues\/42"/);
+      expect(html).toContain('title="Open in browser"');
+      expect(html).not.toContain('Open in browser</');
     });
 
     it('renders plain title text when item has no url', () => {

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -271,7 +271,7 @@ describe('getEditorPanelHtml', () => {
       const item = makeItem({ url: 'https://github.com/org/repo/issues/42' });
       const html = getEditorPanelHtml({ cspSource, item });
       expect(html).toContain('id="title-link"');
-      expect(html).toMatch(/<a\s[^>]*href="#"[^>]*data-url="https:\/\/github\.com\/org\/repo\/issues\/42"/);
+      expect(html).toMatch(/<a\s[^>]*href="https:\/\/github\.com\/org\/repo\/issues\/42"[^>]*data-url="https:\/\/github\.com\/org\/repo\/issues\/42"/);
       expect(html).toContain('title="Open in browser"');
       expect(html).not.toContain('Open in browser</');
     });

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -267,19 +267,18 @@ describe('getEditorPanelHtml', () => {
   });
 
   describe('browser URL link', () => {
-    it('renders a clickable link when item has a url', () => {
+    it('renders the title as a clickable hyperlink when item has a url', () => {
       const item = makeItem({ url: 'https://github.com/org/repo/issues/42' });
       const html = getEditorPanelHtml({ cspSource, item });
-      expect(html).toContain('id="source-link"');
-      expect(html).toMatch(/<button\s[^>]*data-url="https:\/\/github\.com\/org\/repo\/issues\/42"/);
-      expect(html).toContain('Open in browser');
+      expect(html).toContain('id="title-link"');
+      expect(html).toMatch(/<a\s[^>]*data-url="https:\/\/github\.com\/org\/repo\/issues\/42"/);
+      expect(html).not.toContain('Open in browser');
     });
 
-    it('does not render a link when item has no url', () => {
+    it('renders plain title text when item has no url', () => {
       const item = makeItem({ url: undefined });
       const html = getEditorPanelHtml({ cspSource, item });
-      expect(html).not.toContain('id="source-link"');
-      expect(html).not.toContain('Open in browser');
+      expect(html).not.toContain('id="title-link"');
     });
 
     it('escapes HTML entities in the url to prevent XSS', () => {

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -158,28 +158,19 @@ export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDes
       white-space: pre-wrap;
       margin-top: 2px;
     }
-    .source-link {
-      display: inline-flex;
-      align-items: center;
-      gap: 4px;
-      font-size: 0.85em;
-      margin-bottom: 14px;
+    .title-link {
       color: var(--vscode-textLink-foreground);
       cursor: pointer;
-      background: none;
-      border: none;
-      padding: 0;
-      font-family: inherit;
+      text-decoration: none;
     }
-    .source-link:hover {
+    .title-link:hover {
       color: var(--vscode-textLink-activeForeground);
       text-decoration: underline;
     }
   </style>
 </head>
 <body>
-  <h2 id="editor-heading">${escapeHtml(item.title)}</h2>
-${item.url ? `  <button type="button" class="source-link" id="source-link" data-url="${escapeAttr(item.url)}">Open in browser</button>` : ''}
+  <h2 id="editor-heading">${item.url ? `<a class="title-link" id="title-link" data-url="${escapeAttr(item.url)}">${escapeHtml(item.title)}</a>` : escapeHtml(item.title)}</h2>
   <div id="form" role="form" aria-labelledby="editor-heading">
     <div class="field">
       <label for="title">Title</label>
@@ -236,10 +227,11 @@ ${item.providerId && providerLabel ? `      <dt>Provider</dt>
       }
     });
 
-    const sourceLink = document.getElementById('source-link');
-    if (sourceLink) {
-      sourceLink.addEventListener('click', () => {
-        vscode.postMessage({ type: 'openUrl', url: sourceLink.dataset.url });
+    const titleLink = document.getElementById('title-link');
+    if (titleLink) {
+      titleLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        vscode.postMessage({ type: 'openUrl', url: titleLink.dataset.url });
       });
     }
   </script>

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -177,7 +177,7 @@ export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDes
   </style>
 </head>
 <body>
-  <h2 id="editor-heading">${item.url ? `<a href="#" class="title-link" id="title-link" data-url="${escapeAttr(item.url)}" title="Open in browser">${escapeHtml(item.title)}</a>` : escapeHtml(item.title)}</h2>
+  <h2 id="editor-heading">${item.url ? `<a href="${escapeAttr(item.url)}" class="title-link" id="title-link" data-url="${escapeAttr(item.url)}" title="Open in browser">${escapeHtml(item.title)}</a>` : escapeHtml(item.title)}</h2>
   <div id="form" role="form" aria-labelledby="editor-heading">
     <div class="field">
       <label for="title">Title</label>

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -1,5 +1,6 @@
 import * as crypto from 'crypto';
 import { WorkItem, WorkItemState } from '../models/workItem';
+import { isSafeUrl } from '../utils/url';
 
 export interface EditorHtmlOptions {
   cspSource: string;
@@ -177,7 +178,7 @@ export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDes
   </style>
 </head>
 <body>
-  <h2 id="editor-heading">${item.url ? `<a href="${escapeAttr(item.url)}" class="title-link" id="title-link" data-url="${escapeAttr(item.url)}" title="Open in browser">${escapeHtml(item.title)}</a>` : escapeHtml(item.title)}</h2>
+  <h2 id="editor-heading">${item.url && isSafeUrl(item.url) ? `<a href="${escapeAttr(item.url)}" class="title-link" id="title-link" data-url="${escapeAttr(item.url)}" title="Open in browser">${escapeHtml(item.title)}</a>` : escapeHtml(item.title)}</h2>
   <div id="form" role="form" aria-labelledby="editor-heading">
     <div class="field">
       <label for="title">Title</label>

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -167,10 +167,17 @@ export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDes
       color: var(--vscode-textLink-activeForeground);
       text-decoration: underline;
     }
+    .title-link:focus,
+    .title-link:focus-visible {
+      color: var(--vscode-textLink-activeForeground);
+      text-decoration: underline;
+      outline: 1px solid var(--vscode-focusBorder);
+      outline-offset: 2px;
+    }
   </style>
 </head>
 <body>
-  <h2 id="editor-heading">${item.url ? `<a class="title-link" id="title-link" data-url="${escapeAttr(item.url)}">${escapeHtml(item.title)}</a>` : escapeHtml(item.title)}</h2>
+  <h2 id="editor-heading">${item.url ? `<a href="#" class="title-link" id="title-link" data-url="${escapeAttr(item.url)}" title="Open in browser">${escapeHtml(item.title)}</a>` : escapeHtml(item.title)}</h2>
   <div id="form" role="form" aria-labelledby="editor-heading">
     <div class="field">
       <label for="title">Title</label>


### PR DESCRIPTION
## Summary

In the work item editor panel, the title was plain text with a separate "Open in browser" button below it. This change makes the title itself a navigable hyperlink that opens the item's URL directly, reducing visual clutter and being more intuitive.

## Changes

- **`editorPanelHtml.ts`**: Replaced the `<button class="source-link">` element with an `<a class="title-link">` inside the `<h2>` heading. When an item has a URL, the title text renders as a styled link; without a URL, it remains plain text. Updated the JavaScript click handler accordingly.
- **`editorPanelHtml.test.ts`**: Updated the "browser URL link" tests to verify the new `title-link` anchor element instead of the old `source-link` button.

Closes #281
