### PR TITLE
Add onboarding walkthrough for new users

### DIFF
--- a/.squad/agents/fenster/history.md
+++ b/.squad/agents/fenster/history.md
@@ -93,6 +93,15 @@ DevDocket is a VS Code extension monorepo for managing work items from multiple 
 - **Shared utilities in `commandUtils.ts`:** `wrapCommand`, `handleCommandError`, `resolveItemIds`, `formatItemTitle`, `batchTransition`, `batchAcceptItems` + `AcceptableItem` interface — used across multiple domain modules.
 - **Key lesson:** When splitting a monolith, identify cross-cutting helpers first and extract them into a shared utils module. Domain-specific type guards (e.g., `isInboxItem`, `isSourceItem`) stay in their respective domain modules since they're only used there.
 - **Files changed:** 9 new files in `packages/core/src/commands/`, `commands.ts` reduced to ~40 lines.
+### 2026-04-23 — Issue #225 (Add onboarding walkthrough)
+
+**Feature:** Added VS Code walkthrough for new user onboarding using `contributes.walkthroughs` in package.json.
+- **Walkthrough structure:** Four steps — Create First Item, Understand Workflow, Connect Provider, Focus on Work. Each step uses markdown media files in `media/walkthroughs/`.
+- **Key learnings:** VS Code walkthroughs use markdown files with command links (e.g., `[Create Work Item](command:devdocket.createItem)`). The walkthrough appears in the Get Started tab and can be triggered via Command Palette.
+- **Media organization:** Created `packages/core/media/walkthroughs/` directory for step content. Each step has a dedicated markdown file explaining concepts and linking to relevant commands.
+- **Integration:** Added to `contributes.walkthroughs` array in package.json between `main` and `configuration` sections. Walkthrough ID: `devdocket.gettingStarted`.
+- **Files changed:** `packages/core/package.json` (walkthroughs contribution), `media/walkthroughs/create-item.md`, `workflow.md`, `providers.md`, `focus.md`.
+- **Pattern:** When adding user onboarding, use VS Code's native walkthrough API with markdown media for rich content. Keep step descriptions concise with command links for interactive actions.
 
 ### 2026-04-22 — Issue #306 (Scope WorkItemEditorPanel cache to extension lifecycle)
 

--- a/.squad/decisions/inbox/fenster-onboarding-walkthrough.md
+++ b/.squad/decisions/inbox/fenster-onboarding-walkthrough.md
@@ -1,0 +1,46 @@
+# Decision: Onboarding Walkthrough Implementation
+
+**Issue:** #225  
+**Author:** Fenster (Extension Dev)  
+**Status:** Implemented  
+**Date:** 2026-04-23
+
+## Context
+
+Implemented VS Code walkthrough for new user onboarding to guide users through creating their first work item, understanding the Inbox → Queue → Focus → History workflow, connecting providers, and managing active work.
+
+## Key Decisions
+
+### 1. VS Code Native Walkthrough API
+**Decision:** Use `contributes.walkthroughs` in package.json rather than a custom modal or webview.  
+**Why:** VS Code's native walkthrough API provides a consistent UX familiar to users from other extensions. Appears in the Get Started tab automatically. No custom UI code needed.
+
+### 2. Four-Step Onboarding Flow
+**Decision:** Four steps — Create First Item, Understand Workflow, Connect Provider, Focus on Work.  
+**Why:** Mirrors the natural user journey. Start with immediate action (create item), then explain concepts, then expand with providers, then close the loop with completion workflow.
+
+### 3. Markdown Media Files
+**Decision:** Each step uses a markdown file in `media/walkthroughs/` directory with command links.  
+**Why:** Markdown allows rich formatting, code blocks, headers, and interactive command links (e.g., `[Create Work Item](command:devdocket.createItem)`). Easier to maintain than inline JSON strings.
+
+### 4. Command Links for Interactivity
+**Decision:** Embed command links in both step descriptions and markdown media.  
+**Why:** Users can click directly to perform actions (create item, open extensions view, etc.) without searching for commands. Makes onboarding interactive rather than passive reading.
+
+### 5. Media Organization
+**Decision:** Created dedicated `packages/core/media/walkthroughs/` directory.  
+**Why:** Keeps walkthrough content separate from other media assets. Future walkthroughs can add more files here. Mirrors pattern used by other VS Code extensions.
+
+## Files Changed
+
+- `packages/core/package.json` — Added `walkthroughs` contribution
+- `packages/core/media/walkthroughs/create-item.md` — Step 1 content
+- `packages/core/media/walkthroughs/workflow.md` — Step 2 content
+- `packages/core/media/walkthroughs/providers.md` — Step 3 content
+- `packages/core/media/walkthroughs/focus.md` — Step 4 content
+
+## Future Considerations
+
+- Add screenshots or animated GIFs to media files for visual learners
+- Consider per-provider walkthroughs for GitHub/ADO setup
+- Track walkthrough completion via telemetry (if added in the future)

