### PR TITLE
BaseGitHubProvider should extend BaseProvider instead of duplicating it

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -55,7 +55,25 @@ DevDocket is a VS Code extension monorepo for managing work items from multiple 
 
 ## Learnings
 
-### 2026-04-22 — Issue #300 (CancellationToken → AbortSignal wiring)
+### 2026-04-23 — Issue #305 (Split commands.ts into domain modules)
+
+**Refactoring:** Split the 1118-line monolith `commands.ts` into 8 domain-specific modules plus a shared utilities file.
+- **Modules created:** `commandUtils.ts` (shared helpers), `inboxCommands.ts`, `queueCommands.ts`, `focusCommands.ts`, `historyCommands.ts`, `layoutCommands.ts`, `generalCommands.ts`, `sourcesCommands.ts`, `watchCommands.ts`.
+- **Pattern:** Each module exports a single `register*Commands()` function that receives only the dependencies it needs. The original `commands.ts` becomes a thin orchestrator calling each domain registrar.
+- **Shared utilities in `commandUtils.ts`:** `wrapCommand`, `handleCommandError`, `resolveItemIds`, `formatItemTitle`, `batchTransition`, `batchAcceptItems` + `AcceptableItem` interface — used across multiple domain modules.
+- **Key lesson:** When splitting a monolith, identify cross-cutting helpers first and extract them into a shared utils module. Domain-specific type guards (e.g., `isInboxItem`, `isSourceItem`) stay in their respective domain modules since they're only used there.
+- **Files changed:** 9 new files in `packages/core/src/commands/`, `commands.ts` reduced to ~40 lines.
+
+### 2026-04-22 — Issue #306 (Scope WorkItemEditorPanel cache to extension lifecycle)
+
+**Refactor:** Moved the static panel cache from `WorkItemEditorPanel` to a `PanelManager` class instantiated during `activate()` and disposed with the extension context.
+- **Problem:** Static `Map<string, WorkItemEditorPanel>` survived extension reloads during development, leaking stale panel references. `clearPanelCache()` existed but was only called in tests.
+- **Solution:** Created `PanelManager` class owning the `openPanels` map. Each `activate()` creates a fresh `PanelManager`, sets it via `WorkItemEditorPanel.setPanelManager()`, and pushes it to `context.subscriptions`. On deactivation, `PanelManager.dispose()` clears all panels.
+- **Backward compatibility:** Kept static `open()` and `clearPanelCache()` on `WorkItemEditorPanel` as thin delegates to the current manager. Tests work unchanged — they use the default static manager reset by `clearPanelCache()` in `beforeEach`.
+- **Pattern:** When static class state needs lifecycle scoping, use a manager class with `setPanelManager()` injection — preserves static API facade for consumers while scoping ownership to `activate()`/`deactivate()`.
+- **Files changed:** `packages/core/src/views/workItemEditorPanel.ts` (new `PanelManager` class, refactored panel cache ownership), `packages/core/src/extension.ts` (create + register `PanelManager`).
+
+### 2026-04-22 — Issue #300(CancellationToken → AbortSignal wiring)
 
 **Bug fix:** Providers accepted `CancellationToken` in `refresh()` but only checked `isCancellationRequested` at discrete points. In-flight `fetch()` calls ran to completion even after cancellation.
 - **Pattern:** Create `AbortController` at refresh entry point, wire `token?.onCancellationRequested?.(() => abortController.abort())` with double optional chaining (test mocks may lack the event method), pass `abortController.signal` to all `fetch()` calls down the chain.
@@ -308,3 +326,15 @@ See `.squad/orchestration-log/2026-04-20T16-18-00Z-keaton.md` for full triage de
 - Environment variable patterns for sensitive data (applicable to future credential management).
 - Allowlist validation more secure than denylist (applicable to all input validation).
 - Concurrent signal handling requires careful synchronization (document in concurrency guidelines).
