### PR TITLE
Add My GitHub PRs provider with review status tracking

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -49,11 +49,23 @@ DevDocket is a VS Code extension monorepo for managing work items from multiple 
 - **Build:** esbuild, CJS, `--external:vscode`, sourcemaps. Root `npm install` + `npm run build`.
 
 ### Completed Issues
-#282 (provider state in editor), #281 (clickable title), #275 (History→Queue transitions),#273 (tree counts), #265 (auto-complete on close), #250 (group context), #249 (accept-to-focus, pre-shipped), #243 (version resurfacing), #240 (create from URL), #233 (provider health), #232 (clear history), #231 (sources icons), #230 (layout toggle), #229 (emoji removal), #227 (provider labels), #223 (dead code cleanup), #222 (responsive layout), #221 (contextual heading), #219 (source URL link), #217 (editor metadata), #216 (provider description), #215 (dynamic titles), #189 (dismissed fix), #178 (ADO filtering), #158 (markdown injection), #157 (API trust boundary), #156 (URL sanitization), #155 (URL scheme validation), #154 (crypto.randomUUID), #153 (JSON validation), #152 (path traversal fix), #12 (AI PR actions), bulk rename (WorkCenter→DevDocket)
+#276 (auto-track authored PRs), #282 (provider state in editor), #281 (clickable title), #275 (History→Queue transitions),#273 (tree counts), #265 (auto-complete on close), #250 (group context), #249 (accept-to-focus, pre-shipped), #243 (version resurfacing), #240 (create from URL), #233 (provider health), #232 (clear history), #231 (sources icons), #230 (layout toggle), #229 (emoji removal), #227 (provider labels), #223 (dead code cleanup), #222 (responsive layout), #221 (contextual heading), #219 (source URL link), #217 (editor metadata), #216 (provider description), #215 (dynamic titles), #189 (dismissed fix), #178 (ADO filtering), #158 (markdown injection), #157 (API trust boundary), #156 (URL sanitization), #155 (URL scheme validation), #154 (crypto.randomUUID), #153 (JSON validation), #152 (path traversal fix), #12 (AI PR actions), bulk rename (WorkCenter→DevDocket)
 
 > Full issue-level learnings archived to `history-archive.md`
 
 ## Learnings
