### PR TITLE
Remove double disposal of resources in deactivate()

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -49,7 +49,7 @@ DevDocket is a VS Code extension monorepo for managing work items from multiple 
 - **Build:** esbuild, CJS, `--external:vscode`, sourcemaps. Root `npm install` + `npm run build`.
 
 ### Completed Issues
-#323 (watch CI pipelines), #322 (auto-complete activity log), #320 (focus view grouping), #282 (provider state in editor), #281 (clickable title), #276 (auto-track authored PRs), #275 (History→Queue transitions), #273 (tree counts), #265 (auto-complete on close), #255 (provider metadata docs), #250 (group context), #249 (accept-to-focus, pre-shipped), #243 (version resurfacing), #240 (create from URL), #233 (provider health), #232 (clear history), #231 (sources icons), #230 (layout toggle), #229 (emoji removal), #227 (provider labels), #223 (dead code cleanup), #222 (responsive layout), #221 (contextual heading), #219 (source URL link), #217 (editor metadata), #216 (provider description), #215 (dynamic titles), #189 (dismissed fix), #178 (ADO filtering), #158 (markdown injection), #157 (API trust boundary), #156 (URL sanitization), #155 (URL scheme validation), #154 (crypto.randomUUID), #153 (JSON validation), #152 (path traversal fix), #12 (AI PR actions), bulk rename (WorkCenter→DevDocket)
+#299 (fix double disposal), #323 (watch CI pipelines), #322 (auto-complete activity log), #320 (focus view grouping), #282 (provider state in editor), #281 (clickable title), #276 (auto-track authored PRs), #275 (History→Queue transitions), #273 (tree counts), #265 (auto-complete on close), #255 (provider metadata docs), #250 (group context), #249 (accept-to-focus, pre-shipped), #243 (version resurfacing), #240 (create from URL), #233 (provider health), #232 (clear history), #231 (sources icons), #230 (layout toggle), #229 (emoji removal), #227 (provider labels), #223 (dead code cleanup), #222 (responsive layout), #221 (contextual heading), #219 (source URL link), #217 (editor metadata), #216 (provider description), #215 (dynamic titles), #189 (dismissed fix), #178 (ADO filtering), #158 (markdown injection), #157 (API trust boundary), #156 (URL sanitization), #155 (URL scheme validation), #154 (crypto.randomUUID), #153 (JSON validation), #152 (path traversal fix), #12 (AI PR actions), bulk rename (WorkCenter→DevDocket)
 
 > Full issue-level learnings archived to `history-archive.md`
 
@@ -289,3 +289,10 @@ DevDocket is a VS Code extension monorepo for managing work items from multiple 
 - **Tree hierarchy:** In tree mode, items are now grouped: Provider (GitHub, ADO, etc.) → Sub-group (repo name) → Work Items. Manual items appear under "Other" provider group. In flat mode, unchanged.
 - **No breaking changes:** The public API surface is unchanged — only internal tree provider implementation.
 - **Files changed:** `packages/core/src/views/focusTreeProvider.ts` (removed ~60 lines of custom grouping logic).
+
+### 2026-04-20 — Issue #299 (Remove double disposal of resources)
+
+**Bug:** `deactivate()` manually disposed 4 resources (`providerRegistry`, `actionRegistry`, `workGraph`, `stateStore`) that were already registered in `context.subscriptions` for VS Code auto-disposal. This caused every resource to be disposed twice.
+- **Fix:** Removed all manual disposal from `deactivate()`, making it a true no-op. Removed the module-level variables and their assignments since they only existed to support the manual disposal.
+- **VS Code idiom:** Rely exclusively on `context.subscriptions` for resource lifecycle management. VS Code calls `dispose()` on all subscriptions during deactivation automatically.
+- **Files changed:** `packages/core/src/extension.ts` only.

--- a/.squad/agents/keaton/history.md
+++ b/.squad/agents/keaton/history.md
@@ -164,4 +164,68 @@ Detailed findings and patterns documented in:
 - Comments include: assignment, complexity (small/medium/large), category, dependencies, implementation notes
 - All comments posted safely with `--body-file` to avoid PowerShell backtick escaping issues
 
