### PR TITLE
Auto-complete work items when linked issue/PR is closed or merged

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ flowchart LR
     Focus -- Mark complete --> History
 ```
 
-> **Note:** Items in History are a read-only record of completed or archived work. You can open their links (when available), but they can't currently be moved back to Queue or Focus.
+> **Note:** Items in History can be moved back to Queue if needed — right-click and select **Move to Queue**. This is useful for recovering from false positives when an item is auto-completed but you still have work to do.
 
 ### Auto-Completion
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,21 @@ flowchart LR
 
 > **Note:** Items in History are a read-only record of completed or archived work. You can open their links (when available), but they can't currently be moved back to Queue or Focus.
 
+### Auto-Completion
+
+DevDocket can automatically mark work items as **Done** when their linked issue or PR is closed or merged externally. This happens after each provider refresh — no manual intervention needed.
+
+This behavior is controlled by:
+
+```jsonc
+// settings.json
+{
+  "devdocket.autoCompleteOnClose": true  // default: true
+}
+```
+
+Set to `false` to disable auto-completion entirely.
+
 ## Plugin Ecosystem
 
 DevDocket is built around an extensible plugin model with two extension points:

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -102,6 +102,15 @@ interface DevDocketProvider {
    * to call multiple times and during extension activation.
    */
   refresh(): Promise<void>;
+
+  /**
+   * Check which of the given external items have been closed or completed.
+   * Called after each provider refresh to auto-complete linked work items,
+   * including manually-imported items. Return the subset of externalIds
+   * that are closed, merged, or completed.
+   * Optional — providers without this fall back to disappearance detection.
+   */
+  getClosedItems?(externalIds: string[], signal?: AbortSignal): Promise<string[]>;
 }
 ```
 
@@ -271,6 +280,37 @@ Each provider is capped at **10,000 discovered items** per refresh. If a provide
 
 URLs opened via `vscode.env.openExternal` are validated to use `http:` or `https:` schemes only. Other URL schemes (e.g., `file:`, `javascript:`, custom protocols) are rejected. Ensure any URLs your provider or action constructs use standard web URLs.
 
+## Auto-Completion
+
+DevDocket can automatically mark work items as **Done** when their linked external item is closed or merged. This is controlled by the `devdocket.autoCompleteOnClose` setting (default: `true`).
+
+After each provider refresh, DevDocket scans the WorkGraph for items linked to that provider in auto-completable states (`New`, `InProgress`, `Paused`). It then checks whether those external items are closed:
+
+1. **If the provider implements `getClosedItems()`** — DevDocket calls it with the full set of linked external IDs (deduplicated). This covers both provider-discovered items and manually-imported items (e.g., items created via "Create Item from URL"). Return the subset of IDs that are closed, merged, or completed.
+
+2. **Fallback: disappearance detection** — For providers without `getClosedItems()`, DevDocket compares the current discovered items against the previous refresh. Items that were previously present but are now absent are assumed closed. This fallback *cannot* cover manually-imported items since the provider never discovered them.
+
+Matched items are transitioned to `Done` and a notification is shown with a "Show History" action.
+
+### Implementing `getClosedItems()`
+
+```ts
+async getClosedItems(externalIds: string[], signal?: AbortSignal): Promise<string[]> {
+  // Batch-check external IDs against your source system's API
+  // Return only the ones that are closed, merged, or completed
+  const statuses = await this.fetchStatuses(externalIds, signal);
+  return statuses
+    .filter(s => s.isClosed)
+    .map(s => s.externalId);
+}
+```
+
+**Guidelines:**
+- Batch API calls where possible — avoid one network call per item.
+- Handle auth failures gracefully — log and return an empty array rather than throwing.
+- Respect the `AbortSignal` — check `signal?.aborted` between API calls and pass `signal` to `fetch()`.
+- Use silent/non-interactive auth — `getClosedItems()` runs after background refreshes and should never prompt the user.
+
 ## Examples
 
 ### Minimal Provider
