### PR TITLE
Editor panel titles update dynamically from provider source

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -17,6 +17,7 @@ import { registerCommands } from './commands/commands';
 import { ViewRevealer } from './services/viewRevealer';
 import { initLogger, setLogLevel, logger, resolveLogLevel } from './services/logger';
 import { getInboxUnseenCount } from './services/inboxBadge';
+import { syncProviderTitles } from './services/titleSync';
 import { getViewLayout, ViewId } from './views/viewLayout';
 import { performance } from 'perf_hooks';
 
@@ -238,6 +239,10 @@ function wireEvents(
   const providerRegSub = providerRegistry.onDidRegisterProvider(safeHandler('Error handling provider registration', scheduleUiUpdate));
   const discoveredSub = providerRegistry.onDidChangeDiscoveredItems(safeHandler('Error handling discovered items change', () => {
     scheduleUiUpdate();
+
+    void syncProviderTitles(providerRegistry, workGraph).catch(err => {
+      logger.error('Error syncing provider titles', err);
+    });
 
     // Mark initial load complete when loading transitions from true to false
     if (!initialLoadComplete) {

--- a/packages/core/src/services/titleSync.ts
+++ b/packages/core/src/services/titleSync.ts
@@ -1,0 +1,33 @@
+import { WorkGraph } from './workGraph';
+import { ProviderRegistry } from './providerRegistry';
+import { logger } from './logger';
+
+/**
+ * Synchronize provider-discovered titles with persisted WorkItem titles.
+ *
+ * Called after a provider refresh, this function iterates the provider's
+ * discovered items and updates any WorkItems whose persisted title differs
+ * from the live provider title. This keeps tree views, editor panels, and
+ * tooltips current without view-layer title resolution.
+ *
+ * Covers both provider-discovered items and manually imported/linked items
+ * that share the same providerId + externalId.
+ */
+export async function syncProviderTitles(
+  providerRegistry: ProviderRegistry,
+  workGraph: WorkGraph,
+): Promise<void> {
+  for (const [providerId, discoveredItems] of providerRegistry.getAllDiscoveredItems()) {
+    for (const discovered of discoveredItems) {
+      const workItem = workGraph.findItemByProvenance(providerId, discovered.externalId);
+      if (workItem && discovered.title && workItem.title !== discovered.title) {
+        try {
+          await workGraph.updateItem(workItem.id, { title: discovered.title });
+          logger.debug(`Synced title for ${providerId}/${discovered.externalId}: "${workItem.title}" → "${discovered.title}"`);
+        } catch (err) {
+          logger.error(`Failed to sync title for ${providerId}/${discovered.externalId}`, err);
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/services/titleSync.ts
+++ b/packages/core/src/services/titleSync.ts
@@ -20,7 +20,7 @@ export async function syncProviderTitles(
   for (const [providerId, discoveredItems] of providerRegistry.getAllDiscoveredItems()) {
     for (const discovered of discoveredItems) {
       const workItem = workGraph.findItemByProvenance(providerId, discovered.externalId);
-      if (workItem && discovered.title && workItem.title !== discovered.title) {
+      if (workItem && discovered.title?.trim() && workItem.title !== discovered.title) {
         try {
           await workGraph.updateItem(workItem.id, { title: discovered.title });
           logger.debug(`Synced title for ${providerId}/${discovered.externalId}: "${workItem.title}" → "${discovered.title}"`);

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -87,6 +87,40 @@ describe('getEditorPanelHtml', () => {
     expect(html).not.toContain('Edit Work Item');
   });
 
+  it('uses displayTitle for heading and input when provided', () => {
+    const item = makeItem({ title: 'Persisted Title' });
+    const html = getEditorPanelHtml({ cspSource, item, displayTitle: 'Live Title' });
+    expect(html).toContain('<h2 id="editor-heading">Live Title</h2>');
+    expect(html).toContain('value="Live Title"');
+    expect(html).not.toContain('>Persisted Title<');
+  });
+
+  it('falls back to item.title when displayTitle is omitted', () => {
+    const item = makeItem({ title: 'Fallback Title' });
+    const html = getEditorPanelHtml({ cspSource, item });
+    expect(html).toContain('<h2 id="editor-heading">Fallback Title</h2>');
+    expect(html).toContain('value="Fallback Title"');
+  });
+
+  it('escapes displayTitle in heading and input', () => {
+    const item = makeItem({ title: 'safe' });
+    const html = getEditorPanelHtml({ cspSource, item, displayTitle: '<script>alert("xss")</script>' });
+    expect(html).not.toContain('<script>alert');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('includes updateTitle message handler in webview script', () => {
+    const html = getEditorPanelHtml({ cspSource, item: makeItem() });
+    expect(html).toContain('updateTitle');
+    expect(html).toContain("window.addEventListener('message'");
+  });
+
+  it('updateTitle handler preserves title-link element when present', () => {
+    const html = getEditorPanelHtml({ cspSource, item: makeItem() });
+    expect(html).toContain("heading.querySelector('#title-link')");
+    expect(html).toContain('link.textContent = msg.title');
+  });
+
   it('escapes special characters in heading title', () => {
     const item = makeItem({ title: 'Use <div> & "quotes"' });
     const html = getEditorPanelHtml({ cspSource, item });

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -83,30 +83,8 @@ describe('getEditorPanelHtml', () => {
   it('shows item title in heading instead of generic text', () => {
     const item = makeItem({ title: 'Fix login bug' });
     const html = getEditorPanelHtml({ cspSource, item });
-    expect(html).toContain('<h2 id="editor-heading">Fix login bug</h2>');
+    expect(html).toContain('>Fix login bug</');
     expect(html).not.toContain('Edit Work Item');
-  });
-
-  it('uses displayTitle for heading and input when provided', () => {
-    const item = makeItem({ title: 'Persisted Title' });
-    const html = getEditorPanelHtml({ cspSource, item, displayTitle: 'Live Title' });
-    expect(html).toContain('<h2 id="editor-heading">Live Title</h2>');
-    expect(html).toContain('value="Live Title"');
-    expect(html).not.toContain('>Persisted Title<');
-  });
-
-  it('falls back to item.title when displayTitle is omitted', () => {
-    const item = makeItem({ title: 'Fallback Title' });
-    const html = getEditorPanelHtml({ cspSource, item });
-    expect(html).toContain('<h2 id="editor-heading">Fallback Title</h2>');
-    expect(html).toContain('value="Fallback Title"');
-  });
-
-  it('escapes displayTitle in heading and input', () => {
-    const item = makeItem({ title: 'safe' });
-    const html = getEditorPanelHtml({ cspSource, item, displayTitle: '<script>alert("xss")</script>' });
-    expect(html).not.toContain('<script>alert');
-    expect(html).toContain('&lt;script&gt;');
   });
 
   it('includes updateTitle message handler in webview script', () => {

--- a/packages/core/src/test/titleSync.test.ts
+++ b/packages/core/src/test/titleSync.test.ts
@@ -119,4 +119,15 @@ describe('syncProviderTitles', () => {
 
     expect(workGraph.updateItem).not.toHaveBeenCalled();
   });
+
+  it('does not overwrite persisted title with whitespace-only provider title', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [{ externalId: '42', title: '   ' }]],
+    ]));
+    workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', title: 'Good Title' });
+
+    await syncProviderTitles(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/test/titleSync.test.ts
+++ b/packages/core/src/test/titleSync.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { syncProviderTitles } from '../services/titleSync';
+
+function createMockWorkGraph() {
+  return {
+    findItemByProvenance: vi.fn(),
+    updateItem: vi.fn(async () => {}),
+  };
+}
+
+function createMockProviderRegistry() {
+  return {
+    getAllDiscoveredItems: vi.fn(() => new Map<string, any[]>()),
+  };
+}
+
+describe('syncProviderTitles', () => {
+  let workGraph: ReturnType<typeof createMockWorkGraph>;
+  let providerRegistry: ReturnType<typeof createMockProviderRegistry>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    workGraph = createMockWorkGraph();
+    providerRegistry = createMockProviderRegistry();
+  });
+
+  it('updates WorkItem title when provider title differs', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [{ externalId: '42', title: 'New Title' }]],
+    ]));
+    workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', title: 'Old Title' });
+
+    await syncProviderTitles(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.findItemByProvenance).toHaveBeenCalledWith('github', '42');
+    expect(workGraph.updateItem).toHaveBeenCalledWith('item-1', { title: 'New Title' });
+  });
+
+  it('does not update when titles match', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [{ externalId: '42', title: 'Same Title' }]],
+    ]));
+    workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', title: 'Same Title' });
+
+    await syncProviderTitles(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).not.toHaveBeenCalled();
+  });
+
+  it('skips discovered items without matching WorkItem', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [{ externalId: '99', title: 'Orphan' }]],
+    ]));
+    workGraph.findItemByProvenance.mockReturnValue(undefined);
+
+    await syncProviderTitles(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).not.toHaveBeenCalled();
+  });
+
+  it('handles multiple providers and items', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [
+        { externalId: '1', title: 'Updated GH' },
+        { externalId: '2', title: 'Same GH' },
+      ]],
+      ['ado', [
+        { externalId: '100', title: 'Updated ADO' },
+      ]],
+    ]));
+    workGraph.findItemByProvenance
+      .mockReturnValueOnce({ id: 'gh-1', title: 'Old GH' })
+      .mockReturnValueOnce({ id: 'gh-2', title: 'Same GH' })
+      .mockReturnValueOnce({ id: 'ado-1', title: 'Old ADO' });
+
+    await syncProviderTitles(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).toHaveBeenCalledTimes(2);
+    expect(workGraph.updateItem).toHaveBeenCalledWith('gh-1', { title: 'Updated GH' });
+    expect(workGraph.updateItem).toHaveBeenCalledWith('ado-1', { title: 'Updated ADO' });
+  });
+
+  it('continues syncing other items when one update fails', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [
+        { externalId: '1', title: 'Fail' },
+        { externalId: '2', title: 'Updated' },
+      ]],
+    ]));
+    workGraph.findItemByProvenance
+      .mockReturnValueOnce({ id: 'item-1', title: 'Old1' })
+      .mockReturnValueOnce({ id: 'item-2', title: 'Old2' });
+    workGraph.updateItem
+      .mockRejectedValueOnce(new Error('write error'))
+      .mockResolvedValueOnce(undefined);
+
+    await syncProviderTitles(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).toHaveBeenCalledTimes(2);
+    expect(workGraph.updateItem).toHaveBeenCalledWith('item-2', { title: 'Updated' });
+  });
+
+  it('does nothing when no providers have items', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map());
+
+    await syncProviderTitles(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.findItemByProvenance).not.toHaveBeenCalled();
+    expect(workGraph.updateItem).not.toHaveBeenCalled();
+  });
+
+  it('does not overwrite persisted title with empty provider title', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [{ externalId: '42', title: '' }]],
+    ]));
+    workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', title: 'Good Title' });
+
+    await syncProviderTitles(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -77,11 +77,14 @@ function createMockContext() {
 
 function createMockProviderRegistry() {
   const discoveredEmitter = new EventEmitter<void>();
+  const registerEmitter = new EventEmitter<void>();
   return {
     getDiscoveredItems: vi.fn(() => []),
     getProvider: vi.fn((id: string) => id ? { id } : undefined),
     onDidChangeDiscoveredItems: discoveredEmitter.event,
+    onDidRegisterProvider: registerEmitter.event,
     _fireDiscoveredItemsChange: () => discoveredEmitter.fire(),
+    _fireRegisterProvider: () => registerEmitter.fire(),
   };
 }
 
@@ -279,7 +282,7 @@ describe('WorkItemEditorPanel', () => {
       expect(mock.panel.webview.postMessage).not.toHaveBeenCalled();
     });
 
-    it('should do a full re-render when managed state changes', () => {
+    it('should do a full re-render when managed state changes via provider registration', () => {
       const item = makeItem({ title: 'My Item', providerId: 'gh', externalId: '10' });
       const mock = createMockWebviewPanel();
       const registry = createMockProviderRegistry();
@@ -291,9 +294,9 @@ describe('WorkItemEditorPanel', () => {
       // Title input should not be readonly initially
       expect(mock.panel.webview.html).not.toContain('Title is managed by the provider');
 
-      // Provider registers — now getProvider returns a provider
+      // Provider registers — fire the registration event
       vi.mocked(registry.getProvider).mockReturnValue({ id: 'gh' } as any);
-      workGraph._fireChange();
+      registry._fireRegisterProvider();
 
       // Should have done a full re-render with readonly title
       expect(mock.panel.webview.html).toContain('Title is managed by the provider');

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { ViewColumn, window } from 'vscode';
+import { EventEmitter, ViewColumn, window } from 'vscode';
 import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
 import { WorkGraph } from '../services/workGraph';
 import { WorkItem, WorkItemState } from '../models/workItem';
@@ -34,6 +34,7 @@ function createMockWebviewPanel() {
         messageHandler = handler;
         return { dispose: vi.fn(() => { messageHandler = undefined; }) };
       }),
+      postMessage: vi.fn(async () => true),
     },
     onDidDispose: vi.fn((handler: DisposeHandler) => {
       disposeHandler = handler;
@@ -65,9 +66,12 @@ function createMockContext() {
 }
 
 function createMockProviderRegistry() {
+  const discoveredEmitter = new EventEmitter<void>();
   return {
     getDiscoveredItems: vi.fn(() => []),
     getProvider: vi.fn((id: string) => id ? { id } : undefined),
+    onDidChangeDiscoveredItems: discoveredEmitter.event,
+    _fireDiscoveredItemsChange: () => discoveredEmitter.fire(),
   };
 }
 
@@ -106,6 +110,7 @@ function createIntegrationWebviewPanel() {
         messageListeners.push(listener);
         return { dispose: vi.fn() };
       }),
+      postMessage: vi.fn(async () => true),
       _fireMessage: (msg: any) => { messageListeners.forEach(l => l(msg)); },
     },
     onDidDispose: vi.fn((listener: Function) => {
@@ -207,9 +212,110 @@ describe('WorkItemEditorPanel', () => {
 
       expect(mock.panel.webview.html).not.toContain('Provider State');
     });
+
+    it('should display live provider title instead of persisted title', () => {
+      const item = makeItem({ title: 'Old Title', providerId: 'gh', externalId: '42' });
+      const mock = createMockWebviewPanel();
+      const registry = createMockProviderRegistry();
+      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
+        { externalId: '42', title: 'Updated Live Title', url: '' } as any,
+      ]);
+      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
+
+      expect(mock.panel.title).toBe('Edit: Updated Live Title');
+      expect(mock.panel.webview.html).toContain('Updated Live Title');
+    });
+
+    it('should fall back to persisted title when provider item is not found', () => {
+      const item = makeItem({ title: 'Persisted Title', providerId: 'gh', externalId: '42' });
+      const mock = createMockWebviewPanel();
+      const registry = createMockProviderRegistry();
+      vi.mocked(registry.getDiscoveredItems).mockReturnValue([]);
+      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
+
+      expect(mock.panel.title).toBe('Edit: Persisted Title');
+      expect(mock.panel.webview.html).toContain('Persisted Title');
+    });
+
+    it('should use persisted title for manual items (no providerId)', () => {
+      const item = makeItem({ title: 'Manual Item' });
+      const mock = createMockWebviewPanel();
+      openPanel(item, createMockWorkGraph(item), mock);
+
+      expect(mock.panel.title).toBe('Edit: Manual Item');
+      expect(mock.panel.webview.html).toContain('Manual Item');
+    });
   });
 
-  describe('panel reuse', () => {
+  describe('dynamic title updates', () => {
+    it('should update title when provider discovers new title', () => {
+      const item = makeItem({ title: 'Original', providerId: 'gh', externalId: '10' });
+      const mock = createMockWebviewPanel();
+      const registry = createMockProviderRegistry();
+      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
+        { externalId: '10', title: 'Original', url: '' } as any,
+      ]);
+      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
+
+      // Simulate provider refresh with new title
+      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
+        { externalId: '10', title: 'Renamed Issue', url: '' } as any,
+      ]);
+      registry._fireDiscoveredItemsChange();
+
+      expect(mock.panel.title).toBe('Edit: Renamed Issue');
+      expect(mock.panel.webview.postMessage).toHaveBeenCalledWith({
+        type: 'updateTitle',
+        title: 'Renamed Issue',
+      });
+    });
+
+    it('should not post message when title has not changed', () => {
+      const item = makeItem({ title: 'Stable Title', providerId: 'gh', externalId: '10' });
+      const mock = createMockWebviewPanel();
+      const registry = createMockProviderRegistry();
+      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
+        { externalId: '10', title: 'Stable Title', url: '' } as any,
+      ]);
+      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
+
+      // Fire change but title is the same
+      registry._fireDiscoveredItemsChange();
+
+      expect(mock.panel.webview.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('should skip title update for non-provider items', () => {
+      const item = makeItem({ title: 'Manual', providerId: undefined });
+      const mock = createMockWebviewPanel();
+      const registry = createMockProviderRegistry();
+      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
+
+      registry._fireDiscoveredItemsChange();
+
+      expect(mock.panel.webview.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('should skip title update after panel is disposed', () => {
+      const item = makeItem({ title: 'Disposed', providerId: 'gh', externalId: '10' });
+      const mock = createMockWebviewPanel();
+      const registry = createMockProviderRegistry();
+      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
+        { externalId: '10', title: 'Disposed', url: '' } as any,
+      ]);
+      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
+
+      // Dispose the panel
+      mock.simulateDispose();
+
+      // Now fire a title change
+      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
+        { externalId: '10', title: 'New Title', url: '' } as any,
+      ]);
+      registry._fireDiscoveredItemsChange();
+
+      expect(mock.panel.webview.postMessage).not.toHaveBeenCalled();
+    });
     it('should reuse existing panel when opening same item twice', () => {
       const item = makeItem({ id: 'reuse-1', title: 'Reuse Item' });
       const mock = createMockWebviewPanel();

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -51,9 +51,19 @@ function createMockWebviewPanel() {
 }
 
 function createMockWorkGraph(item?: WorkItem) {
+  const changeEmitter = new EventEmitter<void>();
+  const mutableItem = item ? { ...item } : undefined;
   return {
-    getItem: vi.fn((id: string) => (item && item.id === id ? item : undefined)),
-    updateItem: vi.fn(async () => {}),
+    getItem: vi.fn((id: string) => (mutableItem && mutableItem.id === id ? mutableItem : undefined)),
+    updateItem: vi.fn(async (_id: string, patch: Record<string, unknown>) => {
+      if (mutableItem) {
+        Object.assign(mutableItem, patch, { updatedAt: Date.now() });
+      }
+      changeEmitter.fire();
+    }),
+    onDidChange: changeEmitter.event,
+    _fireChange: () => changeEmitter.fire(),
+    _setItem: (newItem: WorkItem) => { Object.assign(mutableItem!, newItem); },
   };
 }
 
@@ -213,55 +223,26 @@ describe('WorkItemEditorPanel', () => {
       expect(mock.panel.webview.html).not.toContain('Provider State');
     });
 
-    it('should display live provider title instead of persisted title', () => {
-      const item = makeItem({ title: 'Old Title', providerId: 'gh', externalId: '42' });
-      const mock = createMockWebviewPanel();
-      const registry = createMockProviderRegistry();
-      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
-        { externalId: '42', title: 'Updated Live Title', url: '' } as any,
-      ]);
-      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
-
-      expect(mock.panel.title).toBe('Edit: Updated Live Title');
-      expect(mock.panel.webview.html).toContain('Updated Live Title');
-    });
-
-    it('should fall back to persisted title when provider item is not found', () => {
-      const item = makeItem({ title: 'Persisted Title', providerId: 'gh', externalId: '42' });
-      const mock = createMockWebviewPanel();
-      const registry = createMockProviderRegistry();
-      vi.mocked(registry.getDiscoveredItems).mockReturnValue([]);
-      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
-
-      expect(mock.panel.title).toBe('Edit: Persisted Title');
-      expect(mock.panel.webview.html).toContain('Persisted Title');
-    });
-
-    it('should use persisted title for manual items (no providerId)', () => {
-      const item = makeItem({ title: 'Manual Item' });
+    it('should display persisted title in editor panel', () => {
+      const item = makeItem({ title: 'Current Title', providerId: 'gh', externalId: '42' });
       const mock = createMockWebviewPanel();
       openPanel(item, createMockWorkGraph(item), mock);
 
-      expect(mock.panel.title).toBe('Edit: Manual Item');
-      expect(mock.panel.webview.html).toContain('Manual Item');
+      expect(mock.panel.title).toBe('Edit: Current Title');
+      expect(mock.panel.webview.html).toContain('Current Title');
     });
   });
 
   describe('dynamic title updates', () => {
-    it('should update title when provider discovers new title', () => {
+    it('should update title when WorkGraph title changes', () => {
       const item = makeItem({ title: 'Original', providerId: 'gh', externalId: '10' });
       const mock = createMockWebviewPanel();
-      const registry = createMockProviderRegistry();
-      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
-        { externalId: '10', title: 'Original', url: '' } as any,
-      ]);
-      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
+      const workGraph = createMockWorkGraph(item);
+      openPanel(item, workGraph, mock);
 
-      // Simulate provider refresh with new title
-      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
-        { externalId: '10', title: 'Renamed Issue', url: '' } as any,
-      ]);
-      registry._fireDiscoveredItemsChange();
+      // Simulate title sync updating the persisted title
+      workGraph._setItem({ ...item, title: 'Renamed Issue' });
+      workGraph._fireChange();
 
       expect(mock.panel.title).toBe('Edit: Renamed Issue');
       expect(mock.panel.webview.postMessage).toHaveBeenCalledWith({
@@ -271,27 +252,13 @@ describe('WorkItemEditorPanel', () => {
     });
 
     it('should not post message when title has not changed', () => {
-      const item = makeItem({ title: 'Stable Title', providerId: 'gh', externalId: '10' });
+      const item = makeItem({ title: 'Stable Title' });
       const mock = createMockWebviewPanel();
-      const registry = createMockProviderRegistry();
-      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
-        { externalId: '10', title: 'Stable Title', url: '' } as any,
-      ]);
-      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
+      const workGraph = createMockWorkGraph(item);
+      openPanel(item, workGraph, mock);
 
       // Fire change but title is the same
-      registry._fireDiscoveredItemsChange();
-
-      expect(mock.panel.webview.postMessage).not.toHaveBeenCalled();
-    });
-
-    it('should skip title update for non-provider items', () => {
-      const item = makeItem({ title: 'Manual', providerId: undefined });
-      const mock = createMockWebviewPanel();
-      const registry = createMockProviderRegistry();
-      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
-
-      registry._fireDiscoveredItemsChange();
+      workGraph._fireChange();
 
       expect(mock.panel.webview.postMessage).not.toHaveBeenCalled();
     });
@@ -299,20 +266,15 @@ describe('WorkItemEditorPanel', () => {
     it('should skip title update after panel is disposed', () => {
       const item = makeItem({ title: 'Disposed', providerId: 'gh', externalId: '10' });
       const mock = createMockWebviewPanel();
-      const registry = createMockProviderRegistry();
-      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
-        { externalId: '10', title: 'Disposed', url: '' } as any,
-      ]);
-      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
+      const workGraph = createMockWorkGraph(item);
+      openPanel(item, workGraph, mock);
 
       // Dispose the panel
       mock.simulateDispose();
 
-      // Now fire a title change
-      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
-        { externalId: '10', title: 'New Title', url: '' } as any,
-      ]);
-      registry._fireDiscoveredItemsChange();
+      // Simulate title change after disposal
+      workGraph._setItem({ ...item, title: 'New Title' });
+      workGraph._fireChange();
 
       expect(mock.panel.webview.postMessage).not.toHaveBeenCalled();
     });
@@ -321,24 +283,20 @@ describe('WorkItemEditorPanel', () => {
       const item = makeItem({ title: 'My Item', providerId: 'gh', externalId: '10' });
       const mock = createMockWebviewPanel();
       const registry = createMockProviderRegistry();
-      // Initially no provider registered — getProvider returns undefined for 'gh'
+      const workGraph = createMockWorkGraph(item);
+      // Initially no provider registered
       vi.mocked(registry.getProvider).mockReturnValue(undefined);
-      vi.mocked(registry.getDiscoveredItems).mockReturnValue([]);
-      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
+      openPanel(item, workGraph, mock, undefined, registry);
 
       // Title input should not be readonly initially
       expect(mock.panel.webview.html).not.toContain('Title is managed by the provider');
 
       // Provider registers — now getProvider returns a provider
       vi.mocked(registry.getProvider).mockReturnValue({ id: 'gh' } as any);
-      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
-        { externalId: '10', title: 'Live Title', url: '' } as any,
-      ]);
-      registry._fireDiscoveredItemsChange();
+      workGraph._fireChange();
 
       // Should have done a full re-render with readonly title
       expect(mock.panel.webview.html).toContain('Title is managed by the provider');
-      expect(mock.panel.webview.html).toContain('Live Title');
     });
   });
 

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -316,6 +316,33 @@ describe('WorkItemEditorPanel', () => {
 
       expect(mock.panel.webview.postMessage).not.toHaveBeenCalled();
     });
