### PR TITLE
Add timeouts to fetch() and git subprocess calls

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -55,6 +55,16 @@ DevDocket is a VS Code extension monorepo for managing work items from multiple 
 
 ## Learnings
 
+### 2026-04-22 — Issue #298 (Add fetch/git timeouts)
+
+**Bug fix:** Added timeout safety nets to all unprotected `fetch()` and `execFile`/`execFileAsync` calls across the extension.
+- **Fetch timeouts:** `AbortSignal.timeout(30_000)` added to 19 fetch() calls across github, ado, ai-reviewer packages that previously had no signal. Calls already receiving an `AbortSignal` from callers (e.g., `getClosedItems`, `resolveUrl`) left unchanged.
+- **Git subprocess timeouts:** `timeout: 30_000` added to all local git operations (`branch`, `show-ref`, `worktree add/remove`, `reset`). Network git ops (`clone`, `fetch`) use `timeout: 300_000` (5 min) since they involve data transfer.
+- **gitExec signature change:** Added optional `timeout` parameter (default 30_000) to `packages/ai-reviewer/src/tools/gitUtils.ts`. `gitAuth` wrapper in `repoManager.ts` passes through. Non-breaking: existing callers get the default.
+- **User-configured commands:** `startWorkAction.ts` post-worktree commands get `timeout: 60_000` (longer than git ops since arbitrary user commands may need more time).
+- **Files changed:** 12 source files + 1 test file across github, ado, ai-reviewer, start-git-work packages.
+- **Related:** #300 (CancellationToken→AbortController wiring) is a separate issue for deeper cancellation integration.
+
 ### 2026-04-21 — Issue #323 (Watch CI Pipelines — PR #323)
 
 **Feature:** Full CI pipeline watcher with ADO support, polling control, tree/flat layout toggle, and persistence.

--- a/.squad/agents/keaton/history.md
+++ b/.squad/agents/keaton/history.md
@@ -164,4 +164,68 @@ Detailed findings and patterns documented in:
 - Comments include: assignment, complexity (small/medium/large), category, dependencies, implementation notes
 - All comments posted safely with `--body-file` to avoid PowerShell backtick escaping issues
 
+## Triage Round 2 — 12 Squad Issues (2026-07-24)
+
+**Status:** COMPLETE — All 12 issues routed and triage comments posted.
+
+### Routing Summary
+
+| Route | Count | Issues |
+|-------|-------|--------|
+| squad:fenster | 7 | 298, 299, 300, 301, 302, 303, 305, 306 |
+| squad:keaton | 5 | 304, 307, 308, 292 |
+
+### Key Decisions
+
+1. **Bugs (High Priority - Fenster):**
+   - #298 (fetch/git timeouts): Medium complexity. Blocks extension activation on slow networks.
+   - #299 (double disposal): Small complexity. Remove manual deactivate() calls, rely on context.subscriptions idiom.
+   - #300 (CancellationToken wiring): Medium complexity. Wire token to AbortSignal in providers. Coordinate with #298.
+
+2. **Enhancement (Fenster):**
+   - #301 (provider health visibility): Medium complexity. Recommend status bar item for unhealthy provider discovery.
+
+3. **Chores (Fenster):**
+   - #302 (consolidated types): Large complexity. Create @devdocket/types or expand @devdocket/shared. ai-reviewer's copy is already stale.
+   - #303 (BaseGitHubProvider extends BaseProvider): Large complexity. Eliminates duplication, matches ADO pattern. Benefits from completing #298/#300 first.
+   - #305 (split monolith commands.ts): Medium complexity. Pure refactoring — no behavior change.
+   - #306 (WorkItemEditorPanel cache lifecycle): Small complexity. Move static Map to instance-level manager.
+
+4. **Architecture Decisions (Keaton):**
+   - #304 (JSON stores → globalState): Large complexity, LOW priority. Architectural decision required before Fenster implements. Trade-offs: raw JSON (debugging) vs. globalState (platform ownership). Defer decision until storage pain is felt.
+   - #307 (weekly codebase review): Medium complexity, LOW priority. Meta-task (workflow setup). Scope decision: implement now or defer? Recommend defer until MVP stabilizes.
+   - #308 (weekly UX review): Medium complexity, LOW priority. Companion to #307. Scope decision: defer until post-MVP usability focus.
+   - #292 (automated code refactoring): Medium complexity, LOW priority. Should automated refactoring PRs be submitted without review? Keaton decision on scope and timing.
+
+### Complexity Summary
+
+- Small: #299, #306 (2 issues)
+- Medium: #298, #300, #301, #305, #304, #307, #308, #292 (8 issues)
+- Large: #302, #303 (2 issues)
+
+### Priority & Sequencing Recommendations
+
+**Immediate (Bugs):**
+1. #299 (small, quick win, lifecycle correctness)
+2. #298 + #300 (coordinate fetch timeout + CancellationToken wiring)
+
+**Next Sprint (Enhancements & Smaller Chores):**
+3. #301 (medium, improves UX for provider failures)
+4. #305 (medium, improves code organization)
+5. #306 (small, improves lifecycle safety)
+
+**Post-MVP or Parallel Track (Large Refactorings):**
+6. #302 (large, consolidates types, enables #303)
+7. #303 (large, eliminates duplication, requires #302 first)
+
+**Deferred (Architecture Decisions & Process Setup):**
+8. #304 (decide architecture, then implement)
+9. #307, #308, #292 (Keaton scopes timing and priorities)
+
+### Triage Process Notes
+
+- All 12 issues read via `gh issue view --json body,comments`
+- Comments include: assignment, complexity, category, dependencies, and implementation guidance
+- All comments posted safely with `--body-file` to avoid shell escaping issues
+- Fenster has 8 routable issues; Keaton has 5 scoping/decision issues
 

