### PR TITLE
Group Focus view items by provider in tree mode

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -224,7 +224,7 @@ DevDocket is a VS Code extension monorepo for managing work items from multiple 
 
 ### 2026-04-18 — Issue #319 (Focus View Provider Grouping)
 
-**PR #XXX:** Focus view now groups items by provider in tree mode, matching Sources view pattern.
+**PR #320:** Focus view now groups items by provider in tree mode, matching Sources view pattern.
 - **Removed custom grouping logic:** Focus view had custom `getChildren()` and `getParent()` implementations that grouped by `item.group` (repo name). Removed these overrides to use the base class `WorkItemViewProvider` pattern which groups by provider.
 - **WorkItemViewProvider base class:** The base class already implements provider grouping via `getTreeModeChildren()` helper in `viewLayout.ts`. It creates a two-level hierarchy: provider → sub-group (item.group) → items. This is consistent with Queue, History, and Sources views.
 - **Tree hierarchy:** In tree mode, items are now grouped: Provider (GitHub, ADO, etc.) → Sub-group (repo name) → Work Items. Manual items appear under "Other" provider group. In flat mode, unchanged.

--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -221,3 +221,12 @@ DevDocket is a VS Code extension monorepo for managing work items from multiple 
 - **Managed state tracking:** Copilot review caught that `onDidChangeDiscoveredItems` also fires when providers register/unregister, which changes the managed (readonly) state. Added `lastManagedState` tracking — when it flips, a full `update()` re-render runs instead of a targeted title-only update.
 - **`displayTitle` on `EditorHtmlOptions`:** Added optional `displayTitle` property; heading and title input use it (falling back to `item.title`). This is an internal interface, not public API — no breaking change.
 - **Files changed:** `packages/core/src/views/editorPanelHtml.ts`, `packages/core/src/views/workItemEditorPanel.ts`, plus test files.
+
+### 2026-04-18 — Issue #319 (Focus View Provider Grouping)
+
+**PR #XXX:** Focus view now groups items by provider in tree mode, matching Sources view pattern.
+- **Removed custom grouping logic:** Focus view had custom `getChildren()` and `getParent()` implementations that grouped by `item.group` (repo name). Removed these overrides to use the base class `WorkItemViewProvider` pattern which groups by provider.
+- **WorkItemViewProvider base class:** The base class already implements provider grouping via `getTreeModeChildren()` helper in `viewLayout.ts`. It creates a two-level hierarchy: provider → sub-group (item.group) → items. This is consistent with Queue, History, and Sources views.
+- **Tree hierarchy:** In tree mode, items are now grouped: Provider (GitHub, ADO, etc.) → Sub-group (repo name) → Work Items. Manual items appear under "Other" provider group. In flat mode, unchanged.
+- **No breaking changes:** The public API surface is unchanged — only internal tree provider implementation.
+- **Files changed:** `packages/core/src/views/focusTreeProvider.ts` (removed ~60 lines of custom grouping logic).

--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -225,7 +225,6 @@ DevDocket is a VS Code extension monorepo for managing work items from multiple 
 ### 2026-04-18 — Issue #319 (Focus View Provider Grouping)
 
 **PR #320:** Focus view now groups items by provider in tree mode, matching Sources view pattern.
-**PR #XXX:** Focus view now groups items by provider in tree mode, matching Sources view pattern.
 - **Removed custom grouping logic:** Focus view had custom `getChildren()` and `getParent()` implementations that grouped by `item.group` (repo name). Removed these overrides to use the base class `WorkItemViewProvider` pattern which groups by provider.
 - **WorkItemViewProvider base class:** The base class already implements provider grouping via `getTreeModeChildren()` helper in `viewLayout.ts`. It creates a two-level hierarchy: provider → sub-group (item.group) → items. This is consistent with Queue, History, and Sources views.
 - **Tree hierarchy:** In tree mode, items are now grouped: Provider (GitHub, ADO, etc.) → Sub-group (repo name) → Work Items. Manual items appear under "Other" provider group. In flat mode, unchanged.

