### PR TITLE
Scope WorkItemEditorPanel cache to extension lifecycle

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -55,7 +55,16 @@ DevDocket is a VS Code extension monorepo for managing work items from multiple 
 
 ## Learnings
 
-### 2026-04-22 — Issue #300 (CancellationToken → AbortSignal wiring)
+### 2026-04-22 — Issue #306 (Scope WorkItemEditorPanel cache to extension lifecycle)
+
+**Refactor:** Moved the static panel cache from `WorkItemEditorPanel` to a `PanelManager` class instantiated during `activate()` and disposed with the extension context.
+- **Problem:** Static `Map<string, WorkItemEditorPanel>` survived extension reloads during development, leaking stale panel references. `clearPanelCache()` existed but was only called in tests.
+- **Solution:** Created `PanelManager` class owning the `openPanels` map. Each `activate()` creates a fresh `PanelManager`, sets it via `WorkItemEditorPanel.setPanelManager()`, and pushes it to `context.subscriptions`. On deactivation, `PanelManager.dispose()` clears all panels.
+- **Backward compatibility:** Kept static `open()` and `clearPanelCache()` on `WorkItemEditorPanel` as thin delegates to the current manager. Tests work unchanged — they use the default static manager reset by `clearPanelCache()` in `beforeEach`.
+- **Pattern:** When static class state needs lifecycle scoping, use a manager class with `setPanelManager()` injection — preserves static API facade for consumers while scoping ownership to `activate()`/`deactivate()`.
+- **Files changed:** `packages/core/src/views/workItemEditorPanel.ts` (new `PanelManager` class, refactored panel cache ownership), `packages/core/src/extension.ts` (create + register `PanelManager`).
+
+### 2026-04-22 — Issue #300(CancellationToken → AbortSignal wiring)
 
 **Bug fix:** Providers accepted `CancellationToken` in `refresh()` but only checked `isCancellationRequested` at discrete points. In-flight `fetch()` calls ran to completion even after cancellation.
 - **Pattern:** Create `AbortController` at refresh entry point, wire `token?.onCancellationRequested?.(() => abortController.abort())` with double optional chaining (test mocks may lack the event method), pass `abortController.signal` to all `fetch()` calls down the chain.

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -421,8 +421,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
 
   // panelManager must be first: its dispose() flushes pending saves via
   // WorkGraph, which must still be alive at that point. VS Code disposes
-  // subscriptions in reverse order, so placing it first ensures it is
-  // disposed last.
+  // subscriptions in array order, so placing it first ensures it runs
+  // before WorkGraph is disposed.
   context.subscriptions.push(
     panelManager,
     ...Object.values(views),

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -419,6 +419,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const panelManager = new PanelManager();
   WorkItemEditorPanel.setPanelManager(panelManager);
 
+  // panelManager must be first: its dispose() flushes pending saves via
+  // WorkGraph, which must still be alive at that point. VS Code disposes
+  // subscriptions in reverse order, so placing it first ensures it is
+  // disposed last.
   context.subscriptions.push(
     panelManager,
     ...Object.values(views),

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -19,6 +19,7 @@ import { SourcesTreeProvider } from './views/sourcesTreeProvider';
 import { HistoryTreeProvider } from './views/historyTreeProvider';
 import { WatchesTreeProvider } from './views/watchesTreeProvider';
 import { WatchesStatusBar } from './views/watchesStatusBar';
+import { WorkItemEditorPanel, PanelManager } from './views/workItemEditorPanel';
 import { registerCommands } from './commands/commands';
 import { isSafeUrl } from './utils/url';
 import { ViewRevealer } from './services/viewRevealer';
@@ -414,7 +415,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     logger.error('Failed to load persisted watches', err);
   });
 
+  // Scope panel cache to extension lifecycle
+  const panelManager = new PanelManager();
+  WorkItemEditorPanel.setPanelManager(panelManager);
+
   context.subscriptions.push(
+    panelManager,
     ...Object.values(views),
     ...viewDisposables,
     ...eventDisposables,

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { EventEmitter, ViewColumn, window } from 'vscode';
-import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
+import { WorkItemEditorPanel, PanelManager } from '../views/workItemEditorPanel';
 import { WorkGraph } from '../services/workGraph';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { ITaskStore } from '../storage/taskStore';

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -1362,4 +1362,130 @@ describe('WorkItemEditorPanel (integration with WorkGraph)', () => {
       expect(() => sub.dispose()).not.toThrow();
     });
   });