--- a/packages/core/media/walkthroughs/create-item.md
+++ b/packages/core/media/walkthroughs/create-item.md
@@ -1,0 +1,14 @@
+# Create Your First Work Item
+
+DevDocket helps you track work from multiple sources. Let's start by creating a manual work item.
+
+**What you'll learn:**
+- How to create a work item manually
+- Understanding the Queue view
+- Viewing and editing work item details
+
+Click the button below to create your first work item:
+
+[Create Work Item](command:devdocket.createItem)
+
+Your new item will appear in the **Queue** view, ready to be worked on!

--- a/packages/core/media/walkthroughs/focus.md
+++ b/packages/core/media/walkthroughs/focus.md
@@ -1,0 +1,33 @@
+# Focus on Active Work
+
+The **Focus** view shows what you're actively working on.
+
+## Moving Items to Focus
+
+From the **Queue** view:
+1. Right-click a work item
+2. Select "Move to Focus"
+3. The item transitions to **In Progress** state
+
+## Working with Focused Items
+
+Once an item is in Focus, you can:
+
+- **Pause** it temporarily (e.g., waiting for feedback)
+- **Resume** a paused item to continue work
+- **Complete** it when done (moves to History)
+- **Run Actions** on it (like creating git branches)
+
+## Completing Work
+
+When you finish a work item:
+1. Right-click the item in Focus
+2. Select "Complete"
+3. The item moves to **History** with state **Done**
+
+---
+
+**Try it now:**
+If you created a work item earlier, find it in the Queue and move it to Focus!
+
+[Open Queue View](command:devdocket.queue.focus)

--- a/packages/core/media/walkthroughs/providers.md
+++ b/packages/core/media/walkthroughs/providers.md
@@ -2,9 +2,9 @@
 
 Providers automatically discover work items from external sources.
 
-## Available Providers
+## Sample Providers
 
-### 🐙 GitHub Provider
+### GitHub Provider
 Discovers:
 - Issues assigned to you or mentioning you
 - Pull requests you created or need to review
@@ -15,7 +15,7 @@ Discovers:
 2. Authenticate with GitHub when prompted
 3. Configure which repositories to watch via settings
 
-### 📘 Azure DevOps Provider
+### Azure DevOps Provider
 Discovers:
 - Work items assigned to you
 - Pull requests you need to review

