### PR TITLE
Add cancellation test coverage for CancellationToken→AbortSignal wiring

### DIFF
--- a/.squad/agents/hockney/history.md
+++ b/.squad/agents/hockney/history.md
@@ -94,3 +94,28 @@ DevDocket is a VS Code extension monorepo for managing work items. Packages: `co
 **Pattern:** Concurrent test writing enabled Fenster to implement two features in parallel while Hockney validated the more complex state transitions (#275) with full test coverage.
 
 **Multi-worktree workflow confirmed:** Worked in dedicated worktree on branch `squad/275-history-to-queue` while main worktree was on different branch.
+
+### 2026-04-22 — PR #327 Cancellation Test Coverage (Issue #300)
+
+**44 new cancellation tests** across 5 test files covering the CancellationToken → AbortSignal wiring from PR #327. Test files:
+- `packages/github/src/test/githubProvider.cancellation.test.ts` — 13 tests
+- `packages/github/src/test/githubMyPrsProvider.cancellation.test.ts` — 9 tests
+- `packages/github/src/test/githubPrReviewProvider.cancellation.test.ts` — 8 tests
+- `packages/ado/src/test/adoWorkItemProvider.cancellation.test.ts` — 7 tests
+- `packages/ado/src/test/adoPrReviewProvider.cancellation.test.ts` — 7 tests
+
+**Key scenarios tested:**
+1. AbortSignal is passed to every `fetch()` call when CancellationToken is provided
+2. Mid-flight cancellation: token fires during fetch → AbortError propagates correctly
+3. No items published on abort (preserves previous provider state)
+4. AbortError logged at debug level, not error level
+5. Worker pool abort: worker loops stop early when signal is aborted
+6. cancelListener disposed in finally block (both success and abort paths)
+7. `_isRefreshing` guard resets after abort so subsequent refresh can proceed
+8. Already-cancelled token: early return without fetch
+9. Pagination abort: stops fetching further pages when aborted mid-pagination
+10. No partial results published when abort happens during multi-repo fetch
+
+**Mock pattern: `createMockCancellationToken()`** — Creates a token with working `onCancellationRequested` callback and trackable `disposeStubs`. Mirrors real vscode.CancellationToken behavior. Returns `{ token, cancel, disposeStubs }`.
+
+**Key behavioral difference discovered:** GitHub providers (via BaseGitHubProvider) do NOT fire empty items on early cancellation — they just return. ADO providers DO fire `[]` on pre-fetch cancellation. Both are correct for their respective patterns. AbortError during fetch does NOT publish items in either package.

--- a/packages/ado/src/test/adoPrReviewProvider.cancellation.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.cancellation.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { authentication } from 'vscode';
+import { AdoPrReviewProvider } from '../adoPrReviewProvider';
+import { initLogger, LogLevel } from '../logger';
+
+const mockFetch = vi.fn();
+
+function createMockCancellationToken() {
+  let isCancellationRequested = false;
+  const listeners: (() => void)[] = [];
+  const disposeStubs: ReturnType<typeof vi.fn>[] = [];
+
+  const token = {
+    get isCancellationRequested() { return isCancellationRequested; },
+    onCancellationRequested: (listener: () => void) => {
+      listeners.push(listener);
+      const dispose = vi.fn();
+      disposeStubs.push(dispose);
+      return { dispose };
+    },
+  };
+
+  const cancel = () => {
+    isCancellationRequested = true;
+    listeners.forEach(l => l());
+  };
+
+  return { token: token as any, cancel, disposeStubs };
+}
+
+describe('AdoPrReviewProvider — cancellation (AbortSignal wiring)', () => {
+  let provider: AdoPrReviewProvider;
+  let mockChannel: { appendLine: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+    provider = new AdoPrReviewProvider([{ org: 'myorg', projects: ['MyProject'] }]);
+
+    mockChannel = { appendLine: vi.fn() };
+    initLogger(mockChannel as any, LogLevel.Debug);
+
+    vi.mocked(authentication.getSession).mockResolvedValue({
+      accessToken: 'test-token',
+      id: 'session-1',
+      scopes: ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+      account: { id: '1', label: 'testuser' },
+    } as any);
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    vi.unstubAllGlobals();
+  });
+
+  // ── Signal wiring ──────────────────────────────────────────────────
+
+  describe('AbortSignal passed to fetch', () => {
+    it('passes AbortSignal to connection data fetch', async () => {
+      const { token } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/connectiondata')) {
+          return {
+            ok: true,
+            json: async () => ({ authenticatedUser: { id: 'user-123' } }),
+          };
+        }
+        if (typeof url === 'string' && url.includes('/pullrequests')) {
+          return { ok: true, json: async () => ({ count: 0, value: [] }) };
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      await provider.refresh(token);
+
+      const connectionCall = mockFetch.mock.calls.find(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('/connectiondata'),
+      );
+      expect(connectionCall).toBeDefined();
+      expect(connectionCall![1].signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('passes AbortSignal to pull request list fetch', async () => {
+      const { token } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/connectiondata')) {
+          return {
+            ok: true,
+            json: async () => ({ authenticatedUser: { id: 'user-123' } }),
+          };
+        }
+        if (typeof url === 'string' && url.includes('/pullrequests')) {
+          return { ok: true, json: async () => ({ count: 0, value: [] }) };
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      await provider.refresh(token);
+
+      const prCall = mockFetch.mock.calls.find(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('/pullrequests'),
+      );
+      expect(prCall).toBeDefined();
+      expect(prCall![1].signal).toBeInstanceOf(AbortSignal);
+    });
+  });
+
+  // ── Mid-fetch cancellation ─────────────────────────────────────────
+
+  describe('mid-fetch cancellation', () => {
+    it('does not publish items when token fires during connection data fetch', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/connectiondata')) {
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      // AbortError → no items published
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('does not publish items when token fires during PR list fetch', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/connectiondata')) {
+          return {
+            ok: true,
+            json: async () => ({ authenticatedUser: { id: 'user-123' } }),
+          };
+        }
+        if (typeof url === 'string' && url.includes('/pullrequests')) {
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('logs cancellation at debug level, not error', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/connectiondata')) {
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      await provider.refresh(token);
+
+      const debugLogged = mockChannel.appendLine.mock.calls.some(
+        (call: string[]) => call[0].includes('[DEBUG]') && call[0].includes('aborted'),
+      );
+      expect(debugLogged).toBe(true);
+
+      const errorLogged = mockChannel.appendLine.mock.calls.some(
+        (call: string[]) => call[0].includes('[ERROR]') && call[0].includes('Failed to fetch'),
+      );
+      expect(errorLogged).toBe(false);
+    });
+  });
+
+  // ── Cleanup ────────────────────────────────────────────────────────
+
+  describe('cleanup', () => {
+    it('disposes cancelListener after abort', async () => {
+      const { token, cancel, disposeStubs } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/connectiondata')) {
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      await provider.refresh(token);
+
+      expect(disposeStubs).toHaveLength(1);
+      expect(disposeStubs[0]).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets _isRefreshing after abort', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementationOnce(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/connectiondata')) {
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      await provider.refresh(token);
+
+      // Reset mock for normal operation
+      mockFetch.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/connectiondata')) {
+          return {
+            ok: true,
+            json: async () => ({ authenticatedUser: { id: 'user-123' } }),
+          };
+        }
+        if (typeof url === 'string' && url.includes('/pullrequests')) {
+          return { ok: true, json: async () => ({ count: 0, value: [] }) };
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      expect(listener).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/ado/src/test/adoWorkItemProvider.cancellation.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.cancellation.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { authentication } from 'vscode';
+import { AdoWorkItemProvider } from '../adoWorkItemProvider';
+import { initLogger, LogLevel } from '../logger';
+
+const mockFetch = vi.fn();
+
+function createMockCancellationToken() {
+  let isCancellationRequested = false;
+  const listeners: (() => void)[] = [];
+  const disposeStubs: ReturnType<typeof vi.fn>[] = [];
+
+  const token = {
+    get isCancellationRequested() { return isCancellationRequested; },
+    onCancellationRequested: (listener: () => void) => {
+      listeners.push(listener);
+      const dispose = vi.fn();
+      disposeStubs.push(dispose);
+      return { dispose };
+    },
+  };
+
+  const cancel = () => {
+    isCancellationRequested = true;
+    listeners.forEach(l => l());
+  };
+
+  return { token: token as any, cancel, disposeStubs };
+}
+
+function createWiqlResponse(ids: number[]) {
+  return {
+    workItems: ids.map(id => ({ id, url: `https://dev.azure.com/myorg/_apis/wit/workitems/${id}` })),
+  };
+}
+
+function createWorkItemDetail(id: number, title: string, project = 'MyProject', type = 'User Story') {
+  return {
+    id,
+    fields: {
+      'System.Title': title,
+      'System.Description': `<p>Description for ${id}</p>`,
+      'System.TeamProject': project,
+      'System.WorkItemType': type,
+      'System.State': 'Active',
+    },
+    _links: {
+      html: { href: `https://dev.azure.com/myorg/${project}/_workitems/edit/${id}` },
+    },
+  };
+}
+
+describe('AdoWorkItemProvider — cancellation (AbortSignal wiring)', () => {
+  let provider: AdoWorkItemProvider;
+  let mockChannel: { appendLine: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+    provider = new AdoWorkItemProvider([{ org: 'myorg', projects: ['MyProject'] }]);
+
+    mockChannel = { appendLine: vi.fn() };
+    initLogger(mockChannel as any, LogLevel.Debug);
+
+    vi.mocked(authentication.getSession).mockResolvedValue({
+      accessToken: 'test-token',
+      id: 'session-1',
+      scopes: ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+      account: { id: '1', label: 'testuser' },
+    } as any);
+
+    // Default fallback: states API calls return no terminal states
+    mockFetch.mockImplementation(async (url: string) => {
+      if (typeof url === 'string' && url.includes('/workitemtypes/') && url.includes('/states')) {
+        return { ok: true, json: async () => ({ count: 0, value: [] }) };
+      }
+      throw new Error(`Unexpected fetch call in test: ${String(url)}`);
+    });
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    vi.unstubAllGlobals();
+  });
+
+  // ── Signal wiring ──────────────────────────────────────────────────
+
+  describe('AbortSignal passed to fetch', () => {
+    it('passes AbortSignal to WIQL fetch call', async () => {
+      const { token } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async (url: string, options?: RequestInit) => {
+        if (typeof url === 'string' && url.includes('/wiql')) {
+          return {
+            ok: true,
+            json: async () => createWiqlResponse([]),
+          };
+        }
+        if (typeof url === 'string' && url.includes('/workitemtypes/') && url.includes('/states')) {
+          return { ok: true, json: async () => ({ count: 0, value: [] }) };
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      await provider.refresh(token);
+
+      // Find the WIQL call
+      const wiqlCall = mockFetch.mock.calls.find(
+        (call: any[]) => typeof call[0] === 'string' && call[0].includes('/wiql'),
+      );
+      expect(wiqlCall).toBeDefined();
+      expect(wiqlCall![1].signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('passes AbortSignal to work item detail fetch calls', async () => {
+      const { token } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/wiql')) {
+          return { ok: true, json: async () => createWiqlResponse([1]) };
+        }
+        if (typeof url === 'string' && url.includes('/workitems?ids=')) {
+          return {
+            ok: true,
+            json: async () => ({ count: 1, value: [createWorkItemDetail(1, 'Test Item')] }),
+          };
+        }
+        if (typeof url === 'string' && url.includes('/workitemtypes/') && url.includes('/states')) {
+          return { ok: true, json: async () => ({ count: 0, value: [] }) };
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      await provider.refresh(token);
+
+      // All fetch calls should have signal
+      for (const call of mockFetch.mock.calls) {
+        expect(call[1]).toHaveProperty('signal');
+        expect(call[1].signal).toBeInstanceOf(AbortSignal);
+      }
+    });
+  });
+
+  // ── Mid-fetch cancellation ─────────────────────────────────────────
+
+  describe('mid-fetch cancellation', () => {
+    it('does not publish items when token fires during WIQL fetch', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/wiql')) {
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        }
+        if (typeof url === 'string' && url.includes('/workitemtypes/') && url.includes('/states')) {
+          return { ok: true, json: async () => ({ count: 0, value: [] }) };
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      // AbortError should NOT fire empty items — preserves previous state
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('logs cancellation at debug level, not error', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/wiql')) {
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        }
+        if (typeof url === 'string' && url.includes('/workitemtypes/') && url.includes('/states')) {
+          return { ok: true, json: async () => ({ count: 0, value: [] }) };
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      await provider.refresh(token);
+
+      const debugLogged = mockChannel.appendLine.mock.calls.some(
+        (call: string[]) => call[0].includes('[DEBUG]') && call[0].includes('aborted'),
+      );
+      expect(debugLogged).toBe(true);
+
+      const errorLogged = mockChannel.appendLine.mock.calls.some(
+        (call: string[]) => call[0].includes('[ERROR]') && call[0].includes('Failed to fetch'),
+      );
+      expect(errorLogged).toBe(false);
+    });
+
+    it('does not publish partial results when abort happens during detail fetch', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/wiql')) {
+          return { ok: true, json: async () => createWiqlResponse([1, 2, 3]) };
+        }
+        if (typeof url === 'string' && url.includes('/workitems?ids=')) {
+          // Cancel during detail fetch
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        }
+        if (typeof url === 'string' && url.includes('/workitemtypes/') && url.includes('/states')) {
+          return { ok: true, json: async () => ({ count: 0, value: [] }) };
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      // No partial items published
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Cleanup ────────────────────────────────────────────────────────
+
+  describe('cleanup', () => {
+    it('disposes cancelListener after abort', async () => {
+      const { token, cancel, disposeStubs } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/wiql')) {
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        }
+        if (typeof url === 'string' && url.includes('/workitemtypes/') && url.includes('/states')) {
+          return { ok: true, json: async () => ({ count: 0, value: [] }) };
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      await provider.refresh(token);
+
+      expect(disposeStubs).toHaveLength(1);
+      expect(disposeStubs[0]).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets _isRefreshing after abort', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementationOnce(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/wiql')) {
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      await provider.refresh(token);
+
+      // Reset mock to normal behavior for second refresh
+      mockFetch.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/wiql')) {
+          return { ok: true, json: async () => createWiqlResponse([]) };
+        }
+        if (typeof url === 'string' && url.includes('/workitemtypes/') && url.includes('/states')) {
+          return { ok: true, json: async () => ({ count: 0, value: [] }) };
+        }
+        throw new Error(`Unexpected fetch: ${String(url)}`);
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      expect(listener).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/github/src/test/githubMyPrsProvider.cancellation.test.ts
+++ b/packages/github/src/test/githubMyPrsProvider.cancellation.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { authentication, workspace } from 'vscode';
+import { GitHubMyPrsProvider, type PrDetail, type PrReview } from '../githubMyPrsProvider';
+import { initLogger, LogLevel } from '../logger';
+
+const mockFetch = vi.fn();
+
+function createMockCancellationToken() {
+  let isCancellationRequested = false;
+  const listeners: (() => void)[] = [];
+  const disposeStubs: ReturnType<typeof vi.fn>[] = [];
+
+  const token = {
+    get isCancellationRequested() { return isCancellationRequested; },
+    onCancellationRequested: (listener: () => void) => {
+      listeners.push(listener);
+      const dispose = vi.fn();
+      disposeStubs.push(dispose);
+      return { dispose };
+    },
+  };
+
+  const cancel = () => {
+    isCancellationRequested = true;
+    listeners.forEach(l => l());
+  };
+
+  return { token: token as any, cancel, disposeStubs };
+}
+
+function createMockPr(number: number, title: string, repo = 'owner/repo') {
+  return {
+    number,
+    title,
+    body: `Body for PR ${number}`,
+    state: 'open',
+    html_url: `https://github.com/${repo}/pull/${number}`,
+    repository_url: `https://api.github.com/repos/${repo}`,
+    pull_request: { url: `https://api.github.com/repos/${repo}/pulls/${number}` },
+  };
+}
+
+function mockSearchResponse(items: ReturnType<typeof createMockPr>[]) {
+  return { ok: true, json: async () => ({ items }) };
+}
+
+function mockPrDetailResponse(detail: PrDetail) {
+  return { ok: true, json: async () => detail };
+}
+
+function mockReviewsResponse(reviews: PrReview[]) {
+  return { ok: true, json: async () => reviews };
+}
+
+describe('GitHubMyPrsProvider — cancellation (AbortSignal wiring)', () => {
+  let provider: GitHubMyPrsProvider;
+  let mockChannel: { appendLine: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+    provider = new GitHubMyPrsProvider();
+
+    mockChannel = { appendLine: vi.fn() };
+    initLogger(mockChannel as any, LogLevel.Debug);
+
+    vi.mocked(authentication.getSession).mockResolvedValue({
+      accessToken: 'test-token',
+      id: 'session-1',
+      scopes: ['repo'],
+      account: { id: '1', label: 'testuser' },
+    } as any);
+
+    vi.mocked(workspace.getConfiguration).mockReturnValue({
+      get: vi.fn((_key: string, defaultValue?: any) => defaultValue),
+    } as any);
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    vi.unstubAllGlobals();
+  });
+
+  // ── Signal wiring ──────────────────────────────────────────────────
+
+  describe('AbortSignal passed to fetch', () => {
+    it('passes AbortSignal to search fetch', async () => {
+      const { token } = createMockCancellationToken();
+      mockFetch.mockResolvedValueOnce(mockSearchResponse([]));
+
+      await provider.refresh(token);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const fetchOptions = mockFetch.mock.calls[0][1];
+      expect(fetchOptions.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('passes AbortSignal to PR detail and review fetch calls', async () => {
+      const { token } = createMockCancellationToken();
+      const pr = createMockPr(1, 'Test PR');
+
+      mockFetch
+        .mockResolvedValueOnce(mockSearchResponse([pr]))
+        .mockResolvedValueOnce(mockPrDetailResponse({ draft: false }))
+        .mockResolvedValueOnce(mockReviewsResponse([]));
+
+      await provider.refresh(token);
+
+      // 3 calls: search, PR detail, reviews
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      for (const call of mockFetch.mock.calls) {
+        expect(call[1].signal).toBeInstanceOf(AbortSignal);
+      }
+    });
+  });
+
+  // ── Mid-fetch cancellation ─────────────────────────────────────────
+
+  describe('mid-fetch cancellation', () => {
+    it('does not publish items when token fires during search fetch', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async () => {
+        cancel();
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('does not publish items when token fires during PR status fetch', async () => {
+      const { token, cancel } = createMockCancellationToken();
+      const pr = createMockPr(1, 'Test PR');
+
+      let fetchCount = 0;
+      mockFetch.mockImplementation(async () => {
+        fetchCount++;
+        if (fetchCount === 1) {
+          // Search succeeds
+          return mockSearchResponse([pr]);
+        }
+        // PR detail fetch: cancel fires
+        cancel();
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('logs cancellation at debug level', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async () => {
+        cancel();
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      await provider.refresh(token);
+
+      const debugLogged = mockChannel.appendLine.mock.calls.some(
+        (call: string[]) => call[0].includes('[DEBUG]') && call[0].includes('fetch aborted'),
+      );
+      expect(debugLogged).toBe(true);
+
+      const errorLogged = mockChannel.appendLine.mock.calls.some(
+        (call: string[]) => call[0].includes('[ERROR]') && call[0].includes('Failed to fetch'),
+      );
+      expect(errorLogged).toBe(false);
+    });
+  });
+
+  // ── Worker pool abort ──────────────────────────────────────────────
+
+  describe('worker pool abort', () => {
+    it('stops fetching PR statuses when signal is aborted between workers', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      const prs = Array.from({ length: 5 }, (_, i) => createMockPr(i + 1, `PR ${i + 1}`));
+
+      let statusFetchCount = 0;
+      mockFetch.mockImplementation(async (url: string) => {
+        // Search call
+        if (url.includes('search/issues')) {
+          return mockSearchResponse(prs);
+        }
+        // PR detail/review calls
+        statusFetchCount++;
+        if (statusFetchCount >= 3) {
+          // After a few status fetches, cancel
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        }
+        if (url.includes('/reviews')) {
+          return mockReviewsResponse([]);
+        }
+        return mockPrDetailResponse({ draft: false });
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      // Should NOT have fetched all 5 PRs × 2 calls = 10 status fetches
+      expect(statusFetchCount).toBeLessThan(10);
+      // No items published due to abort
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('stops worker pool when signal is aborted during fetchPerRepoPrs', async () => {
+      const { token, cancel } = createMockCancellationToken();
+      const repos = ['owner/repo1', 'owner/repo2', 'owner/repo3', 'owner/repo4', 'owner/repo5'];
+
+      vi.mocked(workspace.getConfiguration).mockReturnValue({
+        get: vi.fn((key: string, defaultValue?: any) => {
+          if (key === 'repos') { return repos; }
+          return defaultValue;
+        }),
+      } as any);
+
+      let repoFetchCount = 0;
+      mockFetch.mockImplementation(async () => {
+        repoFetchCount++;
+        if (repoFetchCount >= 2) {
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        }
+        return mockSearchResponse([createMockPr(1, 'PR', repos[repoFetchCount - 1])]);
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      // Workers should have stopped early
+      expect(repoFetchCount).toBeLessThan(5);
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Cleanup ────────────────────────────────────────────────────────
+
+  describe('cleanup', () => {
+    it('disposes cancelListener after abort', async () => {
+      const { token, cancel, disposeStubs } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async () => {
+        cancel();
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      await provider.refresh(token);
+
+      expect(disposeStubs).toHaveLength(1);
+      expect(disposeStubs[0]).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets _isRefreshing after abort', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementationOnce(async () => {
+        cancel();
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      await provider.refresh(token);
+
+      // Next refresh should proceed
+      mockFetch.mockResolvedValueOnce(mockSearchResponse([]));
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      expect(listener).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/github/src/test/githubPrReviewProvider.cancellation.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.cancellation.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { authentication, workspace } from 'vscode';
+import { GitHubPrReviewProvider } from '../githubPrReviewProvider';
+import { initLogger, LogLevel } from '../logger';
+
+const mockFetch = vi.fn();
+
+function createMockCancellationToken() {
+  let isCancellationRequested = false;
+  const listeners: (() => void)[] = [];
+  const disposeStubs: ReturnType<typeof vi.fn>[] = [];
+
+  const token = {
+    get isCancellationRequested() { return isCancellationRequested; },
+    onCancellationRequested: (listener: () => void) => {
+      listeners.push(listener);
+      const dispose = vi.fn();
+      disposeStubs.push(dispose);
+      return { dispose };
+    },
+  };
+
+  const cancel = () => {
+    isCancellationRequested = true;
+    listeners.forEach(l => l());
+  };
+
+  return { token: token as any, cancel, disposeStubs };
+}
+
+function createMockPr(number: number, title: string, repo = 'owner/repo') {
+  return {
+    number,
+    title,
+    body: `Body for PR ${number}`,
+    html_url: `https://github.com/${repo}/pull/${number}`,
+    repository_url: `https://api.github.com/repos/${repo}`,
+    pull_request: { url: `https://api.github.com/repos/${repo}/pulls/${number}` },
+  };
+}
+
+describe('GitHubPrReviewProvider — cancellation (AbortSignal wiring)', () => {
+  let provider: GitHubPrReviewProvider;
+  let mockChannel: { appendLine: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+    provider = new GitHubPrReviewProvider();
+
+    mockChannel = { appendLine: vi.fn() };
+    initLogger(mockChannel as any, LogLevel.Debug);
+
+    // Disable resurfacing features to avoid extra API calls
+    vi.mocked(workspace.getConfiguration).mockReturnValue({
+      get: vi.fn((key: string, defaultValue?: any) => {
+        if (key === 'resurfaceOnNewVersion' || key === 'resurfaceOnReRequestedReview') {
+          return false;
+        }
+        return defaultValue;
+      }),
+    } as any);
+
+    vi.mocked(authentication.getSession).mockResolvedValue({
+      accessToken: 'test-token',
+      id: 'session-1',
+      scopes: ['repo'],
+      account: { id: '1', label: 'testuser' },
+    } as any);
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    vi.unstubAllGlobals();
+  });
+
+  // ── Signal wiring ──────────────────────────────────────────────────
+
+  describe('AbortSignal passed to fetch', () => {
+    it('passes AbortSignal to search fetch', async () => {
+      const { token } = createMockCancellationToken();
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [] }),
+      });
+
+      await provider.refresh(token);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const fetchOptions = mockFetch.mock.calls[0][1];
+      expect(fetchOptions.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('passes AbortSignal to head SHA fetch calls when resurfacing is enabled', async () => {
+      const { token } = createMockCancellationToken();
+      const pr = createMockPr(1, 'Test PR');
+
+      vi.mocked(workspace.getConfiguration).mockReturnValue({
+        get: vi.fn((key: string, defaultValue?: any) => {
+          if (key === 'resurfaceOnNewVersion') { return true; }
+          if (key === 'resurfaceOnReRequestedReview') { return false; }
+          return defaultValue;
+        }),
+      } as any);
+
+      mockFetch
+        // Search response
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ items: [pr] }),
+        })
+        // Head SHA fetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ head: { sha: 'abc123' } }),
+        });
+
+      await provider.refresh(token);
+
+      // Both calls should have signal
+      for (const call of mockFetch.mock.calls) {
+        expect(call[1].signal).toBeInstanceOf(AbortSignal);
+      }
+    });
+  });
+
+  // ── Mid-fetch cancellation ─────────────────────────────────────────
+
+  describe('mid-fetch cancellation', () => {
+    it('does not publish items when token fires during search', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async () => {
+        cancel();
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('does not publish items when abort happens during head SHA fetch', async () => {
+      const { token, cancel } = createMockCancellationToken();
+      const prs = Array.from({ length: 3 }, (_, i) => createMockPr(i + 1, `PR ${i + 1}`));
+
+      vi.mocked(workspace.getConfiguration).mockReturnValue({
+        get: vi.fn((key: string, defaultValue?: any) => {
+          if (key === 'resurfaceOnNewVersion') { return true; }
+          if (key === 'resurfaceOnReRequestedReview') { return false; }
+          return defaultValue;
+        }),
+      } as any);
+
+      let fetchCount = 0;
+      mockFetch.mockImplementation(async () => {
+        fetchCount++;
+        if (fetchCount === 1) {
+          // Search succeeds
+          return { ok: true, json: async () => ({ items: prs }) };
+        }
+        // Head SHA fetches: cancel on second one
+        if (fetchCount >= 3) {
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        }
+        return { ok: true, json: async () => ({ head: { sha: 'abc' } }) };
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('logs cancellation at debug level, not error level', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async () => {
+        cancel();
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      await provider.refresh(token);
+
+      const debugLogged = mockChannel.appendLine.mock.calls.some(
+        (call: string[]) => call[0].includes('[DEBUG]') && call[0].includes('fetch aborted'),
+      );
+      expect(debugLogged).toBe(true);
+
+      const errorLogged = mockChannel.appendLine.mock.calls.some(
+        (call: string[]) => call[0].includes('[ERROR]') && call[0].includes('Failed to fetch'),
+      );
+      expect(errorLogged).toBe(false);
+    });
+  });
+
+  // ── Worker pool abort ──────────────────────────────────────────────
+
+  describe('worker pool abort', () => {
+    it('stops repo worker pool when signal is aborted', async () => {
+      const { token, cancel } = createMockCancellationToken();
+      const repos = ['a/r1', 'a/r2', 'a/r3', 'a/r4', 'a/r5'];
+
+      vi.mocked(workspace.getConfiguration).mockReturnValue({
+        get: vi.fn((key: string, defaultValue?: any) => {
+          if (key === 'repos') { return repos; }
+          if (key === 'resurfaceOnNewVersion' || key === 'resurfaceOnReRequestedReview') {
+            return false;
+          }
+          return defaultValue;
+        }),
+      } as any);
+
+      let repoFetchCount = 0;
+      mockFetch.mockImplementation(async () => {
+        repoFetchCount++;
+        if (repoFetchCount >= 2) {
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        }
+        return { ok: true, json: async () => ({ items: [] }) };
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      expect(repoFetchCount).toBeLessThan(5);
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Cleanup ────────────────────────────────────────────────────────
+
+  describe('cleanup', () => {
+    it('disposes cancelListener after abort', async () => {
+      const { token, cancel, disposeStubs } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async () => {
+        cancel();
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      await provider.refresh(token);
+
+      expect(disposeStubs).toHaveLength(1);
+      expect(disposeStubs[0]).toHaveBeenCalledTimes(1);
+    });
+
+    it('resets _isRefreshing after abort', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementationOnce(async () => {
+        cancel();
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      await provider.refresh(token);
+
+      // Next refresh should proceed
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [] }),
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      expect(listener).toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/github/src/test/githubProvider.cancellation.test.ts
+++ b/packages/github/src/test/githubProvider.cancellation.test.ts
@@ -1,0 +1,375 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { authentication, workspace } from 'vscode';
+import { GitHubIssueProvider } from '../githubProvider';
+import { initLogger, LogLevel } from '../logger';
+
+const mockFetch = vi.fn();
+const noLinkHeaders = { get: () => null };
+
+/**
+ * Creates a mock CancellationToken with a working onCancellationRequested
+ * callback, mirroring real vscode.CancellationToken behavior.
+ */
+function createMockCancellationToken() {
+  let isCancellationRequested = false;
+  const listeners: (() => void)[] = [];
+  const disposeStubs: ReturnType<typeof vi.fn>[] = [];
+
+  const token = {
+    get isCancellationRequested() { return isCancellationRequested; },
+    onCancellationRequested: (listener: () => void) => {
+      listeners.push(listener);
+      const dispose = vi.fn();
+      disposeStubs.push(dispose);
+      return { dispose };
+    },
+  };
+
+  const cancel = () => {
+    isCancellationRequested = true;
+    listeners.forEach(l => l());
+  };
+
+  return { token: token as any, cancel, disposeStubs };
+}
+
+function createMockIssue(number: number, title: string, repo = 'owner/repo') {
+  return {
+    number,
+    title,
+    body: `Body for issue ${number}`,
+    html_url: `https://github.com/${repo}/issues/${number}`,
+    repository_url: `https://api.github.com/repos/${repo}`,
+  };
+}
+
+function configureRepos(repos: string[]) {
+  vi.mocked(workspace.getConfiguration).mockReturnValue({
+    get: vi.fn((key: string, defaultValue?: any) => {
+      if (key === 'repos') { return repos; }
+      return defaultValue;
+    }),
+  } as any);
+}
+
+describe('GitHubIssueProvider — cancellation (AbortSignal wiring)', () => {
+  let provider: GitHubIssueProvider;
+  let mockChannel: { appendLine: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+    provider = new GitHubIssueProvider();
+
+    mockChannel = { appendLine: vi.fn() };
+    initLogger(mockChannel as any, LogLevel.Debug);
+
+    vi.mocked(authentication.getSession).mockResolvedValue({
+      accessToken: 'test-token',
+      id: 'session-1',
+      scopes: ['repo'],
+      account: { id: '1', label: 'testuser' },
+    } as any);
+
+    vi.mocked(workspace.getConfiguration).mockReturnValue({
+      get: vi.fn((_key: string, defaultValue?: any) => defaultValue),
+    } as any);
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    vi.unstubAllGlobals();
+  });
+
+  // ── Signal wiring ──────────────────────────────────────────────────
+
+  describe('AbortSignal passed to fetch', () => {
+    it('passes an AbortSignal to fetch when CancellationToken is provided', async () => {
+      const { token } = createMockCancellationToken();
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: noLinkHeaders,
+        json: async () => [],
+      });
+
+      await provider.refresh(token);
+
+      expect(mockFetch).toHaveBeenCalled();
+      const fetchOptions = mockFetch.mock.calls[0][1];
+      expect(fetchOptions).toHaveProperty('signal');
+      expect(fetchOptions.signal).toBeInstanceOf(AbortSignal);
+    });
+
+    it('passes the same AbortSignal to paginated fetch calls', async () => {
+      const { token } = createMockCancellationToken();
+
+      // Page 1 with Link header pointing to page 2
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: { get: (h: string) => h === 'link' ? '<https://api.github.com/issues?page=2>; rel="next"' : null },
+          json: async () => [createMockIssue(1, 'Issue 1')],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: noLinkHeaders,
+          json: async () => [createMockIssue(2, 'Issue 2')],
+        });
+
+      await provider.refresh(token);
+
+      // Both fetch calls should have the same signal
+      const signal1 = mockFetch.mock.calls[0][1]?.signal;
+      const signal2 = mockFetch.mock.calls[1][1]?.signal;
+      expect(signal1).toBeInstanceOf(AbortSignal);
+      expect(signal2).toBe(signal1);
+    });
+
+    it('passes AbortSignal to per-repo fetch calls', async () => {
+      const { token } = createMockCancellationToken();
+      configureRepos(['owner/repo1', 'owner/repo2']);
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: noLinkHeaders,
+          json: async () => [createMockIssue(1, 'Issue 1', 'owner/repo1')],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: noLinkHeaders,
+          json: async () => [createMockIssue(2, 'Issue 2', 'owner/repo2')],
+        });
+
+      await provider.refresh(token);
+
+      for (const call of mockFetch.mock.calls) {
+        expect(call[1]).toHaveProperty('signal');
+        expect(call[1].signal).toBeInstanceOf(AbortSignal);
+      }
+    });
+  });
+
+  // ── Mid-fetch cancellation ─────────────────────────────────────────
+
+  describe('mid-fetch cancellation', () => {
+    it('does not publish items when token fires during fetch', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async () => {
+        // Simulate: token fires while waiting for network response
+        cancel();
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      // No items should be published — preserves previous provider state
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('logs AbortError at debug level, not error level', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async () => {
+        cancel();
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      await provider.refresh(token);
+
+      // Should log "fetch aborted" at debug level
+      const debugLogged = mockChannel.appendLine.mock.calls.some(
+        (call: string[]) => call[0].includes('[DEBUG]') && call[0].includes('fetch aborted'),
+      );
+      expect(debugLogged).toBe(true);
+
+      // Should NOT log at error level
+      const errorLogged = mockChannel.appendLine.mock.calls.some(
+        (call: string[]) => call[0].includes('[ERROR]') && call[0].includes('Failed to fetch'),
+      );
+      expect(errorLogged).toBe(false);
+    });
+
+    it('does not publish partial results when abort happens during per-repo fetch', async () => {
+      const { token, cancel } = createMockCancellationToken();
+      configureRepos(['owner/repo1', 'owner/repo2']);
+
+      let fetchCount = 0;
+      mockFetch.mockImplementation(async () => {
+        fetchCount++;
+        if (fetchCount === 1) {
+          // First repo succeeds
+          return {
+            ok: true,
+            headers: noLinkHeaders,
+            json: async () => [createMockIssue(1, 'Issue 1', 'owner/repo1')],
+          };
+        }
+        // Second repo: cancel fires mid-fetch
+        cancel();
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      // Even though repo1 succeeded, no items should be published
+      // because the overall operation was cancelled
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Pre-cancelled token ────────────────────────────────────────────
+
+  describe('already-cancelled token', () => {
+    it('returns immediately without fetching when token is already cancelled', async () => {
+      const token = {
+        isCancellationRequested: true,
+        onCancellationRequested: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+      };
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token as any);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(authentication.getSession).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('returns without fetching when token is cancelled during auth', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      vi.mocked(authentication.getSession).mockImplementation(async () => {
+        cancel();
+        return {
+          accessToken: 'test-token',
+          id: 'session-1',
+          scopes: ['repo'],
+          account: { id: '1', label: 'testuser' },
+        } as any;
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── cancelListener cleanup ─────────────────────────────────────────
+
+  describe('cleanup', () => {
+    it('disposes cancelListener after successful refresh', async () => {
+      const { token, disposeStubs } = createMockCancellationToken();
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: noLinkHeaders,
+        json: async () => [],
+      });
+
+      await provider.refresh(token);
+
+      expect(disposeStubs).toHaveLength(1);
+      expect(disposeStubs[0]).toHaveBeenCalledTimes(1);
+    });
+
+    it('disposes cancelListener after aborted refresh', async () => {
+      const { token, cancel, disposeStubs } = createMockCancellationToken();
+
+      mockFetch.mockImplementation(async () => {
+        cancel();
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      await provider.refresh(token);
+
+      expect(disposeStubs).toHaveLength(1);
+      expect(disposeStubs[0]).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not throw when refresh is called without token (no cancelListener)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: noLinkHeaders,
+        json: async () => [],
+      });
+
+      // No token → cancelListener is undefined → dispose() should not be called
+      await expect(provider.refresh()).resolves.toBeUndefined();
+    });
+
+    it('resets _isRefreshing after abort so subsequent refresh can proceed', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch.mockImplementationOnce(async () => {
+        cancel();
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      });
+
+      await provider.refresh(token);
+
+      // Second refresh should proceed (not blocked by stale _isRefreshing)
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        headers: noLinkHeaders,
+        json: async () => [createMockIssue(1, 'After abort')],
+      });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      expect(listener).toHaveBeenCalled();
+      const items = listener.mock.calls[0][0];
+      expect(items).toHaveLength(1);
+    });
+  });
+
+  // ── Pagination abort ───────────────────────────────────────────────
+
+  describe('pagination abort', () => {
+    it('stops fetching further pages when signal is aborted mid-pagination', async () => {
+      const { token, cancel } = createMockCancellationToken();
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          headers: { get: (h: string) => h === 'link' ? '<https://api.github.com/issues?page=2>; rel="next"' : null },
+          json: async () => [createMockIssue(1, 'Page 1 issue')],
+        })
+        .mockImplementation(async () => {
+          // Page 2: cancel during fetch
+          cancel();
+          const error = new Error('The operation was aborted.');
+          error.name = 'AbortError';
+          throw error;
+        });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh(token);
+
+      // Abort during pagination → no items published
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds 44 new tests verifying the CancellationToken → AbortSignal wiring introduced in PR #327 (Issue #300). Matt was surprised there were no affected tests in that PR — this fills the gap with comprehensive cancellation coverage across all 5 affected provider files.

## Test Files

| File | Tests | Provider |
|------|-------|----------|
| `githubProvider.cancellation.test.ts` | 13 | GitHubIssueProvider |
| `githubMyPrsProvider.cancellation.test.ts` | 9 | GitHubMyPrsProvider |
| `githubPrReviewProvider.cancellation.test.ts` | 8 | GitHubPrReviewProvider |
| `adoWorkItemProvider.cancellation.test.ts` | 7 | AdoWorkItemProvider |
| `adoPrReviewProvider.cancellation.test.ts` | 7 | AdoPrReviewProvider |

## Scenarios Covered

1. **Signal wiring**: AbortSignal is passed to every `fetch()` call when CancellationToken is provided
2. **Mid-flight cancellation**: Token fires during fetch → AbortError propagates correctly
3. **No items on abort**: Cancelled refreshes do NOT publish items (preserves previous provider state)
4. **Debug-level logging**: AbortError is logged at DEBUG, not ERROR
5. **Worker pool abort**: Worker loops in MyPrs and PrReview providers stop early when signal fires
6. **Cleanup**: `cancelListener.dispose()` is called in both success and abort paths
7. **Guard reset**: `_isRefreshing` resets after abort so subsequent refresh can proceed
8. **Already-cancelled token**: Early return without fetch when token is pre-cancelled
9. **Pagination abort**: Stops fetching further pages when aborted mid-pagination
10. **No partial results**: Multi-repo fetch aborts don't publish partial data

## Testing

All 1942 tests pass (44 new + 1898 existing).