+
+### 2026-04-20 — Issue #303 (BaseGitHubProvider extends BaseProvider)
+
+**Refactored** BaseGitHubProvider to extend BaseProvider from @devdocket/shared instead of duplicating infrastructure.
+- **Removed duplication:** Event emitter lifecycle, refresh timer, concurrency guard, and disposal were all duplicated from BaseProvider. Now inherited.
+- **Inherited _disposed guard:** BaseProvider.dispose() sets _disposed = true and checks it in startPeriodicRefresh and 
+efreshInBackground. GitHub providers now get this protection automatically.
+- **Split refresh paths:** Replaced single doRefresh(isUserTriggered) with separate 
+efresh(token?) (user-triggered) and doBackgroundRefresh() (silent auth). Matches ADO provider pattern.
+- **Re-exports from shared:** DiscoveredItem, Disposable, Event, ResolvedItem now imported from @devdocket/shared instead of being re-declared locally.
+- **No subclass changes needed:** githubProvider.ts, githubPrReviewProvider.ts, and githubMyPrsProvider.ts required zero changes.
+- **Files changed:** packages/github/src/baseGithubProvider.ts only (37 insertions, 77 deletions).

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -30,9 +30,6 @@ export abstract class BaseGitHubProvider extends BaseProvider implements DevDock
 
   constructor() {
     super(new vscode.EventEmitter<DiscoveredItem[]>());
-    this.onBackgroundRefreshError = (error: unknown) => {
-      logger.error(`${this.label} refresh failed`, error);
-    };
   }
 
   async refresh(token?: vscode.CancellationToken): Promise<void> {

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -1,31 +1,10 @@
 import * as vscode from 'vscode';
-import { isValidGitHubRepo, type ResolvedItem } from '@devdocket/shared';
+import { BaseProvider, type DiscoveredItem, type Disposable, type Event, type ResolvedItem, isValidGitHubRepo } from '@devdocket/shared';
 import { logger } from './logger';
 
-export type { ResolvedItem };
+export type { DiscoveredItem, Disposable, Event, ResolvedItem };
 
 // Re-declared to match core API contract — separate extension cannot import core types directly
-export interface Disposable {
-  dispose(): void;
-}
-
-// Re-declared to match core API contract — separate extension cannot import core types directly
-export interface Event<T> {
-  (listener: (e: T) => void): Disposable;
-}
-
-export interface DiscoveredItem {
-  externalId: string;
-  title: string;
-  description?: string;
-  url?: string;
-  group?: string;
-  reason?: string;
-  state?: string;
-  version?: string;
-  resurfaceVersion?: string;
-}
-
 export interface DevDocketProvider {
   readonly id: string;
   readonly label: string;
@@ -45,47 +24,18 @@ export interface GitHubIssue {
   pull_request?: { url: string };
 }
 
-export abstract class BaseGitHubProvider implements DevDocketProvider {
+export abstract class BaseGitHubProvider extends BaseProvider implements DevDocketProvider {
   abstract readonly id: string;
   abstract readonly label: string;
 
-  protected readonly _onDidDiscoverItems = new vscode.EventEmitter<DiscoveredItem[]>();
-  readonly onDidDiscoverItems = this._onDidDiscoverItems.event;
-
-  private refreshTimer: ReturnType<typeof setInterval> | undefined;
-  private _isRefreshing = false;
-
-  startPeriodicRefresh(intervalSeconds: number): void {
-    this.stopPeriodicRefresh();
-    const interval = Number(intervalSeconds);
-    if (!Number.isFinite(interval) || interval <= 0) {
-      return;
-    }
-    // Clamp to minimum of 60 seconds
-    const clampedInterval = Math.max(interval, 60);
-    this.refreshTimer = setInterval(() => {
-      this.refreshInBackground().catch((err) => {
-        logger.error(`${this.label} refresh failed`, err);
-      });
-    }, clampedInterval * 1000);
-  }
-
-  stopPeriodicRefresh(): void {
-    if (this.refreshTimer) {
-      clearInterval(this.refreshTimer);
-      this.refreshTimer = undefined;
-    }
+  constructor() {
+    super(new vscode.EventEmitter<DiscoveredItem[]>());
+    this.onBackgroundRefreshError = (error: unknown) => {
+      logger.error(`${this.label} refresh failed`, error);
+    };
   }
 
   async refresh(token?: vscode.CancellationToken): Promise<void> {
-    await this.doRefresh(true, token);
-  }
-
-  private async refreshInBackground(): Promise<void> {
-    await this.doRefresh(false);
-  }
-
-  private async doRefresh(isUserTriggered: boolean, token?: vscode.CancellationToken): Promise<void> {
     if (this._isRefreshing) {
       return;
     }
@@ -97,35 +47,26 @@ export abstract class BaseGitHubProvider implements DevDocketProvider {
         return;
       }
 
-      const createIfNone = isUserTriggered;
       let session: vscode.AuthenticationSession | undefined;
       try {
         session = await vscode.authentication.getSession('github', ['repo'], {
-          createIfNone,
+          createIfNone: true,
         });
       } catch (err) {
-        if (isUserTriggered) {
-          const message = err instanceof Error ? err.message : String(err);
-          logger.error('GitHub authentication failed', err);
-          vscode.window.showWarningMessage(`DevDocket GitHub: Authentication failed — ${message}`);
-        } else {
-          logger.warn('GitHub authentication failed during background refresh', err);
-        }
+        const message = err instanceof Error ? err.message : String(err);
+        logger.error('GitHub authentication failed', err);
+        vscode.window.showWarningMessage(`DevDocket GitHub: Authentication failed — ${message}`);
         return;
       }
 
       if (!session || token?.isCancellationRequested) {
         if (!session) {
-          if (isUserTriggered) {
-            logger.info('User cancelled GitHub authentication');
-          } else {
-            logger.debug('No GitHub session available for background refresh');
-          }
+          logger.info('User cancelled GitHub authentication');
         }
         return;
       }
 
-      await this.fetchAndPublish(session.accessToken, isUserTriggered, abortController.signal);
+      await this.fetchAndPublish(session.accessToken, true, abortController.signal);
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError' && abortController.signal.aborted && token?.isCancellationRequested) {
         logger.debug(`${this.label} fetch aborted due to cancellation`);
@@ -135,6 +76,29 @@ export abstract class BaseGitHubProvider implements DevDocketProvider {
     } finally {
       cancelListener?.dispose();
       this._isRefreshing = false;
+    }
+  }
+
+  protected async doBackgroundRefresh(): Promise<void> {
+    let session: vscode.AuthenticationSession | undefined;
+    try {
+      session = await vscode.authentication.getSession('github', ['repo'], {
+        createIfNone: false,
+      });
+    } catch (err) {
+      logger.warn('GitHub authentication failed during background refresh', err);
+      return;
+    }
+
+    if (!session) {
+      logger.debug('No GitHub session available for background refresh');
+      return;
+    }
+
+    try {
+      await this.fetchAndPublish(session.accessToken, false);
+    } catch (err) {
+      logger.error(`Failed to fetch ${this.label}`, err);
     }
   }
 
@@ -304,8 +268,4 @@ export abstract class BaseGitHubProvider implements DevDocketProvider {
     return parsed.filter(p => closedSet.has(p.id)).map(p => p.id);
   }
 
-  dispose(): void {
-    this.stopPeriodicRefresh();
-    this._onDidDiscoverItems.dispose();
-  }
 }


### PR DESCRIPTION
Fixes #303

Refactors `BaseGitHubProvider` to extend the shared `BaseProvider` class instead of re-implementing event emitter lifecycle, periodic refresh, concurrency guard, and disposal. This matches the pattern used by ADO providers and ensures bug fixes to base infrastructure (like the `_disposed` guard) apply to GitHub providers automatically.

## Changes

- **`BaseGitHubProvider` now extends `BaseProvider`** from `@devdocket/shared`, removing ~77 lines of duplicated infrastructure
- **Removed duplicated members:** `_onDidDiscoverItems`, `onDidDiscoverItems`, `refreshTimer`, `_isRefreshing`, `startPeriodicRefresh()`, `stopPeriodicRefresh()`, `dispose()` — all now inherited
- **Replaced `doRefresh(isUserTriggered)`** with separate `refresh(token?)` and `doBackgroundRefresh()` methods matching the ADO provider pattern
- **Inherited `_disposed` guard** — `BaseProvider` checks `_disposed` in `startPeriodicRefresh` and `refreshInBackground`, which `BaseGitHubProvider` previously lacked
- **Replaced local type re-declarations** (`Disposable`, `Event`, `DiscoveredItem`) with imports from `@devdocket/shared`, re-exported for subclass convenience
- **Zero subclass changes** — `githubProvider.ts`, `githubPrReviewProvider.ts`, and `githubMyPrsProvider.ts` are unchanged

## Behavior Preservation

All existing behavior is preserved exactly:
- User-triggered refresh prompts for auth (`createIfNone: true`), shows warnings on failure
- Background refresh uses silent auth (`createIfNone: false`), logs quietly
- Cancellation token wiring and abort signal propagation unchanged
- Error handling paths produce identical log messages

## No API Breaking Changes

`BaseProvider` in `@devdocket/shared` is unchanged. `BaseGitHubProvider` is internal to the GitHub package and not part of the public API surface.