--- a/packages/core/src/test/focusTreeProviderLayout.test.ts
+++ b/packages/core/src/test/focusTreeProviderLayout.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventEmitter, TreeItemCollapsibleState } from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { FocusTreeProvider } from '../views/focusTreeProvider';
-import { isSubGroupNode, SubGroupNode } from '../views/viewLayout';
+import { isSubGroupNode, SubGroupNode, isProviderGroupNode, ProviderGroupNode } from '../views/viewLayout';
 
 function createMockWorkGraph() {
   const emitter = new EventEmitter<void>();
@@ -56,7 +56,7 @@ describe('FocusTreeProvider layout toggle', () => {
       provider.layout = 'tree';
     });
 
-    it('returns group nodes by item.group at top level', () => {
+    it('returns provider group nodes at top level', () => {
       const items = [
         makeItem({ id: '1', title: 'A', providerId: 'github', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
         makeItem({ id: '2', title: 'B', providerId: 'jira', state: WorkItemState.Paused, group: 'myorg/api' }),
@@ -64,83 +64,90 @@ describe('FocusTreeProvider layout toggle', () => {
       workGraph.getItemsByState.mockReturnValue(items);
       const children = provider.getChildren();
       expect(children).toHaveLength(2);
-      expect(children.every(c => isSubGroupNode(c))).toBe(true);
-      const labels = children.map(c => (c as SubGroupNode).label);
-      expect(labels).toContain('contoso/webapp');
-      expect(labels).toContain('myorg/api');
+      expect(children.every(c => isProviderGroupNode(c))).toBe(true);
+      const labels = children.map(c => (c as ProviderGroupNode).label);
+      expect(labels).toContain('GitHub');
+      expect(labels).toContain('Jira');
     });
 
-    it('shows ungrouped items directly at root alongside group nodes', () => {
+    it('groups items without providerId under "Other" provider node', () => {
       const items = [
         makeItem({ id: '1', title: 'Ungrouped', state: WorkItemState.InProgress }),
-        makeItem({ id: '2', title: 'Grouped', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
+        makeItem({ id: '2', title: 'Grouped', providerId: 'github', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
       ];
       workGraph.getItemsByState.mockReturnValue(items);
       const children = provider.getChildren();
       expect(children).toHaveLength(2);
-      const groups = children.filter(c => isSubGroupNode(c)) as SubGroupNode[];
-      const directItems = children.filter(c => !isSubGroupNode(c)) as WorkItem[];
-      expect(groups).toHaveLength(1);
-      expect(groups[0].groupName).toBe('contoso/webapp');
-      expect(directItems).toHaveLength(1);
-      expect(directItems[0].title).toBe('Ungrouped');
+      const providerGroups = children.filter(c => isProviderGroupNode(c)) as ProviderGroupNode[];
+      expect(providerGroups).toHaveLength(2);
+      const otherGroup = providerGroups.find(g => g.label === 'Other');
+      const githubGroup = providerGroups.find(g => g.label === 'GitHub');
+      expect(otherGroup).toBeDefined();
+      expect(githubGroup).toBeDefined();
     });
 
-    it('returns items for a group node', () => {
+    it('returns sub-groups and items for a provider node', () => {
       const items = [
         makeItem({ id: '1', title: 'A', providerId: 'github', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
         makeItem({ id: '2', title: 'B', providerId: 'github', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
         makeItem({ id: '3', title: 'C', providerId: 'github', state: WorkItemState.Paused, group: 'myorg/api' }),
       ];
       workGraph.getItemsByState.mockReturnValue(items);
-      const group: SubGroupNode = { kind: 'subGroup', label: 'contoso/webapp', providerId: undefined, groupName: 'contoso/webapp' };
-      const children = provider.getChildren(group);
+      const providerNode: ProviderGroupNode = { kind: 'providerGroup', label: 'GitHub', providerId: 'github' };
+      const children = provider.getChildren(providerNode);
       expect(children).toHaveLength(2);
+      expect(children.every(c => isSubGroupNode(c))).toBe(true);
+      const labels = children.map(c => (c as SubGroupNode).label);
+      expect(labels).toContain('contoso/webapp');
+      expect(labels).toContain('myorg/api');
     });
 
-    it('renders group node with folder icon', () => {
-      const group: SubGroupNode = { kind: 'subGroup', label: 'contoso/webapp', providerId: undefined, groupName: 'contoso/webapp' };
+    it('renders sub-group node with folder icon', () => {
+      const group: SubGroupNode = { kind: 'subGroup', label: 'contoso/webapp', providerId: 'github', groupName: 'contoso/webapp' };
       const treeItem = provider.getTreeItem(group);
       expect(treeItem.label).toBe('contoso/webapp');
       expect(treeItem.collapsibleState).toBe(TreeItemCollapsibleState.Collapsed);
       expect((treeItem.iconPath as any).id).toBe('folder');
     });
 
-    it('shows item count in group description', () => {
+    it('shows item count in sub-group description', () => {
       const items = [
-        makeItem({ id: '1', title: 'A', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
-        makeItem({ id: '2', title: 'B', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
-        makeItem({ id: '3', title: 'C', state: WorkItemState.InProgress, group: 'fabrikam/api' }),
+        makeItem({ id: '1', title: 'A', providerId: 'github', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
+        makeItem({ id: '2', title: 'B', providerId: 'github', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
+        makeItem({ id: '3', title: 'C', providerId: 'github', state: WorkItemState.InProgress, group: 'fabrikam/api' }),
       ];
       workGraph.getItemsByState.mockReturnValue(items);
 
-      const group: SubGroupNode = { kind: 'subGroup', label: 'contoso/webapp', providerId: undefined, groupName: 'contoso/webapp' };
+      const group: SubGroupNode = { kind: 'subGroup', label: 'contoso/webapp', providerId: 'github', groupName: 'contoso/webapp' };
       const treeItem = provider.getTreeItem(group);
       expect(treeItem.description).toBe('2');
     });
 
     it('normalizes whitespace in group name for count computation', () => {
       const items = [
-        makeItem({ id: '1', title: 'A', state: WorkItemState.InProgress, group: 'valid-group' }),
-        makeItem({ id: '2', title: 'B', state: WorkItemState.InProgress, group: 'valid-group  ' }),
-        makeItem({ id: '3', title: 'C', state: WorkItemState.InProgress, group: '  valid-group' }),
+        makeItem({ id: '1', title: 'A', providerId: 'github', state: WorkItemState.InProgress, group: 'valid-group' }),
+        makeItem({ id: '2', title: 'B', providerId: 'github', state: WorkItemState.InProgress, group: 'valid-group  ' }),
+        makeItem({ id: '3', title: 'C', providerId: 'github', state: WorkItemState.InProgress, group: '  valid-group' }),
       ];
       workGraph.getItemsByState.mockReturnValue(items);
 
-      const group: SubGroupNode = { kind: 'subGroup', label: 'valid-group', providerId: undefined, groupName: 'valid-group' };
+      const group: SubGroupNode = { kind: 'subGroup', label: 'valid-group', providerId: 'github', groupName: 'valid-group' };
       const treeItem = provider.getTreeItem(group);
       expect(treeItem.description).toBe('3');
     });
 
-    it('sorts group nodes alphabetically', () => {
+    it('sorts provider nodes alphabetically, with "Other" last', () => {
       const items = [
-        makeItem({ id: '1', title: 'A', state: WorkItemState.InProgress, group: 'z-repo' }),
-        makeItem({ id: '2', title: 'B', state: WorkItemState.InProgress, group: 'a-repo' }),
+        makeItem({ id: '1', title: 'A', providerId: 'jira', state: WorkItemState.InProgress }),
+        makeItem({ id: '2', title: 'B', providerId: 'github', state: WorkItemState.InProgress }),
+        makeItem({ id: '3', title: 'C', state: WorkItemState.InProgress }),
       ];
       workGraph.getItemsByState.mockReturnValue(items);
       const children = provider.getChildren();
-      expect((children[0] as SubGroupNode).label).toBe('a-repo');
-      expect((children[1] as SubGroupNode).label).toBe('z-repo');
+      expect(children).toHaveLength(3);
+      expect((children[0] as ProviderGroupNode).label).toBe('GitHub');
+      expect((children[1] as ProviderGroupNode).label).toBe('Jira');
+      expect((children[2] as ProviderGroupNode).label).toBe('Other');
     });
 
     it('returns empty for item node children', () => {
@@ -148,18 +155,20 @@ describe('FocusTreeProvider layout toggle', () => {
       expect(provider.getChildren(item)).toEqual([]);
     });
 
-    it('normalizes whitespace-only groups as ungrouped', () => {
+    it('normalizes whitespace-only groups as ungrouped within provider', () => {
       const items = [
-        makeItem({ id: '1', title: 'Whitespace', state: WorkItemState.InProgress, group: '   ' }),
-        makeItem({ id: '2', title: 'Grouped', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
+        makeItem({ id: '1', title: 'Whitespace', providerId: 'github', state: WorkItemState.InProgress, group: '   ' }),
+        makeItem({ id: '2', title: 'Grouped', providerId: 'github', state: WorkItemState.InProgress, group: 'contoso/webapp' }),
       ];
       workGraph.getItemsByState.mockReturnValue(items);
-      const children = provider.getChildren();
-      const groups = children.filter(c => isSubGroupNode(c)) as SubGroupNode[];
-      const directItems = children.filter(c => !isSubGroupNode(c)) as WorkItem[];
-      expect(groups).toHaveLength(1);
-      expect(groups[0].groupName).toBe('contoso/webapp');
+      const providerNode: ProviderGroupNode = { kind: 'providerGroup', label: 'GitHub', providerId: 'github' };
+      const children = provider.getChildren(providerNode);
+      const subGroups = children.filter(c => isSubGroupNode(c)) as SubGroupNode[];
+      const directItems = children.filter(c => !isSubGroupNode(c) && !isProviderGroupNode(c)) as WorkItem[];
+      expect(subGroups).toHaveLength(1);
+      expect(subGroups[0].groupName).toBe('contoso/webapp');
       expect(directItems).toHaveLength(1);
+      expect(directItems[0].title).toBe('Whitespace');
     });
   });
 });

--- a/packages/core/src/test/focusTreeProviderLayout.test.ts
+++ b/packages/core/src/test/focusTreeProviderLayout.test.ts
@@ -170,5 +170,18 @@ describe('FocusTreeProvider layout toggle', () => {
       expect(directItems).toHaveLength(1);
       expect(directItems[0].title).toBe('Whitespace');
     });
+
+    it('sub-group count under "Other" only includes manual items, not provider items with same group', () => {
+      const items = [
+        makeItem({ id: '1', title: 'Manual', state: WorkItemState.InProgress, group: 'shared-group' }),
+        makeItem({ id: '2', title: 'Provider', providerId: 'github', state: WorkItemState.InProgress, group: 'shared-group' }),
+      ];
+      workGraph.getItemsByState.mockReturnValue(items);
+
+      const otherSubGroup: SubGroupNode = { kind: 'subGroup', label: 'shared-group', providerId: undefined, groupName: 'shared-group' };
+      const treeItem = provider.getTreeItem(otherSubGroup);
+      // Only the manual item should be counted, not the GitHub item
+      expect(treeItem.description).toBe('1');
+    });
   });
 });

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -62,8 +62,6 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
     return treeItem;
   }
 
-
-
   private getFocusStatePriority(state: WorkItemState): number {
     switch (state) {
       case WorkItemState.InProgress:

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -3,7 +3,7 @@ import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import { ProviderRegistry } from '../services/providerRegistry';
 import {
-  WorkItemElement, WorkItemViewProvider, SubGroupNode, isProviderGroupNode, isSubGroupNode,
+  WorkItemElement, WorkItemViewProvider, isProviderGroupNode, isSubGroupNode,
 } from './viewLayout';
 
 const DRAG_MIME_TYPE = 'application/vnd.code.tree.devdocket.focus';
@@ -62,67 +62,7 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
     return treeItem;
   }
 
-  getParent(element: FocusElement): FocusElement | undefined {
-    if (this.layout === 'flat') {
-      return undefined;
-    }
-    if (isSubGroupNode(element)) {
-      return undefined;
-    }
-    if (isProviderGroupNode(element)) {
-      return undefined;
-    }
-    // WorkItem — parent is SubGroupNode if item has a group, otherwise root
-    const item = element as import('../models/workItem').WorkItem;
-    const grp = item.group?.trim() || undefined;
-    if (grp) {
-      return { kind: 'subGroup', label: grp, providerId: undefined, groupName: grp };
-    }
-    return undefined;
-  }
 
-  getChildren(element?: FocusElement): FocusElement[] {
-    if (!element) {
-      const items = this.getItems();
-      if (this.layout === 'flat') {
-        return this.sortItems(items);
-      }
-      return this.getGroupRootChildren(items);
-    }
-
-    if (isSubGroupNode(element)) {
-      return this.sortItems(
-        this.getItems().filter(i => (i.group?.trim() || undefined) === element.groupName),
-      );
-    }
-
-    return [];
-  }
-
-  /** Group items by `item.group` (repo name) at the top level in tree mode. */
-  private getGroupRootChildren(items: WorkItem[]): (SubGroupNode | WorkItem)[] {
-    const groups = new Set<string>();
-    const ungrouped: WorkItem[] = [];
-
-    for (const item of items) {
-      const g = item.group?.trim();
-      if (g) {
-        groups.add(g);
-      } else {
-        ungrouped.push(item);
-      }
-    }
-
-    const subGroups: SubGroupNode[] = [];
-    for (const groupName of groups) {
-      subGroups.push({ kind: 'subGroup', label: groupName, providerId: undefined, groupName });
-    }
-
-    const sortedSubGroups = subGroups.sort((a, b) => a.label.localeCompare(b.label));
-    const sortedUngrouped = this.sortItems(ungrouped);
-
-    return [...sortedSubGroups, ...sortedUngrouped];
-  }
 
   private getFocusStatePriority(state: WorkItemState): number {
     switch (state) {

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -424,16 +424,17 @@ export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<Wo
     if (!this._countsCache) {
       const counts = new Map<string, number>();
       for (const item of this.getItems()) {
-        const providerKey = `provider:${normalizeProviderId(item.providerId) ?? ''}`;
+        const normalizedProvider = normalizeProviderId(item.providerId) ?? '';
+        const providerKey = `provider:${normalizedProvider}`;
         counts.set(providerKey, (counts.get(providerKey) ?? 0) + 1);
 
         // Per-provider sub-group key (used when providerId is known)
         const normalizedGroup = normalizeGroup(item.group) ?? '';
-        const groupKeyWithProvider = `group:${normalizeProviderId(item.providerId) ?? ''}:${normalizedGroup}`;
+        const groupKeyWithProvider = `group:${normalizedProvider}:${normalizedGroup}`;
         counts.set(groupKeyWithProvider, (counts.get(groupKeyWithProvider) ?? 0) + 1);
 
         // Provider-less sub-group key (used only for the "Other" provider group)
-        if (!normalizeProviderId(item.providerId)) {
+        if (!normalizedProvider) {
           const groupKeyOnly = `group-only:${normalizedGroup}`;
           counts.set(groupKeyOnly, (counts.get(groupKeyOnly) ?? 0) + 1);
         }

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -427,12 +427,12 @@ export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<Wo
         const providerKey = `provider:${normalizeProviderId(item.providerId) ?? ''}`;
         counts.set(providerKey, (counts.get(providerKey) ?? 0) + 1);
 
-        // Build both keys: one with providerId (for Queue/History) and one without (for Focus)
+        // Per-provider sub-group key (used when providerId is known)
         const normalizedGroup = normalizeGroup(item.group) ?? '';
         const groupKeyWithProvider = `group:${normalizeProviderId(item.providerId) ?? ''}:${normalizedGroup}`;
         counts.set(groupKeyWithProvider, (counts.get(groupKeyWithProvider) ?? 0) + 1);
 
-        // group-only key: only for items without a providerId (the "Other" group)
+        // Provider-less sub-group key (used only for the "Other" provider group)
         if (!normalizeProviderId(item.providerId)) {
           const groupKeyOnly = `group-only:${normalizedGroup}`;
           counts.set(groupKeyOnly, (counts.get(groupKeyOnly) ?? 0) + 1);
@@ -452,8 +452,8 @@ export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<Wo
     }
     if (isSubGroupNode(element)) {
       const counts = this.ensureCountsCache();
-      // When providerId is undefined (Focus view), count by group name only
-      // When providerId is defined (Queue/History), count by provider + group
+      // "Other" provider sub-groups (no providerId) use the provider-less key;
+      // named-provider sub-groups use the per-provider key
       const groupKey = element.providerId !== undefined
         ? `group:${element.providerId}:${element.groupName}`
         : `group-only:${element.groupName}`;

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -432,8 +432,11 @@ export abstract class WorkItemViewProvider implements vscode.TreeDataProvider<Wo
         const groupKeyWithProvider = `group:${normalizeProviderId(item.providerId) ?? ''}:${normalizedGroup}`;
         counts.set(groupKeyWithProvider, (counts.get(groupKeyWithProvider) ?? 0) + 1);
 
-        const groupKeyOnly = `group-only:${normalizedGroup}`;
-        counts.set(groupKeyOnly, (counts.get(groupKeyOnly) ?? 0) + 1);
+        // group-only key: only for items without a providerId (the "Other" group)
+        if (!normalizeProviderId(item.providerId)) {
+          const groupKeyOnly = `group-only:${normalizedGroup}`;
+          counts.set(groupKeyOnly, (counts.get(groupKeyOnly) ?? 0) + 1);
+        }
       }
       this._countsCache = counts;
     }


### PR DESCRIPTION
Closes #319

Focus view now groups items by provider (GitHub, ADO, etc.) in tree mode, matching the Sources view pattern.

## Changes
- Removed custom getChildren() and getParent() implementations from FocusTreeProvider that grouped by item.group (repo name)
- Now uses the WorkItemViewProvider base class pattern which implements the standard two-level hierarchy: Provider → Sub-group (repo name) → Work Items
- Manual items (no provider) appear under 'Other' provider group
- Flat mode behavior is unchanged

## Testing
- All Focus tree provider tests pass (43/43)
- Core package tests pass

This brings consistency across all views — Focus, Queue, History, and Sources now all use the same provider-based grouping pattern in tree mode.