### PR TITLE
Show provider state in item editor panel

### DIFF
--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -8,6 +8,7 @@ interface AdoPullRequest {
   pullRequestId: number;
   title: string;
   description?: string;
+  status?: string;
   repository: {
     name: string;
     project: { name: string };
@@ -278,6 +279,7 @@ export class AdoPrReviewProvider extends BaseProvider {
         url: `${repoUrl}/pullrequest/${pr.pullRequestId}`,
         group: `${projectName}/${repoName}`,
         reason: 'review_requested',
+        state: pr.status,
         version: resurfaceOnNewVersion ? pr.lastMergeSourceCommit?.commitId : undefined,
       };
     });

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -279,7 +279,7 @@ export class AdoPrReviewProvider extends BaseProvider {
         url: `${repoUrl}/pullrequest/${pr.pullRequestId}`,
         group: `${projectName}/${repoName}`,
         reason: 'review_requested',
-        state: pr.status,
+        ...(pr.status ? { state: pr.status } : {}),
         version: resurfaceOnNewVersion ? pr.lastMergeSourceCommit?.commitId : undefined,
       };
     });

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -282,6 +282,7 @@ export class AdoWorkItemProvider extends BaseProvider {
         url: wi._links.html.href,
         group: `${org}/${projectName}`,
         reason: 'assigned',
+        state: wi.fields['System.State'],
       };
     });
 

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -115,6 +115,7 @@ describe('AdoWorkItemProvider', () => {
       url: 'https://dev.azure.com/myorg/MyProject/_workitems/edit/1',
       group: 'myorg/MyProject',
       reason: 'assigned',
+      state: 'Active',
     });
     expect(items[1]).toEqual({
       externalId: 'myorg/MyProject/2',
@@ -123,6 +124,7 @@ describe('AdoWorkItemProvider', () => {
       url: 'https://dev.azure.com/myorg/MyProject/_workitems/edit/2',
       group: 'myorg/MyProject',
       reason: 'assigned',
+      state: 'Active',
     });
   });
 

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -266,6 +266,51 @@ describe('getEditorPanelHtml', () => {
     });
   });
 