+
+  describe('PanelManager lifecycle', () => {
+    it('setPanelManager scopes panels to the new manager', () => {
+      const managerA = new PanelManager();
+      const managerB = new PanelManager();
+
+      // Open a panel under manager A
+      WorkItemEditorPanel.setPanelManager(managerA);
+      const item = makeItem({ id: 'scoped-1', title: 'Scoped' });
+      const mock1 = createMockWebviewPanel();
+      vi.mocked(window.createWebviewPanel).mockReturnValue(mock1.panel as any);
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, createMockProviderRegistry() as any, item);
+
+      expect(managerA.openPanels.has('scoped-1')).toBe(true);
+
+      // Switch to manager B — manager A's panel should not be found
+      WorkItemEditorPanel.setPanelManager(managerB);
+      expect(managerB.openPanels.has('scoped-1')).toBe(false);
+
+      // Opening the same item under manager B creates a new panel
+      const mock2 = createMockWebviewPanel();
+      vi.mocked(window.createWebviewPanel).mockReturnValue(mock2.panel as any);
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, createMockProviderRegistry() as any, item);
+
+      expect(window.createWebviewPanel).toHaveBeenCalledTimes(2);
+      expect(managerB.openPanels.has('scoped-1')).toBe(true);
+
+      // Manager A still has its own panel reference
+      expect(managerA.openPanels.has('scoped-1')).toBe(true);
+    });
+
+    it('PanelManager.dispose() clears all tracked panels', () => {
+      const manager = new PanelManager();
+      WorkItemEditorPanel.setPanelManager(manager);
+
+      const itemA = makeItem({ id: 'disp-a', title: 'A' });
+      const itemB = makeItem({ id: 'disp-b', title: 'B' });
+      const mockA = createMockWebviewPanel();
+      const mockB = createMockWebviewPanel();
+
+      vi.mocked(window.createWebviewPanel)
+        .mockReturnValueOnce(mockA.panel as any)
+        .mockReturnValueOnce(mockB.panel as any);
+
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(itemA) as any, createMockProviderRegistry() as any, itemA);
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(itemB) as any, createMockProviderRegistry() as any, itemB);
+
+      expect(manager.openPanels.size).toBe(2);
+
+      manager.dispose();
+
+      expect(manager.openPanels.size).toBe(0);
+      // Both webview panels should have been disposed
+      expect(mockA.panel.dispose).toHaveBeenCalled();
+      expect(mockB.panel.dispose).toHaveBeenCalled();
+    });
+
+    it('stale panels from previous manager do not leak into new manager', () => {
+      const oldManager = new PanelManager();
+      WorkItemEditorPanel.setPanelManager(oldManager);
+
+      const item = makeItem({ id: 'leak-1', title: 'Leaky' });
+      const mock = createMockWebviewPanel();
+      vi.mocked(window.createWebviewPanel).mockReturnValue(mock.panel as any);
+
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, createMockProviderRegistry() as any, item);
+      expect(oldManager.openPanels.size).toBe(1);
+
+      // Simulate extension reload: set a new manager
+      const newManager = new PanelManager();
+      WorkItemEditorPanel.setPanelManager(newManager);
+
+      // New manager starts empty — stale panels are not inherited
+      expect(newManager.openPanels.size).toBe(0);
+
+      // Opening the same item creates a fresh panel
+      const freshMock = createMockWebviewPanel();
+      vi.mocked(window.createWebviewPanel).mockReturnValue(freshMock.panel as any);
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, createMockProviderRegistry() as any, item);
+
+      expect(window.createWebviewPanel).toHaveBeenCalledTimes(2);
+      expect(newManager.openPanels.size).toBe(1);
+    });
+
+    it('PanelManager.dispose() is idempotent', () => {
+      const manager = new PanelManager();
+      WorkItemEditorPanel.setPanelManager(manager);
+
+      const item = makeItem({ id: 'idem-1', title: 'Idempotent' });
+      const mock = createMockWebviewPanel();
+      vi.mocked(window.createWebviewPanel).mockReturnValue(mock.panel as any);
+
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, createMockProviderRegistry() as any, item);
+
+      manager.dispose();
+      expect(() => manager.dispose()).not.toThrow();
+      expect(mock.panel.dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it('clearPanelCache disposes panels without disposing the manager', () => {
+      const manager = new PanelManager();
+      WorkItemEditorPanel.setPanelManager(manager);
+
+      const item = makeItem({ id: 'clear-1', title: 'Clearable' });
+      const mock1 = createMockWebviewPanel();
+      vi.mocked(window.createWebviewPanel).mockReturnValue(mock1.panel as any);
+
+      const ctx = createMockContext();
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, createMockProviderRegistry() as any, item);
+      expect(manager.openPanels.size).toBe(1);
+
+      manager.clearPanelCache();
+      expect(manager.openPanels.size).toBe(0);
+      expect(mock1.panel.dispose).toHaveBeenCalled();
+
+      // Manager is still usable — can open new panels
+      const mock2 = createMockWebviewPanel();
+      vi.mocked(window.createWebviewPanel).mockReturnValue(mock2.panel as any);
+      WorkItemEditorPanel.open(ctx, createMockWorkGraph(item) as any, createMockProviderRegistry() as any, item);
+      expect(manager.openPanels.size).toBe(1);
+    });
+  });
 });

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -13,6 +13,7 @@ import { isSafeUrl } from '../utils/url';
 export class PanelManager {
   /** @internal Used by WorkItemEditorPanel — not part of public API. */
   readonly openPanels = new Map<string, WorkItemEditorPanel>();
+  private disposed = false;
 
   /** Dispose all tracked panels and clear the cache. */
   clearPanelCache(): void {
@@ -24,6 +25,8 @@ export class PanelManager {
   }
 
   dispose(): void {
+    if (this.disposed) { return; }
+    this.disposed = true;
     this.clearPanelCache();
   }
 }
@@ -35,7 +38,7 @@ export class WorkItemEditorPanel {
   private readonly workGraph: WorkGraph;
   private readonly providerRegistry: ProviderRegistry;
   private readonly itemId: string;
-  private readonly panelCache: PanelManager;
+  private readonly panelManager: PanelManager;
   private disposed = false;
   private debounceTimer: ReturnType<typeof setTimeout> | undefined;
   private pendingData: Record<string, string> | undefined;
@@ -93,14 +96,14 @@ export class WorkItemEditorPanel {
     workGraph: WorkGraph,
     providerRegistry: ProviderRegistry,
     itemId: string,
-    panelCache: PanelManager,
+    panelManager: PanelManager,
     private providerLabel?: string,
   ) {
     this.panel = panel;
     this.workGraph = workGraph;
     this.providerRegistry = providerRegistry;
     this.itemId = itemId;
-    this.panelCache = panelCache;
+    this.panelManager = panelManager;
 
     this.update();
 
@@ -144,7 +147,7 @@ export class WorkItemEditorPanel {
     this.panel.onDidDispose(() => {
       if (!this.disposed) {
         this.disposed = true;
-        this.panelCache.openPanels.delete(this.itemId);
+        this.panelManager.openPanels.delete(this.itemId);
         if (this.debounceTimer) {
           clearTimeout(this.debounceTimer);
           this.debounceTimer = undefined;
@@ -248,7 +251,7 @@ export class WorkItemEditorPanel {
   dispose(): void {
     if (!this.disposed) {
       this.disposed = true;
-      this.panelCache.openPanels.delete(this.itemId);
+      this.panelManager.openPanels.delete(this.itemId);
       if (this.debounceTimer) {
         clearTimeout(this.debounceTimer);
         this.debounceTimer = undefined;

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -5,13 +5,37 @@ import { ProviderRegistry } from '../services/providerRegistry';
 import { getEditorPanelHtml } from './editorPanelHtml';
 import { isSafeUrl } from '../utils/url';
 
+/**
+ * Manages the lifecycle of open WorkItemEditorPanels.
+ * Created during extension activation and disposed with the extension context,
+ * preventing stale panel references across extension reloads.
+ */
+export class PanelManager {
+  /** @internal Used by WorkItemEditorPanel — not part of public API. */
+  readonly openPanels = new Map<string, WorkItemEditorPanel>();
+
+  /** Dispose all tracked panels and clear the cache. */
+  clearPanelCache(): void {
+    const panels = Array.from(this.openPanels.values());
+    for (const editor of panels) {
+      editor.dispose();
+    }
+    this.openPanels.clear();
+  }
+
+  dispose(): void {
+    this.clearPanelCache();
+  }
+}
+
 export class WorkItemEditorPanel {
   private static readonly viewType = 'devdocket.editItem';
-  private static readonly openPanels = new Map<string, WorkItemEditorPanel>();
+  private static panelManager = new PanelManager();
   private readonly panel: vscode.WebviewPanel;
   private readonly workGraph: WorkGraph;
   private readonly providerRegistry: ProviderRegistry;
   private readonly itemId: string;
+  private readonly panelCache: PanelManager;
   private disposed = false;
   private debounceTimer: ReturnType<typeof setTimeout> | undefined;
   private pendingData: Record<string, string> | undefined;
@@ -23,6 +47,14 @@ export class WorkItemEditorPanel {
   private lastDisplayedTitle: string | undefined;
   private lastManagedState: boolean | undefined;
 
+  /**
+   * Replace the active panel manager. Called during `activate()` to scope
+   * the panel cache to the extension lifecycle.
+   */
+  static setPanelManager(manager: PanelManager): void {
+    WorkItemEditorPanel.panelManager = manager;
+  }
+
   static open(
     context: vscode.ExtensionContext,
     workGraph: WorkGraph,
@@ -30,7 +62,8 @@ export class WorkItemEditorPanel {
     item: WorkItem,
     providerLabel?: string,
   ): void {
-    const existing = WorkItemEditorPanel.openPanels.get(item.id);
+    const manager = WorkItemEditorPanel.panelManager;
+    const existing = manager.openPanels.get(item.id);
     if (existing) {
       existing.providerLabel = providerLabel;
       existing.update();
@@ -45,18 +78,14 @@ export class WorkItemEditorPanel {
       { enableScripts: true, retainContextWhenHidden: true },
     );
 
-    const editor = new WorkItemEditorPanel(panel, workGraph, providerRegistry, item.id, providerLabel);
-    WorkItemEditorPanel.openPanels.set(item.id, editor);
+    const editor = new WorkItemEditorPanel(panel, workGraph, providerRegistry, item.id, manager, providerLabel);
+    manager.openPanels.set(item.id, editor);
     context.subscriptions.push({ dispose: () => editor.dispose() });
   }
 
   /** @internal Exposed for testing only. */
   static clearPanelCache(): void {
-    const panels = Array.from(WorkItemEditorPanel.openPanels.values());
-    for (const editor of panels) {
-      editor.dispose();
-    }
-    WorkItemEditorPanel.openPanels.clear();
+    WorkItemEditorPanel.panelManager.clearPanelCache();
   }
 
   private constructor(
@@ -64,12 +93,14 @@ export class WorkItemEditorPanel {
     workGraph: WorkGraph,
     providerRegistry: ProviderRegistry,
     itemId: string,
+    panelCache: PanelManager,
     private providerLabel?: string,
   ) {
     this.panel = panel;
     this.workGraph = workGraph;
     this.providerRegistry = providerRegistry;
     this.itemId = itemId;
+    this.panelCache = panelCache;
 
     this.update();
 
@@ -113,7 +144,7 @@ export class WorkItemEditorPanel {
     this.panel.onDidDispose(() => {
       if (!this.disposed) {
         this.disposed = true;
-        WorkItemEditorPanel.openPanels.delete(this.itemId);
+        this.panelCache.openPanels.delete(this.itemId);
         if (this.debounceTimer) {
           clearTimeout(this.debounceTimer);
           this.debounceTimer = undefined;
@@ -217,7 +248,7 @@ export class WorkItemEditorPanel {
   dispose(): void {
     if (!this.disposed) {
       this.disposed = true;
-      WorkItemEditorPanel.openPanels.delete(this.itemId);
+      this.panelCache.openPanels.delete(this.itemId);
       if (this.debounceTimer) {
         clearTimeout(this.debounceTimer);
         this.debounceTimer = undefined;


### PR DESCRIPTION
Fixes #306

Moves the static panel cache from `WorkItemEditorPanel` to a `PanelManager` class instantiated during `activate()`. The manager is disposed with the extension context, preventing stale panel references across extension reloads.

## Changes

- **New `PanelManager` class** (`workItemEditorPanel.ts`): Owns the `openPanels` map, with `clearPanelCache()` and `dispose()` methods. Created during `activate()` and pushed to `context.subscriptions`.
- **`WorkItemEditorPanel` refactored**: Static `open()` and `clearPanelCache()` delegate to the current `PanelManager` via `setPanelManager()`. Each panel instance holds a reference to its owning manager for self-unregistration on dispose.
- **`extension.ts`**: Creates `PanelManager`, calls `WorkItemEditorPanel.setPanelManager()`, registers manager in `context.subscriptions`.

## Test compatibility

Static `open()` and `clearPanelCache()` are preserved as thin delegates, so existing tests work unchanged without modification.