+
+### 2026-04-19 — Issue #276 (Auto-Track Authored PRs)
+
+**PR:** Added a new `GitHubMyPrsProvider` that discovers open PRs authored by the current user and shows their review/CI status.
+- **New provider pattern:** Follows `BaseGitHubProvider` extension pattern like the existing issue and PR review providers. Registered as third provider in `extension.ts`. Uses the same `devdocketGithub.repos` config for repo filtering.
+- **Status determination:** Static `determinePrStatus()` method computes status from PR detail + reviews. Priority: Draft > Changes requested > Ready to merge (approved + clean) > Approved (approved but not clean) > Review received (comments only) > Waiting on reviews.
+- **Review decision logic:** Tracks latest review per reviewer by `user.id`. Only `APPROVED` and `CHANGES_REQUESTED` count as decisions; `COMMENTED`, `PENDING`, `DISMISSED` are informational. Uses `submitted_at` timestamp comparison for ordering.
+- **Mergeable state as CI proxy:** Uses `mergeable_state === 'clean'` from the PR detail API to determine "Ready to merge" status. This combines CI status and branch protection checks without requiring separate `/commits/{sha}/status` and `/check-runs` API calls — reduces per-PR API calls from 4 to 2.
+- **Concurrent enrichment:** Fetches PR details and reviews in parallel per-PR with 3 concurrent workers (same pattern as PR review provider's head SHA fetching). Best-effort: failures fall back to generic "Open" status.
+- **Test mock pattern:** Concurrent worker tests need URL-based mock routing (`mockImplementation` with URL matching) instead of sequential `mockResolvedValueOnce`, since worker execution order is non-deterministic.
+- **No version-based resurfacing:** Status changes don't trigger resurfacing — status is informational via `DiscoveredItem.state`. Users track open PRs at a glance; merged PRs disappear and auto-complete (#265) handles the work item transition.
+- **Files changed:** `packages/github/src/githubMyPrsProvider.ts` (new), `packages/github/src/extension.ts`, `packages/github/package.json`, `packages/github/src/test/githubMyPrsProvider.test.ts` (new, 24 tests).
 
 ### 2026-04-18 — Issue #264 (Cleanup Branch/Worktree on Complete)
 

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,7 +1,7 @@
 {
   "name": "devdocket-github",
   "displayName": "DevDocket GitHub",
-  "description": "GitHub provider for DevDocket — discovers assigned issues and PR reviews.",
+  "description": "GitHub provider for DevDocket — discovers assigned issues, PR reviews, and authored PRs with status tracking.",
   "version": "0.1.0",
   "publisher": "mthalman",
   "license": "MIT",

--- a/packages/github/src/extension.ts
+++ b/packages/github/src/extension.ts
@@ -1,13 +1,16 @@
 import * as vscode from 'vscode';
 import { GitHubIssueProvider } from './githubProvider';
 import { GitHubPrReviewProvider } from './githubPrReviewProvider';
+import { GitHubMyPrsProvider } from './githubMyPrsProvider';
 import { validateRefreshInterval } from '@devdocket/shared';
 import { initLogger, setLogLevel, logger, resolveLogLevel } from './logger';
 
 let issueProvider: GitHubIssueProvider | undefined;
 let prReviewProvider: GitHubPrReviewProvider | undefined;
+let myPrsProvider: GitHubMyPrsProvider | undefined;
 let providerRegistration: vscode.Disposable | undefined;
 let prReviewRegistration: vscode.Disposable | undefined;
+let myPrsRegistration: vscode.Disposable | undefined;
 
 export async function activate(_context: vscode.ExtensionContext): Promise<void> {
   const outputChannel = vscode.window.createOutputChannel('DevDocket GitHub');
@@ -72,14 +75,21 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
   prReviewProvider.startPeriodicRefresh(intervalSeconds);
   prReviewRegistration = api.registerProvider(prReviewProvider);
 
-  logger.info('DevDocket GitHub activated, registered 2 providers');
+  // Register the My PRs provider (authored PRs with status tracking)
+  myPrsProvider = new GitHubMyPrsProvider();
+  myPrsProvider.startPeriodicRefresh(intervalSeconds);
+  myPrsRegistration = api.registerProvider(myPrsProvider);
+
+  logger.info('DevDocket GitHub activated, registered 3 providers');
 }
 
 export function deactivate(): void {
   logger.info('DevDocket GitHub deactivating...');
   providerRegistration?.dispose();
   prReviewRegistration?.dispose();
+  myPrsRegistration?.dispose();
   issueProvider?.dispose();
   prReviewProvider?.dispose();
+  myPrsProvider?.dispose();
   logger.info('DevDocket GitHub deactivated');
 }

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -54,6 +54,7 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
         description: pr.body?.slice(0, 200),
         url: pr.html_url,
         group: repoName,
+        reason: 'authored',
         state: status,
       };
     });

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -66,7 +66,7 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
         ? `Failed to fetch authored PRs from ${failures[0]}`
         : `Failed to fetch authored PRs from ${failures.length} repositories`;
       if (isUserTriggered) {
-        vscode.window.showWarningMessage(`DevDocket GitHub: ${message}`);
+        void vscode.window.showWarningMessage(`DevDocket GitHub: ${message}`);
       } else {
         logger.warn(message);
       }

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -1,0 +1,298 @@
+import * as vscode from 'vscode';
+import { logger } from './logger';
+import { parseRepoFromUrls } from './parseRepo';
+import { BaseGitHubProvider, DiscoveredItem, GitHubIssue } from './baseGithubProvider';
+
+interface GitHubSearchResponse {
+  items: GitHubIssue[];
+}
+
+export interface PrDetail {
+  draft?: boolean;
+  head?: { sha?: string };
+  mergeable_state?: string;
+}
+
+export interface PrReview {
+  user?: { id?: number; login?: string };
+  state?: string;
+  submitted_at?: string;
+}
+
+/**
+ * DevDocket provider that discovers GitHub pull requests authored by the
+ * current user and surfaces their review/CI status.
+ *
+ * Uses the GitHub Search API (`author:@me`) to find open PRs, then enriches
+ * each with review decisions and mergeable state via the PR detail and
+ * reviews REST endpoints.
+ *
+ * Status values: Draft, Waiting on reviews, Review received,
+ * Changes requested, Approved, Ready to merge.
+ */
+export class GitHubMyPrsProvider extends BaseGitHubProvider {
+  readonly id = 'github-my-prs';
+  readonly label = 'My GitHub PRs';
+
+  protected async fetchAndPublish(accessToken: string, isUserTriggered: boolean): Promise<void> {
+    logger.info('Fetching authored PRs...');
+    const repos = this.getConfiguredRepos();
+    const { prs, failures } = await this.fetchAuthoredPrs(accessToken, repos);
+
+    logger.info(`Discovered ${prs.length} authored PRs`);
+
+    const statusMap = prs.length > 0
+      ? await this.fetchPrStatuses(accessToken, prs)
+      : new Map<string, string>();
+
+    const items: DiscoveredItem[] = prs.map((pr) => {
+      const repoName = this.parseRepo(pr);
+      const status = statusMap.get(pr.html_url) ?? 'Open';
+      return {
+        externalId: `${repoName}#${pr.number}`,
+        title: `#${pr.number}: ${pr.title}`,
+        description: pr.body?.slice(0, 200),
+        url: pr.html_url,
+        group: repoName,
+        state: status,
+      };
+    });
+
+    this._onDidDiscoverItems.fire(items);
+
+    if (failures.length > 0) {
+      const message = failures.length === 1
+        ? `Failed to fetch authored PRs from ${failures[0]}`
+        : `Failed to fetch authored PRs from ${failures.length} repositories`;
+      if (isUserTriggered) {
+        vscode.window.showWarningMessage(`DevDocket GitHub: ${message}`);
+      } else {
+        logger.warn(message);
+      }
+    }
+  }
+
+  private getConfiguredRepos(): string[] {
+    const config = vscode.workspace.getConfiguration('devdocketGithub');
+    return config.get<string[]>('repos', []);
+  }
+
+  private async fetchAuthoredPrs(
+    token: string,
+    repos: string[],
+  ): Promise<{ prs: GitHubIssue[]; failures: string[] }> {
+    if (repos.length > 0) {
+      return this.fetchPerRepoPrs(token, repos);
+    }
+    return this.fetchAllAuthoredPrs(token);
+  }
+
+  private async fetchPerRepoPrs(
+    token: string,
+    repos: string[],
+  ): Promise<{ prs: GitHubIssue[]; failures: string[] }> {
+    const results: PromiseSettledResult<{ prs: GitHubIssue[]; failed: boolean }>[] = new Array(repos.length);
+    let nextIndex = 0;
+
+    const runWorker = async (): Promise<void> => {
+      while (nextIndex < repos.length) {
+        const currentIndex = nextIndex++;
+        try {
+          const value = await this.fetchRepoPrs(token, repos[currentIndex]);
+          results[currentIndex] = { status: 'fulfilled', value };
+        } catch (reason) {
+          results[currentIndex] = { status: 'rejected', reason: reason as Error };
+        }
+      }
+    };
+
+    const workerCount = Math.min(3, repos.length);
+    await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+
+    const allPrs: GitHubIssue[] = [];
+    const failures: string[] = [];
+
+    results.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        allPrs.push(...result.value.prs);
+        if (result.value.failed) {
+          failures.push(repos[index]);
+        }
+      } else {
+        failures.push(repos[index]);
+      }
+    });
+
+    return { prs: allPrs, failures };
+  }
+
+  private async fetchRepoPrs(token: string, repo: string): Promise<{ prs: GitHubIssue[]; failed: boolean }> {
+    logger.debug(`Fetching authored PRs for repo: ${repo}`);
+    const response = await fetch(
+      `https://api.github.com/search/issues?q=type:pr+state:open+author:@me+repo:${repo}&per_page=100`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    );
+
+    if (!response.ok) {
+      logger.error(`Failed to fetch authored PRs for ${repo}: ${response.status}`);
+      return { prs: [], failed: true };
+    }
+
+    const data = (await response.json()) as GitHubSearchResponse;
+    return { prs: data.items, failed: false };
+  }
+
+  private async fetchAllAuthoredPrs(token: string): Promise<{ prs: GitHubIssue[]; failures: string[] }> {
+    const response = await fetch(
+      'https://api.github.com/search/issues?q=type:pr+state:open+author:@me&per_page=100',
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      },
+    );
+
+    if (!response.ok) {
+      logger.error(`Failed to fetch authored PRs: ${response.status}`);
+      return { prs: [], failures: ['all repositories'] };
+    }
+
+    const data = (await response.json()) as GitHubSearchResponse;
+    return { prs: data.items, failures: [] };
+  }
+
+  /**
+   * Fetches PR details and reviews for each PR to determine its status.
+   * Uses concurrent workers to limit API call rate.
+   */
+  private async fetchPrStatuses(token: string, prs: GitHubIssue[]): Promise<Map<string, string>> {
+    const result = new Map<string, string>();
+    const prsWithApiUrl = prs.filter(pr => pr.pull_request?.url);
+    if (prsWithApiUrl.length === 0) {
+      return result;
+    }
+
+    let nextIndex = 0;
+    const runWorker = async (): Promise<void> => {
+      while (nextIndex < prsWithApiUrl.length) {
+        const currentIndex = nextIndex++;
+        const pr = prsWithApiUrl[currentIndex];
+        try {
+          const status = await this.fetchSinglePrStatus(token, pr);
+          if (status) {
+            result.set(pr.html_url, status);
+          }
+        } catch (error) {
+          logger.debug(`Failed to fetch status for PR ${pr.html_url}: ${String(error)}`);
+        }
+      }
+    };
+
+    const workerCount = Math.min(3, prsWithApiUrl.length);
+    await Promise.all(Array.from({ length: workerCount }, () => runWorker()));
+
+    return result;
+  }
+
+  private async fetchSinglePrStatus(token: string, pr: GitHubIssue): Promise<string | undefined> {
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    };
+
+    // Fetch PR details (draft, mergeable state)
+    const detailResponse = await fetch(pr.pull_request!.url, { headers });
+    if (!detailResponse.ok) {
+      logger.debug(`Failed to fetch PR detail for ${pr.html_url}: ${detailResponse.status}`);
+      return undefined;
+    }
+    const detail = (await detailResponse.json()) as PrDetail;
+
+    // Fetch reviews
+    const reviewsUrl = `${pr.pull_request!.url}/reviews`;
+    const reviewsResponse = await fetch(reviewsUrl, { headers });
+    let reviews: PrReview[] = [];
+    if (reviewsResponse.ok) {
+      reviews = (await reviewsResponse.json()) as PrReview[];
+    } else {
+      logger.debug(`Failed to fetch reviews for ${pr.html_url}: ${reviewsResponse.status}`);
+    }
+
+    return GitHubMyPrsProvider.determinePrStatus(detail, reviews);
+  }
+
+  /**
+   * Determines the PR status based on PR detail and review information.
+   *
+   * Priority:
+   * 1. Draft → "Draft"
+   * 2. Any latest-per-reviewer CHANGES_REQUESTED → "Changes requested"
+   * 3. Any APPROVED + mergeable_state clean → "Ready to merge"
+   * 4. Any APPROVED → "Approved"
+   * 5. Any non-PENDING reviews → "Review received"
+   * 6. No reviews → "Waiting on reviews"
+   */
+  static determinePrStatus(detail: PrDetail, reviews: PrReview[]): string {
+    if (detail.draft) {
+      return 'Draft';
+    }
+
+    // Build a map of latest review decision per reviewer (by user ID).
+    // Only APPROVED and CHANGES_REQUESTED count as decisions;
+    // COMMENTED, PENDING, and DISMISSED are informational only.
+    const latestByReviewer = new Map<number, PrReview>();
+    for (const review of reviews) {
+      const userId = review.user?.id;
+      if (userId === undefined || !review.state) {
+        continue;
+      }
+      if (review.state !== 'APPROVED' && review.state !== 'CHANGES_REQUESTED') {
+        continue;
+      }
+
+      const existing = latestByReviewer.get(userId);
+      if (
+        !existing ||
+        (review.submitted_at && existing.submitted_at && review.submitted_at > existing.submitted_at)
+      ) {
+        latestByReviewer.set(userId, review);
+      }
+    }
+
+    const decisions = [...latestByReviewer.values()];
+    const hasChangesRequested = decisions.some(r => r.state === 'CHANGES_REQUESTED');
+    const hasApproval = decisions.some(r => r.state === 'APPROVED');
+
+    if (hasChangesRequested) {
+      return 'Changes requested';
+    }
+
+    if (hasApproval) {
+      if (detail.mergeable_state === 'clean') {
+        return 'Ready to merge';
+      }
+      return 'Approved';
+    }
+
+    // Check for any non-PENDING review activity (comments, dismissed, etc.)
+    const hasAnyReviews = reviews.some(r => r.state && r.state !== 'PENDING');
+    if (hasAnyReviews) {
+      return 'Review received';
+    }
+
+    return 'Waiting on reviews';
+  }
+
+  protected override parseRepo(issue: GitHubIssue): string {
+    return parseRepoFromUrls(issue.html_url, issue.repository_url);
+  }
+}

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -27,7 +27,8 @@ export interface PrReview {
  * each with review decisions and mergeable state via the PR detail and
  * reviews REST endpoints.
  *
- * Status values: Draft, Waiting on reviews, Review received,
+ * Status values: Open (fallback when detailed PR/review status cannot be
+ * determined), Draft, Waiting on reviews, Review received,
  * Changes requested, Approved, Ready to merge.
  */
 export class GitHubMyPrsProvider extends BaseGitHubProvider {

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -248,28 +248,29 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
     }
 
     // Build a map of latest review decision per reviewer (by user ID).
-    // Only APPROVED and CHANGES_REQUESTED count as decisions;
-    // COMMENTED, PENDING, and DISMISSED are informational only.
+    // APPROVED, CHANGES_REQUESTED, and DISMISSED are tracked;
+    // COMMENTED and PENDING are informational only.
+    // A DISMISSED review neutralizes the reviewer's previous decision.
     const latestByReviewer = new Map<number, PrReview>();
     for (const review of reviews) {
       const userId = review.user?.id;
       if (userId === undefined || !review.state) {
         continue;
       }
-      if (review.state !== 'APPROVED' && review.state !== 'CHANGES_REQUESTED') {
+      if (review.state !== 'APPROVED' && review.state !== 'CHANGES_REQUESTED' && review.state !== 'DISMISSED') {
         continue;
       }
 
       const existing = latestByReviewer.get(userId);
-      if (
-        !existing ||
-        (review.submitted_at && existing.submitted_at && review.submitted_at > existing.submitted_at)
-      ) {
+      const reviewSubmittedAt = review.submitted_at ?? '';
+      const existingSubmittedAt = existing?.submitted_at ?? '';
+      if (!existing || reviewSubmittedAt > existingSubmittedAt) {
         latestByReviewer.set(userId, review);
       }
     }
 
-    const decisions = [...latestByReviewer.values()];
+    // Filter out reviewers whose latest decision is DISMISSED (clears prior decision)
+    const decisions = [...latestByReviewer.values()].filter(r => r.state !== 'DISMISSED');
     const hasChangesRequested = decisions.some(r => r.state === 'CHANGES_REQUESTED');
     const hasApproval = decisions.some(r => r.state === 'APPROVED');
 

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -218,15 +218,15 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
     }
     const detail = (await detailResponse.json()) as PrDetail;
 
-    // Fetch reviews
+    // Fetch reviews — treat failure as unknown status since we can't determine
+    // the actual review state without this data
     const reviewsUrl = `${pr.pull_request!.url}/reviews`;
     const reviewsResponse = await fetch(reviewsUrl, { headers });
-    let reviews: PrReview[] = [];
-    if (reviewsResponse.ok) {
-      reviews = (await reviewsResponse.json()) as PrReview[];
-    } else {
+    if (!reviewsResponse.ok) {
       logger.debug(`Failed to fetch reviews for ${pr.html_url}: ${reviewsResponse.status}`);
+      return undefined;
     }
+    const reviews = (await reviewsResponse.json()) as PrReview[];
 
     return GitHubMyPrsProvider.determinePrStatus(detail, reviews);
   }

--- a/packages/github/src/test/githubMyPrsProvider.test.ts
+++ b/packages/github/src/test/githubMyPrsProvider.test.ts
@@ -352,7 +352,7 @@ describe('GitHubMyPrsProvider.determinePrStatus', () => {
     expect(status).toBe('Changes requested');
   });
 
-  it('ignores DISMISSED reviews', () => {
+  it('treats DISMISSED as neutralizing prior decision', () => {
     const status = GitHubMyPrsProvider.determinePrStatus(
       { draft: false },
       [
@@ -360,9 +360,8 @@ describe('GitHubMyPrsProvider.determinePrStatus', () => {
         { user: { id: 1 }, state: 'DISMISSED', submitted_at: '2025-01-02T00:00:00Z' },
       ],
     );
-    // DISMISSED doesn't override — the previous CHANGES_REQUESTED still stands
-    // but since DISMISSED is filtered out, the CHANGES_REQUESTED is the latest decision
-    expect(status).toBe('Changes requested');
+    // DISMISSED clears the reviewer's prior decision but review activity still exists
+    expect(status).toBe('Review received');
   });
 
   it('returns Review received when only DISMISSED reviews exist', () => {
@@ -389,5 +388,17 @@ describe('GitHubMyPrsProvider.determinePrStatus', () => {
       [{ user: { id: 1 }, state: 'APPROVED', submitted_at: '2025-01-01T00:00:00Z' }],
     );
     expect(status).toBe('Draft');
+  });
+
+  it('handles reviews with missing submitted_at', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: false, mergeable_state: 'clean' },
+      [
+        { user: { id: 1 }, state: 'CHANGES_REQUESTED' },
+        { user: { id: 1 }, state: 'APPROVED', submitted_at: '2025-01-02T00:00:00Z' },
+      ],
+    );
+    // The APPROVED review with a timestamp should override the earlier one without
+    expect(status).toBe('Ready to merge');
   });
 });

--- a/packages/github/src/test/githubMyPrsProvider.test.ts
+++ b/packages/github/src/test/githubMyPrsProvider.test.ts
@@ -47,7 +47,7 @@ describe('GitHubMyPrsProvider', () => {
   let mockChannel: { appendLine: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     vi.stubGlobal('fetch', mockFetch);
     provider = new GitHubMyPrsProvider();
 

--- a/packages/github/src/test/githubMyPrsProvider.test.ts
+++ b/packages/github/src/test/githubMyPrsProvider.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { authentication, workspace } from 'vscode';
+import { GitHubMyPrsProvider, type PrDetail, type PrReview } from '../githubMyPrsProvider';
+import { initLogger, LogLevel } from '../logger';
+
+const mockFetch = vi.fn();
+
+function createMockPr(number: number, title: string, repo = 'owner/repo') {
+  return {
+    number,
+    title,
+    body: `Body for PR ${number}`,
+    state: 'open',
+    html_url: `https://github.com/${repo}/pull/${number}`,
+    repository_url: `https://api.github.com/repos/${repo}`,
+    pull_request: { url: `https://api.github.com/repos/${repo}/pulls/${number}` },
+  };
+}
+
+function mockSearchResponse(items: ReturnType<typeof createMockPr>[]) {
+  return {
+    ok: true,
+    json: async () => ({ items }),
+  };
+}
+
+function mockPrDetailResponse(detail: PrDetail) {
+  return {
+    ok: true,
+    json: async () => detail,
+  };
+}
+
+function mockReviewsResponse(reviews: PrReview[]) {
+  return {
+    ok: true,
+    json: async () => reviews,
+  };
+}
+
+function mockFailedResponse(status = 500) {
+  return { ok: false, status, statusText: 'Internal Server Error' };
+}
+
+describe('GitHubMyPrsProvider', () => {
+  let provider: GitHubMyPrsProvider;
+  let mockChannel: { appendLine: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+    provider = new GitHubMyPrsProvider();
+
+    mockChannel = { appendLine: vi.fn() };
+    initLogger(mockChannel as any, LogLevel.Debug);
+
+    vi.mocked(workspace.getConfiguration).mockReturnValue({
+      get: vi.fn((_key: string, defaultValue?: any) => defaultValue),
+    } as any);
+
+    vi.mocked(authentication.getSession).mockResolvedValue({
+      accessToken: 'test-token',
+      id: 'session-1',
+      scopes: ['repo'],
+      account: { id: '1', label: 'testuser' },
+    } as any);
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    vi.unstubAllGlobals();
+  });
+
+  it('has id github-my-prs and label My GitHub PRs', () => {
+    expect(provider.id).toBe('github-my-prs');
+    expect(provider.label).toBe('My GitHub PRs');
+  });
+
+  it('does nothing when no auth session exists', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValue(undefined as any);
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('discovers open authored PRs with status', async () => {
+    const pr1 = createMockPr(1, 'Fix bug');
+    const pr2 = createMockPr(2, 'Add feature');
+
+    // Use URL-based routing because concurrent workers consume mocks in unpredictable order
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('search/issues')) {
+        return mockSearchResponse([pr1, pr2]);
+      }
+      if (url.endsWith('/pulls/1')) {
+        return mockPrDetailResponse({ draft: false, mergeable_state: 'blocked' });
+      }
+      if (url.endsWith('/pulls/1/reviews')) {
+        return mockReviewsResponse([]);
+      }
+      if (url.endsWith('/pulls/2')) {
+        return mockPrDetailResponse({ draft: true });
+      }
+      if (url.endsWith('/pulls/2/reviews')) {
+        return mockReviewsResponse([]);
+      }
+      return mockFailedResponse(404);
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const items = listener.mock.calls[0][0];
+    expect(items).toHaveLength(2);
+
+    expect(items[0].externalId).toBe('owner/repo#1');
+    expect(items[0].title).toBe('#1: Fix bug');
+    expect(items[0].state).toBe('Waiting on reviews');
+    expect(items[0].group).toBe('owner/repo');
+
+    expect(items[1].externalId).toBe('owner/repo#2');
+    expect(items[1].state).toBe('Draft');
+  });
+
+  it('uses search API with repos when configured', async () => {
+    vi.mocked(workspace.getConfiguration).mockReturnValue({
+      get: vi.fn((key: string, defaultValue?: any) => {
+        if (key === 'repos') { return ['myorg/myrepo']; }
+        return defaultValue;
+      }),
+    } as any);
+
+    mockFetch.mockResolvedValueOnce(mockSearchResponse([]));
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toContain('repo:myorg/myrepo');
+    expect(url).toContain('author:@me');
+  });
+
+  it('uses global search when no repos configured', async () => {
+    mockFetch.mockResolvedValueOnce(mockSearchResponse([]));
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const url = mockFetch.mock.calls[0][0];
+    expect(url).toContain('author:@me');
+    expect(url).not.toContain('repo:');
+  });
+
+  it('reports failures for individual repos', async () => {
+    vi.mocked(workspace.getConfiguration).mockReturnValue({
+      get: vi.fn((key: string, defaultValue?: any) => {
+        if (key === 'repos') { return ['good/repo', 'bad/repo']; }
+        return defaultValue;
+      }),
+    } as any);
+
+    mockFetch
+      .mockResolvedValueOnce(mockSearchResponse([]))
+      .mockResolvedValueOnce(mockFailedResponse());
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0]).toHaveLength(0);
+  });
+
+  it('falls back to Open status when PR detail fetch fails', async () => {
+    const pr = createMockPr(1, 'My PR');
+
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('search/issues')) {
+        return mockSearchResponse([pr]);
+      }
+      // PR detail fails
+      return mockFailedResponse(404);
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const items = listener.mock.calls[0][0];
+    expect(items[0].state).toBe('Open');
+  });
+
+  it('handles PRs without pull_request.url gracefully', async () => {
+    const pr = {
+      number: 1,
+      title: 'No API URL',
+      body: 'test',
+      state: 'open',
+      html_url: 'https://github.com/owner/repo/pull/1',
+      repository_url: 'https://api.github.com/repos/owner/repo',
+      // No pull_request field
+    };
+
+    mockFetch.mockResolvedValueOnce(mockSearchResponse([pr as any]));
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const items = listener.mock.calls[0][0];
+    expect(items[0].state).toBe('Open');
+  });
+
+  it('truncates description to 200 chars', async () => {
+    const pr = createMockPr(1, 'Long PR');
+    pr.body = 'a'.repeat(500);
+
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('search/issues')) {
+        return mockSearchResponse([pr]);
+      }
+      if (url.endsWith('/pulls/1')) {
+        return mockPrDetailResponse({ draft: false });
+      }
+      if (url.endsWith('/pulls/1/reviews')) {
+        return mockReviewsResponse([]);
+      }
+      return mockFailedResponse(404);
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items[0].description).toHaveLength(200);
+  });
+
+  it('reports all-repos failure for global search', async () => {
+    mockFetch.mockResolvedValueOnce(mockFailedResponse());
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    // Should still fire with empty items
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0]).toHaveLength(0);
+  });
+});
+
+describe('GitHubMyPrsProvider.determinePrStatus', () => {
+  it('returns Draft for draft PRs', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: true },
+      [],
+    );
+    expect(status).toBe('Draft');
+  });
+
+  it('returns Waiting on reviews when no reviews exist', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: false },
+      [],
+    );
+    expect(status).toBe('Waiting on reviews');
+  });
+
+  it('returns Waiting on reviews when only PENDING reviews exist', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: false },
+      [{ user: { id: 1 }, state: 'PENDING', submitted_at: '2025-01-01T00:00:00Z' }],
+    );
+    expect(status).toBe('Waiting on reviews');
+  });
+
+  it('returns Review received for COMMENTED-only reviews', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: false },
+      [{ user: { id: 1 }, state: 'COMMENTED', submitted_at: '2025-01-01T00:00:00Z' }],
+    );
+    expect(status).toBe('Review received');
+  });
+
+  it('returns Changes requested when latest review is CHANGES_REQUESTED', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: false },
+      [
+        { user: { id: 1 }, state: 'APPROVED', submitted_at: '2025-01-01T00:00:00Z' },
+        { user: { id: 1 }, state: 'CHANGES_REQUESTED', submitted_at: '2025-01-02T00:00:00Z' },
+      ],
+    );
+    expect(status).toBe('Changes requested');
+  });
+
+  it('returns Approved when approved but mergeable_state is not clean', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: false, mergeable_state: 'blocked' },
+      [{ user: { id: 1 }, state: 'APPROVED', submitted_at: '2025-01-01T00:00:00Z' }],
+    );
+    expect(status).toBe('Approved');
+  });
+
+  it('returns Approved when mergeable_state is undefined', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: false },
+      [{ user: { id: 1 }, state: 'APPROVED', submitted_at: '2025-01-01T00:00:00Z' }],
+    );
+    expect(status).toBe('Approved');
+  });
+
+  it('returns Ready to merge when approved and mergeable_state is clean', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: false, mergeable_state: 'clean' },
+      [{ user: { id: 1 }, state: 'APPROVED', submitted_at: '2025-01-01T00:00:00Z' }],
+    );
+    expect(status).toBe('Ready to merge');
+  });
+
+  it('uses latest review per reviewer by submitted_at', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: false, mergeable_state: 'clean' },
+      [
+        { user: { id: 1 }, state: 'CHANGES_REQUESTED', submitted_at: '2025-01-01T00:00:00Z' },
+        { user: { id: 1 }, state: 'APPROVED', submitted_at: '2025-01-02T00:00:00Z' },
+      ],
+    );
+    expect(status).toBe('Ready to merge');
+  });
+
+  it('handles multiple reviewers independently', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: false, mergeable_state: 'clean' },
+      [
+        { user: { id: 1 }, state: 'APPROVED', submitted_at: '2025-01-01T00:00:00Z' },
+        { user: { id: 2 }, state: 'CHANGES_REQUESTED', submitted_at: '2025-01-01T00:00:00Z' },
+      ],
+    );
+    // Changes requested takes priority over approved
+    expect(status).toBe('Changes requested');
+  });
+
+  it('ignores DISMISSED reviews', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: false },
+      [
+        { user: { id: 1 }, state: 'CHANGES_REQUESTED', submitted_at: '2025-01-01T00:00:00Z' },
+        { user: { id: 1 }, state: 'DISMISSED', submitted_at: '2025-01-02T00:00:00Z' },
+      ],
+    );
+    // DISMISSED doesn't override — the previous CHANGES_REQUESTED still stands
+    // but since DISMISSED is filtered out, the CHANGES_REQUESTED is the latest decision
+    expect(status).toBe('Changes requested');
+  });
+
+  it('returns Review received when only DISMISSED reviews exist', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: false },
+      [{ user: { id: 1 }, state: 'DISMISSED', submitted_at: '2025-01-01T00:00:00Z' }],
+    );
+    // DISMISSED is non-PENDING so counts as "review activity" but not a decision
+    expect(status).toBe('Review received');
+  });
+
+  it('skips reviews without user ID', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: false },
+      [{ state: 'APPROVED', submitted_at: '2025-01-01T00:00:00Z' }],
+    );
+    // No user ID, so review is skipped for decision tracking but counts as activity
+    expect(status).toBe('Review received');
+  });
+
+  it('draft takes priority over reviews', () => {
+    const status = GitHubMyPrsProvider.determinePrStatus(
+      { draft: true, mergeable_state: 'clean' },
+      [{ user: { id: 1 }, state: 'APPROVED', submitted_at: '2025-01-01T00:00:00Z' }],
+    );
+    expect(status).toBe('Draft');
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new **My GitHub PRs** provider that automatically discovers open pull requests authored by the current user and surfaces their review/CI status within DevDocket.

### Status values

- **Draft** — PR is in draft mode
- **Waiting on reviews** — No reviews received yet
- **Review received** — Reviewers have commented (but no approval/rejection decisions)
- **Changes requested** — At least one reviewer's latest decision is "changes requested"
- **Approved** — All review decisions are approvals, but CI/branch protection isn't green yet
- **Ready to merge** — Approved and `mergeable_state` is clean (CI green, no conflicts)

### How it works

1. Uses the GitHub Search API (`type:pr author:@me state:open`) to discover the user's open PRs
2. For each PR, fetches details and reviews via the REST API using concurrent workers (max 3)
3. Computes status from the latest review decision per reviewer and the PR's `mergeable_state`
4. Emits discovered items with status shown via `DiscoveredItem.state`

The provider reuses the existing `devdocketGithub.repos` configuration — when repos are specified, only those repos are searched; otherwise all repos are included.

### Testing

24 new tests covering:
- Provider discovery flow (auth, search, enrichment)
- All 6 status determination paths via pure `determinePrStatus()` unit tests
- Edge cases: draft priority, multiple reviewers, dismissed reviews, missing user IDs, concurrent worker mock ordering

Closes #276
