### PR TITLE
Auto-reveal items in destination view after move

### DIFF
--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -11,6 +11,7 @@ import { type SourceItemNode, type SourcesElement } from '../views/sourcesTreePr
 import { logger } from '../services/logger';
 import type { ResolvedItem } from '../api/types';
 import { toggleViewLayout, setViewLayout } from '../views/viewLayout';
+import type { ViewRevealer } from '../services/viewRevealer';
 
 /**
  * Resolves the effective list of inbox items from VS Code's multi-select command args.
@@ -121,9 +122,11 @@ async function batchTransition(
   ids: string[],
   targetState: WorkItemState,
   successMessage: (count: number) => string,
+  revealer?: ViewRevealer,
 ): Promise<void> {
   if (ids.length === 1) {
     await workGraph.transitionState(ids[0], targetState);
+    void revealer?.revealByState(ids[0]);
     return;
   }
   const failedIds: string[] = [];
@@ -212,7 +215,7 @@ async function batchAcceptItems(
   }
 }
 
-async function handleCreateItem(workGraph: WorkGraph): Promise<void> {
+async function handleCreateItem(workGraph: WorkGraph, revealer?: ViewRevealer): Promise<void> {
   const title = await vscode.window.showInputBox({
     prompt: 'Work item title',
     placeHolder: 'e.g. Fix login redirect bug',
@@ -223,8 +226,9 @@ async function handleCreateItem(workGraph: WorkGraph): Promise<void> {
   }
 
   logger.info(`Creating new work item: ${title.trim()}`);
-  await workGraph.createItem({ title: title.trim() });
+  const createdItem = await workGraph.createItem({ title: title.trim() });
   void vscode.window.showInformationMessage(`DevDocket: Created "${title.trim()}"`);
+  void revealer?.revealInQueue(createdItem.id);
 }
 
 async function handleCreateItemFromUrl(
@@ -232,6 +236,7 @@ async function handleCreateItemFromUrl(
   workGraph: WorkGraph,
   providerRegistry: ProviderRegistry,
   labelCache: ProviderLabelCache,
+  revealer?: ViewRevealer,
 ): Promise<void> {
   const url = await vscode.window.showInputBox({
     prompt: 'Enter a URL to create a work item from',
@@ -283,48 +288,49 @@ async function handleCreateItemFromUrl(
   const providerLabel = createdItem.providerId ? labelCache.get(createdItem.providerId) : undefined;
   WorkItemEditorPanel.open(context, workGraph, providerRegistry, createdItem, providerLabel);
   void vscode.window.showInformationMessage(`DevDocket: Created "${details.title}"`);
+  void revealer?.revealInQueue(createdItem.id);
 }
 
-async function handleAcceptToFocus(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[]): Promise<void> {
+async function handleAcceptToFocus(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[], revealer?: ViewRevealer): Promise<void> {
   const ids = resolveItemIds(item, selectedItems);
   if (ids.length === 0) { return; }
   await batchTransition(workGraph, ids, WorkItemState.InProgress,
-    (n) => `Moved ${n} item${n === 1 ? '' : 's'} to Focus`);
+    (n) => `Moved ${n} item${n === 1 ? '' : 's'} to Focus`, revealer);
 }
 
-async function handleArchiveItem(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[]): Promise<void> {
+async function handleArchiveItem(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[], revealer?: ViewRevealer): Promise<void> {
   const ids = resolveItemIds(item, selectedItems);
   if (ids.length === 0) { return; }
   await batchTransition(workGraph, ids, WorkItemState.Archived,
-    (n) => `Archived ${n} item${n === 1 ? '' : 's'}`);
+    (n) => `Archived ${n} item${n === 1 ? '' : 's'}`, revealer);
 }
 
-async function handleCompleteItem(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[]): Promise<void> {
+async function handleCompleteItem(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[], revealer?: ViewRevealer): Promise<void> {
   const ids = resolveItemIds(item, selectedItems);
   if (ids.length === 0) { return; }
   await batchTransition(workGraph, ids, WorkItemState.Done,
-    (n) => `Completed ${n} item${n === 1 ? '' : 's'}`);
+    (n) => `Completed ${n} item${n === 1 ? '' : 's'}`, revealer);
 }
 
-async function handlePauseItem(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[]): Promise<void> {
+async function handlePauseItem(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[], revealer?: ViewRevealer): Promise<void> {
   const ids = resolveItemIds(item, selectedItems);
   if (ids.length === 0) { return; }
   await batchTransition(workGraph, ids, WorkItemState.Paused,
-    (n) => `Paused ${n} item${n === 1 ? '' : 's'}`);
+    (n) => `Paused ${n} item${n === 1 ? '' : 's'}`, revealer);
 }
 
-async function handleResumeItem(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[]): Promise<void> {
+async function handleResumeItem(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[], revealer?: ViewRevealer): Promise<void> {
   const ids = resolveItemIds(item, selectedItems);
   if (ids.length === 0) { return; }
   await batchTransition(workGraph, ids, WorkItemState.InProgress,
-    (n) => `Resumed ${n} item${n === 1 ? '' : 's'}`);
+    (n) => `Resumed ${n} item${n === 1 ? '' : 's'}`, revealer);
 }
 
-async function handleMoveToQueue(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[]): Promise<void> {
+async function handleMoveToQueue(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[], revealer?: ViewRevealer): Promise<void> {
   const ids = resolveItemIds(item, selectedItems);
   if (ids.length === 0) { return; }
   await batchTransition(workGraph, ids, WorkItemState.New,
-    (n) => `Moved ${n} item${n === 1 ? '' : 's'} to Queue`);
+    (n) => `Moved ${n} item${n === 1 ? '' : 's'} to Queue`, revealer);
 }
 
 function handleEditItem(
@@ -500,12 +506,13 @@ async function handleAcceptFromInbox(
   stateStore: DiscoveredStateStore,
   item?: InboxElement,
   selectedItems?: InboxElement[],
+  revealer?: ViewRevealer,
 ): Promise<void> {
   const items = resolveInboxItems(item, selectedItems);
   if (items.length === 0) { return; }
 
   if (items.length === 1) {
-    await acceptSingleInboxItem(workGraph, stateStore, items[0]);
+    await acceptSingleInboxItem(workGraph, stateStore, items[0], revealer);
     return;
   }
 
@@ -516,6 +523,7 @@ async function acceptSingleInboxItem(
   workGraph: WorkGraph,
   stateStore: DiscoveredStateStore,
   item: InboxItem,
+  revealer?: ViewRevealer,
 ): Promise<void> {
   logger.info(`Accepting inbox item: ${item.externalId} from ${item.providerId}`);
   const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
@@ -556,13 +564,16 @@ async function acceptSingleInboxItem(
       logger.error('Failed to roll back created item after setState failure', rollbackErr);
     }
     handleCommandError('Failed to update state after accepting item', err);
+    return;
   }
+  void revealer?.revealInQueue(createdItem.id);
 }
 
 async function acceptToFocusSingleInboxItem(
   workGraph: WorkGraph,
   stateStore: DiscoveredStateStore,
   item: InboxItem,
+  revealer?: ViewRevealer,
 ): Promise<void> {
   logger.info(`Accepting inbox item to Focus: ${item.externalId} from ${item.providerId}`);
   let workItemId: string;
@@ -631,7 +642,9 @@ async function acceptToFocusSingleInboxItem(
     await workGraph.transitionState(workItemId, WorkItemState.InProgress);
   } catch (err: unknown) {
     handleCommandError('Failed to move item to Focus', err);
+    return;
   }
+  void revealer?.revealInFocus(workItemId);
 }
 
 async function batchAcceptToFocusItems(
@@ -735,12 +748,13 @@ async function handleAcceptToFocusFromInbox(
   stateStore: DiscoveredStateStore,
   item?: InboxElement,
   selectedItems?: InboxElement[],
+  revealer?: ViewRevealer,
 ): Promise<void> {
   const items = resolveInboxItems(item, selectedItems);
   if (items.length === 0) { return; }
 
   if (items.length === 1) {
-    await acceptToFocusSingleInboxItem(workGraph, stateStore, items[0]);
+    await acceptToFocusSingleInboxItem(workGraph, stateStore, items[0], revealer);
     return;
   }
 
@@ -792,12 +806,13 @@ async function handleAcceptFromSources(
   stateStore: DiscoveredStateStore,
   item?: SourcesElement,
   selectedItems?: SourcesElement[],
+  revealer?: ViewRevealer,
 ): Promise<void> {
   const items = resolveSourceItems(item, selectedItems);
   if (items.length === 0) { return; }
 
   if (items.length === 1) {
-    await acceptSingleSourceItem(workGraph, stateStore, items[0]);
+    await acceptSingleSourceItem(workGraph, stateStore, items[0], revealer);
     return;
   }
 
@@ -808,6 +823,7 @@ async function acceptSingleSourceItem(
   workGraph: WorkGraph,
   stateStore: DiscoveredStateStore,
   item: SourceItemNode,
+  revealer?: ViewRevealer,
 ): Promise<void> {
   logger.info(`Accepting sources item: ${item.externalId}`);
   const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
@@ -847,7 +863,9 @@ async function acceptSingleSourceItem(
       logger.error('Failed to roll back created item after setState failure', rollbackErr);
     }
     handleCommandError('Failed to update state after accepting item', err);
+    return;
   }
+  void revealer?.revealInQueue(createdItem.id);
 }
 
 async function handleDismissFromSources(
@@ -890,24 +908,25 @@ export function registerCommands(
   stateStore: DiscoveredStateStore,
   providerRegistry: ProviderRegistry,
   labelCache: ProviderLabelCache,
+  revealer?: ViewRevealer,
 ): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('devdocket.refresh',
       wrapCommand('Failed to refresh', () => handleRefresh(providerRegistry))),
     vscode.commands.registerCommand('devdocket.createItem',
-      wrapCommand('Failed to create item', () => handleCreateItem(workGraph))),
+      wrapCommand('Failed to create item', () => handleCreateItem(workGraph, revealer))),
     vscode.commands.registerCommand('devdocket.createItemFromUrl',
-      wrapCommand('Failed to create item from URL', () => handleCreateItemFromUrl(context, workGraph, providerRegistry, labelCache))),
+      wrapCommand('Failed to create item from URL', () => handleCreateItemFromUrl(context, workGraph, providerRegistry, labelCache, revealer))),
     vscode.commands.registerCommand('devdocket.acceptToFocus',
-      wrapCommand('Failed to focus item', (item, selectedItems) => handleAcceptToFocus(workGraph, item, selectedItems))),
+      wrapCommand('Failed to focus item', (item, selectedItems) => handleAcceptToFocus(workGraph, item, selectedItems, revealer))),
     vscode.commands.registerCommand('devdocket.archiveItem',
-      wrapCommand('Failed to archive item', (item, selectedItems) => handleArchiveItem(workGraph, item, selectedItems))),
+      wrapCommand('Failed to archive item', (item, selectedItems) => handleArchiveItem(workGraph, item, selectedItems, revealer))),
     vscode.commands.registerCommand('devdocket.completeItem',
-      wrapCommand('Failed to complete item', (item, selectedItems) => handleCompleteItem(workGraph, item, selectedItems))),
+      wrapCommand('Failed to complete item', (item, selectedItems) => handleCompleteItem(workGraph, item, selectedItems, revealer))),
     vscode.commands.registerCommand('devdocket.pauseItem',
-      wrapCommand('Failed to pause item', (item, selectedItems) => handlePauseItem(workGraph, item, selectedItems))),
+      wrapCommand('Failed to pause item', (item, selectedItems) => handlePauseItem(workGraph, item, selectedItems, revealer))),
     vscode.commands.registerCommand('devdocket.resumeItem',
-      wrapCommand('Failed to resume item', (item, selectedItems) => handleResumeItem(workGraph, item, selectedItems))),
+      wrapCommand('Failed to resume item', (item, selectedItems) => handleResumeItem(workGraph, item, selectedItems, revealer))),
     vscode.commands.registerCommand('devdocket.deleteItem',
       wrapCommand('Failed to delete item', (item, selectedItems) => handleDeleteItem(workGraph, item, selectedItems))),
     vscode.commands.registerCommand('devdocket.clearHistory',
@@ -927,15 +946,15 @@ export function registerCommands(
     vscode.commands.registerCommand('devdocket.focusMoveDown',
       wrapCommand('Failed to move focus item down', (item) => handleFocusMoveDown(workGraph, item))),
     vscode.commands.registerCommand('devdocket.moveToQueue',
-      wrapCommand('Failed to move item to queue', (item, selectedItems) => handleMoveToQueue(workGraph, item, selectedItems))),
+      wrapCommand('Failed to move item to queue', (item, selectedItems) => handleMoveToQueue(workGraph, item, selectedItems, revealer))),
     vscode.commands.registerCommand('devdocket.acceptFromInbox',
-      wrapCommand('Failed to accept from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleAcceptFromInbox(workGraph, stateStore, item, selectedItems))),
+      wrapCommand('Failed to accept from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleAcceptFromInbox(workGraph, stateStore, item, selectedItems, revealer))),
     vscode.commands.registerCommand('devdocket.acceptToFocusFromInbox',
-      wrapCommand('Failed to accept to focus from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleAcceptToFocusFromInbox(workGraph, stateStore, item, selectedItems))),
+      wrapCommand('Failed to accept to focus from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleAcceptToFocusFromInbox(workGraph, stateStore, item, selectedItems, revealer))),
     vscode.commands.registerCommand('devdocket.dismissFromInbox',
       wrapCommand('Failed to dismiss from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleDismissFromInbox(stateStore, item, selectedItems))),
     vscode.commands.registerCommand('devdocket.acceptFromSources',
-      wrapCommand('Failed to accept from sources', (item: SourcesElement, selectedItems?: SourcesElement[]) => handleAcceptFromSources(workGraph, stateStore, item, selectedItems))),
+      wrapCommand('Failed to accept from sources', (item: SourcesElement, selectedItems?: SourcesElement[]) => handleAcceptFromSources(workGraph, stateStore, item, selectedItems, revealer))),
     vscode.commands.registerCommand('devdocket.dismissFromSources',
       wrapCommand('Failed to dismiss from sources', (item: SourcesElement, selectedItems?: SourcesElement[]) => handleDismissFromSources(stateStore, item, selectedItems))),
     vscode.commands.registerCommand('devdocket.switchInboxToTree',

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -14,6 +14,7 @@ import { FocusTreeProvider } from './views/focusTreeProvider';
 import { SourcesTreeProvider } from './views/sourcesTreeProvider';
 import { HistoryTreeProvider } from './views/historyTreeProvider';
 import { registerCommands } from './commands/commands';
+import { ViewRevealer } from './services/viewRevealer';
 import { initLogger, setLogLevel, logger, resolveLogLevel } from './services/logger';
 import { getInboxUnseenCount } from './services/inboxBadge';
 import { getViewLayout, ViewId } from './views/viewLayout';
@@ -326,7 +327,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   );
 
   const commandRegStart = performance.now();
-  registerCommands(context, wg, ar, ss, pr, labelCache);
+  const revealer = new ViewRevealer(wg, views.queueTreeView, views.focusTreeView, views.historyTreeView);
+  registerCommands(context, wg, ar, ss, pr, labelCache, revealer);
   logger.info(`Command registration took ${Math.round(performance.now() - commandRegStart)}ms`);
 
   // Set context keys and listen for layout changes

--- a/packages/core/src/services/viewRevealer.ts
+++ b/packages/core/src/services/viewRevealer.ts
@@ -3,7 +3,9 @@ import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from './workGraph';
 import { logger } from './logger';
 
-type WorkItemTreeView = vscode.TreeView<WorkItem | unknown>;
+// WorkItem | unknown simplifies to unknown; we use the alias for readability
+// at call sites — reveal() matches elements via TreeItem.id, not type identity.
+type WorkItemTreeView = vscode.TreeView<unknown>;
 
 /**
  * Reveals a work item in the appropriate destination tree view after
@@ -65,7 +67,7 @@ export class ViewRevealer {
 
   private async doReveal(view: WorkItemTreeView, item: WorkItem): Promise<void> {
     try {
-      await view.reveal(item, { select: true, focus: false, expand: true });
+      await view.reveal(item, { select: true, focus: false });
     } catch (err: unknown) {
       logger.debug('Auto-reveal failed (view may not be visible)', err);
     }

--- a/packages/core/src/services/viewRevealer.ts
+++ b/packages/core/src/services/viewRevealer.ts
@@ -1,0 +1,73 @@
+import * as vscode from 'vscode';
+import { WorkItem, WorkItemState } from '../models/workItem';
+import { WorkGraph } from './workGraph';
+import { logger } from './logger';
+
+type WorkItemTreeView = vscode.TreeView<WorkItem | unknown>;
+
+/**
+ * Reveals a work item in the appropriate destination tree view after
+ * it moves between views (e.g. Queue → Focus, Inbox → Queue).
+ *
+ * Uses VS Code's TreeView.reveal() API to scroll to and highlight the item.
+ * All reveals are best-effort — failures are logged but never surface to the user.
+ */
+export class ViewRevealer {
+  constructor(
+    private readonly workGraph: WorkGraph,
+    private readonly queueTreeView: WorkItemTreeView,
+    private readonly focusTreeView: WorkItemTreeView,
+    private readonly historyTreeView: WorkItemTreeView,
+  ) {}
+
+  /**
+   * Reveal a work item in the tree view that matches its current state.
+   * Determines the destination view from the item's state after transition.
+   */
+  async revealByState(itemId: string): Promise<void> {
+    const item = this.workGraph.getItem(itemId);
+    if (!item) { return; }
+
+    const view = this.getViewForState(item.state);
+    if (!view) { return; }
+
+    await this.doReveal(view, item);
+  }
+
+  /** Reveal an item specifically in the Queue view. */
+  async revealInQueue(itemId: string): Promise<void> {
+    const item = this.workGraph.getItem(itemId);
+    if (!item) { return; }
+    await this.doReveal(this.queueTreeView, item);
+  }
+
+  /** Reveal an item specifically in the Focus view. */
+  async revealInFocus(itemId: string): Promise<void> {
+    const item = this.workGraph.getItem(itemId);
+    if (!item) { return; }
+    await this.doReveal(this.focusTreeView, item);
+  }
+
+  private getViewForState(state: WorkItemState): WorkItemTreeView | undefined {
+    switch (state) {
+      case WorkItemState.New:
+        return this.queueTreeView;
+      case WorkItemState.InProgress:
+      case WorkItemState.Paused:
+        return this.focusTreeView;
+      case WorkItemState.Done:
+      case WorkItemState.Archived:
+        return this.historyTreeView;
+      default:
+        return undefined;
+    }
+  }
+
+  private async doReveal(view: WorkItemTreeView, item: WorkItem): Promise<void> {
+    try {
+      await view.reveal(item, { select: true, focus: false, expand: true });
+    } catch (err: unknown) {
+      logger.debug('Auto-reveal failed (view may not be visible)', err);
+    }
+  }
+}

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -83,6 +83,7 @@ const window = {
       message: undefined,
       badge: undefined,
       onDidChangeSelection: selectionEmitter.event,
+      reveal: vi.fn().mockResolvedValue(undefined),
       _selectionEmitter: selectionEmitter,
     };
   }),

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -62,6 +62,25 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
     return treeItem;
   }
 