@@ -303,6 +343,7 @@ interface DevDocketProvider {
   readonly label: string;
   readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
   refresh(): Promise<void>;
+  getClosedItems?(externalIds: string[], signal?: AbortSignal): Promise<string[]>;
 }
 
 class MyTaskProvider implements DevDocketProvider {

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -101,7 +101,7 @@ interface DevDocketProvider {
    * discovery) and whenever the user requests a manual refresh. Must be safe
    * to call multiple times and during extension activation.
    */
-  refresh(): Promise<void>;
+  refresh(token?: vscode.CancellationToken): Promise<void>;
 
   /**
    * Check which of the given external items have been closed or completed.
@@ -342,7 +342,7 @@ interface DevDocketProvider {
   readonly id: string;
   readonly label: string;
   readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
-  refresh(): Promise<void>;
+  refresh(token?: unknown): Promise<void>;
   getClosedItems?(externalIds: string[], signal?: AbortSignal): Promise<string[]>;
 }
 

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -342,7 +342,7 @@ interface DevDocketProvider {
   readonly id: string;
   readonly label: string;
   readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
-  refresh(token?: unknown): Promise<void>;
+  refresh(token?: vscode.CancellationToken): Promise<void>;
   getClosedItems?(externalIds: string[], signal?: AbortSignal): Promise<string[]>;
 }
 

--- a/docs/provider-api.md
+++ b/docs/provider-api.md
@@ -121,6 +121,7 @@ interface DevDocketProvider {
   readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
   refresh(token?: vscode.CancellationToken): Promise<void>;
   resolveUrl?(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined>;
+  getClosedItems?(externalIds: string[], signal?: AbortSignal): Promise<string[]>;
 }
 
 interface ResolvedItem {
@@ -166,6 +167,7 @@ interface DevDocketProvider {
   readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
   refresh(token?: vscode.CancellationToken): Promise<void>;
   resolveUrl?(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined>;
+  getClosedItems?(externalIds: string[], signal?: AbortSignal): Promise<string[]>;
 }
 
 interface ResolvedItem {
@@ -253,6 +255,26 @@ class JiraProvider implements DevDocketProvider {
     };
   }
 
+  // Optional: support auto-completion when external items are closed
+  async getClosedItems(
+    externalIds: string[],
+    signal?: AbortSignal,
+  ): Promise<string[]> {
+    // Batch-check which items are closed/resolved in Jira
+    const statuses = await this.fetchStatuses(externalIds, signal);
+    return statuses
+      .filter((s) => s.isClosed)
+      .map((s) => s.externalId);
+  }
+
+  private async fetchStatuses(
+    _externalIds: string[],
+    _signal?: AbortSignal,
+  ): Promise<Array<{ externalId: string; isClosed: boolean }>> {
+    // Replace with your actual API call — batch where possible
+    return [];
+  }
+
   private async fetchTicket(_key: string): Promise<
     { summary: string; description?: string } | undefined
   > {
@@ -281,6 +303,7 @@ class JiraProvider implements DevDocketProvider {
 - **`externalId` must be unique per provider** — DevDocket uses the combination of `providerId + externalId` to track inbox state. Use a stable identifier like `owner/repo#123` or `PROJECT/TICKET-42`.
 - **`group` is optional** — When set, items with the same group value are nested under a folder node in the Inbox and Sources views.
 - **`resolveUrl()` is optional** — Implement it to let users create work items by pasting a URL (e.g. from a browser). When the user runs the "Create Item from URL" command, DevDocket asks each registered provider to resolve the URL. The first provider that returns a `ResolvedItem` wins. If your provider doesn't recognise the URL, return `undefined`.
+- **`getClosedItems()` is optional** — Implement it to enable auto-completion of work items when their linked external item is closed or merged. After each provider refresh, DevDocket collects all work items in the WorkGraph linked to your provider (including manually-imported items) and calls `getClosedItems()` with their external IDs. Return the subset that are closed, merged, or completed. Providers without this method fall back to **disappearance detection** — if a previously-discovered item is absent from the next refresh, it is assumed closed. The disappearance fallback cannot cover manually-imported items since the provider never discovered them. Auto-completion is controlled by the `devdocket.autoCompleteOnClose` setting (default: `true`).
 - **Emit the full set every time** — Each `onDidDiscoverItems` emission replaces all previously known items for that provider. Emit everything currently relevant, not just deltas.
 
 ### Periodic Refresh Pattern
@@ -548,6 +571,20 @@ interface DevDocketProvider {
    * @param signal - Optional AbortSignal for cancellation.
    */
   resolveUrl?(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined>;
+
+  /**
+   * Check which of the given external items have been closed or completed.
+   * Called after each provider refresh to auto-complete linked work items,
+   * including manually-imported items that may not appear in the provider's
+   * discovered-items list.
+   * Optional — providers without this method fall back to disappearance
+   * detection (item was previously discovered but is now absent).
+   *
+   * @param externalIds - The provider-scoped external IDs to check.
+   * @param signal - Optional AbortSignal for cancellation.
+   * @returns The subset of externalIds that are closed, merged, or completed.
+   */
+  getClosedItems?(externalIds: string[], signal?: AbortSignal): Promise<string[]>;
 }
 ```
 

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -322,7 +322,7 @@ export class AdoPrReviewProvider extends BaseProvider {
 
     if (parsed.length === 0) { return []; }
 
-    const closedIds: string[] = [];
+    const closedSet = new Set<string>();
     let nextIndex = 0;
 
     const runWorker = async (): Promise<void> => {
@@ -342,7 +342,7 @@ export class AdoPrReviewProvider extends BaseProvider {
           if (response.ok) {
             const data = await response.json() as { status?: string };
             if (data.status === 'completed' || data.status === 'abandoned') {
-              closedIds.push(item.id);
+              closedSet.add(item.id);
             }
           } else {
             logger.debug(`Failed to check PR ${item.id}: ${response.status}`);
@@ -357,7 +357,8 @@ export class AdoPrReviewProvider extends BaseProvider {
     const workerCount = Math.min(5, parsed.length);
     await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
 
-    return closedIds;
+    // Return in input order for deterministic results
+    return parsed.filter(p => closedSet.has(p.id)).map(p => p.id);
   }
 
   private static readonly ADO_PR_PATTERN = /^https?:\/\/dev\.azure\.com\/([^/]+)\/([^/]+)\/_git\/([^/]+)\/pullrequest\/(\d+)\b/i;

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -310,12 +310,13 @@ export class AdoPrReviewProvider extends BaseProvider {
     // Parse external IDs: "org/project/repo/prId"
     const parsed = externalIds.map(id => {
       const parts = id.split('/');
-      if (parts.length < 4) { return null; }
-      const prId = parseInt(parts[parts.length - 1], 10);
-      if (isNaN(prId)) { return null; }
+      if (parts.length !== 4) { return null; }
       const org = parts[0];
       const project = parts[1];
-      const repo = parts.slice(2, parts.length - 1).join('/');
+      const repo = parts[2];
+      const prIdSegment = parts[3];
+      if (!/^\d+$/.test(prIdSegment)) { return null; }
+      const prId = Number(prIdSegment);
       return { id, org, project, repo, prId };
     }).filter((p): p is NonNullable<typeof p> => p !== null);
 

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -287,6 +287,77 @@ export class AdoPrReviewProvider extends BaseProvider {
     return { items, failed: false };
   }
 
+  /**
+   * Check which of the given external IDs correspond to completed/abandoned ADO PRs.
+   * Uses concurrent individual API calls with a worker pool since there is
+   * no batch PR-get endpoint.
+   */
+  async getClosedItems(externalIds: string[], signal?: AbortSignal): Promise<string[]> {
+    if (externalIds.length === 0) { return []; }
+
+    let session: vscode.AuthenticationSession | undefined;
+    try {
+      session = await vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], {
+        createIfNone: false,
+      });
+    } catch {
+      logger.debug('No ADO auth session for getClosedItems');
+    }
+    if (!session) { return []; }
+    const token = session.accessToken;
+
+    // Parse external IDs: "org/project/repo/prId"
+    const parsed = externalIds.map(id => {
+      const parts = id.split('/');
+      if (parts.length < 4) { return null; }
+      const prId = parseInt(parts[parts.length - 1], 10);
+      if (isNaN(prId)) { return null; }
+      const org = parts[0];
+      const project = parts[1];
+      const repo = parts.slice(2, parts.length - 1).join('/');
+      return { id, org, project, repo, prId };
+    }).filter((p): p is NonNullable<typeof p> => p !== null);
+
+    if (parsed.length === 0) { return []; }
+
+    const closedIds: string[] = [];
+    let nextIndex = 0;
+
+    const runWorker = async (): Promise<void> => {
+      while (nextIndex < parsed.length) {
+        if (signal?.aborted) { break; }
+        const currentIndex = nextIndex++;
+        const item = parsed[currentIndex];
+        try {
+          if (!isValidUrlSegment(item.org) || !isValidUrlSegment(item.project) || !isValidUrlSegment(item.repo)) {
+            continue;
+          }
+          const url = `https://dev.azure.com/${encodeURIComponent(item.org)}/${encodeURIComponent(item.project)}/_apis/git/repositories/${encodeURIComponent(item.repo)}/pullrequests/${item.prId}?api-version=7.1`;
+          const response = await fetch(url, {
+            headers: { Authorization: `Bearer ${token}` },
+            signal,
+          });
+          if (response.ok) {
+            const data = await response.json() as { status?: string };
+            if (data.status === 'completed' || data.status === 'abandoned') {
+              closedIds.push(item.id);
+            }
+          } else {
+            logger.debug(`Failed to check PR ${item.id}: ${response.status}`);
+          }
+        } catch (err) {
+          if (signal?.aborted) { break; }
+          logger.debug(`Failed to check PR ${item.id}: ${String(err)}`);
+        }
+      }
+    };
+
+    const workerCount = Math.min(5, parsed.length);
+    await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+
+    return closedIds;
+  }
+
   private static readonly ADO_PR_PATTERN = /^https?:\/\/dev\.azure\.com\/([^/]+)\/([^/]+)\/_git\/([^/]+)\/pullrequest\/(\d+)\b/i;
 
   async resolveUrl(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined> {

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -299,6 +299,7 @@ export class AdoPrReviewProvider extends BaseProvider {
     try {
       session = await vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], {
         createIfNone: false,
+        silent: true,
       });
     } catch {
       logger.debug('No ADO auth session for getClosedItems');

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -433,6 +433,99 @@ export class AdoWorkItemProvider extends BaseProvider {
     return activeItems;
   }
 
+  /**
+   * Check which of the given external IDs correspond to closed/completed ADO work items.
+   * Uses the batch work items API (up to 200 per request) and checks against
+   * terminal state categories (Completed, Removed, Resolved).
+   */
+  async getClosedItems(externalIds: string[], signal?: AbortSignal): Promise<string[]> {
+    if (externalIds.length === 0) { return []; }
+
+    let session: vscode.AuthenticationSession | undefined;
+    try {
+      session = await vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], {
+        createIfNone: false,
+      });
+    } catch {
+      logger.debug('No ADO auth session for getClosedItems');
+    }
+    if (!session) { return []; }
+    const token = session.accessToken;
+
+    // Parse external IDs: "org/project/id"
+    const parsed = externalIds.map(id => {
+      const parts = id.split('/');
+      if (parts.length < 3) { return null; }
+      const numStr = parts[parts.length - 1];
+      const num = parseInt(numStr, 10);
+      if (isNaN(num)) { return null; }
+      const org = parts[0];
+      const project = parts.slice(1, parts.length - 1).join('/');
+      return { id, org, project, workItemId: num };
+    }).filter((p): p is NonNullable<typeof p> => p !== null);
+
+    if (parsed.length === 0) { return []; }
+
+    // Group by org for batch API calls
+    const byOrg = new Map<string, typeof parsed>();
+    for (const item of parsed) {
+      const group = byOrg.get(item.org);
+      if (group) { group.push(item); } else { byOrg.set(item.org, [item]); }
+    }
+
+    const closedIds: string[] = [];
+
+    for (const [org, items] of byOrg) {
+      if (signal?.aborted) { break; }
+      if (!isValidUrlSegment(org)) { continue; }
+
+      const ids = items.map(i => i.workItemId);
+      const batchSize = 200;
+
+      for (let i = 0; i < ids.length; i += batchSize) {
+        if (signal?.aborted) { break; }
+        const batchIds = ids.slice(i, i + batchSize);
+        const batchItems = items.slice(i, i + batchSize);
+        const detailUrl = `https://dev.azure.com/${encodeURIComponent(org)}/_apis/wit/workitems?ids=${batchIds.join(',')}&fields=System.State,System.WorkItemType,System.TeamProject&api-version=7.1`;
+
+        try {
+          const response = await fetch(detailUrl, {
+            headers: { Authorization: `Bearer ${token}` },
+            signal,
+          });
+
+          if (!response.ok) {
+            logger.debug(`Failed to fetch work item details for org ${org}: ${response.status}`);
+            continue;
+          }
+
+          const data = (await response.json()) as { value: AdoWorkItem[] };
+          const workItemMap = new Map<number, AdoWorkItem>();
+          for (const wi of data.value) {
+            workItemMap.set(wi.id, wi);
+          }
+
+          for (const item of batchItems) {
+            const wi = workItemMap.get(item.workItemId);
+            if (!wi) { continue; }
+            const state = wi.fields['System.State'];
+            const project = wi.fields['System.TeamProject'];
+            const workItemType = wi.fields['System.WorkItemType'];
+            const terminalStates = await this.fetchTerminalStates(token, org, project, workItemType);
+            if (terminalStates.has(state)) {
+              closedIds.push(item.id);
+            }
+          }
+        } catch (err) {
+          if (signal?.aborted) { break; }
+          logger.debug(`Failed to check work items for org ${org}: ${String(err)}`);
+        }
+      }
+    }
+
+    return closedIds;
+  }
+
   private static readonly ADO_WORKITEM_PATTERN = /^https?:\/\/dev\.azure\.com\/([^/]+)\/([^/]+)\/_workitems\/edit\/(\d+)\b/i;
 
   async resolveUrl(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined> {

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -459,8 +459,8 @@ export class AdoWorkItemProvider extends BaseProvider {
     const parsed = externalIds.map(id => {
       const parts = id.split('/');
       if (parts.length !== 3) { return null; }
-      const [org, , numStr] = parts;
-      if (!isValidUrlSegment(org)) { return null; }
+      const [org, project, numStr] = parts;
+      if (!isValidUrlSegment(org) || !isValidUrlSegment(project)) { return null; }
       if (!/^\d+$/.test(numStr)) { return null; }
       const num = parseInt(numStr, 10);
       return { id, org, workItemId: num };

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -305,6 +305,7 @@ export class AdoWorkItemProvider extends BaseProvider {
     org: string,
     project: string,
     workItemType: string,
+    signal?: AbortSignal,
   ): Promise<Set<string>> {
     const cacheKey = `${org}/${project}/${workItemType}`;
     
@@ -324,6 +325,7 @@ export class AdoWorkItemProvider extends BaseProvider {
         headers: {
           Authorization: `Bearer ${token}`,
         },
+        signal,
       });
     } catch (err) {
       logger.warn(`Failed to fetch states for ${cacheKey}: network error`, err);
@@ -445,6 +447,7 @@ export class AdoWorkItemProvider extends BaseProvider {
     try {
       session = await vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], {
         createIfNone: false,
+        silent: true,
       });
     } catch {
       logger.debug('No ADO auth session for getClosedItems');
@@ -505,15 +508,43 @@ export class AdoWorkItemProvider extends BaseProvider {
             workItemMap.set(wi.id, wi);
           }
 
+          // Group by (project, workItemType) and fetch terminal states per group
+          const groupedItems = new Map<string, {
+            project: string;
+            workItemType: string;
+            items: Array<{ id: string; state: string }>;
+          }>();
+
           for (const item of batchItems) {
             const wi = workItemMap.get(item.workItemId);
             if (!wi) { continue; }
             const state = wi.fields['System.State'];
             const project = wi.fields['System.TeamProject'];
             const workItemType = wi.fields['System.WorkItemType'];
-            const terminalStates = await this.fetchTerminalStates(token, org, project, workItemType);
-            if (terminalStates.has(state)) {
-              closedIds.push(item.id);
+            const groupKey = `${project}\0${workItemType}`;
+            const group = groupedItems.get(groupKey);
+            if (group) {
+              group.items.push({ id: item.id, state });
+            } else {
+              groupedItems.set(groupKey, { project, workItemType, items: [{ id: item.id, state }] });
+            }
+          }
+
+          const terminalStatesByGroup = new Map<string, Set<string>>();
+          await Promise.all(
+            Array.from(groupedItems.entries()).map(async ([groupKey, group]) => {
+              const terminalStates = await this.fetchTerminalStates(token, org, group.project, group.workItemType, signal);
+              terminalStatesByGroup.set(groupKey, terminalStates);
+            }),
+          );
+
+          for (const [groupKey, group] of groupedItems) {
+            const terminalStates = terminalStatesByGroup.get(groupKey);
+            if (!terminalStates) { continue; }
+            for (const item of group.items) {
+              if (terminalStates.has(item.state)) {
+                closedIds.push(item.id);
+              }
             }
           }
         } catch (err) {

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -458,11 +458,11 @@ export class AdoWorkItemProvider extends BaseProvider {
     // Parse external IDs: "org/project/id"
     const parsed = externalIds.map(id => {
       const parts = id.split('/');
-      if (parts.length < 3) { return null; }
-      const numStr = parts[parts.length - 1];
+      if (parts.length !== 3) { return null; }
+      const [org, , numStr] = parts;
+      if (!isValidUrlSegment(org)) { return null; }
       if (!/^\d+$/.test(numStr)) { return null; }
       const num = parseInt(numStr, 10);
-      const org = parts[0];
       return { id, org, workItemId: num };
     }).filter((p): p is NonNullable<typeof p> => p !== null);
 

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -460,11 +460,10 @@ export class AdoWorkItemProvider extends BaseProvider {
       const parts = id.split('/');
       if (parts.length < 3) { return null; }
       const numStr = parts[parts.length - 1];
+      if (!/^\d+$/.test(numStr)) { return null; }
       const num = parseInt(numStr, 10);
-      if (isNaN(num)) { return null; }
       const org = parts[0];
-      const project = parts.slice(1, parts.length - 1).join('/');
-      return { id, org, project, workItemId: num };
+      return { id, org, workItemId: num };
     }).filter((p): p is NonNullable<typeof p> => p !== null);
 
     if (parsed.length === 0) { return []; }

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -475,7 +475,7 @@ export class AdoWorkItemProvider extends BaseProvider {
       if (group) { group.push(item); } else { byOrg.set(item.org, [item]); }
     }
 
-    const closedIds: string[] = [];
+    const closedSet = new Set<string>();
 
     for (const [org, items] of byOrg) {
       if (signal?.aborted) { break; }
@@ -542,7 +542,7 @@ export class AdoWorkItemProvider extends BaseProvider {
             if (!terminalStates) { continue; }
             for (const item of group.items) {
               if (terminalStates.has(item.state)) {
-                closedIds.push(item.id);
+                closedSet.add(item.id);
               }
             }
           }
@@ -553,7 +553,8 @@ export class AdoWorkItemProvider extends BaseProvider {
       }
     }
 
-    return closedIds;
+    // Return in input order for deterministic results
+    return parsed.filter(p => closedSet.has(p.id)).map(p => p.id);
   }
 
   private static readonly ADO_WORKITEM_PATTERN = /^https?:\/\/dev\.azure\.com\/([^/]+)\/([^/]+)\/_workitems\/edit\/(\d+)\b/i;

--- a/packages/ado/src/test/adoPrReviewProvider.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.test.ts
@@ -541,4 +541,66 @@ describe('AdoPrReviewProvider', () => {
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
   });
+
+  describe('getClosedItems', () => {
+    it('returns completed and abandoned PR IDs', async () => {
+      mockFetch.mockImplementation(async (url: string) => {
+        if (url.includes('/pullrequests/101?')) {
+          return { ok: true, json: async () => ({ status: 'completed' }) };
+        }
+        if (url.includes('/pullrequests/102?')) {
+          return { ok: true, json: async () => ({ status: 'active' }) };
+        }
+        throw new Error(`Unexpected fetch call: ${url}`);
+      });
+
+      const result = await provider.getClosedItems([
+        'myorg/MyProject/myrepo/101',
+        'myorg/MyProject/myrepo/102',
+      ]);
+
+      expect(result).toEqual(['myorg/MyProject/myrepo/101']);
+    });
+
+    it('returns abandoned PRs', async () => {
+      mockFetch.mockImplementation(async (url: string) => {
+        if (url.includes('/pullrequests/200?')) {
+          return { ok: true, json: async () => ({ status: 'abandoned' }) };
+        }
+        throw new Error(`Unexpected fetch call: ${url}`);
+      });
+
+      const result = await provider.getClosedItems(['myorg/MyProject/myrepo/200']);
+
+      expect(result).toEqual(['myorg/MyProject/myrepo/200']);
+    });
+
+    it('returns empty array when no auth session', async () => {
+      vi.mocked(authentication.getSession).mockResolvedValue(undefined as any);
+
+      const result = await provider.getClosedItems(['myorg/MyProject/myrepo/101']);
+
+      expect(result).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('ignores malformed external IDs', async () => {
+      const result = await provider.getClosedItems([
+        'bad',
+        'only/two/segments',
+        'org/project/repo/abc',
+        'a/b/c/d/e',
+      ]);
+
+      expect(result).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns empty array for empty input', async () => {
+      const result = await provider.getClosedItems([]);
+
+      expect(result).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -468,4 +468,83 @@ describe('AdoWorkItemProvider', () => {
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener).toHaveBeenCalledWith([]);
   });
+
+  describe('getClosedItems', () => {
+    it('returns closed work item IDs based on terminal states', async () => {
+      mockFetch.mockImplementation(async (url: string) => {
+        // Batch work item details API
+        if (url.includes('/_apis/wit/workitems?ids=')) {
+          return {
+            ok: true,
+            json: async () => ({
+              value: [
+                {
+                  id: 10,
+                  fields: {
+                    'System.State': 'Closed',
+                    'System.WorkItemType': 'User Story',
+                    'System.TeamProject': 'MyProject',
+                  },
+                },
+                {
+                  id: 20,
+                  fields: {
+                    'System.State': 'Active',
+                    'System.WorkItemType': 'User Story',
+                    'System.TeamProject': 'MyProject',
+                  },
+                },
+              ],
+            }),
+          };
+        }
+        // Terminal states API
+        if (url.includes('/workitemtypes/') && url.includes('/states')) {
+          return {
+            ok: true,
+            json: async () => ({
+              count: 1,
+              value: [{ name: 'Closed', category: 'Completed' }],
+            }),
+          };
+        }
+        throw new Error(`Unexpected fetch call: ${url}`);
+      });
+
+      const result = await provider.getClosedItems([
+        'myorg/MyProject/10',
+        'myorg/MyProject/20',
+      ]);
+
+      expect(result).toEqual(['myorg/MyProject/10']);
+    });
+
+    it('returns empty array when no auth session', async () => {
+      vi.mocked(authentication.getSession).mockResolvedValue(undefined as any);
+
+      const result = await provider.getClosedItems(['myorg/MyProject/10']);
+
+      expect(result).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('ignores malformed external IDs', async () => {
+      // None of these should trigger a fetch
+      const result = await provider.getClosedItems([
+        'bad',
+        'only/two',
+        'org/project/abc',
+      ]);
+
+      expect(result).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns empty array for empty input', async () => {
+      const result = await provider.getClosedItems([]);
+
+      expect(result).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,11 @@
           "default": true,
           "description": "Show a notification when new items arrive in the Inbox"
         },
+        "devdocket.autoCompleteOnClose": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically mark work items as Done when their linked issue or PR is closed or merged externally"
+        },
         "devdocket.viewLayout": {
           "type": "object",
           "default": {},

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -60,9 +60,10 @@ export interface DevDocketProvider {
    * in the provider's discovered-items list.
    *
    * @param externalIds - The provider-scoped external IDs to check.
+   * @param signal - Optional abort signal for cancellation.
    * @returns The subset of `externalIds` that are closed, merged, or completed.
    */
-  getClosedItems?(externalIds: string[]): Promise<string[]>;
+  getClosedItems?(externalIds: string[], signal?: AbortSignal): Promise<string[]>;
 }
 
 /**

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -52,6 +52,17 @@ export interface DevDocketProvider {
    * @param signal - Optional abort signal for cancellation.
    */
   resolveUrl?(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined>;
+  /**
+   * Check which of the given external items have been closed or completed.
+   *
+   * The core extension calls this after each provider refresh to auto-complete
+   * linked work items — including manually-imported items that may not appear
+   * in the provider's discovered-items list.
+   *
+   * @param externalIds - The provider-scoped external IDs to check.
+   * @returns The subset of `externalIds` that are closed, merged, or completed.
+   */
+  getClosedItems?(externalIds: string[]): Promise<string[]>;
 }
 
 /**

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -274,22 +274,27 @@ function wireEvents(
 
   // Auto-complete: after each provider refresh, scan all WorkGraph items with
   // that providerId and check whether their external items are closed/merged.
-  // Per-provider guard prevents overlapping runs from concurrent refreshes.
-  const autoCompleteInFlight = new Set<string>();
+  // Per-provider guard prevents overlapping runs; AbortController cancels in-flight checks.
+  const autoCompleteControllers = new Map<string, AbortController>();
   const autoCompleteSub = providerRegistry.onDidRefreshProvider(safeHandler('Error handling auto-complete', async (providerId) => {
     const config = vscode.workspace.getConfiguration('devdocket');
     if (!config.get<boolean>('autoCompleteOnClose', true)) {
       return;
     }
-    if (autoCompleteInFlight.has(providerId)) {
-      return;
+    // Abort any in-flight check for this provider
+    const prev = autoCompleteControllers.get(providerId);
+    if (prev) {
+      prev.abort();
     }
-    autoCompleteInFlight.add(providerId);
+    const controller = new AbortController();
+    autoCompleteControllers.set(providerId, controller);
     try {
-      const completedTitles = await checkAutoComplete(providerId, workGraph, providerRegistry);
+      const completedTitles = await checkAutoComplete(providerId, workGraph, providerRegistry, controller.signal);
       showAutoCompleteNotification(completedTitles);
     } finally {
-      autoCompleteInFlight.delete(providerId);
+      if (autoCompleteControllers.get(providerId) === controller) {
+        autoCompleteControllers.delete(providerId);
+      }
     }
   }));
 

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -6,8 +6,8 @@ import { DiscoveredStateStore } from './storage/discoveredStateStore';
 import { ReadStateStore } from './storage/readStateStore';
 import { ProviderLabelCache } from './storage/providerLabelCache';
 import { WorkGraph } from './services/workGraph';
-import { WorkItemState } from './models/workItem';
 import { ProviderRegistry } from './services/providerRegistry';
+import { checkAutoComplete, showAutoCompleteNotification } from './services/autoComplete';
 import { ActionRegistry } from './services/actionRegistry';
 import { InboxTreeProvider } from './views/inboxTreeProvider';
 import { QueueTreeProvider } from './views/queueTreeProvider';
@@ -34,9 +34,6 @@ function safeHandler<T extends unknown[]>(label: string, fn: (...args: T) => voi
       });
   };
 }
-
-/** Work item states eligible for auto-completion when the external item is closed/merged. */
-const AUTO_COMPLETABLE_STATES = new Set([WorkItemState.New, WorkItemState.InProgress, WorkItemState.Paused]);
 
 let providerRegistry: ProviderRegistry | undefined;
 let actionRegistry: ActionRegistry | undefined;
@@ -277,87 +274,13 @@ function wireEvents(
 
   // Auto-complete: after each provider refresh, scan all WorkGraph items with
   // that providerId and check whether their external items are closed/merged.
-  // Uses the provider's getClosedItems() if available; otherwise falls back to
-  // disappearance detection (item was previously discovered but is now absent).
   const autoCompleteSub = providerRegistry.onDidRefreshProvider(safeHandler('Error handling auto-complete', async (providerId) => {
     const config = vscode.workspace.getConfiguration('devdocket');
     if (!config.get<boolean>('autoCompleteOnClose', true)) {
       return;
     }
-
-    // Collect all work items linked to this provider in auto-completable states
-    const candidates = workGraph.getAll().filter(
-      item => item.providerId === providerId && item.externalId && AUTO_COMPLETABLE_STATES.has(item.state),
-    );
-    if (candidates.length === 0) {
-      return;
-    }
-
-    let closedIds: Set<string>;
-    const provider = providerRegistry.getProvider(providerId);
-
-    if (provider && typeof provider.getClosedItems === 'function') {
-      // Provider supports batch status checks — covers imported items too
-      try {
-        const externalIds = candidates.map(item => item.externalId!);
-        const result = await provider.getClosedItems(externalIds);
-        closedIds = new Set(result);
-      } catch (err) {
-        logger.error(`Provider "${providerId}" getClosedItems failed, skipping auto-complete`, err);
-        return;
-      }
-    } else {
-      // Fallback: compare current vs previous discovered items.
-      // Only items that were previously discovered and are now absent are considered closed.
-      // This avoids false positives for imported items that the provider never tracked.
-      if (providerRegistry.wasLastRefreshTruncated(providerId)) {
-        return;
-      }
-      const currentItems = providerRegistry.getDiscoveredItems(providerId);
-      if (currentItems.length === 0) {
-        return;
-      }
-      const currentIds = new Set(currentItems.map(i => i.externalId));
-      closedIds = new Set<string>();
-      for (const item of candidates) {
-        if (
-          !currentIds.has(item.externalId!) &&
-          providerRegistry.wasItemPreviouslyDiscovered(providerId, item.externalId!)
-        ) {
-          closedIds.add(item.externalId!);
-        }
-      }
-    }
-
-    const completedTitles: string[] = [];
-    for (const item of candidates) {
-      if (closedIds.has(item.externalId!)) {
-        try {
-          await workGraph.transitionState(item.id, WorkItemState.Done);
-          completedTitles.push(item.title);
-          logger.info(`Auto-completed work item "${item.title}" (${item.id}) — external item closed/merged`);
-        } catch (err) {
-          logger.error(`Failed to auto-complete work item ${item.id}`, err);
-        }
-      }
-    }
-
-    if (completedTitles.length > 0) {
-      const message = completedTitles.length === 1
-        ? `Item completed: ${completedTitles[0]} was closed/merged externally`
-        : `${completedTitles.length} items completed — closed/merged externally`;
-      void vscode.window.showInformationMessage(`DevDocket: ${message}`, 'Show History').then(
-        action => {
-          if (action === 'Show History') {
-            vscode.commands.executeCommand('devdocket.history.focus').then(
-              undefined,
-              () => { /* view focus is best-effort */ },
-            );
-          }
-        },
-        () => { /* notification is best-effort */ },
-      );
-    }
+    const completedTitles = await checkAutoComplete(providerId, workGraph, providerRegistry);
+    showAutoCompleteNotification(completedTitles);
   }));
 
   return [discoveredSub, newItemsSub, providerRegSub, stateStoreSub, markSeenSub, workGraphSub, autoCompleteSub];

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -274,13 +274,23 @@ function wireEvents(
 
   // Auto-complete: after each provider refresh, scan all WorkGraph items with
   // that providerId and check whether their external items are closed/merged.
+  // Per-provider guard prevents overlapping runs from concurrent refreshes.
+  const autoCompleteInFlight = new Set<string>();
   const autoCompleteSub = providerRegistry.onDidRefreshProvider(safeHandler('Error handling auto-complete', async (providerId) => {
     const config = vscode.workspace.getConfiguration('devdocket');
     if (!config.get<boolean>('autoCompleteOnClose', true)) {
       return;
     }
-    const completedTitles = await checkAutoComplete(providerId, workGraph, providerRegistry);
-    showAutoCompleteNotification(completedTitles);
+    if (autoCompleteInFlight.has(providerId)) {
+      return;
+    }
+    autoCompleteInFlight.add(providerId);
+    try {
+      const completedTitles = await checkAutoComplete(providerId, workGraph, providerRegistry);
+      showAutoCompleteNotification(completedTitles);
+    } finally {
+      autoCompleteInFlight.delete(providerId);
+    }
   }));
 
   return [discoveredSub, newItemsSub, providerRegSub, stateStoreSub, markSeenSub, workGraphSub, autoCompleteSub];

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -6,6 +6,7 @@ import { DiscoveredStateStore } from './storage/discoveredStateStore';
 import { ReadStateStore } from './storage/readStateStore';
 import { ProviderLabelCache } from './storage/providerLabelCache';
 import { WorkGraph } from './services/workGraph';
+import { WorkItemState } from './models/workItem';
 import { ProviderRegistry } from './services/providerRegistry';
 import { ActionRegistry } from './services/actionRegistry';
 import { InboxTreeProvider } from './views/inboxTreeProvider';
@@ -33,6 +34,9 @@ function safeHandler<T extends unknown[]>(label: string, fn: (...args: T) => voi
       });
   };
 }
+
+/** Work item states eligible for auto-completion when the external item is closed/merged. */
+const AUTO_COMPLETABLE_STATES = new Set([WorkItemState.New, WorkItemState.InProgress, WorkItemState.Paused]);
 
 let providerRegistry: ProviderRegistry | undefined;
 let actionRegistry: ActionRegistry | undefined;
@@ -271,7 +275,92 @@ function wireEvents(
   const stateStoreSub = stateStore.onDidChange(safeHandler('Error handling state store change', scheduleUiUpdate));
   const markSeenSub = inboxProvider.onDidMarkSeen(safeHandler('Error handling mark seen', scheduleUiUpdate));
 
-  return [discoveredSub, newItemsSub, providerRegSub, stateStoreSub, markSeenSub, workGraphSub];
+  // Auto-complete: after each provider refresh, scan all WorkGraph items with
+  // that providerId and check whether their external items are closed/merged.
+  // Uses the provider's getClosedItems() if available; otherwise falls back to
+  // disappearance detection (item was previously discovered but is now absent).
+  const autoCompleteSub = providerRegistry.onDidRefreshProvider(safeHandler('Error handling auto-complete', async (providerId) => {
+    const config = vscode.workspace.getConfiguration('devdocket');
+    if (!config.get<boolean>('autoCompleteOnClose', true)) {
+      return;
+    }
+
+    // Collect all work items linked to this provider in auto-completable states
+    const candidates = workGraph.getAll().filter(
+      item => item.providerId === providerId && item.externalId && AUTO_COMPLETABLE_STATES.has(item.state),
+    );
+    if (candidates.length === 0) {
+      return;
+    }
+
+    let closedIds: Set<string>;
+    const provider = providerRegistry.getProvider(providerId);
+
+    if (provider && typeof provider.getClosedItems === 'function') {
+      // Provider supports batch status checks — covers imported items too
+      try {
+        const externalIds = candidates.map(item => item.externalId!);
+        const result = await provider.getClosedItems(externalIds);
+        closedIds = new Set(result);
+      } catch (err) {
+        logger.error(`Provider "${providerId}" getClosedItems failed, skipping auto-complete`, err);
+        return;
+      }
+    } else {
+      // Fallback: compare current vs previous discovered items.
+      // Only items that were previously discovered and are now absent are considered closed.
+      // This avoids false positives for imported items that the provider never tracked.
+      if (providerRegistry.wasLastRefreshTruncated(providerId)) {
+        return;
+      }
+      const currentItems = providerRegistry.getDiscoveredItems(providerId);
+      if (currentItems.length === 0) {
+        return;
+      }
+      const currentIds = new Set(currentItems.map(i => i.externalId));
+      closedIds = new Set<string>();
+      for (const item of candidates) {
+        if (
+          !currentIds.has(item.externalId!) &&
+          providerRegistry.wasItemPreviouslyDiscovered(providerId, item.externalId!)
+        ) {
+          closedIds.add(item.externalId!);
+        }
+      }
+    }
+
+    const completedTitles: string[] = [];
+    for (const item of candidates) {
+      if (closedIds.has(item.externalId!)) {
+        try {
+          await workGraph.transitionState(item.id, WorkItemState.Done);
+          completedTitles.push(item.title);
+          logger.info(`Auto-completed work item "${item.title}" (${item.id}) — external item closed/merged`);
+        } catch (err) {
+          logger.error(`Failed to auto-complete work item ${item.id}`, err);
+        }
+      }
+    }
+
+    if (completedTitles.length > 0) {
+      const message = completedTitles.length === 1
+        ? `Item completed: ${completedTitles[0]} was closed/merged externally`
+        : `${completedTitles.length} items completed — closed/merged externally`;
+      void vscode.window.showInformationMessage(`DevDocket: ${message}`, 'Show History').then(
+        action => {
+          if (action === 'Show History') {
+            vscode.commands.executeCommand('devdocket.history.focus').then(
+              undefined,
+              () => { /* view focus is best-effort */ },
+            );
+          }
+        },
+        () => { /* notification is best-effort */ },
+      );
+    }
+  }));
+
+  return [discoveredSub, newItemsSub, providerRegSub, stateStoreSub, markSeenSub, workGraphSub, autoCompleteSub];
 }
 
 /**

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -298,7 +298,15 @@ function wireEvents(
     }
   }));
 
-  return [discoveredSub, newItemsSub, providerRegSub, stateStoreSub, markSeenSub, workGraphSub, autoCompleteSub];
+  // Abort all in-flight auto-complete checks on disposal
+  const autoCompleteCleanup = { dispose: () => {
+    for (const controller of autoCompleteControllers.values()) {
+      controller.abort();
+    }
+    autoCompleteControllers.clear();
+  }};
+
+  return [discoveredSub, newItemsSub, providerRegSub, stateStoreSub, markSeenSub, workGraphSub, autoCompleteSub, autoCompleteCleanup];
 }
 
 /**

--- a/packages/core/src/models/workItem.ts
+++ b/packages/core/src/models/workItem.ts
@@ -5,19 +5,21 @@
  *
  * ```
  * New ⇄ InProgress ⇄ Paused
- *  ↑        ↓
- *  ↑      Done
+ *  ↑↓       ↓           ↓
+ *  ↑      Done  ←───────┘
  *  ↑        ↓
  *  └──── Archived
  * ```
  *
  * Valid transitions:
- * - New → InProgress | Archived
+ * - New → InProgress | Done | Archived
  * - InProgress → Paused | Done | New | Archived
- * - Paused → InProgress | New | Archived
+ * - Paused → InProgress | Done | New | Archived
  * - Done → Archived | New
  * - Archived → New
  *
+ * New and Paused may transition directly to Done (e.g. when an external
+ * issue is closed or merged while the work item is still queued or paused).
  * InProgress and Paused may transition back to New (returning to Queue).
  * Done and Archived may also transition back to New (for re-work after
  * discovering the item was not actually complete).

--- a/packages/core/src/services/autoComplete.ts
+++ b/packages/core/src/services/autoComplete.ts
@@ -21,6 +21,7 @@ export async function checkAutoComplete(
   providerId: string,
   workGraph: WorkGraph,
   providerRegistry: ProviderRegistry,
+  signal?: AbortSignal,
 ): Promise<string[]> {
   // Collect all work items linked to this provider in auto-completable states
   const candidates = workGraph.getAll().filter(
@@ -37,7 +38,7 @@ export async function checkAutoComplete(
     // Provider supports batch status checks — covers imported items too
     try {
       const externalIds = [...new Set(candidates.map(item => item.externalId!))];
-      const result = await provider.getClosedItems(externalIds);
+      const result = await provider.getClosedItems(externalIds, signal);
       closedIds = new Set(result);
     } catch (err) {
       logger.error(`Provider "${providerId}" getClosedItems failed, skipping auto-complete`, err);

--- a/packages/core/src/services/autoComplete.ts
+++ b/packages/core/src/services/autoComplete.ts
@@ -39,8 +39,10 @@ export async function checkAutoComplete(
     try {
       const externalIds = [...new Set(candidates.map(item => item.externalId!))];
       const result = await provider.getClosedItems(externalIds, signal);
+      if (signal?.aborted) { return []; }
       closedIds = new Set(result);
     } catch (err) {
+      if (signal?.aborted) { return []; }
       logger.error(`Provider "${providerId}" getClosedItems failed, skipping auto-complete`, err);
       return [];
     }
@@ -73,6 +75,7 @@ export async function checkAutoComplete(
 
   const completedTitles: string[] = [];
   for (const item of candidates) {
+    if (signal?.aborted) { break; }
     if (closedIds.has(item.externalId!)) {
       const currentItem = workGraph.getItem(item.id);
       if (!currentItem || !currentItem.externalId || !AUTO_COMPLETABLE_STATES.has(currentItem.state)) {

--- a/packages/core/src/services/autoComplete.ts
+++ b/packages/core/src/services/autoComplete.ts
@@ -1,0 +1,110 @@
+import * as vscode from 'vscode';
+import { WorkGraph } from './workGraph';
+import { WorkItemState } from '../models/workItem';
+import { ProviderRegistry } from './providerRegistry';
+import { logger } from './logger';
+
+/** Work item states eligible for auto-completion when the external item is closed/merged. */
+export const AUTO_COMPLETABLE_STATES = new Set([WorkItemState.New, WorkItemState.InProgress, WorkItemState.Paused]);
+
+/**
+ * Check for work items that should be auto-completed after a provider refresh.
+ *
+ * Scans the full WorkGraph for items linked to the given provider — covering both
+ * provider-discovered and manually-imported items. Uses the provider's
+ * `getClosedItems()` for batch status checks when available; otherwise falls back
+ * to disappearance detection (item was previously discovered but is now absent).
+ *
+ * @returns Titles of items that were transitioned to Done, for notification purposes.
+ */
+export async function checkAutoComplete(
+  providerId: string,
+  workGraph: WorkGraph,
+  providerRegistry: ProviderRegistry,
+): Promise<string[]> {
+  // Collect all work items linked to this provider in auto-completable states
+  const candidates = workGraph.getAll().filter(
+    item => item.providerId === providerId && item.externalId && AUTO_COMPLETABLE_STATES.has(item.state),
+  );
+  if (candidates.length === 0) {
+    return [];
+  }
+
+  let closedIds: Set<string>;
+  const provider = providerRegistry.getProvider(providerId);
+
+  if (provider && typeof provider.getClosedItems === 'function') {
+    // Provider supports batch status checks — covers imported items too
+    try {
+      const externalIds = candidates.map(item => item.externalId!);
+      const result = await provider.getClosedItems(externalIds);
+      closedIds = new Set(result);
+    } catch (err) {
+      logger.error(`Provider "${providerId}" getClosedItems failed, skipping auto-complete`, err);
+      return [];
+    }
+  } else {
+    // Fallback: compare current vs previous discovered items.
+    // Only items that were previously discovered and are now absent are considered closed.
+    // This avoids false positives for imported items that the provider never tracked.
+    if (providerRegistry.wasLastRefreshTruncated(providerId)) {
+      return [];
+    }
+    const currentItems = providerRegistry.getDiscoveredItems(providerId);
+    // Guard: if the provider returned zero items, skip auto-complete. Zero items could
+    // indicate a transient API failure or auth error rather than all items being closed.
+    // Providers that need to handle the "all items closed" case should implement
+    // getClosedItems() for explicit status checking.
+    if (currentItems.length === 0) {
+      return [];
+    }
+    const currentIds = new Set(currentItems.map(i => i.externalId));
+    closedIds = new Set<string>();
+    for (const item of candidates) {
+      if (
+        !currentIds.has(item.externalId!) &&
+        providerRegistry.wasItemPreviouslyDiscovered(providerId, item.externalId!)
+      ) {
+        closedIds.add(item.externalId!);
+      }
+    }
+  }
+
+  const completedTitles: string[] = [];
+  for (const item of candidates) {
+    if (closedIds.has(item.externalId!)) {
+      try {
+        await workGraph.transitionState(item.id, WorkItemState.Done);
+        completedTitles.push(item.title);
+        logger.info(`Auto-completed work item "${item.title}" (${item.id}) — external item closed/merged`);
+      } catch (err) {
+        logger.error(`Failed to auto-complete work item ${item.id}`, err);
+      }
+    }
+  }
+
+  return completedTitles;
+}
+
+/**
+ * Show a notification summarising auto-completed items with a "Show History" action.
+ */
+export function showAutoCompleteNotification(completedTitles: string[]): void {
+  if (completedTitles.length === 0) {
+    return;
+  }
+  const message = completedTitles.length === 1
+    ? `Item completed: ${completedTitles[0]} was closed/merged externally`
+    : `${completedTitles.length} items completed — closed/merged externally`;
+  void vscode.window.showInformationMessage(`DevDocket: ${message}`, 'Show History').then(
+    action => {
+      if (action === 'Show History') {
+        vscode.commands.executeCommand('devdocket.history.focus').then(
+          undefined,
+          () => { /* view focus is best-effort */ },
+        );
+      }
+    },
+    () => { /* notification is best-effort */ },
+  );
+}

--- a/packages/core/src/services/autoComplete.ts
+++ b/packages/core/src/services/autoComplete.ts
@@ -5,7 +5,7 @@ import { ProviderRegistry } from './providerRegistry';
 import { logger } from './logger';
 
 /** Work item states eligible for auto-completion when the external item is closed/merged. */
-export const AUTO_COMPLETABLE_STATES = new Set([WorkItemState.New, WorkItemState.InProgress, WorkItemState.Paused]);
+export const AUTO_COMPLETABLE_STATES: ReadonlySet<WorkItemState> = new Set([WorkItemState.New, WorkItemState.InProgress, WorkItemState.Paused]);
 
 /**
  * Check for work items that should be auto-completed after a provider refresh.
@@ -73,12 +73,16 @@ export async function checkAutoComplete(
   const completedTitles: string[] = [];
   for (const item of candidates) {
     if (closedIds.has(item.externalId!)) {
+      const currentItem = workGraph.getItem(item.id);
+      if (!currentItem || !currentItem.externalId || !AUTO_COMPLETABLE_STATES.has(currentItem.state)) {
+        continue;
+      }
       try {
-        await workGraph.transitionState(item.id, WorkItemState.Done);
-        completedTitles.push(item.title);
-        logger.info(`Auto-completed work item "${item.title}" (${item.id}) — external item closed/merged`);
+        await workGraph.transitionState(currentItem.id, WorkItemState.Done);
+        completedTitles.push(currentItem.title);
+        logger.info(`Auto-completed work item "${currentItem.title}" (${currentItem.id}) — external item closed/merged`);
       } catch (err) {
-        logger.error(`Failed to auto-complete work item ${item.id}`, err);
+        logger.error(`Failed to auto-complete work item ${currentItem.id}`, err);
       }
     }
   }

--- a/packages/core/src/services/autoComplete.ts
+++ b/packages/core/src/services/autoComplete.ts
@@ -36,7 +36,7 @@ export async function checkAutoComplete(
   if (provider && typeof provider.getClosedItems === 'function') {
     // Provider supports batch status checks — covers imported items too
     try {
-      const externalIds = candidates.map(item => item.externalId!);
+      const externalIds = [...new Set(candidates.map(item => item.externalId!))];
       const result = await provider.getClosedItems(externalIds);
       closedIds = new Set(result);
     } catch (err) {

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -43,6 +43,18 @@ export class ProviderRegistry {
   private readonly _onDidChangeProviderHealth = new vscode.EventEmitter<string>();
   /** Fired when a provider's health info changes (status, lastError, or lastRefreshTime), with the provider ID. */
   readonly onDidChangeProviderHealth = this._onDidChangeProviderHealth.event;
+  private readonly _onDidRefreshProvider = new vscode.EventEmitter<string>();
+  /**
+   * Fired after a provider's discovered items have been processed, carrying the
+   * provider ID. Listeners can use this to run cross-cutting checks (e.g.
+   * auto-complete) against the full WorkGraph rather than just the provider's
+   * own discovered-items list.
+   */
+  readonly onDidRefreshProvider = this._onDidRefreshProvider.event;
+  /** Previous discovered-item external IDs per provider, for fallback disappearance detection. */
+  private readonly previousDiscoveredIds = new Map<string, Set<string>>();
+  /** Tracks whether each provider's most recent refresh was truncated. */
+  private readonly lastRefreshTruncated = new Map<string, boolean>();
   private readonly healthStatus = new Map<string, ProviderHealthStatus>();
   private readonly _loadingProviders = new Set<string>();
   private readonly _pendingRefreshes = new Map<string, { cts: vscode.CancellationTokenSource; timeoutId: ReturnType<typeof setTimeout> }>();
@@ -111,6 +123,8 @@ export class ProviderRegistry {
       this.subscriptions.get(provider.id)?.dispose();
       this.subscriptions.delete(provider.id);
       this.discoveredItems.delete(provider.id);
+      this.previousDiscoveredIds.delete(provider.id);
+      this.lastRefreshTruncated.delete(provider.id);
       this.healthStatus.delete(provider.id);
       this._loadingProviders.delete(provider.id);
       if (!this._disposed) {
@@ -166,6 +180,24 @@ export class ProviderRegistry {
    */
   getAllDiscoveredItems(): Map<string, DiscoveredItem[]> {
     return this.discoveredItems;
+  }
+
+  /**
+   * Check whether an item was in the provider's discovered-items list before
+   * the most recent refresh. Used as a fallback for auto-complete when the
+   * provider does not implement `getClosedItems`.
+   */
+  wasItemPreviouslyDiscovered(providerId: string, externalId: string): boolean {
+    return this.previousDiscoveredIds.get(providerId)?.has(externalId) ?? false;
+  }
+
+  /**
+   * Whether the most recent refresh for the given provider was truncated due to
+   * exceeding {@link MAX_ITEMS_PER_PROVIDER}. When truncated, disappearance-based
+   * completion detection is unreliable.
+   */
+  wasLastRefreshTruncated(providerId: string): boolean {
+    return this.lastRefreshTruncated.get(providerId) ?? false;
   }
 
   /**
@@ -292,15 +324,24 @@ export class ProviderRegistry {
     if (this._disposed) {
       return;
     }
+    let wasTruncated = false;
     if (items.length > ProviderRegistry.MAX_ITEMS_PER_PROVIDER) {
       logger.warn(
         `Provider "${providerId}" emitted ${items.length} items, exceeding the limit of ${ProviderRegistry.MAX_ITEMS_PER_PROVIDER}. Truncating.`,
       );
       items = items.slice(0, ProviderRegistry.MAX_ITEMS_PER_PROVIDER);
+      wasTruncated = true;
     } else {
       items = items.slice();
     }
     logger.info(`Provider ${providerId} discovered ${items.length} items`);
+
+    // Snapshot previous IDs before replacing, for fallback disappearance detection.
+    const prevItems = this.discoveredItems.get(providerId) ?? [];
+    if (prevItems.length > 0) {
+      this.previousDiscoveredIds.set(providerId, new Set(prevItems.map(i => i.externalId)));
+    }
+    this.lastRefreshTruncated.set(providerId, wasTruncated);
     this.discoveredItems.set(providerId, items);
 
     const newUnseenUpdates: Array<{ providerId: string; externalId: string; state: 'unseen'; version?: string; resurfaceVersion?: string }> = [];
@@ -375,6 +416,7 @@ export class ProviderRegistry {
     }
     if (!this._disposed) {
       this._onDidChangeDiscoveredItems.fire();
+      this._onDidRefreshProvider.fire(providerId);
     }
   }
 
@@ -397,5 +439,6 @@ export class ProviderRegistry {
     this._onDidRegisterProvider.dispose();
     this._onDidAddNewUnseenItems.dispose();
     this._onDidChangeProviderHealth.dispose();
+    this._onDidRefreshProvider.dispose();
   }
 }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -337,10 +337,10 @@ export class ProviderRegistry {
     logger.info(`Provider ${providerId} discovered ${items.length} items`);
 
     // Snapshot previous IDs before replacing, for fallback disappearance detection.
+    // Always update — even when prevItems is empty — to avoid stale snapshots from
+    // an earlier non-empty refresh persisting across an empty intermediate refresh.
     const prevItems = this.discoveredItems.get(providerId) ?? [];
-    if (prevItems.length > 0) {
-      this.previousDiscoveredIds.set(providerId, new Set(prevItems.map(i => i.externalId)));
-    }
+    this.previousDiscoveredIds.set(providerId, new Set(prevItems.map(i => i.externalId)));
     this.lastRefreshTruncated.set(providerId, wasTruncated);
     this.discoveredItems.set(providerId, items);
 

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -7,9 +7,9 @@ import { logger } from './logger';
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const VALID_TRANSITIONS: ReadonlyMap<WorkItemState, ReadonlySet<WorkItemState>> = new Map([
-  [WorkItemState.New, new Set([WorkItemState.InProgress, WorkItemState.Archived])],
+  [WorkItemState.New, new Set([WorkItemState.InProgress, WorkItemState.Done, WorkItemState.Archived])],
   [WorkItemState.InProgress, new Set([WorkItemState.Paused, WorkItemState.Done, WorkItemState.New, WorkItemState.Archived])],
-  [WorkItemState.Paused, new Set([WorkItemState.InProgress, WorkItemState.New, WorkItemState.Archived])],
+  [WorkItemState.Paused, new Set([WorkItemState.InProgress, WorkItemState.Done, WorkItemState.New, WorkItemState.Archived])],
   [WorkItemState.Done, new Set([WorkItemState.Archived, WorkItemState.New])],
   [WorkItemState.Archived, new Set([WorkItemState.New])],
 ]);

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -480,13 +480,12 @@ describe('WorkGraph', () => {
   });
 
   describe('state transition validation', () => {
-    it('rejects New → Done (skipping InProgress)', async () => {
+    it('allows New → Done (e.g. auto-complete when external item is closed)', async () => {
       const item = await graph.createItem({ title: 'Test' });
       vi.mocked(store.save).mockClear();
-      await expect(graph.transitionState(item.id, WorkItemState.Done))
-        .rejects.toThrow('Invalid state transition');
-      expect(store.save).not.toHaveBeenCalled();
-      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.New);
+      await graph.transitionState(item.id, WorkItemState.Done);
+      expect(store.save).toHaveBeenCalled();
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Done);
     });
 
     it('allows New → Archived', async () => {
@@ -584,6 +583,15 @@ describe('WorkGraph', () => {
 
       await graph.transitionState(item.id, WorkItemState.Archived);
       expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Archived);
+    });
+
+    it('allows Paused → Done (e.g. auto-complete when external item is closed)', async () => {
+      const item = await graph.createItem({ title: 'Test' });
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Paused);
+
+      await graph.transitionState(item.id, WorkItemState.Done);
+      expect(graph.getItem(item.id)?.state).toBe(WorkItemState.Done);
     });
 
     it('rejects undefined state value', async () => {

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -253,7 +253,8 @@ export abstract class BaseGitHubProvider implements DevDocketProvider {
 
     if (parsed.length === 0) { return []; }
 
-    const closedIds: string[] = [];
+    // Track which IDs are closed; use a Set so worker order doesn't affect results
+    const closedSet = new Set<string>();
     let nextIndex = 0;
 
     const runWorker = async (): Promise<void> => {
@@ -277,7 +278,7 @@ export abstract class BaseGitHubProvider implements DevDocketProvider {
           if (response.ok) {
             const data = await response.json() as { state?: string };
             if (data.state === 'closed') {
-              closedIds.push(item.id);
+              closedSet.add(item.id);
             }
           } else {
             logger.debug(`Failed to check ${apiType} ${item.id}: ${response.status}`);
@@ -292,7 +293,8 @@ export abstract class BaseGitHubProvider implements DevDocketProvider {
     const workerCount = Math.min(5, parsed.length);
     await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
 
-    return closedIds;
+    // Return in input order for deterministic results
+    return parsed.filter(p => closedSet.has(p.id)).map(p => p.id);
   }
 
   dispose(): void {

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -244,8 +244,9 @@ export abstract class BaseGitHubProvider implements DevDocketProvider {
       const hashIdx = id.lastIndexOf('#');
       if (hashIdx === -1) { return null; }
       const rawRepo = id.substring(0, hashIdx);
-      const num = parseInt(id.substring(hashIdx + 1), 10);
-      if (isNaN(num) || !isValidGitHubRepo(rawRepo)) { return null; }
+      const rawNumber = id.substring(hashIdx + 1);
+      if (!/^\d+$/.test(rawNumber) || !isValidGitHubRepo(rawRepo)) { return null; }
+      const num = Number(rawNumber);
       const [owner, repoName] = rawRepo.split('/');
       return { id, owner, repoName, number: num };
     }).filter((p): p is NonNullable<typeof p> => p !== null);

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import type { ResolvedItem } from '@devdocket/shared';
+import { isValidGitHubRepo, type ResolvedItem } from '@devdocket/shared';
 import { logger } from './logger';
 
 export type { ResolvedItem };
@@ -212,6 +212,86 @@ export abstract class BaseGitHubProvider implements DevDocketProvider {
   /** Decode a percent-encoded URL path segment, returning the original on malformed input. */
   protected static safeDecodeComponent(value: string): string {
     try { return decodeURIComponent(value); } catch { return value; }
+  }
+
+  /**
+   * Shared implementation for getClosedItems across GitHub providers.
+   * Parses external IDs ("owner/repo#number"), validates repo slugs, and
+   * checks item state via the specified API endpoint using a worker pool.
+   *
+   * @param externalIds - External IDs in "owner/repo#number" format.
+   * @param apiType - GitHub API path segment: `'issues'` or `'pulls'`.
+   * @param signal - Optional abort signal for cancellation.
+   * @returns External IDs whose GitHub state is `'closed'`.
+   */
+  protected async fetchClosedGitHubItems(
+    externalIds: string[],
+    apiType: 'issues' | 'pulls',
+    signal?: AbortSignal,
+  ): Promise<string[]> {
+    if (externalIds.length === 0) { return []; }
+
+    let session: vscode.AuthenticationSession | undefined;
+    try {
+      session = await vscode.authentication.getSession('github', ['repo'], { silent: true });
+    } catch {
+      logger.debug(`No GitHub auth session for getClosedItems (${apiType})`);
+    }
+    if (!session) { return []; }
+    const token = session.accessToken;
+
+    const parsed = externalIds.map(id => {
+      const hashIdx = id.lastIndexOf('#');
+      if (hashIdx === -1) { return null; }
+      const rawRepo = id.substring(0, hashIdx);
+      const num = parseInt(id.substring(hashIdx + 1), 10);
+      if (isNaN(num) || !isValidGitHubRepo(rawRepo)) { return null; }
+      const [owner, repoName] = rawRepo.split('/');
+      return { id, owner, repoName, number: num };
+    }).filter((p): p is NonNullable<typeof p> => p !== null);
+
+    if (parsed.length === 0) { return []; }
+
+    const closedIds: string[] = [];
+    let nextIndex = 0;
+
+    const runWorker = async (): Promise<void> => {
+      while (nextIndex < parsed.length) {
+        if (signal?.aborted) { break; }
+        const currentIndex = nextIndex++;
+        const item = parsed[currentIndex];
+        try {
+          const response = await fetch(
+            `https://api.github.com/repos/${encodeURIComponent(item.owner)}/${encodeURIComponent(item.repoName)}/${apiType}/${item.number}`,
+            {
+              headers: {
+                Authorization: `Bearer ${token}`,
+                Accept: 'application/vnd.github+json',
+                'User-Agent': 'DevDocket-VSCode',
+                'X-GitHub-Api-Version': '2022-11-28',
+              },
+              signal,
+            },
+          );
+          if (response.ok) {
+            const data = await response.json() as { state?: string };
+            if (data.state === 'closed') {
+              closedIds.push(item.id);
+            }
+          } else {
+            logger.debug(`Failed to check ${apiType} ${item.id}: ${response.status}`);
+          }
+        } catch (err) {
+          if (signal?.aborted) { break; }
+          logger.debug(`Failed to check ${apiType} ${item.id}: ${String(err)}`);
+        }
+      }
+    };
+
+    const workerCount = Math.min(5, parsed.length);
+    await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+
+    return closedIds;
   }
 
   dispose(): void {

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -32,6 +32,7 @@ export interface DevDocketProvider {
   readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
   refresh(token?: vscode.CancellationToken): Promise<void>;
   resolveUrl?(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined>;
+  getClosedItems?(externalIds: string[], signal?: AbortSignal): Promise<string[]>;
 }
 
 export interface GitHubIssue {

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { isValidGitHubRepo } from '@devdocket/shared';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
 import { BaseGitHubProvider, DiscoveredItem, GitHubIssue, type ResolvedItem } from './baseGithubProvider';
@@ -140,10 +141,11 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
     const parsed = externalIds.map(id => {
       const hashIdx = id.lastIndexOf('#');
       if (hashIdx === -1) { return null; }
-      const repo = id.substring(0, hashIdx);
+      const rawRepo = id.substring(0, hashIdx);
       const num = parseInt(id.substring(hashIdx + 1), 10);
-      if (isNaN(num)) { return null; }
-      return { id, repo, number: num };
+      if (isNaN(num) || !isValidGitHubRepo(rawRepo)) { return null; }
+      const [owner, repoName] = rawRepo.split('/');
+      return { id, owner, repoName, number: num };
     }).filter((p): p is NonNullable<typeof p> => p !== null);
 
     if (parsed.length === 0) { return []; }
@@ -158,7 +160,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
         const item = parsed[currentIndex];
         try {
           const response = await fetch(
-            `https://api.github.com/repos/${item.repo}/pulls/${item.number}`,
+            `https://api.github.com/repos/${encodeURIComponent(item.owner)}/${encodeURIComponent(item.repoName)}/pulls/${item.number}`,
             {
               headers: {
                 Authorization: `Bearer ${token}`,

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -120,6 +120,75 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
     };
   }
 
+  /**
+   * Check which of the given external IDs correspond to closed/merged GitHub PRs.
+   * Uses concurrent individual API calls with a worker pool.
+   */
+  async getClosedItems(externalIds: string[], signal?: AbortSignal): Promise<string[]> {
+    if (externalIds.length === 0) { return []; }
+
+    let session: vscode.AuthenticationSession | undefined;
+    try {
+      session = await vscode.authentication.getSession('github', ['repo'], { silent: true });
+    } catch {
+      logger.debug('No GitHub auth session for getClosedItems');
+    }
+    if (!session) { return []; }
+    const token = session.accessToken;
+
+    // Parse external IDs: "owner/repo#number"
+    const parsed = externalIds.map(id => {
+      const hashIdx = id.lastIndexOf('#');
+      if (hashIdx === -1) { return null; }
+      const repo = id.substring(0, hashIdx);
+      const num = parseInt(id.substring(hashIdx + 1), 10);
+      if (isNaN(num)) { return null; }
+      return { id, repo, number: num };
+    }).filter((p): p is NonNullable<typeof p> => p !== null);
+
+    if (parsed.length === 0) { return []; }
+
+    const closedIds: string[] = [];
+    let nextIndex = 0;
+
+    const runWorker = async (): Promise<void> => {
+      while (nextIndex < parsed.length) {
+        if (signal?.aborted) { break; }
+        const currentIndex = nextIndex++;
+        const item = parsed[currentIndex];
+        try {
+          const response = await fetch(
+            `https://api.github.com/repos/${item.repo}/pulls/${item.number}`,
+            {
+              headers: {
+                Authorization: `Bearer ${token}`,
+                Accept: 'application/vnd.github+json',
+                'X-GitHub-Api-Version': '2022-11-28',
+              },
+              signal,
+            },
+          );
+          if (response.ok) {
+            const data = await response.json() as { state?: string };
+            if (data.state === 'closed') {
+              closedIds.push(item.id);
+            }
+          } else {
+            logger.debug(`Failed to check PR ${item.id}: ${response.status}`);
+          }
+        } catch (err) {
+          if (signal?.aborted) { break; }
+          logger.debug(`Failed to check PR ${item.id}: ${String(err)}`);
+        }
+      }
+    };
+
+    const workerCount = Math.min(5, parsed.length);
+    await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+
+    return closedIds;
+  }
+
   private getConfiguredRepos(): string[] {
     const config = vscode.workspace.getConfiguration('devdocketGithub');
     return config.get<string[]>('repos', []);

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { isValidGitHubRepo } from '@devdocket/shared';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
 import { BaseGitHubProvider, DiscoveredItem, GitHubIssue, type ResolvedItem } from './baseGithubProvider';
@@ -123,72 +122,9 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
 
   /**
    * Check which of the given external IDs correspond to closed/merged GitHub PRs.
-   * Uses concurrent individual API calls with a worker pool.
    */
   async getClosedItems(externalIds: string[], signal?: AbortSignal): Promise<string[]> {
-    if (externalIds.length === 0) { return []; }
-
-    let session: vscode.AuthenticationSession | undefined;
-    try {
-      session = await vscode.authentication.getSession('github', ['repo'], { silent: true });
-    } catch {
-      logger.debug('No GitHub auth session for getClosedItems');
-    }
-    if (!session) { return []; }
-    const token = session.accessToken;
-
-    // Parse external IDs: "owner/repo#number"
-    const parsed = externalIds.map(id => {
-      const hashIdx = id.lastIndexOf('#');
-      if (hashIdx === -1) { return null; }
-      const rawRepo = id.substring(0, hashIdx);
-      const num = parseInt(id.substring(hashIdx + 1), 10);
-      if (isNaN(num) || !isValidGitHubRepo(rawRepo)) { return null; }
-      const [owner, repoName] = rawRepo.split('/');
-      return { id, owner, repoName, number: num };
-    }).filter((p): p is NonNullable<typeof p> => p !== null);
-
-    if (parsed.length === 0) { return []; }
-
-    const closedIds: string[] = [];
-    let nextIndex = 0;
-
-    const runWorker = async (): Promise<void> => {
-      while (nextIndex < parsed.length) {
-        if (signal?.aborted) { break; }
-        const currentIndex = nextIndex++;
-        const item = parsed[currentIndex];
-        try {
-          const response = await fetch(
-            `https://api.github.com/repos/${encodeURIComponent(item.owner)}/${encodeURIComponent(item.repoName)}/pulls/${item.number}`,
-            {
-              headers: {
-                Authorization: `Bearer ${token}`,
-                Accept: 'application/vnd.github+json',
-                'X-GitHub-Api-Version': '2022-11-28',
-              },
-              signal,
-            },
-          );
-          if (response.ok) {
-            const data = await response.json() as { state?: string };
-            if (data.state === 'closed') {
-              closedIds.push(item.id);
-            }
-          } else {
-            logger.debug(`Failed to check PR ${item.id}: ${response.status}`);
-          }
-        } catch (err) {
-          if (signal?.aborted) { break; }
-          logger.debug(`Failed to check PR ${item.id}: ${String(err)}`);
-        }
-      }
-    };
-
-    const workerCount = Math.min(5, parsed.length);
-    await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
-
-    return closedIds;
+    return this.fetchClosedGitHubItems(externalIds, 'pulls', signal);
   }
 
   private getConfiguredRepos(): string[] {

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -88,6 +88,76 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
     };
   }
 
+  /**
+   * Check which of the given external IDs correspond to closed GitHub issues.
+   * Uses concurrent individual API calls with a worker pool since the GitHub
+   * REST API has no batch issue-get endpoint.
+   */
+  async getClosedItems(externalIds: string[], signal?: AbortSignal): Promise<string[]> {
+    if (externalIds.length === 0) { return []; }
+
+    let session: vscode.AuthenticationSession | undefined;
+    try {
+      session = await vscode.authentication.getSession('github', ['repo'], { silent: true });
+    } catch {
+      logger.debug('No GitHub auth session for getClosedItems');
+    }
+    if (!session) { return []; }
+    const token = session.accessToken;
+
+    // Parse external IDs: "owner/repo#number"
+    const parsed = externalIds.map(id => {
+      const hashIdx = id.lastIndexOf('#');
+      if (hashIdx === -1) { return null; }
+      const repo = id.substring(0, hashIdx);
+      const num = parseInt(id.substring(hashIdx + 1), 10);
+      if (isNaN(num)) { return null; }
+      return { id, repo, number: num };
+    }).filter((p): p is NonNullable<typeof p> => p !== null);
+
+    if (parsed.length === 0) { return []; }
+
+    const closedIds: string[] = [];
+    let nextIndex = 0;
+
+    const runWorker = async (): Promise<void> => {
+      while (nextIndex < parsed.length) {
+        if (signal?.aborted) { break; }
+        const currentIndex = nextIndex++;
+        const item = parsed[currentIndex];
+        try {
+          const response = await fetch(
+            `https://api.github.com/repos/${item.repo}/issues/${item.number}`,
+            {
+              headers: {
+                Authorization: `Bearer ${token}`,
+                Accept: 'application/vnd.github+json',
+                'X-GitHub-Api-Version': '2022-11-28',
+              },
+              signal,
+            },
+          );
+          if (response.ok) {
+            const data = await response.json() as { state?: string };
+            if (data.state === 'closed') {
+              closedIds.push(item.id);
+            }
+          } else {
+            logger.debug(`Failed to check issue ${item.id}: ${response.status}`);
+          }
+        } catch (err) {
+          if (signal?.aborted) { break; }
+          logger.debug(`Failed to check issue ${item.id}: ${String(err)}`);
+        }
+      }
+    };
+
+    const workerCount = Math.min(5, parsed.length);
+    await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+
+    return closedIds;
+  }
+
   private getConfiguredRepos(): string[] {
     const config = vscode.workspace.getConfiguration('devdocketGithub');
     return config.get<string[]>('repos', []);

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -90,73 +90,9 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
 
   /**
    * Check which of the given external IDs correspond to closed GitHub issues.
-   * Uses concurrent individual API calls with a worker pool since the GitHub
-   * REST API has no batch issue-get endpoint.
    */
   async getClosedItems(externalIds: string[], signal?: AbortSignal): Promise<string[]> {
-    if (externalIds.length === 0) { return []; }
-
-    let session: vscode.AuthenticationSession | undefined;
-    try {
-      session = await vscode.authentication.getSession('github', ['repo'], { silent: true });
-    } catch {
-      logger.debug('No GitHub auth session for getClosedItems');
-    }
-    if (!session) { return []; }
-    const token = session.accessToken;
-
-    // Parse external IDs: "owner/repo#number"
-    const parsed = externalIds.map(id => {
-      const hashIdx = id.lastIndexOf('#');
-      if (hashIdx === -1) { return null; }
-      const rawRepo = id.substring(0, hashIdx);
-      const num = parseInt(id.substring(hashIdx + 1), 10);
-      if (isNaN(num) || !isValidGitHubRepo(rawRepo)) { return null; }
-      const [owner, repoName] = rawRepo.split('/');
-      return { id, owner, repoName, number: num };
-    }).filter((p): p is NonNullable<typeof p> => p !== null);
-
-    if (parsed.length === 0) { return []; }
-
-    const closedIds: string[] = [];
-    let nextIndex = 0;
-
-    const runWorker = async (): Promise<void> => {
-      while (nextIndex < parsed.length) {
-        if (signal?.aborted) { break; }
-        const currentIndex = nextIndex++;
-        const item = parsed[currentIndex];
-        try {
-          const response = await fetch(
-            `https://api.github.com/repos/${encodeURIComponent(item.owner)}/${encodeURIComponent(item.repoName)}/issues/${item.number}`,
-            {
-              headers: {
-                Authorization: `Bearer ${token}`,
-                Accept: 'application/vnd.github+json',
-                'X-GitHub-Api-Version': '2022-11-28',
-              },
-              signal,
-            },
-          );
-          if (response.ok) {
-            const data = await response.json() as { state?: string };
-            if (data.state === 'closed') {
-              closedIds.push(item.id);
-            }
-          } else {
-            logger.debug(`Failed to check issue ${item.id}: ${response.status}`);
-          }
-        } catch (err) {
-          if (signal?.aborted) { break; }
-          logger.debug(`Failed to check issue ${item.id}: ${String(err)}`);
-        }
-      }
-    };
-
-    const workerCount = Math.min(5, parsed.length);
-    await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
-
-    return closedIds;
+    return this.fetchClosedGitHubItems(externalIds, 'issues', signal);
   }
 
   private getConfiguredRepos(): string[] {

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -109,10 +109,11 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
     const parsed = externalIds.map(id => {
       const hashIdx = id.lastIndexOf('#');
       if (hashIdx === -1) { return null; }
-      const repo = id.substring(0, hashIdx);
+      const rawRepo = id.substring(0, hashIdx);
       const num = parseInt(id.substring(hashIdx + 1), 10);
-      if (isNaN(num)) { return null; }
-      return { id, repo, number: num };
+      if (isNaN(num) || !isValidGitHubRepo(rawRepo)) { return null; }
+      const [owner, repoName] = rawRepo.split('/');
+      return { id, owner, repoName, number: num };
     }).filter((p): p is NonNullable<typeof p> => p !== null);
 
     if (parsed.length === 0) { return []; }
@@ -127,7 +128,7 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
         const item = parsed[currentIndex];
         try {
           const response = await fetch(
-            `https://api.github.com/repos/${item.repo}/issues/${item.number}`,
+            `https://api.github.com/repos/${encodeURIComponent(item.owner)}/${encodeURIComponent(item.repoName)}/issues/${item.number}`,
             {
               headers: {
                 Authorization: `Bearer ${token}`,

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -840,4 +840,67 @@ describe('GitHubPrReviewProvider', () => {
       expect(items[0].resurfaceVersion).toBe('2024-01-15T10:30:00Z');
     });
   });
+
+  describe('getClosedItems', () => {
+    it('returns closed/merged PR IDs', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ state: 'closed' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ state: 'closed' }),
+        });
+
+      const result = await provider.getClosedItems!(['owner/repo#10', 'owner/repo#20']);
+
+      expect(result).toEqual(['owner/repo#10', 'owner/repo#20']);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.github.com/repos/owner/repo/pulls/10',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+          }),
+        }),
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.github.com/repos/owner/repo/pulls/20',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+          }),
+        }),
+      );
+    });
+
+    it('excludes open PRs', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ state: 'open' }),
+      });
+
+      const result = await provider.getClosedItems!(['owner/repo#5']);
+
+      expect(result).toEqual([]);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns empty when no auth', async () => {
+      vi.mocked(authentication.getSession).mockResolvedValue(null as any);
+
+      const result = await provider.getClosedItems!(['owner/repo#1']);
+
+      expect(result).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('ignores malformed external IDs', async () => {
+      const result = await provider.getClosedItems!(['bad', 'no-hash', 'not/valid#abc']);
+
+      expect(result).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/github/src/test/githubProvider.test.ts
+++ b/packages/github/src/test/githubProvider.test.ts
@@ -619,4 +619,73 @@ describe('GitHubIssueProvider', () => {
     const items = listener.mock.calls[0][0];
     expect(items).toHaveLength(1);
   });
+
+  describe('getClosedItems', () => {
+    it('returns closed issue IDs', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ state: 'closed' }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ state: 'open' }),
+        });
+
+      const result = await provider.getClosedItems!(['owner/repo#1', 'owner/repo#2']);
+
+      expect(result).toEqual(['owner/repo#1']);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.github.com/repos/owner/repo/issues/1',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+          }),
+        }),
+      );
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.github.com/repos/owner/repo/issues/2',
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-token',
+          }),
+        }),
+      );
+    });
+
+    it('returns empty array when no auth session', async () => {
+      vi.mocked(authentication.getSession).mockResolvedValue(null as any);
+
+      const result = await provider.getClosedItems!(['owner/repo#1']);
+
+      expect(result).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('ignores malformed external IDs', async () => {
+      const result = await provider.getClosedItems!(['bad', 'no-hash', 'not/valid#abc']);
+
+      expect(result).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns empty array for empty input', async () => {
+      const result = await provider.getClosedItems!([]);
+
+      expect(result).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('handles API errors gracefully', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+
+      const result = await provider.getClosedItems!(['owner/repo#1']);
+
+      expect(result).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Auto-complete work items when their linked external issue or PR is closed or merged. **Redesigned** to scan the full WorkGraph after each provider refresh, covering both provider-discovered items and manually-imported items with provider links.

### Key design changes from v1

- **Scope expanded**: Previous approach only detected items disappearing from a provider's discovered-items list. New approach scans ALL work items in the WorkGraph with a matching `providerId`, covering imported items too.
- **`getClosedItems()` API**: Added optional `getClosedItems?(externalIds: string[]): Promise<string[]>` to `DevDocketProvider`. Providers that implement this enable auto-complete for imported items (not just provider-tracked ones).
- **Fallback path**: For providers without `getClosedItems`, falls back to disappearance detection (item was previously discovered but now absent). Same safety guards: skip on truncation, skip on first refresh, require non-empty current items.
- **`onDidRefreshProvider` event**: Replaces `onDidDetectCompletedItems`. Fires after each provider discovery with the provider ID, allowing `extension.ts` to run WorkGraph-scoped checks.

### What it does

1. After each provider refresh, collects all work items from the WorkGraph with that `providerId` in auto-completable states (New, InProgress, Paused)
2. If the provider implements `getClosedItems()`, batch-checks all linked external IDs
3. Otherwise, falls back to comparing current vs previous discovered items
4. Transitions matched items to Done and shows a notification with "Show History" action
 
### Files changed

- `packages/core/src/api/types.ts` — Added optional `getClosedItems` to `DevDocketProvider`
- `packages/core/src/services/providerRegistry.ts` — `onDidRefreshProvider` event, previous-ID tracking, `wasItemPreviouslyDiscovered()`, `wasLastRefreshTruncated()`
- `packages/core/src/extension.ts` — WorkGraph-scanning auto-complete logic
- `packages/core/src/models/workItem.ts` — New→Done and Paused→Done transitions
- `packages/core/src/services/workGraph.ts` — Updated valid transitions
- `packages/core/package.json` — `devdocket.autoCompleteOnClose` setting

### API change note

Added **optional** `getClosedItems` method to `DevDocketProvider`. This is a non-breaking, additive change — existing providers continue to work via the fallback path.

Closes #265

## Cross-Issue Design Notes

This PR is part of the **Completion Pipeline** cluster (#260, #265, #264, #234, #232). All five issues hook into the work-item-reaches-Done moment.

**Dependency:** #260 (activity log) should ideally land first to provide a shared `onDidTransition` event API. The auto-complete code path should fire the same transition events that manual completion fires, so that #264 (worktree cleanup) can attach to the same hook later without needing to know about auto-complete specifically.

**Risk:** Currently wires scanning logic directly in `extension.ts`. Future work (#264) will need a way to hook into auto-completed transitions — ensure the transition path is the same as manual completion (via `workGraph.transitionState`).