+
+    it('should do a full re-render when managed state changes', () => {
+      const item = makeItem({ title: 'My Item', providerId: 'gh', externalId: '10' });
+      const mock = createMockWebviewPanel();
+      const registry = createMockProviderRegistry();
+      // Initially no provider registered — getProvider returns undefined for 'gh'
+      vi.mocked(registry.getProvider).mockReturnValue(undefined);
+      vi.mocked(registry.getDiscoveredItems).mockReturnValue([]);
+      openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
+
+      // Title input should not be readonly initially
+      expect(mock.panel.webview.html).not.toContain('Title is managed by the provider');
+
+      // Provider registers — now getProvider returns a provider
+      vi.mocked(registry.getProvider).mockReturnValue({ id: 'gh' } as any);
+      vi.mocked(registry.getDiscoveredItems).mockReturnValue([
+        { externalId: '10', title: 'Live Title', url: '' } as any,
+      ]);
+      registry._fireDiscoveredItemsChange();
+
+      // Should have done a full re-render with readonly title
+      expect(mock.panel.webview.html).toContain('Title is managed by the provider');
+      expect(mock.panel.webview.html).toContain('Live Title');
+    });
+  });
+
+  describe('panel reuse', () => {
     it('should reuse existing panel when opening same item twice', () => {
       const item = makeItem({ id: 'reuse-1', title: 'Reuse Item' });
       const mock = createMockWebviewPanel();

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -13,16 +13,10 @@ export interface EditorHtmlOptions {
   providerState?: string;
   /** When true, the title field is read-only (managed by a live provider). */
   titleReadonly?: boolean;
-  /**
-   * Live title resolved from the provider, used for display instead of the
-   * persisted item.title. Falls back to item.title when omitted.
-   */
-  displayTitle?: string;
 }
 
-export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDescription, providerState, titleReadonly, displayTitle }: EditorHtmlOptions): string {
+export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDescription, providerState, titleReadonly }: EditorHtmlOptions): string {
   const nonce = getNonce();
-  const title = displayTitle ?? item.title;
   const descriptionSection = providerDescription
     ? `    <div class="field">
       <label id="provider-desc-label">Provider Description</label>
@@ -186,11 +180,11 @@ export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDes
   </style>
 </head>
 <body>
-  <h2 id="editor-heading">${item.url && isSafeUrl(item.url) ? `<a href="${escapeAttr(item.url)}" class="title-link" id="title-link" data-url="${escapeAttr(item.url)}" title="Open in browser">${escapeHtml(title)}</a>` : escapeHtml(title)}</h2>
+  <h2 id="editor-heading">${item.url && isSafeUrl(item.url) ? `<a href="${escapeAttr(item.url)}" class="title-link" id="title-link" data-url="${escapeAttr(item.url)}" title="Open in browser">${escapeHtml(item.title)}</a>` : escapeHtml(item.title)}</h2>
   <div id="form" role="form" aria-labelledby="editor-heading">
     <div class="field">
       <label for="title">Title</label>
-      <input type="text" id="title" value="${escapeAttr(title)}" ${titleReadonly ? 'readonly aria-readonly="true" aria-describedby="readonly-title-hint"' : ''} />
+      <input type="text" id="title" value="${escapeAttr(item.title)}" ${titleReadonly ? 'readonly aria-readonly="true" aria-describedby="readonly-title-hint"' : ''} />
 ${titleReadonly ? '      <span id="readonly-title-hint" class="hint">Title is managed by the provider</span>' : ''}
     </div>
 ${descriptionSection}

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -13,10 +13,16 @@ export interface EditorHtmlOptions {
   providerState?: string;
   /** When true, the title field is read-only (managed by a live provider). */
   titleReadonly?: boolean;
+  /**
+   * Live title resolved from the provider, used for display instead of the
+   * persisted item.title. Falls back to item.title when omitted.
+   */
+  displayTitle?: string;
 }
 
-export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDescription, providerState, titleReadonly }: EditorHtmlOptions): string {
+export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDescription, providerState, titleReadonly, displayTitle }: EditorHtmlOptions): string {
   const nonce = getNonce();
+  const title = displayTitle ?? item.title;
   const descriptionSection = providerDescription
     ? `    <div class="field">
       <label id="provider-desc-label">Provider Description</label>
@@ -180,11 +186,11 @@ export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDes
   </style>
 </head>
 <body>
-  <h2 id="editor-heading">${item.url && isSafeUrl(item.url) ? `<a href="${escapeAttr(item.url)}" class="title-link" id="title-link" data-url="${escapeAttr(item.url)}" title="Open in browser">${escapeHtml(item.title)}</a>` : escapeHtml(item.title)}</h2>
+  <h2 id="editor-heading">${item.url && isSafeUrl(item.url) ? `<a href="${escapeAttr(item.url)}" class="title-link" id="title-link" data-url="${escapeAttr(item.url)}" title="Open in browser">${escapeHtml(title)}</a>` : escapeHtml(title)}</h2>
   <div id="form" role="form" aria-labelledby="editor-heading">
     <div class="field">
       <label for="title">Title</label>
-      <input type="text" id="title" value="${escapeAttr(item.title)}" ${titleReadonly ? 'readonly aria-readonly="true" aria-describedby="readonly-title-hint"' : ''} />
+      <input type="text" id="title" value="${escapeAttr(title)}" ${titleReadonly ? 'readonly aria-readonly="true" aria-describedby="readonly-title-hint"' : ''} />
 ${titleReadonly ? '      <span id="readonly-title-hint" class="hint">Title is managed by the provider</span>' : ''}
     </div>
 ${descriptionSection}
@@ -246,6 +252,25 @@ ${providerState && item.providerId ? `      <dt>Provider State</dt>
         vscode.postMessage({ type: 'openUrl', url: titleLink.dataset.url });
       });
     }
+
+    window.addEventListener('message', event => {
+      const msg = event.data;
+      if (msg && msg.type === 'updateTitle' && typeof msg.title === 'string') {
+        const heading = document.getElementById('editor-heading');
+        if (heading) {
+          const link = heading.querySelector('#title-link');
+          if (link) {
+            link.textContent = msg.title;
+          } else {
+            heading.textContent = msg.title;
+          }
+        }
+        const titleInput = document.getElementById('title');
+        if (titleInput instanceof HTMLInputElement && titleInput.readOnly) {
+          titleInput.value = msg.title;
+        }
+      }
+    });
   </script>
 </body>
 </html>`;

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -19,6 +19,7 @@ export class WorkItemEditorPanel {
   private readonly messageSubscription: vscode.Disposable;
   private readonly discoveredItemsSub: vscode.Disposable;
   private lastResolvedTitle: string | undefined;
+  private lastManagedState: boolean | undefined;
 
   static open(
     context: vscode.ExtensionContext,
@@ -136,14 +137,24 @@ export class WorkItemEditorPanel {
   }
 
   /**
-   * Check whether the live provider title has changed and, if so, push the
-   * new title to the webview without a full re-render (which would lose any
-   * unsaved edits in the notes field).
+   * Check whether the live provider title or managed state has changed.
+   * A managed-state change (provider registered/unregistered while panel is
+   * open) requires a full re-render to toggle the title input's readonly
+   * state. A title-only change uses a targeted postMessage to avoid losing
+   * unsaved notes edits.
    */
   private checkTitleUpdate(): void {
     if (this.disposed) { return; }
     const item = this.workGraph.getItem(this.itemId);
-    if (!item || !item.providerId || !item.externalId) { return; }
+    if (!item) { return; }
+
+    const currentManaged = this.isProviderManaged(item);
+    if (currentManaged !== this.lastManagedState) {
+      this.update();
+      return;
+    }
+
+    if (!item.providerId || !item.externalId) { return; }
 
     const newTitle = this.resolveTitle(item);
     if (newTitle !== this.lastResolvedTitle) {
@@ -190,6 +201,7 @@ export class WorkItemEditorPanel {
     }
     const resolvedTitle = this.resolveTitle(item);
     this.lastResolvedTitle = resolvedTitle;
+    this.lastManagedState = this.isProviderManaged(item);
     this.panel.title = `Edit: ${resolvedTitle}`;
     this.panel.webview.html = this.getHtml(item, resolvedTitle);
   }

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -17,6 +17,8 @@ export class WorkItemEditorPanel {
   private pendingData: Record<string, string> | undefined;
   private saveQueue: Promise<void> = Promise.resolve();
   private readonly messageSubscription: vscode.Disposable;
+  private readonly discoveredItemsSub: vscode.Disposable;
+  private lastResolvedTitle: string | undefined;
 
   static open(
     context: vscode.ExtensionContext,
@@ -27,7 +29,6 @@ export class WorkItemEditorPanel {
   ): void {
     const existing = WorkItemEditorPanel.openPanels.get(item.id);
     if (existing) {
-      existing.panel.title = `Edit: ${item.title}`;
       existing.providerLabel = providerLabel;
       existing.update();
       existing.panel.reveal();
@@ -69,6 +70,10 @@ export class WorkItemEditorPanel {
 
     this.update();
 
+    this.discoveredItemsSub = this.providerRegistry.onDidChangeDiscoveredItems(() => {
+      this.checkTitleUpdate();
+    });
+
     this.messageSubscription = this.panel.webview.onDidReceiveMessage((msg) => {
       if (msg?.type === 'openUrl' && typeof msg.url === 'string') {
         const safeUrl = isSafeUrl(msg.url);
@@ -104,12 +109,48 @@ export class WorkItemEditorPanel {
         }
         this.flushPendingData();
         this.messageSubscription.dispose();
+        this.discoveredItemsSub.dispose();
       }
     });
   }
 
   private isProviderManaged(item: WorkItem): boolean {
     return !!(item.providerId && this.providerRegistry.getProvider(item.providerId));
+  }
+
+  /**
+   * Resolve the display title for the work item. For provider-backed items,
+   * returns the live title from the provider when available; otherwise falls
+   * back to the persisted title.
+   */
+  private resolveTitle(item: WorkItem): string {
+    if (item.providerId && item.externalId) {
+      const discovered = this.providerRegistry
+        .getDiscoveredItems(item.providerId)
+        .find((d) => d.externalId === item.externalId);
+      if (discovered) {
+        return discovered.title;
+      }
+    }
+    return item.title;
+  }
+
+  /**
+   * Check whether the live provider title has changed and, if so, push the
+   * new title to the webview without a full re-render (which would lose any
+   * unsaved edits in the notes field).
+   */
+  private checkTitleUpdate(): void {
+    if (this.disposed) { return; }
+    const item = this.workGraph.getItem(this.itemId);
+    if (!item || !item.providerId || !item.externalId) { return; }
+
+    const newTitle = this.resolveTitle(item);
+    if (newTitle !== this.lastResolvedTitle) {
+      this.lastResolvedTitle = newTitle;
+      this.panel.title = `Edit: ${newTitle}`;
+      void this.panel.webview.postMessage({ type: 'updateTitle', title: newTitle });
+    }
   }
 
   private async saveData(data: Record<string, string>): Promise<void> {
@@ -147,10 +188,13 @@ export class WorkItemEditorPanel {
       this.panel.webview.html = '<html><body><p>Item not found.</p></body></html>';
       return;
     }
-    this.panel.webview.html = this.getHtml(item);
+    const resolvedTitle = this.resolveTitle(item);
+    this.lastResolvedTitle = resolvedTitle;
+    this.panel.title = `Edit: ${resolvedTitle}`;
+    this.panel.webview.html = this.getHtml(item, resolvedTitle);
   }
 
-  private getHtml(item: WorkItem): string {
+  private getHtml(item: WorkItem, displayTitle: string): string {
     let providerDescription: string | undefined;
     let providerState: string | undefined;
     if (item.providerId && item.externalId) {
@@ -167,6 +211,7 @@ export class WorkItemEditorPanel {
       providerDescription,
       providerState,
       titleReadonly: this.isProviderManaged(item),
+      displayTitle,
     });
   }
 
@@ -180,6 +225,7 @@ export class WorkItemEditorPanel {
       }
       this.flushPendingData();
       this.messageSubscription.dispose();
+      this.discoveredItemsSub.dispose();
       this.panel.dispose();
     }
   }

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -17,8 +17,8 @@ export class WorkItemEditorPanel {
   private pendingData: Record<string, string> | undefined;
   private saveQueue: Promise<void> = Promise.resolve();
   private readonly messageSubscription: vscode.Disposable;
-  private readonly discoveredItemsSub: vscode.Disposable;
-  private lastResolvedTitle: string | undefined;
+  private readonly workGraphSub: vscode.Disposable;
+  private lastDisplayedTitle: string | undefined;
   private lastManagedState: boolean | undefined;
 
   static open(
@@ -71,8 +71,8 @@ export class WorkItemEditorPanel {
 
     this.update();
 
-    this.discoveredItemsSub = this.providerRegistry.onDidChangeDiscoveredItems(() => {
-      this.checkTitleUpdate();
+    this.workGraphSub = this.workGraph.onDidChange(() => {
+      this.checkForUpdates();
     });
 
     this.messageSubscription = this.panel.webview.onDidReceiveMessage((msg) => {
@@ -110,7 +110,7 @@ export class WorkItemEditorPanel {
         }
         this.flushPendingData();
         this.messageSubscription.dispose();
-        this.discoveredItemsSub.dispose();
+        this.workGraphSub.dispose();
       }
     });
   }
@@ -120,30 +120,13 @@ export class WorkItemEditorPanel {
   }
 
   /**
-   * Resolve the display title for the work item. For provider-backed items,
-   * returns the live title from the provider when available; otherwise falls
-   * back to the persisted title.
+   * Respond to WorkGraph changes. When the persisted title changes (e.g. from
+   * a provider title sync), push the new title to the webview without a full
+   * re-render to preserve unsaved notes edits. When the managed state changes
+   * (provider registered/unregistered), do a full re-render to toggle the
+   * title input's readonly state.
    */
-  private resolveTitle(item: WorkItem): string {
-    if (item.providerId && item.externalId) {
-      const discovered = this.providerRegistry
-        .getDiscoveredItems(item.providerId)
-        .find((d) => d.externalId === item.externalId);
-      if (discovered) {
-        return discovered.title;
-      }
-    }
-    return item.title;
-  }
-
-  /**
-   * Check whether the live provider title or managed state has changed.
-   * A managed-state change (provider registered/unregistered while panel is
-   * open) requires a full re-render to toggle the title input's readonly
-   * state. A title-only change uses a targeted postMessage to avoid losing
-   * unsaved notes edits.
-   */
-  private checkTitleUpdate(): void {
+  private checkForUpdates(): void {
     if (this.disposed) { return; }
     const item = this.workGraph.getItem(this.itemId);
     if (!item) { return; }
@@ -154,13 +137,10 @@ export class WorkItemEditorPanel {
       return;
     }
 
-    if (!item.providerId || !item.externalId) { return; }
-
-    const newTitle = this.resolveTitle(item);
-    if (newTitle !== this.lastResolvedTitle) {
-      this.lastResolvedTitle = newTitle;
-      this.panel.title = `Edit: ${newTitle}`;
-      void this.panel.webview.postMessage({ type: 'updateTitle', title: newTitle });
+    if (item.title !== this.lastDisplayedTitle) {
+      this.lastDisplayedTitle = item.title;
+      this.panel.title = `Edit: ${item.title}`;
+      void this.panel.webview.postMessage({ type: 'updateTitle', title: item.title });
     }
   }
 
@@ -188,9 +168,6 @@ export class WorkItemEditorPanel {
     }
 
     await this.workGraph.updateItem(this.itemId, patch);
-    if (!this.disposed && data.title && !managed) {
-      this.panel.title = `Edit: ${data.title}`;
-    }
   }
 
   private update(): void {
@@ -199,14 +176,13 @@ export class WorkItemEditorPanel {
       this.panel.webview.html = '<html><body><p>Item not found.</p></body></html>';
       return;
     }
-    const resolvedTitle = this.resolveTitle(item);
-    this.lastResolvedTitle = resolvedTitle;
+    this.lastDisplayedTitle = item.title;
     this.lastManagedState = this.isProviderManaged(item);
-    this.panel.title = `Edit: ${resolvedTitle}`;
-    this.panel.webview.html = this.getHtml(item, resolvedTitle);
+    this.panel.title = `Edit: ${item.title}`;
+    this.panel.webview.html = this.getHtml(item);
   }
 
-  private getHtml(item: WorkItem, displayTitle: string): string {
+  private getHtml(item: WorkItem): string {
     let providerDescription: string | undefined;
     let providerState: string | undefined;
     if (item.providerId && item.externalId) {
@@ -223,7 +199,6 @@ export class WorkItemEditorPanel {
       providerDescription,
       providerState,
       titleReadonly: this.isProviderManaged(item),
-      displayTitle,
     });
   }
 
@@ -237,7 +212,7 @@ export class WorkItemEditorPanel {
       }
       this.flushPendingData();
       this.messageSubscription.dispose();
-      this.discoveredItemsSub.dispose();
+      this.workGraphSub.dispose();
       this.panel.dispose();
     }
   }

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -18,6 +18,7 @@ export class WorkItemEditorPanel {
   private saveQueue: Promise<void> = Promise.resolve();
   private readonly messageSubscription: vscode.Disposable;
   private readonly workGraphSub: vscode.Disposable;
+  private readonly providerRegSub: vscode.Disposable;
   private lastDisplayedTitle: string | undefined;
   private lastManagedState: boolean | undefined;
 
@@ -75,6 +76,10 @@ export class WorkItemEditorPanel {
       this.checkForUpdates();
     });
 
+    this.providerRegSub = this.providerRegistry.onDidRegisterProvider(() => {
+      this.checkForUpdates();
+    });
+
     this.messageSubscription = this.panel.webview.onDidReceiveMessage((msg) => {
       if (msg?.type === 'openUrl' && typeof msg.url === 'string') {
         const safeUrl = isSafeUrl(msg.url);
@@ -111,6 +116,7 @@ export class WorkItemEditorPanel {
         this.flushPendingData();
         this.messageSubscription.dispose();
         this.workGraphSub.dispose();
+        this.providerRegSub.dispose();
       }
     });
   }
@@ -213,6 +219,7 @@ export class WorkItemEditorPanel {
       this.flushPendingData();
       this.messageSubscription.dispose();
       this.workGraphSub.dispose();
+      this.providerRegSub.dispose();
       this.panel.dispose();
     }
   }

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -19,6 +19,7 @@ export class WorkItemEditorPanel {
   private readonly messageSubscription: vscode.Disposable;
   private readonly workGraphSub: vscode.Disposable;
   private readonly providerRegSub: vscode.Disposable;
+  private readonly providerChangeSub: vscode.Disposable;
   private lastDisplayedTitle: string | undefined;
   private lastManagedState: boolean | undefined;
 
@@ -80,6 +81,10 @@ export class WorkItemEditorPanel {
       this.checkForUpdates();
     });
 
+    this.providerChangeSub = this.providerRegistry.onDidChangeDiscoveredItems(() => {
+      this.checkForUpdates();
+    });
+
     this.messageSubscription = this.panel.webview.onDidReceiveMessage((msg) => {
       if (msg?.type === 'openUrl' && typeof msg.url === 'string') {
         const safeUrl = isSafeUrl(msg.url);
@@ -117,6 +122,7 @@ export class WorkItemEditorPanel {
         this.messageSubscription.dispose();
         this.workGraphSub.dispose();
         this.providerRegSub.dispose();
+        this.providerChangeSub.dispose();
       }
     });
   }
@@ -220,6 +226,7 @@ export class WorkItemEditorPanel {
       this.messageSubscription.dispose();
       this.workGraphSub.dispose();
       this.providerRegSub.dispose();
+      this.providerChangeSub.dispose();
       this.panel.dispose();
     }
   }


### PR DESCRIPTION
When a provider refreshes, provider-backed work item titles are now synced into the WorkGraph store. This keeps persisted titles current, naturally updating all tree views (Queue, Focus, History), editor panels, and tooltips through the existing `onDidChange` event system.

## Approach

Instead of resolving live titles at display time in each view, a new `syncProviderTitles` service runs after provider refresh. It iterates discovered items, finds matching WorkItems by `providerId + externalId` (covering both provider-discovered and manually imported/linked items), and updates stale titles. Guards against empty provider titles overwriting valid persisted titles.

## Changes

- **titleSync.ts** (new): `syncProviderTitles()` iterates all providers' discovered items, looks up matching WorkItems via `findItemByProvenance()`, and updates stale titles with per-item error handling.

- **extension.ts**: Wires `syncProviderTitles` into the `onDidChangeDiscoveredItems` handler.

- **workItemEditorPanel.ts**: Subscribes to `workGraph.onDidChange` and `providerRegistry.onDidRegisterProvider` to detect title and managed-state changes. Sends targeted `postMessage` updates to the webview for title changes (preserving unsaved notes edits), and does a full re-render when the managed state toggles.

- **editorPanelHtml.ts**: Added `updateTitle` message handler in the webview script that updates the heading (preserving clickable `#title-link` if present) and readonly title input.

- **Tests**: New `titleSync.test.ts` with 7 tests covering title updates, no-op matching, error resilience, empty title guard, and multi-provider scenarios. Updated editor panel tests to verify WorkGraph-driven title updates and provider-registration-driven managed state changes.

Closes #215
