### PR TITLE
Add AI model selection prompt to Code Review and Walkthrough

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -55,6 +55,16 @@ DevDocket is a VS Code extension monorepo for managing work items from multiple 
 
 ## Learnings
 
+### 2026-04-22 — Issue #254 (AI Model Selection for Walkthrough)
+
+**Feature:** Added AI model selection prompt to both AI Code Review and AI Walkthrough, giving users control over cost/quality tradeoff.
+- **Shared utility:** Created `packages/ai-reviewer/src/modelSelection.ts` with `promptForModel()` — returns the model directly if only one is available, shows QuickPick if multiple.
+- **Review action:** Replaced `models[0]` auto-selection in `AiReviewAction.doWork()` with `promptForModel()` call.
+- **Walkthrough action:** Added `promptForModel()` to `AiWalkthroughAction.doWork()`. Passes selected model to `WalkthroughParticipant` via `setPreferredModel()`. Made participant param optional to avoid breaking existing tests.
+- **Participant integration:** `WalkthroughParticipant.setPreferredModel()` sets a one-shot preferred model consumed on the next `handleRequest()`. After use, clears so subsequent chat messages defer to the VS Code chat UI model picker.
+- **Wiring:** In `extension.ts`, `WalkthroughParticipant` is now created before the walkthrough action and injected into its constructor.
+- **Key files:** `modelSelection.ts` (new), `aiReviewAction.ts`, `aiWalkthroughAction.ts`, `walkthroughParticipant.ts`, `extension.ts`.
+
 ### 2026-04-21 — Issue #323 (Watch CI Pipelines — PR #323)
 
 **Feature:** Full CI pipeline watcher with ADO support, polling control, tree/flat layout toggle, and persistence.

--- a/packages/ai-reviewer/src/aiReviewAction.ts
+++ b/packages/ai-reviewer/src/aiReviewAction.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { BasePrAction, sanitizePrUrl } from './basePrAction';
 import { DEFAULT_REVIEW_PROMPT } from './defaultPrompt';
+import { promptForModel } from './modelSelection';
 import { truncateToolContent } from './toolUtils';
 import { gitExec } from './tools/gitUtils';
 import type { RepoManager, WorktreeInfo } from './repoManager';