--- a/packages/core/media/walkthroughs/providers.md
+++ b/packages/core/media/walkthroughs/providers.md
@@ -1,0 +1,34 @@
+# Connect a Provider
+
+Providers automatically discover work items from external sources.
+
+## Available Providers
+
+### 🐙 GitHub Provider
+Discovers:
+- Issues assigned to you or mentioning you
+- Pull requests you created or need to review
+- Configurable per-repository tracking
+
+**Setup:**
+1. Install the **DevDocket GitHub** extension (if not already installed)
+2. Authenticate with GitHub when prompted
+3. Configure which repositories to watch via settings
+
+### 📘 Azure DevOps Provider
+Discovers:
+- Work items assigned to you
+- Pull requests you need to review
+- Pipeline runs to watch
+
+**Setup:**
+1. Install the **DevDocket ADO** extension
+2. Configure your organization and project
+3. Authenticate when prompted
+
+---
+
+**Next steps:**
+Open the Extensions view and search for "DevDocket" to see available provider extensions!
+
+[Open Extensions](command:workbench.view.extensions)

--- a/packages/core/media/walkthroughs/workflow.md
+++ b/packages/core/media/walkthroughs/workflow.md
@@ -1,6 +1,6 @@
 # Understanding the DevDocket Workflow
 
-DevDocket organizes your work across five core work-item views:
+DevDocket organizes your work across six core work-item views:
 
 ## 📥 Inbox
 New items discovered by providers (like GitHub issues or pull requests). Review and either **Accept** to move them to your Queue, or **Dismiss** if they're not relevant.
@@ -13,6 +13,9 @@ Active work you're currently working on. Items here are **In Progress** or **Pau
 
 ## 📜 History
 Completed and archived items. Items marked **Done** or **Archived** appear here.
+
+## 👁️ Watches
+Fire-and-forget monitoring of CI/CD pipeline runs from GitHub Actions and Azure DevOps Pipelines. Watch a run and get notified when it completes or fails — no need to keep checking manually.
 
 ## 📚 Sources
 A browsable library of everything providers know about, grouped by provider.

--- a/packages/core/media/walkthroughs/workflow.md
+++ b/packages/core/media/walkthroughs/workflow.md
@@ -1,6 +1,6 @@
 # Understanding the DevDocket Workflow
 
-DevDocket organizes your work across five views:
+DevDocket organizes your work across five core work-item views:
 
 ## 📥 Inbox
 New items discovered by providers (like GitHub issues or pull requests). Review and either **Accept** to move them to your Queue, or **Dismiss** if they're not relevant.