--- a/packages/ado/src/adoPipelineWatcher.ts
+++ b/packages/ado/src/adoPipelineWatcher.ts
@@ -88,7 +88,15 @@ export class AdoPipelineWatcher implements DevDocketRunWatcher {
 
     // Fetch build details
     const buildUrl = `https://dev.azure.com/${encodedOrg}/${encodedProject}/_apis/build/builds/${encodedBuildId}?api-version=7.1`;
-    const buildResponse = await fetch(buildUrl, { headers, signal: AbortSignal.timeout(30_000) });
+    let buildResponse: Response;
+    try {
+      buildResponse = await fetch(buildUrl, { headers, signal: AbortSignal.timeout(30_000) });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new Error(`ADO API request timed out after 30s for build ${identifier.runId}`);
+      }
+      throw err;
+    }
     if (!buildResponse.ok) {
       throwAdoApiError(buildResponse, `Build ${identifier.runId}`);
     }
@@ -101,7 +109,17 @@ export class AdoPipelineWatcher implements DevDocketRunWatcher {
 
     // Fetch timeline for job details
     const timelineUrl = `https://dev.azure.com/${encodedOrg}/${encodedProject}/_apis/build/builds/${encodedBuildId}/timeline?api-version=7.1`;
-    const timelineResponse = await fetch(timelineUrl, { headers, signal: AbortSignal.timeout(30_000) });
+    let timelineResponse: Response;
+    try {
+      timelineResponse = await fetch(timelineUrl, { headers, signal: AbortSignal.timeout(30_000) });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        logger.warn(`ADO timeline request timed out after 30s for build ${identifier.runId}`);
+        timelineResponse = { ok: false } as Response;
+      } else {
+        throw err;
+      }
+    }
 
     let jobs: JobStatus[] = [];
     if (timelineResponse.ok) {

--- a/packages/ado/src/adoPipelineWatcher.ts
+++ b/packages/ado/src/adoPipelineWatcher.ts
@@ -88,7 +88,7 @@ export class AdoPipelineWatcher implements DevDocketRunWatcher {
 
     // Fetch build details
     const buildUrl = `https://dev.azure.com/${encodedOrg}/${encodedProject}/_apis/build/builds/${encodedBuildId}?api-version=7.1`;
-    const buildResponse = await fetch(buildUrl, { headers });
+    const buildResponse = await fetch(buildUrl, { headers, signal: AbortSignal.timeout(30_000) });
     if (!buildResponse.ok) {
       throwAdoApiError(buildResponse, `Build ${identifier.runId}`);
     }
@@ -101,7 +101,7 @@ export class AdoPipelineWatcher implements DevDocketRunWatcher {
 
     // Fetch timeline for job details
     const timelineUrl = `https://dev.azure.com/${encodedOrg}/${encodedProject}/_apis/build/builds/${encodedBuildId}/timeline?api-version=7.1`;
-    const timelineResponse = await fetch(timelineUrl, { headers });
+    const timelineResponse = await fetch(timelineUrl, { headers, signal: AbortSignal.timeout(30_000) });
 
     let jobs: JobStatus[] = [];
     if (timelineResponse.ok) {

--- a/packages/ado/src/adoPipelineWatcher.ts
+++ b/packages/ado/src/adoPipelineWatcher.ts
@@ -30,6 +30,8 @@ interface AdoTimelineRecord {
   finishTime?: string;
 }
 
+const FETCH_TIMEOUT_MS = 30_000;
+
 export class AdoPipelineWatcher implements DevDocketRunWatcher {
   readonly id = 'ado-pipelines';
   readonly label = 'Azure DevOps Pipelines';
@@ -90,10 +92,10 @@ export class AdoPipelineWatcher implements DevDocketRunWatcher {
     const buildUrl = `https://dev.azure.com/${encodedOrg}/${encodedProject}/_apis/build/builds/${encodedBuildId}?api-version=7.1`;
     let buildResponse: Response;
     try {
-      buildResponse = await fetch(buildUrl, { headers, signal: AbortSignal.timeout(30_000) });
+      buildResponse = await fetch(buildUrl, { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
-        throw new Error(`ADO API request timed out after 30s for build ${identifier.runId}`);
+        throw new Error(`ADO API request timed out after ${FETCH_TIMEOUT_MS / 1000}s for build ${identifier.runId}`);
       }
       throw err;
     }
@@ -111,10 +113,10 @@ export class AdoPipelineWatcher implements DevDocketRunWatcher {
     const timelineUrl = `https://dev.azure.com/${encodedOrg}/${encodedProject}/_apis/build/builds/${encodedBuildId}/timeline?api-version=7.1`;
     let timelineResponse: Response | undefined;
     try {
-      timelineResponse = await fetch(timelineUrl, { headers, signal: AbortSignal.timeout(30_000) });
+      timelineResponse = await fetch(timelineUrl, { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
-        logger.warn(`ADO timeline request timed out after 30s for build ${identifier.runId}`);
+        logger.warn(`ADO timeline request timed out after ${FETCH_TIMEOUT_MS / 1000}s for build ${identifier.runId}`);
       } else {
         throw err;
       }

--- a/packages/ado/src/adoPipelineWatcher.ts
+++ b/packages/ado/src/adoPipelineWatcher.ts
@@ -109,20 +109,19 @@ export class AdoPipelineWatcher implements DevDocketRunWatcher {
 
     // Fetch timeline for job details
     const timelineUrl = `https://dev.azure.com/${encodedOrg}/${encodedProject}/_apis/build/builds/${encodedBuildId}/timeline?api-version=7.1`;
-    let timelineResponse: Response;
+    let timelineResponse: Response | undefined;
     try {
       timelineResponse = await fetch(timelineUrl, { headers, signal: AbortSignal.timeout(30_000) });
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
         logger.warn(`ADO timeline request timed out after 30s for build ${identifier.runId}`);
-        timelineResponse = { ok: false } as Response;
       } else {
         throw err;
       }
     }
 
     let jobs: JobStatus[] = [];
-    if (timelineResponse.ok) {
+    if (timelineResponse?.ok) {
       const timelineData = await timelineResponse.json() as { records: AdoTimelineRecord[] };
       jobs = timelineData.records
         .filter(r => r.type === 'Job')
@@ -134,7 +133,7 @@ export class AdoPipelineWatcher implements DevDocketRunWatcher {
           startedAt: r.startTime,
           completedAt: r.finishTime,
         }));
-    } else {
+    } else if (timelineResponse) {
       logger.warn(`Failed to fetch timeline for build ${identifier.runId}: ${timelineResponse.status} ${timelineResponse.statusText}`);
     }
 

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -203,6 +203,7 @@ export class AdoPrReviewProvider extends BaseProvider {
         `https://dev.azure.com/${encodeURIComponent(org)}/_apis/connectiondata`,
         {
           headers: { Authorization: `Bearer ${token}` },
+          signal: AbortSignal.timeout(30_000),
         },
       );
     } catch (err) {
@@ -251,6 +252,7 @@ export class AdoPrReviewProvider extends BaseProvider {
       headers: {
         Authorization: `Bearer ${token}`,
       },
+      signal: AbortSignal.timeout(30_000),
     });
 
     if (!response.ok) {

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -201,6 +201,7 @@ export class AdoWorkItemProvider extends BaseProvider {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ query: wiqlQuery }),
+        signal: AbortSignal.timeout(30_000),
       });
     } catch (err) {
       logger.error(`Network error querying work items for project "${project || org}":`, err);
@@ -241,6 +242,7 @@ export class AdoWorkItemProvider extends BaseProvider {
           headers: {
             Authorization: `Bearer ${token}`,
           },
+          signal: AbortSignal.timeout(30_000),
         });
       } catch (err) {
         logger.error(

--- a/packages/ai-reviewer/src/basePrAction.ts
+++ b/packages/ai-reviewer/src/basePrAction.ts
@@ -117,6 +117,7 @@ export abstract class BasePrAction implements DevDocketAction {
           Accept: 'application/vnd.github.diff',
           'X-GitHub-Api-Version': '2022-11-28',
         },
+        signal: AbortSignal.timeout(30_000),
       },
     );
 

--- a/packages/ai-reviewer/src/repoManager.ts
+++ b/packages/ai-reviewer/src/repoManager.ts
@@ -23,7 +23,7 @@ function authHeader(token: string): string {
 }
 
 /** Run a git command with transient auth injected via http.extraheader. */
-function gitAuth(args: string[], cwd: string, token: string, timeout?: number): Promise<string> {
+function gitAuth(args: string[], cwd: string, token: string, timeout = 30_000): Promise<string> {
   return gitExec(
     ['-c', `http.extraheader=${authHeader(token)}`, ...args],
     cwd,

--- a/packages/ai-reviewer/src/repoManager.ts
+++ b/packages/ai-reviewer/src/repoManager.ts
@@ -23,10 +23,11 @@ function authHeader(token: string): string {
 }
 
 /** Run a git command with transient auth injected via http.extraheader. */
-function gitAuth(args: string[], cwd: string, token: string): Promise<string> {
+function gitAuth(args: string[], cwd: string, token: string, timeout?: number): Promise<string> {
   return gitExec(
     ['-c', `http.extraheader=${authHeader(token)}`, ...args],
     cwd,
+    timeout,
   );
 }
 
@@ -83,6 +84,7 @@ export class RepoManager {
         ['clone', '--no-checkout', cloneUrl, clonePath],
         path.dirname(clonePath),
         session.accessToken,
+        300_000,
       );
       this.log.info('Clone complete');
     }
@@ -103,6 +105,7 @@ export class RepoManager {
         ['fetch', 'origin', `pull/${prNumber}/head`],
         worktreePath,
         session.accessToken,
+        300_000,
       );
       await gitExec(['reset', '--hard', 'FETCH_HEAD'], worktreePath);
       this.log.info('Worktree updated');
@@ -112,6 +115,7 @@ export class RepoManager {
         ['fetch', 'origin', `pull/${prNumber}/head:${headRef}`],
         clonePath,
         session.accessToken,
+        300_000,
       );
       this.log.info('PR head fetched');
     }
@@ -126,6 +130,7 @@ export class RepoManager {
       ['fetch', 'origin', `refs/heads/${baseRef}:refs/remotes/origin/${baseRef}`],
       clonePath,
       session.accessToken,
+      300_000,
     );
     this.log.info('Base branch fetched');
 
@@ -230,6 +235,7 @@ export class RepoManager {
           Accept: 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28',
         },
+        signal: AbortSignal.timeout(30_000),
       },
     );
 

--- a/packages/ai-reviewer/src/tools/gitUtils.ts
+++ b/packages/ai-reviewer/src/tools/gitUtils.ts
@@ -9,12 +9,12 @@ export class GitExecError extends Error {
 }
 
 /** Run a git command in the given directory. Returns stdout. */
-export function gitExec(args: string[], cwd: string): Promise<string> {
+export function gitExec(args: string[], cwd: string, timeout = 30_000): Promise<string> {
   return new Promise((resolve, reject) => {
     execFile(
       'git',
       ['--no-pager', ...args],
-      { cwd, maxBuffer: 10 * 1024 * 1024 },
+      { cwd, maxBuffer: 10 * 1024 * 1024, timeout },
       (err, stdout, stderr) => {
         if (err) {
           const errorOutput = stderr?.trim() || 'git command failed';

--- a/packages/github/src/githubActionsWatcher.ts
+++ b/packages/github/src/githubActionsWatcher.ts
@@ -151,7 +151,7 @@ export class GitHubActionsWatcher implements DevDocketRunWatcher {
       throw new Error('Request cancelled');
     }
 
-    const response = await fetch(url, { headers });
+    const response = await fetch(url, { headers, signal: AbortSignal.timeout(30_000) });
 
     if (!response.ok) {
       if (response.status === 404) {

--- a/packages/github/src/githubActionsWatcher.ts
+++ b/packages/github/src/githubActionsWatcher.ts
@@ -151,7 +151,15 @@ export class GitHubActionsWatcher implements DevDocketRunWatcher {
       throw new Error('Request cancelled');
     }
 
-    const response = await fetch(url, { headers, signal: AbortSignal.timeout(30_000) });
+    let response: Response;
+    try {
+      response = await fetch(url, { headers, signal: AbortSignal.timeout(30_000) });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new Error('GitHub API request timed out after 30s');
+      }
+      throw err;
+    }
 
     if (!response.ok) {
       if (response.status === 404) {

--- a/packages/github/src/githubActionsWatcher.ts
+++ b/packages/github/src/githubActionsWatcher.ts
@@ -132,6 +132,8 @@ export class GitHubActionsWatcher implements DevDocketRunWatcher {
     }
   }
 
+  private static readonly FETCH_TIMEOUT_MS = 30_000;
+
   private async fetchApi<T>(url: string, token?: CancellationTokenLike): Promise<T> {
     // Background polling must not trigger interactive sign-in prompts.
     // Reuse an existing session if available; fail gracefully if not.
@@ -153,10 +155,10 @@ export class GitHubActionsWatcher implements DevDocketRunWatcher {
 
     let response: Response;
     try {
-      response = await fetch(url, { headers, signal: AbortSignal.timeout(30_000) });
+      response = await fetch(url, { headers, signal: AbortSignal.timeout(GitHubActionsWatcher.FETCH_TIMEOUT_MS) });
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
-        throw new Error('GitHub API request timed out after 30s');
+        throw new Error(`GitHub API request timed out after ${GitHubActionsWatcher.FETCH_TIMEOUT_MS / 1000}s`);
       }
       throw err;
     }

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -138,6 +138,7 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
           Accept: 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28',
         },
+        signal: AbortSignal.timeout(30_000),
       },
     );
 
@@ -159,6 +160,7 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
           Accept: 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28',
         },
+        signal: AbortSignal.timeout(30_000),
       },
     );
 
@@ -212,7 +214,7 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
     };
 
     // Fetch PR details (draft, mergeable state)
-    const detailResponse = await fetch(pr.pull_request!.url, { headers });
+    const detailResponse = await fetch(pr.pull_request!.url, { headers, signal: AbortSignal.timeout(30_000) });
     if (!detailResponse.ok) {
       logger.debug(`Failed to fetch PR detail for ${pr.html_url}: ${detailResponse.status}`);
       return undefined;
@@ -222,7 +224,7 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
     // Fetch reviews — treat failure as unknown status since we can't determine
     // the actual review state without this data
     const reviewsUrl = `${pr.pull_request!.url}/reviews`;
-    const reviewsResponse = await fetch(reviewsUrl, { headers });
+    const reviewsResponse = await fetch(reviewsUrl, { headers, signal: AbortSignal.timeout(30_000) });
     if (!reviewsResponse.ok) {
       logger.debug(`Failed to fetch reviews for ${pr.html_url}: ${reviewsResponse.status}`);
       return undefined;

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -199,6 +199,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
           Accept: 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28',
         },
+        signal: AbortSignal.timeout(30_000),
       },
     );
 
@@ -220,6 +221,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
           Accept: 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28',
         },
+        signal: AbortSignal.timeout(30_000),
       },
     );
 
@@ -256,6 +258,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
               Accept: 'application/vnd.github+json',
               'X-GitHub-Api-Version': '2022-11-28',
             },
+            signal: AbortSignal.timeout(30_000),
           });
           if (response.ok) {
             const data = (await response.json()) as { head?: { sha?: string } };
@@ -295,6 +298,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
           Accept: 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28',
         },