@@ -49,14 +50,9 @@ export class AiReviewAction extends BasePrAction {
     const diff = await this.fetchDiff(item.url!);
     if (!diff || token.isCancellationRequested) return;
 
-    // Check model availability before expensive worktree preparation
-    const models = await vscode.lm.selectChatModels();
-    if (models.length === 0) {
-      vscode.window.showWarningMessage(
-        `${this.progressTitle}: No language model available. Install GitHub Copilot.`,
-      );
-      return;
-    }
+    // Prompt user to select a model before expensive worktree preparation
+    const model = await promptForModel(this.progressTitle);
+    if (!model || token.isCancellationRequested) return;
 
     // Prepare worktree (best-effort — review falls back to diff-only)
     progress.report({ message: 'Preparing repository...' });
@@ -75,9 +71,9 @@ export class AiReviewAction extends BasePrAction {
 
     let result: string | undefined;
     if (worktreeInfo) {
-      result = await this.analyzeWithTools(diff, item.url!, worktreeInfo, models[0], token);
+      result = await this.analyzeWithTools(diff, item.url!, worktreeInfo, model, token);
     } else {
-      result = await this.analyzeWithAi(diff, item.url!, token, models[0]);
+      result = await this.analyzeWithAi(diff, item.url!, token, model);
     }
     if (!result || token.isCancellationRequested) return;
 

--- a/packages/ai-reviewer/src/aiWalkthroughAction.ts
+++ b/packages/ai-reviewer/src/aiWalkthroughAction.ts
@@ -1,7 +1,9 @@
 import * as vscode from 'vscode';
 import type { WorkItem } from './types';
 import { BasePrAction, sanitizePrUrl } from './basePrAction';
-import { RepoManager } from './repoManager';
+import { promptForModel } from './modelSelection';
+import type { RepoManager } from './repoManager';
+import type { WalkthroughParticipant } from './walkthroughParticipant';
 
 export class AiWalkthroughAction extends BasePrAction {
   readonly id = 'ai-reviewer.walkthrough';
@@ -14,6 +16,7 @@ export class AiWalkthroughAction extends BasePrAction {
   constructor(
     private readonly repoManager: RepoManager,
     private readonly log: vscode.LogOutputChannel,
+    private readonly walkthroughParticipant?: WalkthroughParticipant,
   ) {
     super();
   }
@@ -23,6 +26,13 @@ export class AiWalkthroughAction extends BasePrAction {
     progress: vscode.Progress<{ message?: string }>,
     token: vscode.CancellationToken,
   ): Promise<void> {
+    // Prompt for model selection so the user controls the cost/quality tradeoff
+    const model = await promptForModel(this.progressTitle);
+    if (!model || token.isCancellationRequested) return;
+
+    // Pass model preference to the walkthrough participant for its first request
+    this.walkthroughParticipant?.setPreferredModel(model);
+
     progress.report({ message: 'Preparing repository...' });
     this.log.info('Preparing worktree for walkthrough');
 

--- a/packages/ai-reviewer/src/extension.ts
+++ b/packages/ai-reviewer/src/extension.ts
@@ -45,13 +45,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // Shared infrastructure for both actions
   const repoManager = new RepoManager(context.globalStorageUri, log);
 
+  // Create participant first so the walkthrough action can pass model preferences to it
+  const participant = new WalkthroughParticipant(repoManager, log);
+
   // Register code review action (uses shared RepoManager)
   const reviewAction = new AiReviewAction(repoManager, log);
   context.subscriptions.push(api.registerAction(reviewAction));
   log.info('Registered AI Code Review action');
 
-  // Register walkthrough action (uses shared RepoManager)
-  const walkthroughAction = new AiWalkthroughAction(repoManager, log);
+  // Register walkthrough action (uses shared RepoManager + participant for model handoff)
+  const walkthroughAction = new AiWalkthroughAction(repoManager, log, participant);
   context.subscriptions.push(api.registerAction(walkthroughAction));
   log.info('Registered AI Walkthrough action');
 
@@ -60,8 +63,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   toolDisposables.forEach(d => context.subscriptions.push(d));
   log.info(`Registered ${toolDisposables.length} LM tools`);
 
-  // Register chat participant (uses shared RepoManager)
-  const participant = new WalkthroughParticipant(repoManager, log);
+  // Register chat participant
   context.subscriptions.push(participant.register());
   log.info('Registered @walkthrough chat participant');
 

--- a/packages/ai-reviewer/src/modelSelection.ts
+++ b/packages/ai-reviewer/src/modelSelection.ts
@@ -1,0 +1,36 @@
+import * as vscode from 'vscode';
+
+/**
+ * Prompt the user to select an AI model from available language models.
+ * If only one model is available, returns it without prompting.
+ * Returns undefined if the user cancels or no models are available.
+ */
+export async function promptForModel(
+  title: string,
+): Promise<vscode.LanguageModelChat | undefined> {
+  const models = await vscode.lm.selectChatModels();
+  if (models.length === 0) {
+    vscode.window.showWarningMessage(
+      `${title}: No language model available. Install GitHub Copilot.`,
+    );
+    return undefined;
+  }
+
+  if (models.length === 1) {
+    return models[0];
+  }
+
+  const items = models.map(m => ({
+    label: m.name ?? m.id,
+    description: `${m.vendor} — ${m.family}`,
+    detail: m.name ? m.id : undefined,
+    model: m,
+  }));
+
+  const picked = await vscode.window.showQuickPick(items, {
+    title: `${title}: Select AI Model`,
+    placeHolder: 'Choose which AI model to use',
+  });
+
+  return picked?.model;
+}

--- a/packages/ai-reviewer/src/walkthroughParticipant.ts
+++ b/packages/ai-reviewer/src/walkthroughParticipant.ts
@@ -5,11 +5,21 @@ import { truncateToolContent } from './toolUtils';
 
 export class WalkthroughParticipant {
   private sessions = new Map<string, WorktreeInfo>();
+  private preferredModel: vscode.LanguageModelChat | undefined;
 
   constructor(
     private readonly repoManager: RepoManager,
     private readonly log: vscode.LogOutputChannel,
   ) {}
+
+  /**
+   * Set a preferred model for the next chat request.
+   * Consumed once — after the first request uses it, it clears automatically
+   * so subsequent messages defer to the chat UI's model picker.
+   */
+  setPreferredModel(model: vscode.LanguageModelChat): void {
+    this.preferredModel = model;
+  }
 
   /** Register the chat participant. Returns disposable. */
   register(): vscode.Disposable {
@@ -135,9 +145,13 @@ export class WalkthroughParticipant {
     messages.push(vscode.LanguageModelChatMessage.User(request.prompt));
     this.log.info(`Built message array: ${messages.length} messages (1 system + ${messages.length - 2} history + 1 user)`);
 
-    // Select model
+    // Select model — prefer action-provided model, then chat UI model, then fallback
     let model: vscode.LanguageModelChat;
-    if (request.model) {
+    if (this.preferredModel) {
+      this.log.info(`Using action-provided model: ${this.preferredModel.id}`);
+      model = this.preferredModel;
+      this.preferredModel = undefined;
+    } else if (request.model) {
       this.log.info(`Using request-provided model: ${request.model.id}`);
       model = request.model;
     } else {


### PR DESCRIPTION
## Summary

Both AI Code Review and AI Walkthrough now prompt the user to select which language model to use before proceeding. This gives users control over the cost/quality tradeoff for both actions, consistent with user expectations.

## Changes

- **New shared utility** (`modelSelection.ts`): `promptForModel()` lists available models via `vscode.lm.selectChatModels()`. If only one model is available, it's selected automatically. If multiple are available, a QuickPick dialog lets the user choose.
- **AI Code Review** (`aiReviewAction.ts`): Replaced auto-selection of `models[0]` with `promptForModel()` call before worktree preparation.
- **AI Walkthrough** (`aiWalkthroughAction.ts`): Added `promptForModel()` call before worktree preparation. The selected model is passed to the `WalkthroughParticipant` via a new `setPreferredModel()` method for use in the first chat request.
- **WalkthroughParticipant** (`walkthroughParticipant.ts`): Added `setPreferredModel()` — a one-shot model preference consumed on the next `handleRequest()`, after which subsequent messages defer to the VS Code chat UI's model picker.
- **Extension wiring** (`extension.ts`): `WalkthroughParticipant` is now created before the walkthrough action so it can be injected into the action constructor.

## Testing

All 1898 existing tests pass. The `walkthroughParticipant` constructor parameter is optional, so existing test code is unaffected.

Closes #254
