### PR TITLE
Add history cleanup commands and auto-pruning

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,6 +97,12 @@
           "default": 30,
           "minimum": 1,
           "description": "Age threshold in days for the Clear Old History command. Items older than this are removed."
+        },
+        "devdocket.maxHistoryItems": {
+          "type": "integer",
+          "default": 0,
+          "minimum": 0,
+          "description": "Maximum number of items to keep in History. Oldest items are pruned automatically when the limit is exceeded. Set to 0 for unlimited."
         }
       }
     },
@@ -368,6 +374,12 @@
         "icon": "$(clear-all)"
       },
       {
+        "command": "devdocket.clearAllHistory",
+        "title": "Clear All History",
+        "category": "DevDocket",
+        "icon": "$(trash)"
+      },
+      {
         "command": "devdocket.moveToQueue",
         "title": "Move to Queue",
         "category": "DevDocket",
@@ -436,6 +448,11 @@
           "command": "devdocket.clearHistory",
           "when": "view == devdocket.history",
           "group": "navigation"
+        },
+        {
+          "command": "devdocket.clearAllHistory",
+          "when": "view == devdocket.history",
+          "group": "2_clear"
         },
         {
           "command": "devdocket.switchSourcesToTree",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,8 @@
     "onCommand:devdocket.dismissFromSources",
     "onCommand:devdocket.deleteItem",
     "onCommand:devdocket.createItemFromUrl",
-    "onCommand:devdocket.clearHistory"
+    "onCommand:devdocket.clearHistory",
+    "onCommand:devdocket.clearAllHistory"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -479,6 +479,27 @@ async function handleClearHistory(workGraph: WorkGraph): Promise<void> {
   }
 }
 
