### PR TITLE
Truncate large diff output to prevent walkthrough context overflow

### DIFF
--- a/.squad/commit-msg-temp.txt
+++ b/.squad/commit-msg-temp.txt
@@ -1,0 +1,1 @@
+docs(squad): log Fenster 5-issue dispatch (261, 281, 280, 265, 282)

--- a/.squad/commit-msg-temp.txt
+++ b/.squad/commit-msg-temp.txt
@@ -1,1 +1,0 @@
-docs(squad): log Fenster 5-issue dispatch (261, 281, 280, 265, 282)

--- a/packages/ai-reviewer/src/tools/getDiffTool.ts
+++ b/packages/ai-reviewer/src/tools/getDiffTool.ts
@@ -4,9 +4,13 @@ import { gitExec } from './gitUtils';
 import { validWorktreePaths } from './worktreeRegistry';
 
 /** Maximum characters of diff output before truncation.
- *  Large PRs can produce multi-MB diffs that overflow the model's context window,
- *  causing tool_use/tool_result mismatch errors on the next iteration. */
-export const MAX_DIFF_LENGTH = 100_000;
+ *  Keep below the walkthrough tool-result limit (MAX_TOOL_RESULT_LENGTH)
+ *  so this tool's own truncation footer and stat framing survive
+ *  end-to-end without being re-truncated downstream.
+ *  Large PRs can produce multi-MB diffs that overflow the model's context
+ *  window, causing tool_use/tool_result mismatch errors on the next
+ *  iteration. */
+export const MAX_DIFF_LENGTH = 75_000;
 
 interface GetDiffInput {
   worktreePath: string;

--- a/packages/ai-reviewer/src/tools/getDiffTool.ts
+++ b/packages/ai-reviewer/src/tools/getDiffTool.ts
@@ -3,6 +3,11 @@ import * as path from 'path';
 import { gitExec } from './gitUtils';
 import { validWorktreePaths } from './worktreeRegistry';
 
+/** Maximum characters of diff output before truncation.
+ *  Large PRs can produce multi-MB diffs that overflow the model's context window,
+ *  causing tool_use/tool_result mismatch errors on the next iteration. */
+export const MAX_DIFF_LENGTH = 100_000;
+
 interface GetDiffInput {
   worktreePath: string;
   baseRef: string;
@@ -34,8 +39,42 @@ export function registerGetDiffTool(): vscode.Disposable {
           ['diff', '--no-color', `${baseRef}...${headRef}`],
           worktreePath,
         );
+
+        if (!output) {
+          return new vscode.LanguageModelToolResult([
+            new vscode.LanguageModelTextPart('(no diff)'),
+          ]);
+        }
+
+        if (output.length <= MAX_DIFF_LENGTH) {
+          return new vscode.LanguageModelToolResult([
+            new vscode.LanguageModelTextPart(output),
+          ]);
+        }
+
+        // Diff exceeds the limit — get a stat summary so the model still
+        // knows every changed file, then include a truncated portion of
+        // the actual diff for initial context.
+        let stat = '';
+        try {
+          stat = await gitExec(
+            ['diff', '--stat', '--no-color', `${baseRef}...${headRef}`],
+            worktreePath,
+          );
+        } catch {
+          // best-effort — proceed without stat
+        }
+
+        const truncatedDiff = output.slice(0, MAX_DIFF_LENGTH);
+        const parts = [
+          stat ? `## Diff stat summary\n\n${stat}\n\n` : '',
+          `## Diff (truncated — ${output.length.toLocaleString()} chars total, showing first ${MAX_DIFF_LENGTH.toLocaleString()})\n\n`,
+          truncatedDiff,
+          '\n\n(truncated — use devdocket-getFileDiff to read individual file diffs)',
+        ];
+
         return new vscode.LanguageModelToolResult([
-          new vscode.LanguageModelTextPart(output || '(no diff)'),
+          new vscode.LanguageModelTextPart(parts.join('')),
         ]);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/packages/ai-reviewer/src/tools/getDiffTool.ts
+++ b/packages/ai-reviewer/src/tools/getDiffTool.ts
@@ -65,16 +65,21 @@ export function registerGetDiffTool(): vscode.Disposable {
           // best-effort — proceed without stat
         }
 
-        const framing = stat ? `## Diff stat summary\n\n${stat}\n\n` : '';
-        // Reserve space for the stat and framing text so total output
-        // stays within MAX_DIFF_LENGTH.
-        const diffBudget = Math.max(MAX_DIFF_LENGTH - framing.length - 200, Math.floor(MAX_DIFF_LENGTH * 0.8));
+        const footer = '\n\n(truncated — use devdocket-getFileDiff to read individual file diffs)';
+        // Ensure at least half the budget goes to actual diff content.
+        // If the stat is too large, skip it to preserve diff context.
+        const minDiffBudget = Math.floor(MAX_DIFF_LENGTH / 2);
+        const statSection = stat ? `## Diff stat summary\n\n${stat}\n\n` : '';
+        const framing = statSection.length + footer.length + 200 > MAX_DIFF_LENGTH - minDiffBudget
+          ? '' // stat too large — skip it
+          : statSection;
+        const diffBudget = Math.max(0, MAX_DIFF_LENGTH - framing.length - footer.length - 200);
         const truncatedDiff = output.slice(0, diffBudget);
         const parts = [
           framing,
           `## Diff (truncated — ${output.length.toLocaleString()} chars total, showing first ${diffBudget.toLocaleString()})\n\n`,
           truncatedDiff,
-          '\n\n(truncated — use devdocket-getFileDiff to read individual file diffs)',
+          footer,
         ];
 
         return new vscode.LanguageModelToolResult([

--- a/packages/ai-reviewer/src/tools/getDiffTool.ts
+++ b/packages/ai-reviewer/src/tools/getDiffTool.ts
@@ -71,12 +71,18 @@ export function registerGetDiffTool(): vscode.Disposable {
 
         const footer = '\n\n(truncated — use devdocket-getFileDiff to read individual file diffs)';
         // Ensure at least half the budget goes to actual diff content.
-        // If the stat is too large, skip it to preserve diff context.
+        // If the stat is too large, truncate it to fit the available space.
         const minDiffBudget = Math.floor(MAX_DIFF_LENGTH / 2);
-        const statSection = stat ? `## Diff stat summary\n\n${stat}\n\n` : '';
-        const framing = statSection.length + footer.length + 200 > MAX_DIFF_LENGTH - minDiffBudget
-          ? '' // stat too large — skip it
-          : statSection;
+        const statPrefix = '## Diff stat summary\n\n';
+        const statSuffix = '\n\n';
+        const maxStatLength = MAX_DIFF_LENGTH - minDiffBudget - footer.length - 200 - statPrefix.length - statSuffix.length;
+        let framing = '';
+        if (stat && maxStatLength > 0) {
+          const trimmedStat = stat.length <= maxStatLength
+            ? stat
+            : stat.slice(0, maxStatLength) + '\n(stat truncated)';
+          framing = `${statPrefix}${trimmedStat}${statSuffix}`;
+        }
         const diffBudget = Math.max(0, MAX_DIFF_LENGTH - framing.length - footer.length - 200);
         const truncatedDiff = output.slice(0, diffBudget);
         const parts = [

--- a/packages/ai-reviewer/src/tools/getDiffTool.ts
+++ b/packages/ai-reviewer/src/tools/getDiffTool.ts
@@ -65,10 +65,14 @@ export function registerGetDiffTool(): vscode.Disposable {
           // best-effort — proceed without stat
         }
 
-        const truncatedDiff = output.slice(0, MAX_DIFF_LENGTH);
+        const framing = stat ? `## Diff stat summary\n\n${stat}\n\n` : '';
+        // Reserve space for the stat and framing text so total output
+        // stays within MAX_DIFF_LENGTH.
+        const diffBudget = Math.max(MAX_DIFF_LENGTH - framing.length - 200, Math.floor(MAX_DIFF_LENGTH * 0.8));
+        const truncatedDiff = output.slice(0, diffBudget);
         const parts = [
-          stat ? `## Diff stat summary\n\n${stat}\n\n` : '',
-          `## Diff (truncated — ${output.length.toLocaleString()} chars total, showing first ${MAX_DIFF_LENGTH.toLocaleString()})\n\n`,
+          framing,
+          `## Diff (truncated — ${output.length.toLocaleString()} chars total, showing first ${diffBudget.toLocaleString()})\n\n`,
           truncatedDiff,
           '\n\n(truncated — use devdocket-getFileDiff to read individual file diffs)',
         ];

--- a/packages/ai-reviewer/src/walkthroughParticipant.ts
+++ b/packages/ai-reviewer/src/walkthroughParticipant.ts
@@ -2,6 +2,10 @@ import * as vscode from 'vscode';
 import { RepoManager, type WorktreeInfo } from './repoManager';
 import { buildWalkthroughPrompt } from './walkthroughPrompt';
 
+/** Maximum characters per tool-result text part in the conversation.
+ *  Prevents any single tool result from overflowing the model's context window. */
+const MAX_TOOL_RESULT_LENGTH = 80_000;
+
 export class WalkthroughParticipant {
   private sessions = new Map<string, WorktreeInfo>();
 
@@ -245,7 +249,7 @@ export class WalkthroughParticipant {
               token,
             );
             this.log.debug(`Tool ${part.name} completed successfully`);
-            toolResults.push({ callId: part.callId, content: result.content });
+            toolResults.push({ callId: part.callId, content: truncateToolContent(result.content) });
           } catch (err) {
             const errMsg = err instanceof Error ? err.message : String(err);
             this.log.error(`Tool ${part.name} failed: ${errMsg}`);
@@ -309,4 +313,20 @@ export class WalkthroughParticipant {
 
     return undefined;
   }
+}
+
+/** Truncate oversized text parts in tool result content to stay within
+ *  the model's context budget. Non-text parts are passed through. */
+function truncateToolContent(
+  content: (vscode.LanguageModelTextPart | vscode.LanguageModelToolResultPart)[],
+): (vscode.LanguageModelTextPart | vscode.LanguageModelToolResultPart)[] {
+  return content.map((part) => {
+    if (part instanceof vscode.LanguageModelTextPart && part.value.length > MAX_TOOL_RESULT_LENGTH) {
+      return new vscode.LanguageModelTextPart(
+        part.value.slice(0, MAX_TOOL_RESULT_LENGTH) +
+        '\n\n(truncated — content exceeded context budget)',
+      );
+    }
+    return part;
+  });
 }

--- a/packages/ai-reviewer/src/walkthroughParticipant.ts
+++ b/packages/ai-reviewer/src/walkthroughParticipant.ts
@@ -322,9 +322,11 @@ export function truncateToolContent(
 ): (vscode.LanguageModelTextPart | vscode.LanguageModelToolResultPart)[] {
   return content.map((part) => {
     if (part instanceof vscode.LanguageModelTextPart && part.value.length > MAX_TOOL_RESULT_LENGTH) {
+      const truncationNotice =
+        `\n\n(truncated from ${part.value.length.toLocaleString()} chars — content exceeded context budget)`;
+      const sliceLength = Math.max(0, MAX_TOOL_RESULT_LENGTH - truncationNotice.length);
       return new vscode.LanguageModelTextPart(
-        part.value.slice(0, MAX_TOOL_RESULT_LENGTH) +
-        `\n\n(truncated from ${part.value.length.toLocaleString()} chars — content exceeded context budget)`,
+        part.value.slice(0, sliceLength) + truncationNotice,
       );
     }
     return part;

--- a/packages/ai-reviewer/src/walkthroughParticipant.ts
+++ b/packages/ai-reviewer/src/walkthroughParticipant.ts
@@ -4,7 +4,7 @@ import { buildWalkthroughPrompt } from './walkthroughPrompt';
 
 /** Maximum characters per tool-result text part in the conversation.
  *  Prevents any single tool result from overflowing the model's context window. */
-const MAX_TOOL_RESULT_LENGTH = 80_000;
+export const MAX_TOOL_RESULT_LENGTH = 80_000;
 
 export class WalkthroughParticipant {
   private sessions = new Map<string, WorktreeInfo>();
@@ -317,14 +317,14 @@ export class WalkthroughParticipant {
 
 /** Truncate oversized text parts in tool result content to stay within
  *  the model's context budget. Non-text parts are passed through. */
-function truncateToolContent(
+export function truncateToolContent(
   content: (vscode.LanguageModelTextPart | vscode.LanguageModelToolResultPart)[],
 ): (vscode.LanguageModelTextPart | vscode.LanguageModelToolResultPart)[] {
   return content.map((part) => {
     if (part instanceof vscode.LanguageModelTextPart && part.value.length > MAX_TOOL_RESULT_LENGTH) {
       return new vscode.LanguageModelTextPart(
         part.value.slice(0, MAX_TOOL_RESULT_LENGTH) +
-        '\n\n(truncated — content exceeded context budget)',
+        `\n\n(truncated from ${part.value.length.toLocaleString()} chars — content exceeded context budget)`,
       );
     }
     return part;


### PR DESCRIPTION
Closes #261

## Problem

When running AI Walkthrough on large external PRs (e.g., dotnet/sdk#53714), the walkthrough fails after the initial tool calls complete. The `getDiff` tool returns the raw `git diff` output without any size limit. For large PRs with hundreds of changed files, this produces multi-MB diffs that overflow the model's context window.

On the next tool-use loop iteration, the model provider drops messages from the front of the conversation to fit within the context budget. This removes the assistant message containing `tool_use` blocks while keeping the `tool_result` messages — causing the API error:

```
messages.0.content.0: unexpected tool_use_id found in tool_result blocks
```

## Solution

Two-layer fix:

1. **`getDiffTool.ts`** — Truncate diff output at 100K characters. When truncated, a `git diff --stat` summary is prepended so the model still knows every changed file and their line counts. A note directs the model to use `getFileDiff` for individual file diffs.

2. **`walkthroughParticipant.ts`** — Defense-in-depth: truncate any tool result text part exceeding 80K characters before adding it to the conversation history. This protects against any tool (not just getDiff) returning unexpectedly large output.

## Testing

- All 1071 existing tests pass
- The fix is backward-compatible: small PRs are unaffected (no truncation occurs)