--- a/packages/core/media/walkthroughs/workflow.md
+++ b/packages/core/media/walkthroughs/workflow.md
@@ -1,0 +1,28 @@
+# Understanding the DevDocket Workflow
+
+DevDocket organizes your work across five views:
+
+## 📥 Inbox
+New items discovered by providers (like GitHub issues or pull requests). Review and either **Accept** to move them to your Queue, or **Dismiss** if they're not relevant.
+
+## 📋 Queue
+Your personal backlog of work items waiting to be started. Items here are in the **New** state.
+
+## 🎯 Focus
+Active work you're currently working on. Items here are **In Progress** or **Paused**.
+
+## 📜 History
+Completed and archived items. Items marked **Done** or **Archived** appear here.
+
+## 📚 Sources
+A browsable library of everything providers know about, grouped by provider.
+
+---
+
+**The typical flow:**
+1. Provider discovers an item → **Inbox**
+2. You accept it → **Queue**
+3. You start working → **Focus**
+4. You complete it → **History**
+
+You can also create manual items that start directly in the Queue!

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,10 +41,13 @@
           {
             "id": "createFirstItem",
             "title": "Create Your First Work Item",
-            "description": "Start by creating a manual work item to track your work.\n[Create Work Item](command:devdocket.createItem)",
+            "description": "Start by creating a manual work item to track your work.",
             "media": {
               "markdown": "media/walkthroughs/create-item.md"
-            }
+            },
+            "completionEvents": [
+              "onCommand:devdocket.createItem"
+            ]
           },
           {
             "id": "understandWorkflow",
@@ -57,18 +60,27 @@
           {
             "id": "connectProvider",
             "title": "Connect a Provider",
-            "description": "Automatically discover work from GitHub, Azure DevOps, and more.\n[Open Extensions](command:workbench.view.extensions)",
+            "description": "Automatically discover work from GitHub, Azure DevOps, and more.",
             "media": {
               "markdown": "media/walkthroughs/providers.md"
-            }
+            },
+            "completionEvents": [
+              "extensionInstalled:mthalman.devdocket-github",
+              "extensionInstalled:mthalman.devdocket-ado"
+            ]
           },
           {
             "id": "focusOnWork",
             "title": "Focus on Active Work",
-            "description": "Move items to Focus and complete them when done.\n[Open Queue](command:devdocket.queue.focus)",
+            "description": "Move items to Focus and complete them when done.",
             "media": {
               "markdown": "media/walkthroughs/focus.md"
-            }
+            },
+            "completionEvents": [
+              "onCommand:devdocket.acceptToFocus",
+              "onCommand:devdocket.acceptToFocusFromInbox",
+              "onCommand:devdocket.completeItem"
+            ]
           }
         ]
       }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,47 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "walkthroughs": [
+      {
+        "id": "devdocket.gettingStarted",
+        "title": "Get Started with DevDocket",
+        "description": "Learn how to manage your work items across Inbox, Queue, Focus, and History",
+        "steps": [
+          {
+            "id": "createFirstItem",
+            "title": "Create Your First Work Item",
+            "description": "Start by creating a manual work item to track your work.\n[Create Work Item](command:devdocket.createItem)",
+            "media": {
+              "markdown": "media/walkthroughs/create-item.md"
+            }
+          },
+          {
+            "id": "understandWorkflow",
+            "title": "Understand the Workflow",
+            "description": "Learn how items flow through Inbox → Queue → Focus → History.",
+            "media": {
+              "markdown": "media/walkthroughs/workflow.md"
+            }
+          },
+          {
+            "id": "connectProvider",
+            "title": "Connect a Provider",
+            "description": "Automatically discover work from GitHub, Azure DevOps, and more.\n[Open Extensions](command:workbench.view.extensions)",
+            "media": {
+              "markdown": "media/walkthroughs/providers.md"
+            }
+          },
+          {
+            "id": "focusOnWork",
+            "title": "Focus on Active Work",
+            "description": "Move items to Focus and complete them when done.\n[Open Queue](command:devdocket.queue.focus)",
+            "media": {
+              "markdown": "media/walkthroughs/focus.md"
+            }
+          }
+        ]
+      }
+    ],
     "configuration": {
       "title": "DevDocket",
       "properties": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,7 +28,11 @@
     "onCommand:devdocket.dismissAllCompletedWatches",
     "onCommand:devdocket.openWatchUrl",
     "onCommand:devdocket.showWatchesQuickPick",
-    "onCommand:devdocket.addActivity"
+    "onCommand:devdocket.addActivity",
+    "onCommand:devdocket.createItem",
+    "onCommand:devdocket.acceptToFocus",
+    "onCommand:devdocket.acceptToFocusFromInbox",
+    "onCommand:devdocket.completeItem"
   ],
   "main": "./dist/extension.js",
   "contributes": {


### PR DESCRIPTION
Implements VS Code walkthrough for new user onboarding.

## What this PR does

Adds a 4-step interactive walkthrough that guides users through:
1. **Create First Item** — Create a manual work item with `devdocket.createItem` command
2. **Understand Workflow** — Explains Inbox → Queue → Focus → History lifecycle
3. **Connect Provider** — Guide to installing GitHub or ADO provider extensions
4. **Focus on Work** — Moving items to Focus and completing them

## Implementation details

- Uses `contributes.walkthroughs` in package.json
- Each step has a dedicated markdown file in `media/walkthroughs/`
- Steps track completion via `completionEvents` for interactive feedback
- Command links embedded in markdown media for click-to-run actions

## Testing

- ✅ All 426 tests pass across all packages
- ✅ Build completes successfully
- ✅ Code review clean (no Critical or Important issues)
- Walkthrough schema follows VS Code API correctly

Closes #225
