### PR TITLE
Log auto-complete transitions in the activity log

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -55,6 +55,13 @@ DevDocket is a VS Code extension monorepo for managing work items from multiple 
 
 ## Learnings
 
+### 2026-04-21 — Auto-complete activity log integration
+
+**Fix:** Auto-complete transitions to Done now log an `'auto-completed'` activity entry with detail like "Provider detected external closure (InProgress → Done)".
+- **Pattern:** `transitionState()` already logs `'state-changed'`; the new `addActivity()` call adds a second entry distinguishing automatic from manual transitions.
+- **ActivityType extension:** Added `'auto-completed'` to the string union. Store validator accepts any non-empty string, so no migration needed.
+- **Three files changed:** `activityLog.ts` (type union), `autoComplete.ts` (addActivity call), `editorPanelHtml.ts` (display label).
+
 ### 2026-04-21 — Issue #255 (Provider Metadata Docs)
 
 **PR:** Created `docs/provider-discovery.md` documenting what causes items to appear in each provider.

--- a/packages/core/src/models/activityLog.ts
+++ b/packages/core/src/models/activityLog.ts
@@ -11,8 +11,9 @@ export const MAX_ACTIVITY_LOG_ENTRIES = 100;
  * - `state-changed` — lifecycle state transition.
  * - `updated` — user edited title or notes.
  * - `action-executed` — an extension-defined action was run.
+ * - `auto-completed` — item was automatically completed because the linked external item was closed/merged.
  */