+## Triage Round 2 — 12 Squad Issues (2026-07-24)
+
+**Status:** COMPLETE — All 12 issues routed and triage comments posted.
+
+### Routing Summary
+
+| Route | Count | Issues |
+|-------|-------|--------|
+| squad:fenster | 7 | 298, 299, 300, 301, 302, 303, 305, 306 |
+| squad:keaton | 5 | 304, 307, 308, 292 |
+
+### Key Decisions
+
+1. **Bugs (High Priority - Fenster):**
+   - #298 (fetch/git timeouts): Medium complexity. Blocks extension activation on slow networks.
+   - #299 (double disposal): Small complexity. Remove manual deactivate() calls, rely on context.subscriptions idiom.
+   - #300 (CancellationToken wiring): Medium complexity. Wire token to AbortSignal in providers. Coordinate with #298.
+
+2. **Enhancement (Fenster):**
+   - #301 (provider health visibility): Medium complexity. Recommend status bar item for unhealthy provider discovery.
+
+3. **Chores (Fenster):**
+   - #302 (consolidated types): Large complexity. Create @devdocket/types or expand @devdocket/shared. ai-reviewer's copy is already stale.
+   - #303 (BaseGitHubProvider extends BaseProvider): Large complexity. Eliminates duplication, matches ADO pattern. Benefits from completing #298/#300 first.
+   - #305 (split monolith commands.ts): Medium complexity. Pure refactoring — no behavior change.
+   - #306 (WorkItemEditorPanel cache lifecycle): Small complexity. Move static Map to instance-level manager.
+
+4. **Architecture Decisions (Keaton):**
+   - #304 (JSON stores → globalState): Large complexity, LOW priority. Architectural decision required before Fenster implements. Trade-offs: raw JSON (debugging) vs. globalState (platform ownership). Defer decision until storage pain is felt.
+   - #307 (weekly codebase review): Medium complexity, LOW priority. Meta-task (workflow setup). Scope decision: implement now or defer? Recommend defer until MVP stabilizes.
+   - #308 (weekly UX review): Medium complexity, LOW priority. Companion to #307. Scope decision: defer until post-MVP usability focus.
+   - #292 (automated code refactoring): Medium complexity, LOW priority. Should automated refactoring PRs be submitted without review? Keaton decision on scope and timing.
+
+### Complexity Summary
+
+- Small: #299, #306 (2 issues)
+- Medium: #298, #300, #301, #305, #304, #307, #308, #292 (8 issues)
+- Large: #302, #303 (2 issues)
+
+### Priority & Sequencing Recommendations
+
+**Immediate (Bugs):**
+1. #299 (small, quick win, lifecycle correctness)
+2. #298 + #300 (coordinate fetch timeout + CancellationToken wiring)
+
+**Next Sprint (Enhancements & Smaller Chores):**
+3. #301 (medium, improves UX for provider failures)
+4. #305 (medium, improves code organization)
+5. #306 (small, improves lifecycle safety)
+
+**Post-MVP or Parallel Track (Large Refactorings):**
+6. #302 (large, consolidates types, enables #303)
+7. #303 (large, eliminates duplication, requires #302 first)
+
+**Deferred (Architecture Decisions & Process Setup):**
+8. #304 (decide architecture, then implement)
+9. #307, #308, #292 (Keaton scopes timing and priorities)
+
+### Triage Process Notes
+
+- All 12 issues read via `gh issue view --json body,comments`
+- Comments include: assignment, complexity, category, dependencies, and implementation guidance
+- All comments posted safely with `--body-file` to avoid shell escaping issues
+- Fenster has 8 routable issues; Keaton has 5 scoping/decision issues
 

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -42,10 +42,6 @@ function safeHandler<T extends unknown[]>(label: string, fn: (...args: T) => voi
   };
 }
 
-let providerRegistry: ProviderRegistry | undefined;
-let actionRegistry: ActionRegistry | undefined;
-let workGraph: WorkGraph | undefined;
-let stateStore: DiscoveredStateStore | undefined;
 
 function initializeLogging(context: vscode.ExtensionContext): void {
   const outputChannel = vscode.window.createOutputChannel('DevDocket');
@@ -73,12 +69,10 @@ function initializeLogging(context: vscode.ExtensionContext): void {
 async function loadStores(storagePath: string): Promise<{ workGraph: WorkGraph; stateStore: DiscoveredStateStore; readStateStore: ReadStateStore; labelCache: ProviderLabelCache }> {
   const store = new JsonTaskStore(storagePath);
   const wg = new WorkGraph(store);
-  workGraph = wg;
   await wg.load();
   logger.debug(`Loaded ${wg.getAll().length} work items`);
 
   const ss = new DiscoveredStateStore(storagePath);
-  stateStore = ss;
   await ss.load();
   logger.debug('Loaded discovered state');
 
@@ -395,9 +389,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   await migrateDiscoveredState(wg, ss);
 
   const pr = new ProviderRegistry(ss, labelCache);
-  providerRegistry = pr;
   const ar = new ActionRegistry();
-  actionRegistry = ar;
   const wr = new WatcherRegistry(logger);
   const watchStore = new WatchStore(storagePath);
   const ws = new WatcherService(wr, watchStore, logger);
@@ -482,10 +474,5 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
  * so this function is intentionally a no-op.
  */
 export function deactivate(): void {
-  logger.info('DevDocket deactivating...');
-  providerRegistry?.dispose();
-  actionRegistry?.dispose();
-  workGraph?.dispose();
-  stateStore?.dispose();
-  logger.info('DevDocket deactivated');
+  // All resources are disposed automatically via context.subscriptions.
 }


### PR DESCRIPTION
Fixes #299

## Problem

`deactivate()` in `packages/core/src/extension.ts` manually disposed 4 resources (`providerRegistry`, `actionRegistry`, `workGraph`, `stateStore`) that were already registered in `context.subscriptions` for VS Code auto-disposal. This caused every resource to be disposed twice. The manual disposal was also incomplete — only 4 of ~12 resources pushed to subscriptions were covered.

## Solution

- Removed all manual disposal calls from `deactivate()`, making it a true no-op
- Removed the 4 module-level variables (`providerRegistry`, `actionRegistry`, `workGraph`, `stateStore`) and their assignments, since they only existed to support the manual disposal
- VS Code handles resource cleanup automatically via `context.subscriptions` — this is the idiomatic pattern

## Testing

- All 1555 tests pass across all packages
- Build succeeds with no errors