+async function handleClearAllHistory(workGraph: WorkGraph): Promise<void> {
+  const confirm = await vscode.window.showWarningMessage(
+    'Delete all history items? This cannot be undone.',
+    { modal: true },
+    'Delete',
+  );
+  if (confirm !== 'Delete') { return; }
+
+  const result = await workGraph.clearAllHistory();
+  if (result.failed > 0) {
+    void vscode.window.showErrorMessage(
+      `DevDocket: Failed to delete ${result.failed} item(s); see Output for details`,
+    );
+  }
+  if (result.deleted > 0) {
+    void vscode.window.showInformationMessage(`DevDocket: Cleared ${result.deleted} history item${result.deleted === 1 ? '' : 's'}`);
+  } else if (result.failed === 0) {
+    void vscode.window.showInformationMessage('DevDocket: No history items to clear');
+  }
+}
+
 async function handleFocusMoveUp(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
   if (!item?.id) {
     void vscode.window.showInformationMessage('DevDocket: Select an item in Focus to move.');
@@ -912,6 +933,8 @@ export function registerCommands(
       wrapCommand('Failed to delete item', (item, selectedItems) => handleDeleteItem(workGraph, item, selectedItems))),
     vscode.commands.registerCommand('devdocket.clearHistory',
       wrapCommand('Failed to clear history', () => handleClearHistory(workGraph))),
+    vscode.commands.registerCommand('devdocket.clearAllHistory',
+      wrapCommand('Failed to clear all history', () => handleClearAllHistory(workGraph))),
     vscode.commands.registerCommand('devdocket.editItem',
       wrapCommand('Failed to open editor', (item) => handleEditItem(context, workGraph, providerRegistry, labelCache, item))),
     vscode.commands.registerCommand('devdocket.openInBrowser',

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -297,8 +297,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   let pruning = false;
   async function autoTrimHistory(): Promise<void> {
     if (pruning) { return; }
-    const maxItems = vscode.workspace.getConfiguration('devdocket').get<number>('maxHistoryItems', 0);
-    if (!maxItems || maxItems <= 0) { return; }
+    const rawMaxItems = vscode.workspace.getConfiguration('devdocket').get('maxHistoryItems', 0);
+    const maxItems = Number(rawMaxItems);
+    if (!Number.isFinite(maxItems) || maxItems <= 0) { return; }
     pruning = true;
     try {
       const result = await wg.pruneHistory(maxItems);

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -273,23 +273,6 @@ function wireEvents(
   return [discoveredSub, newItemsSub, providerRegSub, stateStoreSub, markSeenSub, workGraphSub];
 }
 
-/** Read maxHistoryItems from config and prune history if a limit is set. */
-let pruning = false;
-async function autoTrimHistory(wg: WorkGraph): Promise<void> {
-  if (pruning) { return; }
-  const maxItems = vscode.workspace.getConfiguration('devdocket').get<number>('maxHistoryItems', 0);
-  if (!maxItems || maxItems <= 0) { return; }
-  pruning = true;
-  try {
-    const result = await wg.pruneHistory(maxItems);
-    if (result.deleted > 0) {
-      logger.info(`Auto-pruned ${result.deleted} old history item(s) (limit: ${maxItems})`);
-    }
-  } finally {
-    pruning = false;
-  }
-}
-
 /**
  * Activate the DevDocket extension.
  *
@@ -310,8 +293,25 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const { workGraph: wg, stateStore: ss, readStateStore, labelCache } = await loadStores(storagePath);
   await migrateDiscoveredState(wg, ss);
 
+  // Auto-prune: scoped to this activation to avoid stale refs across restarts
+  let pruning = false;
+  async function autoTrimHistory(): Promise<void> {
+    if (pruning) { return; }
+    const maxItems = vscode.workspace.getConfiguration('devdocket').get<number>('maxHistoryItems', 0);
+    if (!maxItems || maxItems <= 0) { return; }
+    pruning = true;
+    try {
+      const result = await wg.pruneHistory(maxItems);
+      if (result.deleted > 0) {
+        logger.info(`Auto-pruned ${result.deleted} old history item(s) (limit: ${maxItems})`);
+      }
+    } finally {
+      pruning = false;
+    }
+  }
+
   // Auto-prune history on startup if a max limit is configured
-  await autoTrimHistory(wg);
+  await autoTrimHistory();
 
   const pr = new ProviderRegistry(ss, labelCache);
   providerRegistry = pr;
@@ -353,7 +353,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   let trimTimer: ReturnType<typeof setTimeout> | undefined;
   function scheduleAutoTrim(): void {
     if (trimTimer !== undefined) { clearTimeout(trimTimer); }
-    trimTimer = setTimeout(() => { void autoTrimHistory(wg); }, 2000);
+    trimTimer = setTimeout(() => { void autoTrimHistory(); }, 2000);
   }
   context.subscriptions.push(
     wg.onDidChange(safeHandler('Error scheduling auto-trim', scheduleAutoTrim)),
@@ -382,7 +382,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
         }
       }
       if (e.affectsConfiguration('devdocket.maxHistoryItems')) {
-        void autoTrimHistory(wg);
+        scheduleAutoTrim();
       }
     })),
   );

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -354,7 +354,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   let trimTimer: ReturnType<typeof setTimeout> | undefined;
   function scheduleAutoTrim(): void {
     if (trimTimer !== undefined) { clearTimeout(trimTimer); }
-    trimTimer = setTimeout(() => { void autoTrimHistory(); }, 2000);
+    trimTimer = setTimeout(() => {
+      void autoTrimHistory().catch((err: unknown) => logger.error('Error during auto-trim', err));
+    }, 2000);
   }
   context.subscriptions.push(
     wg.onDidChange(safeHandler('Error scheduling auto-trim', scheduleAutoTrim)),

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -273,6 +273,16 @@ function wireEvents(
   return [discoveredSub, newItemsSub, providerRegSub, stateStoreSub, markSeenSub, workGraphSub];
 }
 
+/** Read maxHistoryItems from config and prune history if a limit is set. */
+async function autoTrimHistory(wg: WorkGraph): Promise<void> {
+  const maxItems = vscode.workspace.getConfiguration('devdocket').get<number>('maxHistoryItems', 0);
+  if (!maxItems || maxItems <= 0) { return; }
+  const result = await wg.pruneHistory(maxItems);
+  if (result.deleted > 0) {
+    logger.info(`Auto-pruned ${result.deleted} old history item(s) (limit: ${maxItems})`);
+  }
+}
+
 /**
  * Activate the DevDocket extension.
  *
@@ -292,6 +302,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const storagePath = context.globalStorageUri.fsPath;
   const { workGraph: wg, stateStore: ss, readStateStore, labelCache } = await loadStores(storagePath);
   await migrateDiscoveredState(wg, ss);
+
+  // Auto-prune history on startup if a max limit is configured
+  await autoTrimHistory(wg);
 
   const pr = new ProviderRegistry(ss, labelCache);
   providerRegistry = pr;
@@ -328,6 +341,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const commandRegStart = performance.now();
   registerCommands(context, wg, ar, ss, pr, labelCache);
   logger.info(`Command registration took ${Math.round(performance.now() - commandRegStart)}ms`);
+
+  // Auto-prune history when items change (e.g. after completing/archiving)
+  context.subscriptions.push(
+    wg.onDidChange(safeHandler('Error auto-trimming history', () => autoTrimHistory(wg))),
+  );
 
   // Set context keys and listen for layout changes
   const viewIds: ViewId[] = ['inbox', 'queue', 'focus', 'history', 'sources'];

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -274,12 +274,19 @@ function wireEvents(
 }
 
 /** Read maxHistoryItems from config and prune history if a limit is set. */
+let pruning = false;
 async function autoTrimHistory(wg: WorkGraph): Promise<void> {
+  if (pruning) { return; }
   const maxItems = vscode.workspace.getConfiguration('devdocket').get<number>('maxHistoryItems', 0);
   if (!maxItems || maxItems <= 0) { return; }
-  const result = await wg.pruneHistory(maxItems);
-  if (result.deleted > 0) {
-    logger.info(`Auto-pruned ${result.deleted} old history item(s) (limit: ${maxItems})`);
+  pruning = true;
+  try {
+    const result = await wg.pruneHistory(maxItems);
+    if (result.deleted > 0) {
+      logger.info(`Auto-pruned ${result.deleted} old history item(s) (limit: ${maxItems})`);
+    }
+  } finally {
+    pruning = false;
   }
 }
 
@@ -342,9 +349,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   registerCommands(context, wg, ar, ss, pr, labelCache);
   logger.info(`Command registration took ${Math.round(performance.now() - commandRegStart)}ms`);
 
-  // Auto-prune history when items change (e.g. after completing/archiving)
+  // Debounced auto-prune: collapses rapid mutations into a single prune check
+  let trimTimer: ReturnType<typeof setTimeout> | undefined;
+  function scheduleAutoTrim(): void {
+    if (trimTimer !== undefined) { clearTimeout(trimTimer); }
+    trimTimer = setTimeout(() => { void autoTrimHistory(wg); }, 2000);
+  }
   context.subscriptions.push(
-    wg.onDidChange(safeHandler('Error auto-trimming history', () => autoTrimHistory(wg))),
+    wg.onDidChange(safeHandler('Error scheduling auto-trim', scheduleAutoTrim)),
+    { dispose: () => { if (trimTimer !== undefined) { clearTimeout(trimTimer); } } },
   );
 
   // Set context keys and listen for layout changes
@@ -367,6 +380,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
           providerMap[id].layout = layout;
           void vscode.commands.executeCommand('setContext', `devdocket.${id}Layout`, layout);
         }
+      }
+      if (e.affectsConfiguration('devdocket.maxHistoryItems')) {
+        void autoTrimHistory(wg);
       }
     })),
   );

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -418,6 +418,79 @@ export class WorkGraph {
   }
 
   /**
+   * Delete all history items (Done and Archived), regardless of age.
+   * @returns `deleted` — number of items successfully removed; `failed` — number of items that
+   * could not be deleted (individual errors are logged and do not abort the batch).
+   */
+  async clearAllHistory(): Promise<{ deleted: number; failed: number }> {
+    const toDelete = this.getItemsByState(WorkItemState.Done, WorkItemState.Archived);
+    if (toDelete.length === 0) {
+      return { deleted: 0, failed: 0 };
+    }
+
+    let deleted = 0;
+    let failed = 0;
+    try {
+      for (const item of toDelete) {
+        try {
+          await this.deleteItem(item.id, { silent: true });
+          deleted++;
+        } catch (err) {
+          failed++;
+          logger.warn(`Failed to delete history item ${item.id}, skipping: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+    } finally {
+      if (deleted > 0) {
+        this._onDidChange.fire();
+      }
+    }
+
+    return { deleted, failed };
+  }
+
+  /**
+   * Trim history to the most recent `maxItems` items (by `updatedAt`).
+   * Items beyond the limit are deleted, oldest first.
+   * A `maxItems` of 0 or less is treated as unlimited (no pruning).
+   * @returns `deleted` — number of items pruned; `failed` — number that could not be deleted.
+   */
+  async pruneHistory(maxItems: number): Promise<{ deleted: number; failed: number }> {
+    if (!Number.isFinite(maxItems) || maxItems <= 0) {
+      return { deleted: 0, failed: 0 };
+    }
+
+    const historyItems = this.getItemsByState(WorkItemState.Done, WorkItemState.Archived);
+    if (historyItems.length <= maxItems) {
+      return { deleted: 0, failed: 0 };
+    }
+
+    // Sort by updatedAt descending — keep the most recent
+    historyItems.sort((a, b) => b.updatedAt - a.updatedAt);
+    const toDelete = historyItems.slice(maxItems);
+
+    let deleted = 0;
+    let failed = 0;
+    try {
+      for (const item of toDelete) {
+        try {
+          await this.deleteItem(item.id, { silent: true });
+          deleted++;
+        } catch (err) {
+          failed++;
+          logger.warn(`Failed to prune history item ${item.id}, skipping: ${err instanceof Error ? err.message : String(err)}`);
+        }
+      }
+    } finally {
+      if (deleted > 0) {
+        this._onDidChange.fire();
+      }
+    }
+
+    return { deleted, failed };
+  }
+
+  /**
    * Permanently delete a work item from the store.
    * @param options.silent When true, suppresses the `onDidChange` event (used for batch operations).
    */

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -57,7 +57,7 @@ function makeSourceItem(overrides: Partial<SourceItemNode> = {}): SourceItemNode
 
 type UsedWorkGraphMethods = Pick<
   WorkGraph,
-  'transitionState' | 'getItem' | 'createItem' | 'findItemByProvenance' | 'moveItem' | 'deleteItem' | 'clearOldHistory'
+  'transitionState' | 'getItem' | 'createItem' | 'findItemByProvenance' | 'moveItem' | 'deleteItem' | 'clearOldHistory' | 'clearAllHistory'
 >;
 
 function createMockWorkGraph(): { [K in keyof UsedWorkGraphMethods]: Mock } {
@@ -69,6 +69,7 @@ function createMockWorkGraph(): { [K in keyof UsedWorkGraphMethods]: Mock } {
     moveItem: vi.fn(),
     deleteItem: vi.fn(),
     clearOldHistory: vi.fn(async () => ({ deleted: 0, failed: 0 })),
+    clearAllHistory: vi.fn(async () => ({ deleted: 0, failed: 0 })),
   };
 }
 
@@ -187,6 +188,7 @@ describe('registerCommands', () => {
       'devdocket.dismissFromSources',
       'devdocket.createItemFromUrl',
       'devdocket.clearHistory',
+      'devdocket.clearAllHistory',
     ];
     for (const cmd of expected) {
       expect(commandHandlers.has(cmd), `missing command: ${cmd}`).toBe(true);
@@ -2072,6 +2074,69 @@ describe('registerCommands', () => {
       await invoke('devdocket.clearHistory');
 
       expect(workGraph.clearOldHistory).toHaveBeenCalledWith(30);
+    });
+  });
+
+  describe('devdocket.clearAllHistory', () => {
+    it('shows confirmation dialog and clears all history', async () => {
+      (vscode.window.showWarningMessage as Mock).mockResolvedValue('Delete');
+      workGraph.clearAllHistory.mockResolvedValue({ deleted: 3, failed: 0 });
+
+      await invoke('devdocket.clearAllHistory');
+
+      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+        'Delete all history items? This cannot be undone.',
+        { modal: true },
+        'Delete',
+      );
+      expect(workGraph.clearAllHistory).toHaveBeenCalled();
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining('3 history items'),
+      );
+    });
+
+    it('does nothing when user cancels confirmation', async () => {
+      (vscode.window.showWarningMessage as Mock).mockResolvedValue(undefined);
+
+      await invoke('devdocket.clearAllHistory');
+
+      expect(workGraph.clearAllHistory).not.toHaveBeenCalled();
+    });
+
+    it('shows no-items message when nothing to clear', async () => {
+      (vscode.window.showWarningMessage as Mock).mockResolvedValue('Delete');
+      workGraph.clearAllHistory.mockResolvedValue({ deleted: 0, failed: 0 });
+
+      await invoke('devdocket.clearAllHistory');
+
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining('No history items to clear'),
+      );
+    });
+
+    it('shows error when some items fail to delete', async () => {
+      (vscode.window.showWarningMessage as Mock).mockResolvedValue('Delete');
+      workGraph.clearAllHistory.mockResolvedValue({ deleted: 2, failed: 1 });
+
+      await invoke('devdocket.clearAllHistory');
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to delete 1 item(s)'),
+      );
+    });
+
+    it('uses singular form for 1 item', async () => {
+      (vscode.window.showWarningMessage as Mock).mockResolvedValue('Delete');
+      workGraph.clearAllHistory.mockResolvedValue({ deleted: 1, failed: 0 });
+
+      await invoke('devdocket.clearAllHistory');
+
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining('1 history item'),
+      );
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        expect.not.stringContaining('1 history items'),
+      );
     });
   });
 });

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -968,6 +968,7 @@ describe('WorkGraph', () => {
       await g.transitionState(item.id, WorkItemState.InProgress);
       await g.transitionState(item.id, WorkItemState.Done);
       const updated = g.getItem(item.id)!;
+      // Mutate updatedAt directly on the Map-stored reference — pruneHistory sorts by this field.
       (updated as any).updatedAt = Date.now() + updatedAtOffset;
       return updated;
     }

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -902,4 +902,160 @@ describe('WorkGraph', () => {
       expect(changeSpy).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('clearAllHistory', () => {
+    it('deletes all Done and Archived items', async () => {
+      const a = await graph.createItem({ title: 'Done item' });
+      await graph.transitionState(a.id, WorkItemState.InProgress);
+      await graph.transitionState(a.id, WorkItemState.Done);
+      const b = await graph.createItem({ title: 'Archived item' });
+      await graph.transitionState(b.id, WorkItemState.InProgress);
+      await graph.transitionState(b.id, WorkItemState.Done);
+      await graph.transitionState(b.id, WorkItemState.Archived);
+
+      const result = await graph.clearAllHistory();
+
+      expect(result.deleted).toBe(2);
+      expect(result.failed).toBe(0);
+      expect(graph.getItemsByState(WorkItemState.Done, WorkItemState.Archived)).toHaveLength(0);
+    });
+
+    it('does not affect non-history items', async () => {
+      const newItem = await graph.createItem({ title: 'New' });
+      const ipItem = await graph.createItem({ title: 'In Progress' });
+      await graph.transitionState(ipItem.id, WorkItemState.InProgress);
+      const doneItem = await graph.createItem({ title: 'Done' });
+      await graph.transitionState(doneItem.id, WorkItemState.InProgress);
+      await graph.transitionState(doneItem.id, WorkItemState.Done);
+
+      await graph.clearAllHistory();
+
+      expect(graph.getItem(newItem.id)).toBeDefined();
+      expect(graph.getItem(ipItem.id)).toBeDefined();
+      expect(graph.getItem(doneItem.id)).toBeUndefined();
+    });
+
+    it('returns 0 when no history items exist', async () => {
+      await graph.createItem({ title: 'New' });
+
+      const result = await graph.clearAllHistory();
+
+      expect(result.deleted).toBe(0);
+      expect(result.failed).toBe(0);
+    });
+
+    it('fires onDidChange only once for batch deletion', async () => {
+      const a = await graph.createItem({ title: 'A' });
+      await graph.transitionState(a.id, WorkItemState.InProgress);
+      await graph.transitionState(a.id, WorkItemState.Done);
+      const b = await graph.createItem({ title: 'B' });
+      await graph.transitionState(b.id, WorkItemState.InProgress);
+      await graph.transitionState(b.id, WorkItemState.Done);
+
+      const changeSpy = vi.fn();
+      graph.onDidChange(changeSpy);
+      changeSpy.mockClear();
+
+      await graph.clearAllHistory();
+
+      expect(changeSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('pruneHistory', () => {
+    async function createHistoryItem(g: WorkGraph, title: string, updatedAtOffset: number) {
+      const item = await g.createItem({ title });
+      await g.transitionState(item.id, WorkItemState.InProgress);
+      await g.transitionState(item.id, WorkItemState.Done);
+      const updated = g.getItem(item.id)!;
+      (updated as any).updatedAt = Date.now() + updatedAtOffset;
+      return updated;
+    }
+
+    it('keeps only the most recent N items', async () => {
+      await createHistoryItem(graph, 'Oldest', -3000);
+      await createHistoryItem(graph, 'Middle', -2000);
+      await createHistoryItem(graph, 'Newest', -1000);
+
+      const result = await graph.pruneHistory(2);
+
+      expect(result.deleted).toBe(1);
+      expect(result.failed).toBe(0);
+      const remaining = graph.getItemsByState(WorkItemState.Done);
+      expect(remaining).toHaveLength(2);
+      expect(remaining.map(i => i.title).sort()).toEqual(['Middle', 'Newest']);
+    });
+
+    it('does nothing when under the limit', async () => {
+      await createHistoryItem(graph, 'A', -1000);
+      await createHistoryItem(graph, 'B', -2000);
+
+      const result = await graph.pruneHistory(5);
+
+      expect(result.deleted).toBe(0);
+      expect(graph.getItemsByState(WorkItemState.Done)).toHaveLength(2);
+    });
+
+    it('does nothing when maxItems is 0 (unlimited)', async () => {
+      await createHistoryItem(graph, 'A', -1000);
+
+      const result = await graph.pruneHistory(0);
+
+      expect(result.deleted).toBe(0);
+    });
+
+    it('does nothing when maxItems is negative', async () => {
+      await createHistoryItem(graph, 'A', -1000);
+
+      const result = await graph.pruneHistory(-1);
+
+      expect(result.deleted).toBe(0);
+    });
+
+    it('handles exactly at limit (no pruning needed)', async () => {
+      await createHistoryItem(graph, 'A', -1000);
+      await createHistoryItem(graph, 'B', -2000);
+
+      const result = await graph.pruneHistory(2);
+
+      expect(result.deleted).toBe(0);
+    });
+
+    it('prunes both Done and Archived items', async () => {
+      await createHistoryItem(graph, 'Old Done', -3000);
+      const archived = await createHistoryItem(graph, 'Old Archived', -4000);
+      await graph.transitionState(archived.id, WorkItemState.Archived);
+      (graph.getItem(archived.id)! as any).updatedAt = Date.now() - 4000;
+      await createHistoryItem(graph, 'Recent', -500);
+
+      const result = await graph.pruneHistory(1);
+
+      expect(result.deleted).toBe(2);
+      const remaining = graph.getItemsByState(WorkItemState.Done, WorkItemState.Archived);
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].title).toBe('Recent');
+    });
+
+    it('fires onDidChange only once for batch pruning', async () => {
+      await createHistoryItem(graph, 'A', -3000);
+      await createHistoryItem(graph, 'B', -2000);
+      await createHistoryItem(graph, 'C', -1000);
+
+      const changeSpy = vi.fn();
+      graph.onDidChange(changeSpy);
+      changeSpy.mockClear();
+
+      await graph.pruneHistory(1);
+
+      expect(changeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('handles NaN maxItems gracefully', async () => {
+      await createHistoryItem(graph, 'A', -1000);
+
+      const result = await graph.pruneHistory(NaN);
+
+      expect(result.deleted).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
Closes #232## SummaryAdds three capabilities to manage unbounded History view growth:1. **Clear All History** command — removes all Done/Archived items (vs. the existing age-based clear)
2. **Auto-pruning via `maxHistoryItems` setting** — automatically trims history to the N most recent items on startup and after every work item change
3. **`pruneHistory(maxItems)` method on WorkGraph** — programmatic trimming, oldest items first by `updatedAt`## Changes- **WorkGraph**: Added `clearAllHistory()` and `pruneHistory(maxItems)` methods
- **Commands**: Added `devdocket.clearAllHistory` command with modal confirmation dialog
- **Settings**: Added `devdocket.maxHistoryItems` (integer, default 0 = unlimited)
- **Extension**: Auto-prune on startup and after work item mutations when limit is configured
- **Package.json**: Registered new command and setting; added Clear All History to history view overflow menu
- **Tests**: 17 new tests covering clearAllHistory, pruneHistory, and the new command handler

## Cross-Issue Design Notes

This PR is part of the **Completion Pipeline** cluster (#260, #265, #264, #234, #232).

**Dependency on #234:** The Done vs Archived distinction (#234) may change what "prune history" means. Currently this PR treats Done and Archived items identically for pruning. If #234 introduces auto-archiving (Done → Archived after N days), then `maxHistoryItems` should potentially count only Archived items, not Done ones.

**Recommendation:** This PR is safe to merge as-is, but behavior may need adjustment after #234's design decision lands.