+  describe('provider state', () => {
+    it('should render Provider State row when providerState is provided for a provider-backed item', () => {
+      const item = makeItem({ providerId: 'github' });
+      const html = getEditorPanelHtml({ cspSource, item, providerState: 'open' });
+      const metadata = getMetadataSection(html);
+      expect(metadata).toContain('Provider State');
+      expect(metadata).toContain('open');
+    });
+
+    it('should omit Provider State row when providerState is not supplied', () => {
+      const item = makeItem({ providerId: 'github' });
+      const html = getEditorPanelHtml({ cspSource, item });
+      const metadata = getMetadataSection(html);
+      expect(metadata).not.toContain('Provider State');
+    });
+
+    it('should omit Provider State row when providerState is undefined', () => {
+      const item = makeItem({ providerId: 'github' });
+      const html = getEditorPanelHtml({ cspSource, item, providerState: undefined });
+      const metadata = getMetadataSection(html);
+      expect(metadata).not.toContain('Provider State');
+    });
+
+    it('should omit Provider State row when providerState is empty string', () => {
+      const item = makeItem({ providerId: 'github' });
+      const html = getEditorPanelHtml({ cspSource, item, providerState: '' });
+      const metadata = getMetadataSection(html);
+      expect(metadata).not.toContain('Provider State');
+    });
+
+    it('should omit Provider State row for manual items even when providerState is given', () => {
+      const item = makeItem({ providerId: undefined });
+      const html = getEditorPanelHtml({ cspSource, item, providerState: 'open' });
+      const metadata = getMetadataSection(html);
+      expect(metadata).not.toContain('Provider State');
+    });
+
+    it('should HTML-escape providerState to prevent XSS', () => {
+      const item = makeItem({ providerId: 'github' });
+      const html = getEditorPanelHtml({ cspSource, item, providerState: '<script>alert("xss")</script>' });
+      expect(html).not.toContain('<script>alert("xss")');
+      expect(html).toContain('&lt;script&gt;');
+    });
+  });
+
   describe('browser URL link', () => {
     it('renders a clickable link when item has a url', () => {
       const item = makeItem({ url: 'https://github.com/org/repo/issues/42' });

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -182,6 +182,31 @@ describe('WorkItemEditorPanel', () => {
       expect(registry.getDiscoveredItems).toHaveBeenCalledWith('gh');
       expect(mock.panel.webview.html).toContain('Fix the login page');
     });
+
+    it('should pass provider state to HTML when discovered item has state', () => {
+      const item = makeItem({ providerId: 'gh', externalId: '42' });
+      const mock = createMockWebviewPanel();
+      const registry = createMockProviderRegistry();
+      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
+        { externalId: '42', title: 'Bug', state: 'open' } as any,
+      ]);
+      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
+
+      expect(mock.panel.webview.html).toContain('Provider State');
+      expect(mock.panel.webview.html).toContain('open');
+    });
+
+    it('should omit provider state from HTML when discovered item has no state', () => {
+      const item = makeItem({ providerId: 'gh', externalId: '42' });
+      const mock = createMockWebviewPanel();
+      const registry = createMockProviderRegistry();
+      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
+        { externalId: '42', title: 'Bug' } as any,
+      ]);
+      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
+
+      expect(mock.panel.webview.html).not.toContain('Provider State');
+    });
   });
 
   describe('panel reuse', () => {

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -201,7 +201,7 @@ ${descriptionSection}
       <dd><span class="badge ${stateBadgeClass(item.state)}">${escapeHtml(stateLabel(item.state))}</span></dd>
 ${item.providerId && providerLabel ? `      <dt>Provider</dt>
       <dd>${escapeHtml(providerLabel)}</dd>` : ''}
-${providerState ? `      <dt>Provider State</dt>
+${providerState && item.providerId ? `      <dt>Provider State</dt>
       <dd>${escapeHtml(providerState)}</dd>` : ''}
       <dt>Created</dt>
       <dd>${escapeHtml(formatTimestamp(item.createdAt))}</dd>

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -8,11 +8,13 @@ export interface EditorHtmlOptions {
   providerLabel?: string;
   /** Read-only description from the provider. Will be HTML-escaped before rendering. */
   providerDescription?: string;
+  /** Upstream state from the provider (e.g. "open", "closed", "Active"). Will be HTML-escaped. */
+  providerState?: string;
   /** When true, the title field is read-only (managed by a live provider). */
   titleReadonly?: boolean;
 }
 
-export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDescription, titleReadonly }: EditorHtmlOptions): string {
+export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDescription, providerState, titleReadonly }: EditorHtmlOptions): string {
   const nonce = getNonce();
   const descriptionSection = providerDescription
     ? `    <div class="field">
@@ -199,6 +201,8 @@ ${descriptionSection}
       <dd><span class="badge ${stateBadgeClass(item.state)}">${escapeHtml(stateLabel(item.state))}</span></dd>
 ${item.providerId && providerLabel ? `      <dt>Provider</dt>
       <dd>${escapeHtml(providerLabel)}</dd>` : ''}
+${providerState ? `      <dt>Provider State</dt>
+      <dd>${escapeHtml(providerState)}</dd>` : ''}
       <dt>Created</dt>
       <dd>${escapeHtml(formatTimestamp(item.createdAt))}</dd>
       <dt>Updated</dt>

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -152,17 +152,20 @@ export class WorkItemEditorPanel {
 
   private getHtml(item: WorkItem): string {
     let providerDescription: string | undefined;
+    let providerState: string | undefined;
     if (item.providerId && item.externalId) {
       const discovered = this.providerRegistry
         .getDiscoveredItems(item.providerId)
         .find((d) => d.externalId === item.externalId);
       providerDescription = discovered?.description ?? undefined;
+      providerState = discovered?.state ?? undefined;
     }
     return getEditorPanelHtml({
       cspSource: this.panel.webview.cspSource,
       item,
       providerLabel: this.providerLabel,
       providerDescription,
+      providerState,
       titleReadonly: this.isProviderManaged(item),
     });
   }

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -41,7 +41,7 @@ export interface GitHubIssue {
   state?: string;
   html_url: string;
   repository_url: string;
-  pull_request?: { url: string; merged_at?: string | null };
+  pull_request?: { url: string };
 }
 
 export abstract class BaseGitHubProvider implements DevDocketProvider {

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -21,6 +21,7 @@ export interface DiscoveredItem {
   url?: string;
   group?: string;
   reason?: string;
+  state?: string;
   version?: string;
   resurfaceVersion?: string;
 }
@@ -37,9 +38,10 @@ export interface GitHubIssue {
   number: number;
   title: string;
   body?: string;
+  state?: string;
   html_url: string;
   repository_url: string;
-  pull_request?: { url: string };
+  pull_request?: { url: string; merged_at?: string | null };
 }
 
 export abstract class BaseGitHubProvider implements DevDocketProvider {

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -53,6 +53,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
 
     const items: DiscoveredItem[] = prs.map((pr) => {
       const repoName = this.parseRepo(pr);
+      const prState = pr.pull_request?.merged_at ? 'merged' : pr.state;
       const item: DiscoveredItem = {
         externalId: `${repoName}#${pr.number}`,
         title: `#${pr.number}: ${pr.title}`,
@@ -60,6 +61,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
         url: pr.html_url,
         group: repoName,
         reason: 'review_requested',
+        state: prState,
       };
       const headSha = headShas.get(pr.html_url);
       if (headSha !== undefined) { item.version = headSha; }

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -53,7 +53,6 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
 
     const items: DiscoveredItem[] = prs.map((pr) => {
       const repoName = this.parseRepo(pr);
-      const prState = pr.pull_request?.merged_at ? 'merged' : pr.state;
       const item: DiscoveredItem = {
         externalId: `${repoName}#${pr.number}`,
         title: `#${pr.number}: ${pr.title}`,
@@ -61,8 +60,8 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
         url: pr.html_url,
         group: repoName,
         reason: 'review_requested',
-        state: prState,
       };
+      if (pr.state) { item.state = pr.state; }
       const headSha = headShas.get(pr.html_url);
       if (headSha !== undefined) { item.version = headSha; }
       const reRequestTime = reRequestTimes.get(pr.html_url);

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -32,7 +32,7 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
         url: issue.html_url,
         group: repoName,
         reason: 'assigned',
-        state: issue.state,
+        ...(issue.state ? { state: issue.state } : {}),
       };
     });
 

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -32,6 +32,7 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
         url: issue.html_url,
         group: repoName,
         reason: 'assigned',
+        state: issue.state,
       };
     });
 

--- a/packages/github/src/test/githubProvider.test.ts
+++ b/packages/github/src/test/githubProvider.test.ts
@@ -149,6 +149,42 @@ describe('GitHubIssueProvider', () => {
     });
   });
 
+  it('should include state when issue has a state field', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{
+        ...createMockIssue(5, 'Stateful issue'),
+        state: 'open',
+      }],
+      headers: { get: () => null },
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items[0]).toEqual(expect.objectContaining({
+      externalId: 'owner/repo#5',
+      state: 'open',
+    }));
+  });
+
+  it('should omit state when issue has no state field', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [createMockIssue(6, 'Stateless issue')],
+      headers: { get: () => null },
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items[0]).not.toHaveProperty('state');
+  });
+
   it('truncates description to 200 chars', async () => {
     const longBody = 'A'.repeat(300);
     mockFetch.mockResolvedValueOnce({

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -27,6 +27,8 @@ export interface DiscoveredItem {
   group?: string;
   /** Optional notification reason explaining why this item was surfaced (e.g. `"assigned"`, `"review_requested"`). */
   reason?: string;
+  /** Optional upstream state from the provider (e.g. `"open"`, `"closed"`, `"Active"`). */
+  state?: string;
   /**
    * Optional version identifier that changes when the item needs re-attention.
    * When a previously accepted item reappears with a different version,


### PR DESCRIPTION
Adds upstream provider state display (e.g. open/closed/merged for GitHub, Active for ADO) to the work item editor panel metadata section.

## Changes

- Added optional \state\ field to \DiscoveredItem\ interface (shared + GitHub re-declaration)
- All four providers now populate \state\: GitHub Issues, GitHub PR Reviews, ADO Work Items, ADO PR Reviews
- Editor panel metadata section displays Provider State when available
- GitHub PRs detect merged status via \pull_request.merged_at\

Closes #282