+        signal: AbortSignal.timeout(30_000),
       });
       if (response.ok) {
         const data = (await response.json()) as { login?: string };
@@ -339,6 +343,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
               Accept: 'application/vnd.github+json',
               'X-GitHub-Api-Version': '2022-11-28',
             },
+            signal: AbortSignal.timeout(30_000),
           });
           if (response.ok) {
             const events = (await response.json()) as TimelineEvent[];

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -197,6 +197,7 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
             Accept: 'application/vnd.github+json',
             'X-GitHub-Api-Version': '2022-11-28',
           },
+          signal: AbortSignal.timeout(30_000),
         });
       } catch (err) {
         if (allItems.length > 0) {

--- a/packages/start-git-work/src/gitCleanup.ts
+++ b/packages/start-git-work/src/gitCleanup.ts
@@ -120,7 +120,7 @@ async function checkCleanupState(item: WorkItem): Promise<CleanupState | undefin
 
   if (info.branchName) {
     try {
-      await execFileAsync('git', ['show-ref', '--verify', '--quiet', '--', `refs/heads/${info.branchName}`], { cwd: repoPath });
+      await execFileAsync('git', ['show-ref', '--verify', '--quiet', '--', `refs/heads/${info.branchName}`], { cwd: repoPath, timeout: 30_000 });
       branchExists = true;
     } catch (err) {
       if ((err as { code?: number | string }).code === 1) {
@@ -188,7 +188,7 @@ export async function promptGitCleanup(
 
   if (worktreeExists && worktreePath && repoPath) {
     try {
-      await execFileAsync('git', ['worktree', 'remove', '--', worktreePath], { cwd: repoPath });
+      await execFileAsync('git', ['worktree', 'remove', '--', worktreePath], { cwd: repoPath, timeout: 30_000 });
       logger.info('Removed worktree for work item');
       cleaned.push(`worktree`);
     } catch (err) {
@@ -202,7 +202,7 @@ export async function promptGitCleanup(
   // Skip branch deletion if worktree removal failed — branch is likely still checked out
   if (branchExists && branchName && repoPath && worktreeRemoved) {
     try {
-      await execFileAsync('git', ['branch', '-d', '--', branchName], { cwd: repoPath });
+      await execFileAsync('git', ['branch', '-d', '--', branchName], { cwd: repoPath, timeout: 30_000 });
       logger.info(`Deleted branch: ${branchName}`);
       cleaned.push(`branch ${branchName}`);
     } catch (err) {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -104,13 +104,13 @@ export class StartWorkAction implements DevDocketAction {
           progress.report({ message: 'Creating branch...' });
 
           // Check if branch already exists
-          const { stdout: branchList } = await execFileAsync('git', ['branch', '--list', branchName], { cwd: repoPath });
+          const { stdout: branchList } = await execFileAsync('git', ['branch', '--list', branchName], { cwd: repoPath, timeout: 30_000 });
           if (branchList.trim()) {
             void vscode.window.showErrorMessage(`DevDocket: Branch "${branchName}" already exists.`);
             return;
           }
 
-          await execFileAsync('git', ['branch', branchName, baseBranch], { cwd: repoPath });
+          await execFileAsync('git', ['branch', branchName, baseBranch], { cwd: repoPath, timeout: 30_000 });
           logger.info(`Starting work: creating branch ${branchName}`);
 
           progress.report({ message: 'Creating worktree...' });
@@ -118,11 +118,12 @@ export class StartWorkAction implements DevDocketAction {
           try {
             await execFileAsync('git', ['worktree', 'add', worktreePath, branchName], {
               cwd: repoPath,
+              timeout: 30_000,
             });
           } catch (worktreeErr) {
             // Rollback: delete the branch we just created
             try {
-              await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath });
+              await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath, timeout: 30_000 });
             } catch (rollbackErr) {
               const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
               void vscode.window.showWarningMessage(`DevDocket: Failed to delete branch during rollback — ${rollbackMessage}`);
@@ -160,7 +161,7 @@ export class StartWorkAction implements DevDocketAction {
               arg => arg.replace(/\{path\}/g, worktreePath),
             );
             try {
-              await execFileAsync(cmd.command, resolvedArgs, { cwd: worktreePath });
+              await execFileAsync(cmd.command, resolvedArgs, { cwd: worktreePath, timeout: 60_000 });
             } catch (cmdErr) {
               const cmdMessage = cmdErr instanceof Error ? cmdErr.message : String(cmdErr);
               logger.error(`Post-worktree command failed: ${cmd.command}`, cmdErr);

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -375,6 +375,7 @@ describe('StartWorkAction', () => {
       expect(postCmd[0]).toBe('npm');
       const expectedWorktreePath = path.join('/mock', 'workspace-issue123');
       expect(postCmd[1]).toEqual(['install', '--prefix', expectedWorktreePath]);
+      expect(postCmd[2]).toEqual({ cwd: expectedWorktreePath, timeout: 60_000 });
     });
 
     it('shows warning when post-worktree command fails', async () => {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -229,13 +229,13 @@ describe('StartWorkAction', () => {
       const firstCall = vi.mocked(execFile).mock.calls[0];
       expect(firstCall[0]).toBe('git');
       expect(firstCall[1]).toEqual(['branch', '--list', 'issue123']);
-      expect(firstCall[2]).toEqual({ cwd: '/mock/workspace' });
+      expect(firstCall[2]).toEqual({ cwd: '/mock/workspace', timeout: 30_000 });
 
       // Second call: create branch from user-specified base
       const secondCall = vi.mocked(execFile).mock.calls[1];
       expect(secondCall[0]).toBe('git');
       expect(secondCall[1]).toEqual(['branch', 'issue123', 'origin/dev']);
-      expect(secondCall[2]).toEqual({ cwd: '/mock/workspace' });
+      expect(secondCall[2]).toEqual({ cwd: '/mock/workspace', timeout: 30_000 });
 
       // Third call: create worktree
       const thirdCall = vi.mocked(execFile).mock.calls[2];
@@ -245,6 +245,7 @@ describe('StartWorkAction', () => {
         path.join('/mock', 'workspace-issue123'),
         'issue123',
       ]);
+      expect(thirdCall[2]).toEqual({ cwd: '/mock/workspace', timeout: 30_000 });
     });
 
     it('creates branch and worktree with correct names for ADO items', async () => {
@@ -261,7 +262,7 @@ describe('StartWorkAction', () => {
       const firstCall = vi.mocked(execFile).mock.calls[0];
       expect(firstCall[0]).toBe('git');
       expect(firstCall[1]).toEqual(['branch', '--list', 'issue456']);
-      expect(firstCall[2]).toEqual({ cwd: '/mock/workspace' });
+      expect(firstCall[2]).toEqual({ cwd: '/mock/workspace', timeout: 30_000 });
 
       // Second call: create branch
       const secondCall = vi.mocked(execFile).mock.calls[1];
@@ -276,6 +277,7 @@ describe('StartWorkAction', () => {
         path.join('/mock', 'workspace-issue456'),
         'issue456',
       ]);
+      expect(thirdCall[2]).toEqual({ cwd: '/mock/workspace', timeout: 30_000 });
     });
 
     it('uses user-specified base branch for branch creation', async () => {


### PR DESCRIPTION
## Summary

Adds timeout safety nets to all unprotected `fetch()` and git subprocess calls across the extension, preventing the extension from hanging indefinitely on slow or unresponsive APIs and networks.

Closes #298

## Changes

### fetch() timeouts (19 call sites)

Added `AbortSignal.timeout(30_000)` to every `fetch()` call that previously lacked an abort signal:

- **packages/github**: `githubProvider.ts` (paginated fetch), `githubPrReviewProvider.ts` (5 calls: repo/all PR search, head SHA fetch, current user, timeline), `githubActionsWatcher.ts` (API fetch), `githubMyPrsProvider.ts` (4 calls: repo/all authored PR search, PR detail, reviews)
- **packages/ado**: `adoWorkItemProvider.ts` (WIQL query, batch detail fetch), `adoPrReviewProvider.ts` (connection data, PR list), `adoPipelineWatcher.ts` (build details, timeline)
- **packages/ai-reviewer**: `basePrAction.ts` (GitHub diff fetch), `repoManager.ts` (PR metadata)

Fetch calls that already receive an `AbortSignal` from their callers (e.g., `getClosedItems`, `resolveUrl`) are left unchanged — the caller controls cancellation.

### Git subprocess timeouts (13 call sites)

- **Local git operations** (`branch`, `show-ref`, `worktree add/remove`, `reset`): `timeout: 30_000` (30s)
- **Network git operations** (`clone`, `fetch`): `timeout: 300_000` (5 min) — these involve data transfer over the network
- **User-configured post-worktree commands**: `timeout: 60_000` (60s) — longer since arbitrary user commands may need more time

### API changes

- `gitExec()` in `packages/ai-reviewer/src/tools/gitUtils.ts` now accepts an optional `timeout` parameter (default: `30_000`). This is additive and non-breaking.

## Related

- #300 — CancellationToken → AbortController wiring (deeper cancellation integration, separate issue)