+  getParent(element: FocusElement): FocusElement | undefined {
+    if (this.layout === 'flat') {
+      return undefined;
+    }
+    if (isSubGroupNode(element)) {
+      return undefined;
+    }
+    if (isProviderGroupNode(element)) {
+      return undefined;
+    }
+    // WorkItem — parent is SubGroupNode if item has a group, otherwise root
+    const item = element as import('../models/workItem').WorkItem;
+    const grp = item.group?.trim() || undefined;
+    if (grp) {
+      return { kind: 'subGroup', label: grp, providerId: undefined, groupName: grp };
+    }
+    return undefined;
+  }
+
   getChildren(element?: FocusElement): FocusElement[] {
     if (!element) {
       const items = this.getItems();

--- a/packages/core/src/views/historyTreeProvider.ts
+++ b/packages/core/src/views/historyTreeProvider.ts
@@ -34,6 +34,7 @@ export class HistoryTreeProvider extends WorkItemViewProvider {
   protected createWorkItemTreeItem(item: WorkItem): vscode.TreeItem {
     const title = this.resolveTitle(item);
     const treeItem = new vscode.TreeItem(title, vscode.TreeItemCollapsibleState.None);
+    treeItem.id = item.id;
     treeItem.description = this.layout === 'tree'
       ? this.getStateLabel(item.state)
       : this.buildDescription(item.group, this.getProviderLabel(item.providerId), this.getStateLabel(item.state));

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -460,6 +460,30 @@ export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<Wo
     return this.createWorkItemTreeItem(element);
   }
 
+  getParent(element: WorkItemElement): WorkItemElement | undefined {
+    if (this._layoutState.value === 'flat') {
+      return undefined;
+    }
+    if (isProviderGroupNode(element)) {
+      return undefined;
+    }
+    if (isSubGroupNode(element)) {
+      const label = element.providerId
+        ? (this.labelResolver?.(element.providerId) ?? element.providerId)
+        : 'Other';
+      return { kind: 'providerGroup', label, providerId: element.providerId };
+    }
+    // WorkItem — find its parent node
+    const item = element as WorkItem;
+    const pid = item.providerId?.trim() || undefined;
+    const grp = item.group?.trim() || undefined;
+    if (grp) {
+      return { kind: 'subGroup', label: grp, providerId: pid, groupName: grp };
+    }
+    const label = pid ? (this.labelResolver?.(pid) ?? pid) : 'Other';
+    return { kind: 'providerGroup', label, providerId: pid };
+  }
+
   getChildren(element?: WorkItemElement): WorkItemElement[] {
     return getTreeModeChildren(
       element,


### PR DESCRIPTION
Closes #280

## Summary

When a work item moves between views (e.g. Queue → Focus, Inbox → Queue), the destination tree view now automatically scrolls to and highlights the moved item using VS Code's `TreeView.reveal()` API. Previously, users had to manually find the item in the new view.

## Changes

### New: `ViewRevealer` service (`packages/core/src/services/viewRevealer.ts`)
- Wraps `TreeView.reveal()` calls for Queue, Focus, and History views
- `revealByState(itemId)` — determines the right view from the item's current state
- `revealInQueue(itemId)` / `revealInFocus(itemId)` — direct view targeting for inbox/sources accept flows
- All reveals are best-effort with debug-level logging on failure

### `WorkItemViewProvider` base class — added `getParent()`
- Required by `TreeView.reveal()` to walk up the tree hierarchy
- Handles both flat mode (returns `undefined`) and tree mode (returns `ProviderGroupNode` or `SubGroupNode`)

### `FocusTreeProvider` — overrides `getParent()`
- Focus view uses a different grouping hierarchy (groups by `item.group` at top level with `SubGroupNode`, not `ProviderGroupNode`)

### Command handlers — threaded `ViewRevealer` through all state transitions
- **Single-item operations** trigger auto-reveal in the destination view
- **Batch operations** (multi-select) skip reveal since there's no single target
- Covered transitions: accept from inbox, accept from sources, create item, create from URL, move to focus, pause, resume, complete, archive, move to queue

### Mock update
- Added `reveal` mock to `createTreeView` return value so existing tests continue to pass

## Testing

All 1,723 tests pass across all packages (0 failures).
