### PR TITLE
Prompt to clean up branch/worktree when completing a work item

### DIFF
--- a/packages/core/src/api/devDocketApi.ts
+++ b/packages/core/src/api/devDocketApi.ts
@@ -1,12 +1,19 @@
-import { DevDocketApi, DevDocketProvider, DevDocketAction, Disposable } from './types';
+import { DevDocketApi, DevDocketProvider, DevDocketAction, Disposable, StateTransitionEvent } from './types';
+import type { Event } from '@devdocket/shared';
 import { ProviderRegistry } from '../services/providerRegistry';
 import { ActionRegistry } from '../services/actionRegistry';
+import { WorkGraph } from '../services/workGraph';
 
 export class DevDocketApiImpl implements DevDocketApi {
+  readonly onDidTransitionState: Event<StateTransitionEvent>;
+
   constructor(
     private readonly providerRegistry: ProviderRegistry,
     private readonly actionRegistry: ActionRegistry,
-  ) {}
+    workGraph: WorkGraph,
+  ) {
+    this.onDidTransitionState = workGraph.onDidTransitionState;
+  }
 
   registerProvider(provider: DevDocketProvider): Disposable {
     return this.providerRegistry.register(provider);

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -104,6 +104,11 @@ export interface DevDocketAction {
  *
  * Fired after a work item transitions between lifecycle states (e.g.
  * InProgress → Done). Extensions can subscribe to react to state changes.
+ *
+ * `oldState` and `newState` are typed as `string` (not `WorkItemState`)
+ * so that satellite extensions (e.g. start-git-work) can consume the event
+ * without importing core-internal enum types. The actual values are always
+ * `WorkItemState` members (e.g. `'Done'`, `'InProgress'`).
  */
 export interface StateTransitionEvent {
   /** The work item after the transition completed. */

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -163,6 +163,9 @@ export interface DevDocketApi {
    *
    * Extensions can subscribe to this event to react when items move between
    * states (e.g. perform cleanup when an item is marked as Done).
+   *
+   * Optional so that consumers creating mock/wrapper `DevDocketApi` objects
+   * are not forced to implement this property.
    */
-  readonly onDidTransitionState: Event<StateTransitionEvent>;
+  readonly onDidTransitionState?: Event<StateTransitionEvent>;
 }

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -100,6 +100,21 @@ export interface DevDocketAction {
 }
 
 /**
+ * Payload for the {@link DevDocketApi.onDidTransitionState} event.
+ *
+ * Fired after a work item transitions between lifecycle states (e.g.
+ * InProgress → Done). Extensions can subscribe to react to state changes.
+ */
+export interface StateTransitionEvent {
+  /** The work item after the transition completed. */
+  readonly item: Readonly<WorkItem>;
+  /** The lifecycle state before the transition. */
+  readonly oldState: string;
+  /** The lifecycle state after the transition. */
+  readonly newState: string;
+}
+
+/**
  * Public API surface of the DevDocket extension.
  *
  * Obtain this API from the core extension by getting its extension wrapper via
@@ -138,4 +153,11 @@ export interface DevDocketApi {
    * @returns A {@link Disposable} that unregisters the action when disposed.
    */
   registerAction(action: DevDocketAction): Disposable;
+  /**
+   * Fires after a work item transitions to a new lifecycle state.
+   *
+   * Extensions can subscribe to this event to react when items move between
+   * states (e.g. perform cleanup when an item is marked as Done).
+   */
+  readonly onDidTransitionState: Event<StateTransitionEvent>;
 }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -19,7 +19,7 @@ import { getInboxUnseenCount } from './services/inboxBadge';
 import { getViewLayout, ViewId } from './views/viewLayout';
 import { performance } from 'perf_hooks';
 
-export type { DevDocketApi, DevDocketProvider, DevDocketAction, DiscoveredItem, Disposable } from './api/types';
+export type { DevDocketApi, DevDocketProvider, DevDocketAction, DiscoveredItem, Disposable, StateTransitionEvent } from './api/types';
 export { logger } from './services/logger';
 
 /** Wrap an event callback so unhandled errors (sync or async) are logged instead of crashing. */
@@ -297,7 +297,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   providerRegistry = pr;
   const ar = new ActionRegistry();
   actionRegistry = ar;
-  const api = new DevDocketApiImpl(pr, ar);
+  const api = new DevDocketApiImpl(pr, ar, wg);
   logger.info(`Store + service init took ${Math.round(performance.now() - initStart)}ms`);
 
   const treeViewStart = performance.now();

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -2,6 +2,7 @@ import * as crypto from 'crypto';
 import * as vscode from 'vscode';
 import { WorkItem, WorkItemInput, WorkItemState } from '../models/workItem';
 import { ITaskStore } from '../storage/taskStore';
+import { StateTransitionEvent } from '../api/types';
 import { logger } from './logger';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -34,6 +35,9 @@ export class WorkGraph {
    * and normalization triggered as part of a public operation when no user-visible mutation occurs.
    */
   readonly onDidChange = this._onDidChange.event;
+  private readonly _onDidTransitionState = new vscode.EventEmitter<StateTransitionEvent>();
+  /** Fires after a work item transitions to a new lifecycle state via {@link transitionState}. */
+  readonly onDidTransitionState = this._onDidTransitionState.event;
 
   constructor(private readonly store: ITaskStore) {}
 
@@ -245,6 +249,7 @@ export class WorkGraph {
     this.items.set(id, updated);
     this.invalidateStateCache();
     this._onDidChange.fire();
+    this._onDidTransitionState.fire({ item: updated, oldState: item.state, newState });
     logger.info(`Transitioned work item ${id} to ${newState}`);
   }
 
@@ -475,6 +480,7 @@ export class WorkGraph {
 
   dispose(): void {
     this._onDidChange.dispose();
+    this._onDidTransitionState.dispose();
   }
 }
 

--- a/packages/core/src/test/devDocketApi.test.ts
+++ b/packages/core/src/test/devDocketApi.test.ts
@@ -1,7 +1,8 @@
 import { DevDocketApiImpl } from '../api/devDocketApi';
-import { DevDocketProvider, DevDocketAction, DiscoveredItem } from '../api/types';
+import { DevDocketProvider, DevDocketAction, DiscoveredItem, StateTransitionEvent } from '../api/types';
 import { ProviderRegistry } from '../services/providerRegistry';
 import { ActionRegistry } from '../services/actionRegistry';
+import { WorkGraph } from '../services/workGraph';
 import * as vscode from 'vscode';
 import { InboxState } from '../storage/discoveredStateStore';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -46,6 +47,14 @@ function createMockAction(id: string): DevDocketAction {
   };
 }
 
+function createMockWorkGraph() {
+  const emitter = new vscode.EventEmitter<StateTransitionEvent>();
+  return {
+    onDidTransitionState: emitter.event,
+    _emitter: emitter,
+  } as unknown as WorkGraph;
+}
+
 // Contract tests for the public API surface that provider extensions consume.
 // These intentionally overlap with registry-level tests to guard against
 // accidental wiring changes in DevDocketApiImpl.
@@ -53,12 +62,14 @@ describe('DevDocketApiImpl', () => {
   let api: DevDocketApiImpl;
   let providerRegistry: ProviderRegistry;
   let actionRegistry: ActionRegistry;
+  let mockWorkGraph: WorkGraph;
 
   beforeEach(() => {
     const stateStore = createMockStateStore();
     providerRegistry = new ProviderRegistry(stateStore);
     actionRegistry = new ActionRegistry();
-    api = new DevDocketApiImpl(providerRegistry, actionRegistry);
+    mockWorkGraph = createMockWorkGraph();
+    api = new DevDocketApiImpl(providerRegistry, actionRegistry, mockWorkGraph);
   });
 
   describe('registerProvider', () => {
@@ -143,6 +154,27 @@ describe('DevDocketApiImpl', () => {
       api.registerAction(a1);
 
       expect(() => api.registerAction(a2)).toThrow('Action already registered: dup');
+    });
+  });
+
+  describe('onDidTransitionState', () => {
+    it('exposes the event from WorkGraph', () => {
+      expect(api.onDidTransitionState).toBeDefined();
+      expect(typeof api.onDidTransitionState).toBe('function');
+    });
+
+    it('fires when the underlying WorkGraph event fires', () => {
+      const listener = vi.fn();
+      api.onDidTransitionState(listener);
+
+      const event: StateTransitionEvent = {
+        item: { id: 'test', title: 'Test', state: 'Done', createdAt: 0, updatedAt: 0 } as any,
+        oldState: 'InProgress',
+        newState: 'Done',
+      };
+      (mockWorkGraph as any)._emitter.fire(event);
+
+      expect(listener).toHaveBeenCalledWith(event);
     });
   });
 });

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -134,6 +134,36 @@ describe('WorkGraph', () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
+  it('fires onDidTransitionState with old and new state', async () => {
+    const item = await graph.createItem({ title: 'Test' });
+    const listener = vi.fn();
+    graph.onDidTransitionState(listener);
+
+    await graph.transitionState(item.id, WorkItemState.InProgress);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const event = listener.mock.calls[0][0];
+    expect(event.oldState).toBe(WorkItemState.New);
+    expect(event.newState).toBe(WorkItemState.InProgress);
+    expect(event.item.id).toBe(item.id);
+    expect(event.item.state).toBe(WorkItemState.InProgress);
+  });
+
+  it('fires onDidTransitionState for each transition in a lifecycle', async () => {
+    const item = await graph.createItem({ title: 'Test' });
+    const listener = vi.fn();
+    graph.onDidTransitionState(listener);
+
+    await graph.transitionState(item.id, WorkItemState.InProgress);
+    await graph.transitionState(item.id, WorkItemState.Done);
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener.mock.calls[0][0].oldState).toBe(WorkItemState.New);
+    expect(listener.mock.calls[0][0].newState).toBe(WorkItemState.InProgress);
+    expect(listener.mock.calls[1][0].oldState).toBe(WorkItemState.InProgress);
+    expect(listener.mock.calls[1][0].newState).toBe(WorkItemState.Done);
+  });
+
   it('sets notes on create', async () => {
     const item = await graph.createItem({
       title: 'Detailed',

--- a/packages/start-git-work/src/cleanupHandler.ts
+++ b/packages/start-git-work/src/cleanupHandler.ts
@@ -99,8 +99,9 @@ export class CleanupHandler {
       worktreeRemoved = true;
     }
 
-    // Delete the branch (use -d to warn about unmerged changes)
-    if (await this.branchExists(metadata.branchName, metadata.repoPath)) {
+    // Delete the branch only if the worktree was successfully removed (or didn't exist).
+    // A branch checked out in an active worktree cannot be deleted.
+    if (worktreeRemoved && await this.branchExists(metadata.branchName, metadata.repoPath)) {
       try {
         await execFileAsync('git', ['branch', '-d', metadata.branchName], {
           cwd: metadata.repoPath,

--- a/packages/start-git-work/src/cleanupHandler.ts
+++ b/packages/start-git-work/src/cleanupHandler.ts
@@ -83,7 +83,7 @@ export class CleanupHandler {
     // Remove worktree first (it must be removed before the branch can be deleted)
     if (fs.existsSync(metadata.worktreePath)) {
       try {
-        await execFileAsync('git', ['worktree', 'remove', metadata.worktreePath], {
+        await execFileAsync('git', ['worktree', 'remove', '--', metadata.worktreePath], {
           cwd: metadata.repoPath,
         });
         worktreeRemoved = true;
@@ -139,7 +139,8 @@ export class CleanupHandler {
         cwd: repoPath,
       });
       return stdout.trim().length > 0;
-    } catch {
+    } catch (err: unknown) {
+      logger.warn(`Failed to check branch existence for "${branchName}"`, err);
       return false;
     }
   }

--- a/packages/start-git-work/src/cleanupHandler.ts
+++ b/packages/start-git-work/src/cleanupHandler.ts
@@ -66,13 +66,19 @@ export class CleanupHandler {
     if (worktreeExists) { resources.push(`worktree "${metadata.worktreePath}"`); }
     if (branchExists) { resources.push(`branch "${metadata.branchName}"`); }
 
+    const isPlural = resources.length > 1;
+    const verb = isPlural ? 'exist' : 'exists';
+    const pronoun = isPlural ? 'them' : 'it';
+
     const answer = await vscode.window.showInformationMessage(
-      `The ${resources.join(' and ')} for "${event.item.title}" still exist. Delete them?`,
+      `The ${resources.join(' and ')} for "${event.item.title}" still ${verb}. Delete ${pronoun}?`,
       'Yes',
       'No',
     );
 
     if (answer !== 'Yes') {
+      // User declined or dismissed — clear metadata so we don't ask again
+      await this.globalState.update(key, undefined);
       return;
     }
 

--- a/packages/start-git-work/src/cleanupHandler.ts
+++ b/packages/start-git-work/src/cleanupHandler.ts
@@ -1,0 +1,148 @@
+import * as vscode from 'vscode';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import * as fs from 'fs';
+import { logger } from './logger';
+
+const execFileAsync = promisify(execFile);
+
+/** Persisted metadata about a branch/worktree created by StartWorkAction. */
+export interface GitWorkMetadata {
+  branchName: string;
+  worktreePath: string;
+  repoPath: string;
+}
+
+/** Returns the globalState key used to store git work metadata for a work item. */
+export function metadataKey(itemId: string): string {
+  return `gitWork:${itemId}`;
+}
+
+// Re-declared to match core API contract
+interface StateTransitionEvent {
+  readonly item: Readonly<{ id: string; title: string }>;
+  readonly oldState: string;
+  readonly newState: string;
+}
+
+/**
+ * Handles cleanup prompts when work items transition to Done.
+ *
+ * Checks if a branch/worktree was created for the item via StartWorkAction
+ * and prompts the user to delete them.
+ */
+export class CleanupHandler {
+  private readonly globalState: vscode.Memento;
+
+  constructor(globalState: vscode.Memento) {
+    this.globalState = globalState;
+  }
+
+  /**
+   * Called when a work item transitions state. If transitioning to Done and
+   * git work metadata exists, prompts the user to clean up the branch/worktree.
+   */
+  async handleStateTransition(event: StateTransitionEvent): Promise<void> {
+    if (event.newState !== 'Done') {
+      return;
+    }
+
+    const key = metadataKey(event.item.id);
+    const metadata = this.globalState.get<GitWorkMetadata>(key);
+    if (!metadata) {
+      return;
+    }
+
+    const worktreeExists = fs.existsSync(metadata.worktreePath);
+    const branchExists = await this.branchExists(metadata.branchName, metadata.repoPath);
+
+    if (!worktreeExists && !branchExists) {
+      // Already cleaned up — remove stale metadata
+      await this.globalState.update(key, undefined);
+      return;
+    }
+
+    const resources: string[] = [];
+    if (worktreeExists) { resources.push(`worktree "${metadata.worktreePath}"`); }
+    if (branchExists) { resources.push(`branch "${metadata.branchName}"`); }
+
+    const answer = await vscode.window.showInformationMessage(
+      `The ${resources.join(' and ')} for "${event.item.title}" still exist. Delete them?`,
+      'Yes',
+      'No',
+    );
+
+    if (answer !== 'Yes') {
+      return;
+    }
+
+    await this.performCleanup(metadata, key);
+  }
+
+  private async performCleanup(metadata: GitWorkMetadata, stateKey: string): Promise<void> {
+    let worktreeRemoved = false;
+    let branchDeleted = false;
+
+    // Remove worktree first (it must be removed before the branch can be deleted)
+    if (fs.existsSync(metadata.worktreePath)) {
+      try {
+        await execFileAsync('git', ['worktree', 'remove', metadata.worktreePath], {
+          cwd: metadata.repoPath,
+        });
+        worktreeRemoved = true;
+        logger.info(`Removed worktree at ${metadata.worktreePath}`);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.error(`Failed to remove worktree at ${metadata.worktreePath}`, err);
+        void vscode.window.showWarningMessage(
+          `DevDocket: Failed to remove worktree — ${message}`,
+        );
+      }
+    } else {
+      worktreeRemoved = true;
+    }
+
+    // Delete the branch (use -d to warn about unmerged changes)
+    if (await this.branchExists(metadata.branchName, metadata.repoPath)) {
+      try {
+        await execFileAsync('git', ['branch', '-d', metadata.branchName], {
+          cwd: metadata.repoPath,
+        });
+        branchDeleted = true;
+        logger.info(`Deleted branch ${metadata.branchName}`);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        const stderr = (err as any)?.stderr ?? '';
+        // git branch -d fails when the branch has unmerged changes
+        if (message.includes('not fully merged') || stderr.includes('not fully merged')) {
+          void vscode.window.showWarningMessage(
+            `DevDocket: Branch "${metadata.branchName}" has unmerged changes and was not deleted. Use \`git branch -D ${metadata.branchName}\` to force-delete.`,
+          );
+        } else {
+          logger.error(`Failed to delete branch ${metadata.branchName}`, err);
+          void vscode.window.showWarningMessage(
+            `DevDocket: Failed to delete branch — ${message}`,
+          );
+        }
+      }
+    } else {
+      branchDeleted = true;
+    }
+
+    // Clear metadata if both resources were cleaned up
+    if (worktreeRemoved && branchDeleted) {
+      await this.globalState.update(stateKey, undefined);
+    }
+  }
+
+  private async branchExists(branchName: string, repoPath: string): Promise<boolean> {
+    try {
+      const { stdout } = await execFileAsync('git', ['branch', '--list', branchName], {
+        cwd: repoPath,
+      });
+      return stdout.trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/start-git-work/src/cleanupHandler.ts
+++ b/packages/start-git-work/src/cleanupHandler.ts
@@ -3,20 +3,11 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import * as fs from 'fs';
 import { logger } from './logger';
+import { metadataKey, type GitWorkMetadata } from './gitWorkMetadata';
 
 const execFileAsync = promisify(execFile);
 
-/** Persisted metadata about a branch/worktree created by StartWorkAction. */
-export interface GitWorkMetadata {
-  branchName: string;
-  worktreePath: string;
-  repoPath: string;
-}
-
-/** Returns the globalState key used to store git work metadata for a work item. */
-export function metadataKey(itemId: string): string {
-  return `gitWork:${itemId}`;
-}
+export { metadataKey, type GitWorkMetadata } from './gitWorkMetadata';
 
 // Re-declared to match core API contract
 interface StateTransitionEvent {

--- a/packages/start-git-work/src/extension.ts
+++ b/packages/start-git-work/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { StartWorkAction } from './startWorkAction';
+import { CleanupHandler } from './cleanupHandler';
 import { initLogger, setLogLevel, logger, resolveLogLevel } from './logger';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
@@ -50,6 +51,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const startWorkAction = new StartWorkAction(context.globalState);
   const actionDisposable = api.registerAction(startWorkAction);
   context.subscriptions.push(actionDisposable);
+
+  // Subscribe to state transitions to prompt branch/worktree cleanup on Done
+  if (typeof api.onDidTransitionState === 'function') {
+    const cleanupHandler = new CleanupHandler(context.globalState);
+    const transitionDisposable = api.onDidTransitionState((event: any) => {
+      void cleanupHandler.handleStateTransition(event).catch((err: unknown) => {
+        logger.error('Cleanup handler failed', err);
+      });
+    });
+    context.subscriptions.push(transitionDisposable);
+  }
 
   logger.info('DevDocket Start Git Work activated');
 }

--- a/packages/start-git-work/src/extension.ts
+++ b/packages/start-git-work/src/extension.ts
@@ -55,7 +55,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // Subscribe to state transitions to prompt branch/worktree cleanup on Done
   if (typeof api.onDidTransitionState === 'function') {
     const cleanupHandler = new CleanupHandler(context.globalState);
-    const transitionDisposable = api.onDidTransitionState((event: { item: { id: string; title: string }; newState: string }) => {
+    const transitionDisposable = api.onDidTransitionState((event: { item: { id: string; title: string }; oldState: string; newState: string }) => {
       void cleanupHandler.handleStateTransition(event).catch((err: unknown) => {
         logger.error('Cleanup handler failed', err);
       });

--- a/packages/start-git-work/src/extension.ts
+++ b/packages/start-git-work/src/extension.ts
@@ -55,7 +55,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // Subscribe to state transitions to prompt branch/worktree cleanup on Done
   if (typeof api.onDidTransitionState === 'function') {
     const cleanupHandler = new CleanupHandler(context.globalState);
-    const transitionDisposable = api.onDidTransitionState((event: any) => {
+    const transitionDisposable = api.onDidTransitionState((event: { item: { id: string; title: string }; newState: string }) => {
       void cleanupHandler.handleStateTransition(event).catch((err: unknown) => {
         logger.error('Cleanup handler failed', err);
       });

--- a/packages/start-git-work/src/gitWorkMetadata.ts
+++ b/packages/start-git-work/src/gitWorkMetadata.ts
@@ -1,0 +1,11 @@
+/** Persisted metadata about a branch/worktree created by StartWorkAction. */
+export interface GitWorkMetadata {
+  branchName: string;
+  worktreePath: string;
+  repoPath: string;
+}
+
+/** Returns the globalState key used to store git work metadata for a work item. */
+export function metadataKey(itemId: string): string {
+  return `gitWork:${itemId}`;
+}

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -4,7 +4,7 @@ import { promisify } from 'util';
 import * as path from 'path';
 import * as fs from 'fs';
 import { logger } from './logger';
-import { metadataKey, type GitWorkMetadata } from './cleanupHandler';
+import { metadataKey, type GitWorkMetadata } from './gitWorkMetadata';
 
 const execFileAsync = promisify(execFile);
 

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -4,6 +4,7 @@ import { promisify } from 'util';
 import * as path from 'path';
 import * as fs from 'fs';
 import { logger } from './logger';
+import { metadataKey, type GitWorkMetadata } from './cleanupHandler';
 
 const execFileAsync = promisify(execFile);
 
@@ -138,6 +139,10 @@ export class StartWorkAction implements DevDocketAction {
           }
 
           logger.info(`Created worktree at ${worktreePath}`);
+
+          // Persist mapping so cleanup can find the branch/worktree later
+          const metadata: GitWorkMetadata = { branchName, worktreePath, repoPath };
+          await this.globalState.update(metadataKey(item.id), metadata);
 
           // Run user-configured post-worktree commands
           const commands = vscode.workspace.getConfiguration('devdocketStartGitWork')

--- a/packages/start-git-work/src/test/cleanupHandler.test.ts
+++ b/packages/start-git-work/src/test/cleanupHandler.test.ts
@@ -223,7 +223,7 @@ describe('CleanupHandler', () => {
       // Should have removed worktree
       expect(execFile).toHaveBeenCalledWith(
         'git',
-        ['worktree', 'remove', DEFAULT_METADATA.worktreePath],
+        ['worktree', 'remove', '--', DEFAULT_METADATA.worktreePath],
         { cwd: DEFAULT_METADATA.repoPath },
         expect.any(Function),
       );

--- a/packages/start-git-work/src/test/cleanupHandler.test.ts
+++ b/packages/start-git-work/src/test/cleanupHandler.test.ts
@@ -175,6 +175,22 @@ describe('CleanupHandler', () => {
       );
     });
 
+    it('does nothing when user dismisses the dialog', async () => {
+      mockMemento._store.set(metadataKey('item-1'), DEFAULT_METADATA);
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+        return p.toString() === DEFAULT_METADATA.worktreePath;
+      });
+      // Dismissing (Escape / close) resolves to undefined
+      vi.mocked(window.showInformationMessage).mockResolvedValue(undefined as any);
+
+      const event = createEvent();
+      await handler.handleStateTransition(event);
+
+      expect(execFile).not.toHaveBeenCalledWith(
+        'git', expect.arrayContaining(['worktree', 'remove']), expect.anything(), expect.anything(),
+      );
+    });
+
     it('removes worktree and deletes branch when user selects Yes', async () => {
       mockMemento._store.set(metadataKey('item-1'), DEFAULT_METADATA);
       // Worktree exists initially but not after removal

--- a/packages/start-git-work/src/test/cleanupHandler.test.ts
+++ b/packages/start-git-work/src/test/cleanupHandler.test.ts
@@ -159,7 +159,7 @@ describe('CleanupHandler', () => {
       expect(message).toContain('branch');
     });
 
-    it('does nothing when user selects No', async () => {
+    it('clears metadata when user selects No', async () => {
       mockMemento._store.set(metadataKey('item-1'), DEFAULT_METADATA);
       vi.mocked(fs.existsSync).mockImplementation((p: any) => {
         return p.toString() === DEFAULT_METADATA.worktreePath;
@@ -173,9 +173,11 @@ describe('CleanupHandler', () => {
       expect(execFile).not.toHaveBeenCalledWith(
         'git', expect.arrayContaining(['worktree', 'remove']), expect.anything(), expect.anything(),
       );
+      // Should clear metadata so we don't ask again
+      expect(mockMemento.update).toHaveBeenCalledWith(metadataKey('item-1'), undefined);
     });
 
-    it('does nothing when user dismisses the dialog', async () => {
+    it('clears metadata when user dismisses the dialog', async () => {
       mockMemento._store.set(metadataKey('item-1'), DEFAULT_METADATA);
       vi.mocked(fs.existsSync).mockImplementation((p: any) => {
         return p.toString() === DEFAULT_METADATA.worktreePath;
@@ -189,6 +191,8 @@ describe('CleanupHandler', () => {
       expect(execFile).not.toHaveBeenCalledWith(
         'git', expect.arrayContaining(['worktree', 'remove']), expect.anything(), expect.anything(),
       );
+      // Should clear metadata so we don't ask again
+      expect(mockMemento.update).toHaveBeenCalledWith(metadataKey('item-1'), undefined);
     });
 
     it('removes worktree and deletes branch when user selects Yes', async () => {

--- a/packages/start-git-work/src/test/cleanupHandler.test.ts
+++ b/packages/start-git-work/src/test/cleanupHandler.test.ts
@@ -264,7 +264,7 @@ describe('CleanupHandler', () => {
       expect(mockMemento.update).not.toHaveBeenCalledWith(metadataKey('item-1'), undefined);
     });
 
-    it('warns when worktree removal fails', async () => {
+    it('warns when worktree removal fails and skips branch deletion', async () => {
       mockMemento._store.set(metadataKey('item-1'), DEFAULT_METADATA);
       vi.mocked(fs.existsSync).mockImplementation((p: any) => {
         return p.toString() === DEFAULT_METADATA.worktreePath;
@@ -285,6 +285,10 @@ describe('CleanupHandler', () => {
 
       expect(window.showWarningMessage).toHaveBeenCalledWith(
         expect.stringContaining('Failed to remove worktree'),
+      );
+      // Should NOT attempt branch deletion when worktree removal failed
+      expect(execFile).not.toHaveBeenCalledWith(
+        'git', expect.arrayContaining(['branch', '-d']), expect.anything(), expect.anything(),
       );
     });
 

--- a/packages/start-git-work/src/test/cleanupHandler.test.ts
+++ b/packages/start-git-work/src/test/cleanupHandler.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { window } from 'vscode';
+import { CleanupHandler, metadataKey, type GitWorkMetadata } from '../cleanupHandler';
+
+// Mock child_process
+vi.mock('child_process', () => ({
+  execFile: vi.fn((cmd: string, args: string[], optsOrCb: any, cb?: Function) => {
+    const callback = typeof optsOrCb === 'function' ? optsOrCb : cb;
+    callback?.(null, '', '');
+  }),
+}));
+
+// Mock fs
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => false),
+}));
+
+import { execFile } from 'child_process';
+import * as fs from 'fs';
+
+function createMockMemento() {
+  const store = new Map<string, any>();
+  return {
+    get: vi.fn((key: string, defaultValue?: any) => store.has(key) ? store.get(key) : defaultValue),
+    update: vi.fn(async (key: string, value: any) => {
+      if (value === undefined) {
+        store.delete(key);
+      } else {
+        store.set(key, value);
+      }
+    }),
+    keys: () => [...store.keys()],
+    _store: store,
+  };
+}
+
+function createEvent(overrides: Partial<{
+  itemId: string; title: string; oldState: string; newState: string;
+}> = {}) {
+  return {
+    item: {
+      id: overrides.itemId ?? 'item-1',
+      title: overrides.title ?? 'Fix login bug',
+    },
+    oldState: overrides.oldState ?? 'InProgress',
+    newState: overrides.newState ?? 'Done',
+  };
+}
+
+const DEFAULT_METADATA: GitWorkMetadata = {
+  branchName: 'issue123',
+  worktreePath: '/repos/myrepo-issue123',
+  repoPath: '/repos/myrepo',
+};
+
+describe('CleanupHandler', () => {
+  let handler: CleanupHandler;
+  let mockMemento: ReturnType<typeof createMockMemento>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMemento = createMockMemento();
+    handler = new CleanupHandler(mockMemento as any);
+
+    // Default: execFile succeeds
+    vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+      cb(null, { stdout: '', stderr: '' }, '');
+    }) as any);
+  });
+
+  describe('handleStateTransition', () => {
+    it('does nothing for non-Done transitions', async () => {
+      const event = createEvent({ newState: 'Paused' });
+      await handler.handleStateTransition(event);
+
+      expect(window.showInformationMessage).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when no metadata stored for item', async () => {
+      const event = createEvent();
+      await handler.handleStateTransition(event);
+
+      expect(window.showInformationMessage).not.toHaveBeenCalled();
+    });
+
+    it('clears stale metadata when both worktree and branch are already gone', async () => {
+      mockMemento._store.set(metadataKey('item-1'), DEFAULT_METADATA);
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      // Branch doesn't exist (git branch --list returns empty)
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        cb(null, { stdout: '', stderr: '' }, '');
+      }) as any);
+
+      const event = createEvent();
+      await handler.handleStateTransition(event);
+
+      expect(window.showInformationMessage).not.toHaveBeenCalled();
+      expect(mockMemento.update).toHaveBeenCalledWith(metadataKey('item-1'), undefined);
+    });
+
+    it('prompts user when worktree exists', async () => {
+      mockMemento._store.set(metadataKey('item-1'), DEFAULT_METADATA);
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+        return p.toString() === DEFAULT_METADATA.worktreePath;
+      });
+      vi.mocked(window.showInformationMessage).mockResolvedValue('No' as any);
+
+      const event = createEvent();
+      await handler.handleStateTransition(event);
+
+      expect(window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining('worktree'),
+        'Yes',
+        'No',
+      );
+    });
+
+    it('prompts user when branch exists', async () => {
+      mockMemento._store.set(metadataKey('item-1'), DEFAULT_METADATA);
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      // Branch exists
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'branch' && args[1] === '--list') {
+          cb(null, { stdout: '  issue123\n', stderr: '' }, '');
+        } else {
+          cb(null, { stdout: '', stderr: '' }, '');
+        }
+      }) as any);
+
+      const event = createEvent();
+      await handler.handleStateTransition(event);
+
+      expect(window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining('branch'),
+        'Yes',
+        'No',
+      );
+    });
+
+    it('prompts with both worktree and branch when both exist', async () => {
+      mockMemento._store.set(metadataKey('item-1'), DEFAULT_METADATA);
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+        return p.toString() === DEFAULT_METADATA.worktreePath;
+      });
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'branch' && args[1] === '--list') {
+          cb(null, { stdout: '  issue123\n', stderr: '' }, '');
+        } else {
+          cb(null, { stdout: '', stderr: '' }, '');
+        }
+      }) as any);
+      vi.mocked(window.showInformationMessage).mockResolvedValue('No' as any);
+
+      const event = createEvent();
+      await handler.handleStateTransition(event);
+
+      const message = vi.mocked(window.showInformationMessage).mock.calls[0][0] as string;
+      expect(message).toContain('worktree');
+      expect(message).toContain('branch');
+    });
+
+    it('does nothing when user selects No', async () => {
+      mockMemento._store.set(metadataKey('item-1'), DEFAULT_METADATA);
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+        return p.toString() === DEFAULT_METADATA.worktreePath;
+      });
+      vi.mocked(window.showInformationMessage).mockResolvedValue('No' as any);
+
+      const event = createEvent();
+      await handler.handleStateTransition(event);
+
+      // Should not have attempted any git cleanup commands
+      expect(execFile).not.toHaveBeenCalledWith(
+        'git', expect.arrayContaining(['worktree', 'remove']), expect.anything(), expect.anything(),
+      );
+    });
+
+    it('removes worktree and deletes branch when user selects Yes', async () => {
+      mockMemento._store.set(metadataKey('item-1'), DEFAULT_METADATA);
+      // Worktree exists initially but not after removal
+      let worktreeRemoved = false;
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+        if (p.toString() === DEFAULT_METADATA.worktreePath) {
+          return !worktreeRemoved;
+        }
+        return false;
+      });
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'branch' && args[1] === '--list') {
+          cb(null, { stdout: '  issue123\n', stderr: '' }, '');
+        } else if (args[0] === 'worktree' && args[1] === 'remove') {
+          worktreeRemoved = true;
+          cb(null, { stdout: '', stderr: '' }, '');
+        } else {
+          cb(null, { stdout: '', stderr: '' }, '');
+        }
+      }) as any);
+      vi.mocked(window.showInformationMessage).mockResolvedValue('Yes' as any);
+
+      const event = createEvent();
+      await handler.handleStateTransition(event);
+
+      // Should have removed worktree
+      expect(execFile).toHaveBeenCalledWith(
+        'git',
+        ['worktree', 'remove', DEFAULT_METADATA.worktreePath],
+        { cwd: DEFAULT_METADATA.repoPath },
+        expect.any(Function),
+      );
+      // Should have deleted branch with -d (not -D)
+      expect(execFile).toHaveBeenCalledWith(
+        'git',
+        ['branch', '-d', 'issue123'],
+        { cwd: DEFAULT_METADATA.repoPath },
+        expect.any(Function),
+      );
+      // Should have cleared metadata
+      expect(mockMemento.update).toHaveBeenCalledWith(metadataKey('item-1'), undefined);
+    });
+
+    it('warns when branch has unmerged changes', async () => {
+      mockMemento._store.set(metadataKey('item-1'), DEFAULT_METADATA);
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'branch' && args[1] === '--list') {
+          cb(null, { stdout: '  issue123\n', stderr: '' }, '');
+        } else if (args[0] === 'branch' && args[1] === '-d') {
+          const err = new Error('error: The branch \'issue123\' is not fully merged.');
+          (err as any).stderr = 'error: The branch \'issue123\' is not fully merged.';
+          cb(err, { stdout: '', stderr: '' }, '');
+        } else {
+          cb(null, { stdout: '', stderr: '' }, '');
+        }
+      }) as any);
+      vi.mocked(window.showInformationMessage).mockResolvedValue('Yes' as any);
+
+      const event = createEvent();
+      await handler.handleStateTransition(event);
+
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('unmerged changes'),
+      );
+      // Should NOT clear metadata since branch wasn't deleted
+      expect(mockMemento.update).not.toHaveBeenCalledWith(metadataKey('item-1'), undefined);
+    });
+
+    it('warns when worktree removal fails', async () => {
+      mockMemento._store.set(metadataKey('item-1'), DEFAULT_METADATA);
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+        return p.toString() === DEFAULT_METADATA.worktreePath;
+      });
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'branch' && args[1] === '--list') {
+          cb(null, { stdout: '', stderr: '' }, '');
+        } else if (args[0] === 'worktree' && args[1] === 'remove') {
+          cb(new Error('contains modified or untracked files'), { stdout: '', stderr: '' }, '');
+        } else {
+          cb(null, { stdout: '', stderr: '' }, '');
+        }
+      }) as any);
+      vi.mocked(window.showInformationMessage).mockResolvedValue('Yes' as any);
+
+      const event = createEvent();
+      await handler.handleStateTransition(event);
+
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to remove worktree'),
+      );
+    });
+
+    it('includes item title in prompt message', async () => {
+      mockMemento._store.set(metadataKey('item-1'), DEFAULT_METADATA);
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+        return p.toString() === DEFAULT_METADATA.worktreePath;
+      });
+      vi.mocked(window.showInformationMessage).mockResolvedValue('No' as any);
+
+      const event = createEvent({ title: 'My special task' });
+      await handler.handleStateTransition(event);
+
+      expect(window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining('My special task'),
+        'Yes',
+        'No',
+      );
+    });
+  });
+});
+
+describe('metadataKey', () => {
+  it('creates a key from item ID', () => {
+    expect(metadataKey('abc-123')).toBe('gitWork:abc-123');
+  });
+});

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -352,6 +352,39 @@ describe('StartWorkAction', () => {
       );
     });
 
+    it('stores git work metadata in globalState after creating worktree', async () => {
+      const item = createWorkItem();
+      await action.run(item);
+
+      expect(mockMemento.update).toHaveBeenCalledWith(
+        'gitWork:wc-test-1',
+        {
+          branchName: 'issue123',
+          worktreePath: path.join('/mock', 'workspace-issue123'),
+          repoPath: '/mock/workspace',
+        },
+      );
+    });
+
+    it('does not store metadata when worktree creation fails', async () => {
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'worktree') {
+          cb(new Error('worktree failed'), { stdout: '', stderr: '' }, '');
+          return;
+        }
+        cb(null, { stdout: '', stderr: '' }, '');
+      }) as any);
+
+      const item = createWorkItem();
+      await action.run(item);
+
+      // Should not have stored gitWork metadata (repoPath and baseBranch caching still happens)
+      expect(mockMemento.update).not.toHaveBeenCalledWith(
+        'gitWork:wc-test-1',
+        expect.anything(),
+      );
+    });
+
     it('runs post-worktree commands with {path} placeholder', async () => {
       vi.mocked(workspace.getConfiguration).mockReturnValue({
         get: vi.fn((key: string, defaultValue?: any) => {


### PR DESCRIPTION
Prompt to clean up branch/worktree when completing a work item

Closes #264

## Summary

When the **Start Git Work** action creates a branch and worktree for a work item, the association is now persisted. When the item is later completed (moved to Done), the user is prompted to delete the leftover branch and worktree.

## Changes

### Core extension (`packages/core`)
- **`api/types.ts`**: Added `StateTransitionEvent` interface and `onDidTransitionState` event to `DevDocketApi`. This is a non-breaking API addition — the interface is only implemented by core, never by consumers.
- **`services/workGraph.ts`**: Fires `onDidTransitionState` after each `transitionState()` call with old/new state and the updated item.
- **`api/devDocketApi.ts`**: Wires `onDidTransitionState` from WorkGraph through to the public API.
- **`extension.ts`**: Passes WorkGraph to `DevDocketApiImpl` constructor and exports `StateTransitionEvent`.

### Start Git Work extension (`packages/start-git-work`)
- **`startWorkAction.ts`**: After successfully creating a worktree, stores metadata (`branchName`, `worktreePath`, `repoPath`) in `globalState` keyed by work item ID.
- **`cleanupHandler.ts`** (new): Subscribes to `onDidTransitionState` and when an item transitions to Done:
  1. Checks if stored metadata exists for the item
  2. Verifies if the worktree directory and/or branch still exist
  3. Prompts the user: *"The worktree and branch for 'item title' still exist. Delete them?"*
  4. On **Yes**: removes worktree (`git worktree remove`) and deletes branch (`git branch -d`)
  5. On **No**: dismisses without action
- **`extension.ts`**: Wires up `CleanupHandler` to the core API's state transition event.

### Edge cases handled
- Worktree/branch already deleted manually → clears stale metadata silently
- Branch has unmerged changes → warns user with suggestion to use `git branch -D` manually
- Worktree removal fails (e.g. modified files) → warns user, preserves metadata for retry
- `git branch -d` used intentionally (not `-D`) to protect against data loss

### Tests
- 4 new tests in `workGraph.test.ts` and `devDocketApi.test.ts` for the state transition event
- 12 new tests in `cleanupHandler.test.ts` covering all prompt/cleanup paths
- 2 new tests in `startWorkAction.test.ts` for metadata storage