-export type ActivityType = 'created' | 'state-changed' | 'updated' | 'action-executed';
+export type ActivityType = 'created' | 'state-changed' | 'updated' | 'action-executed' | 'auto-completed';
 
 /**
  * A single, immutable entry in a work item's activity log.

--- a/packages/core/src/services/autoComplete.ts
+++ b/packages/core/src/services/autoComplete.ts
@@ -82,8 +82,9 @@ export async function checkAutoComplete(
         continue;
       }
       try {
+        const oldState = currentItem.state;
         await workGraph.transitionState(currentItem.id, WorkItemState.Done);
-        await workGraph.addActivity(currentItem.id, 'auto-completed', `Provider detected external closure (${currentItem.state} → Done)`);
+        await workGraph.addActivity(currentItem.id, 'auto-completed', `Provider detected external closure (${oldState} → Done)`);
         completedTitles.push(currentItem.title);
         logger.info(`Auto-completed work item "${currentItem.title}" (${currentItem.id}) — external item closed/merged`);
       } catch (err) {

--- a/packages/core/src/services/autoComplete.ts
+++ b/packages/core/src/services/autoComplete.ts
@@ -83,6 +83,7 @@ export async function checkAutoComplete(
       }
       try {
         await workGraph.transitionState(currentItem.id, WorkItemState.Done);
+        await workGraph.addActivity(currentItem.id, 'auto-completed', `Provider detected external closure (${currentItem.state} → Done)`);
         completedTitles.push(currentItem.title);
         logger.info(`Auto-completed work item "${currentItem.title}" (${currentItem.id}) — external item closed/merged`);
       } catch (err) {

--- a/packages/core/src/services/autoComplete.ts
+++ b/packages/core/src/services/autoComplete.ts
@@ -84,9 +84,13 @@ export async function checkAutoComplete(
       try {
         const oldState = currentItem.state;
         await workGraph.transitionState(currentItem.id, WorkItemState.Done);
-        await workGraph.addActivity(currentItem.id, 'auto-completed', `Provider detected external closure (${oldState} → Done)`);
         completedTitles.push(currentItem.title);
         logger.info(`Auto-completed work item "${currentItem.title}" (${currentItem.id}) — external item closed/merged`);
+        try {
+          await workGraph.addActivity(currentItem.id, 'auto-completed', `Provider detected external closure (${oldState} → Done)`);
+        } catch (activityErr) {
+          logger.error(`Failed to record auto-complete activity for work item ${currentItem.id}`, activityErr);
+        }
       } catch (err) {
         logger.error(`Failed to auto-complete work item ${currentItem.id}`, err);
       }

--- a/packages/core/src/test/autoComplete.test.ts
+++ b/packages/core/src/test/autoComplete.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { checkAutoComplete } from '../services/autoComplete';
+import { WorkGraph } from '../services/workGraph';
+import { WorkItemState, WorkItem } from '../models/workItem';
+import { ITaskStore } from '../storage/taskStore';
+import { ProviderRegistry } from '../services/providerRegistry';
+
+function createMockStore(): ITaskStore {
+  const items: Map<string, any> = new Map();
+  return {
+    loadAll: vi.fn(async () => Array.from(items.values())),
+    save: vi.fn(async (item) => { items.set(item.id, item); }),
+    saveAll: vi.fn(async (batch) => { for (const item of batch) { items.set(item.id, item); } }),
+    delete: vi.fn(async (id) => { items.delete(id); }),
+  };
+}
+
+function createMockRegistry(overrides: {
+  getProvider?: () => any;
+  getDiscoveredItems?: () => any[];
+  wasLastRefreshTruncated?: () => boolean;
+  wasItemPreviouslyDiscovered?: () => boolean;
+} = {}): ProviderRegistry {
+  return {
+    getProvider: overrides.getProvider ?? (() => undefined),
+    getDiscoveredItems: overrides.getDiscoveredItems ?? (() => []),
+    wasLastRefreshTruncated: overrides.wasLastRefreshTruncated ?? (() => false),
+    wasItemPreviouslyDiscovered: overrides.wasItemPreviouslyDiscovered ?? (() => true),
+  } as unknown as ProviderRegistry;
+}
+
+describe('checkAutoComplete', () => {
+  const providerId = 'test-provider';
+  let store: ITaskStore;
+  let graph: WorkGraph;
+
+  beforeEach(async () => {
+    store = createMockStore();
+    graph = new WorkGraph(store);
+    await graph.load();
+  });
+
+  describe('activity log entries', () => {
+    it('appends an auto-completed activity entry after transition', async () => {
+      const item = await graph.createItem(
+        { title: 'Issue A' },
+        { providerId, externalId: 'ext-1' },
+      );
+
+      const registry = createMockRegistry({
+        getProvider: () => ({
+          getClosedItems: async () => ['ext-1'],
+        }),
+      });
+
+      await checkAutoComplete(providerId, graph, registry);
+
+      const updated = graph.getItem(item.id)!;
+      expect(updated.state).toBe(WorkItemState.Done);
+
+      const autoEntry = updated.activityLog!.find(e => e.type === 'auto-completed');
+      expect(autoEntry).toBeDefined();
+      expect(autoEntry!.detail).toBe('Provider detected external closure (New → Done)');
+    });
+
+    it('records pre-transition state in auto-completed detail for InProgress items', async () => {
+      const item = await graph.createItem(
+        { title: 'In-progress task' },
+        { providerId, externalId: 'ext-2' },
+      );
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+
+      const registry = createMockRegistry({
+        getProvider: () => ({
+          getClosedItems: async () => ['ext-2'],
+        }),
+      });
+
+      await checkAutoComplete(providerId, graph, registry);
+
+      const updated = graph.getItem(item.id)!;
+      const autoEntry = updated.activityLog!.find(e => e.type === 'auto-completed');
+      expect(autoEntry).toBeDefined();
+      expect(autoEntry!.detail).toBe('Provider detected external closure (InProgress → Done)');
+    });
+
+    it('records pre-transition state in auto-completed detail for Paused items', async () => {
+      const item = await graph.createItem(
+        { title: 'Paused task' },
+        { providerId, externalId: 'ext-3' },
+      );
+      await graph.transitionState(item.id, WorkItemState.InProgress);
+      await graph.transitionState(item.id, WorkItemState.Paused);
+
+      const registry = createMockRegistry({
+        getProvider: () => ({
+          getClosedItems: async () => ['ext-3'],
+        }),
+      });
+
+      await checkAutoComplete(providerId, graph, registry);
+
+      const updated = graph.getItem(item.id)!;
+      const autoEntry = updated.activityLog!.find(e => e.type === 'auto-completed');
+      expect(autoEntry).toBeDefined();
+      expect(autoEntry!.detail).toBe('Provider detected external closure (Paused → Done)');
+    });
+
+    it('auto-completed entry appears after the state-changed entry', async () => {
+      const item = await graph.createItem(
+        { title: 'Order check' },
+        { providerId, externalId: 'ext-4' },
+      );
+
+      const registry = createMockRegistry({
+        getProvider: () => ({
+          getClosedItems: async () => ['ext-4'],
+        }),
+      });
+
+      await checkAutoComplete(providerId, graph, registry);
+
+      const updated = graph.getItem(item.id)!;
+      const log = updated.activityLog!;
+      const stateIdx = log.findIndex(e => e.type === 'state-changed' && e.detail?.includes('Done'));
+      const autoIdx = log.findIndex(e => e.type === 'auto-completed');
+      expect(stateIdx).toBeGreaterThanOrEqual(0);
+      expect(autoIdx).toBeGreaterThan(stateIdx);
+    });
+
+    it('returns completed titles', async () => {
+      await graph.createItem(
+        { title: 'Closed issue' },
+        { providerId, externalId: 'ext-5' },
+      );
+
+      const registry = createMockRegistry({
+        getProvider: () => ({
+          getClosedItems: async () => ['ext-5'],
+        }),
+      });
+
+      const titles = await checkAutoComplete(providerId, graph, registry);
+      expect(titles).toEqual(['Closed issue']);
+    });
+
+    it('does not log auto-completed for items not in closedIds', async () => {
+      const item = await graph.createItem(
+        { title: 'Still open' },
+        { providerId, externalId: 'ext-6' },
+      );
+
+      const registry = createMockRegistry({
+        getProvider: () => ({
+          getClosedItems: async () => [],
+        }),
+      });
+
+      await checkAutoComplete(providerId, graph, registry);
+
+      const updated = graph.getItem(item.id)!;
+      expect(updated.state).toBe(WorkItemState.New);
+      const autoEntry = updated.activityLog?.find(e => e.type === 'auto-completed');
+      expect(autoEntry).toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/test/autoComplete.test.ts
+++ b/packages/core/src/test/autoComplete.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { checkAutoComplete } from '../services/autoComplete';
 import { WorkGraph } from '../services/workGraph';
-import { WorkItemState, WorkItem } from '../models/workItem';
+import { WorkItemState } from '../models/workItem';
 import { ITaskStore } from '../storage/taskStore';
 import { ProviderRegistry } from '../services/providerRegistry';
 

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -427,6 +427,17 @@ describe('getEditorPanelHtml', () => {
       expect(html).toContain('New');
     });
 
+    it('renders auto-completed activity type with correct label', () => {
+      const item = makeItem({
+        activityLog: [
+          { timestamp: 1700000000000, type: 'auto-completed', detail: 'Provider detected external closure (New → Done)' },
+        ],
+      });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).toContain('Auto-completed');
+      expect(html).toContain('Provider detected external closure');
+    });
+
     it('renders unknown activity types safely', () => {
       const item = makeItem({
         activityLog: [

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -326,6 +326,7 @@ function activityTypeLabel(type: ActivityLogEntry['type']): string {
     case 'state-changed': return 'State changed';
     case 'updated': return 'Updated';
     case 'action-executed': return 'Action executed';
+    case 'auto-completed': return 'Auto-completed';
     default: return type;
   }
 }


### PR DESCRIPTION
## Summary

The auto-complete feature (PR #297, issue #265) was merged without integrating with the activity log (PR #312, issue #260). When auto-complete transitions a work item to Done, no `auto-completed` activity entry was logged — making it impossible to distinguish automatic completions from manual state changes in the activity log.

This PR adds a dedicated `auto-completed` activity log entry whenever a work item is auto-completed due to external closure/merge.

## Changes

- **`packages/core/src/models/activityLog.ts`** — Added `'auto-completed'` to the `ActivityType` string union.
- **`packages/core/src/services/autoComplete.ts`** — After `transitionState()`, calls `workGraph.addActivity()` with type `'auto-completed'` and detail describing the previous state and reason.
- **`packages/core/src/views/editorPanelHtml.ts`** — Added display label for the new activity type.

## How it works

`transitionState()` already logs a generic `state-changed` entry (e.g., "InProgress → Done"). The new `auto-completed` entry is appended immediately after, providing explicit context: "Provider detected external closure (InProgress → Done)". This gives users a clear audit trail distinguishing automatic from manual completions.

Closes #260
