### PR TITLE
Extract shared composite action for Copilot agent workflows

### DIFF
--- a/.github/actions/create-copilot-issue/action.yml
+++ b/.github/actions/create-copilot-issue/action.yml
@@ -1,0 +1,151 @@
+name: Create Copilot Issue
+description: >
+  Creates a GitHub issue with dedup checking and assigns the Copilot coding agent.
+  Handles agent_assignment API with fallback to plain assignment + instructions comment.
+
+inputs:
+  issue-title:
+    description: Title for the GitHub issue
+    required: true
+  issue-body:
+    description: Body markdown for the GitHub issue
+    required: true
+  issue-labels:
+    description: Comma-separated labels to apply to the issue
+    required: true
+  dedup-labels:
+    description: >
+      Comma-separated labels to check for duplicate open issues.
+      Defaults to issue-labels if not specified.
+    required: false
+    default: ''
+  custom-instructions:
+    description: Instructions to provide to the Copilot coding agent
+    required: true
+  copilot-assign-token:
+    description: >
+      PAT with permissions for the agent_assignment API.
+      Falls back to github-token if not provided.
+    required: false
+    default: ''
+  github-token:
+    description: GitHub token for issue creation and fallback assignment
+    required: true
+
+outputs:
+  issue-number:
+    description: The number of the created or existing issue
+    value: ${{ steps.create-issue.outputs.issue_number }}
+  created:
+    description: Whether a new issue was created ('true' or 'false')
+    value: ${{ steps.create-issue.outputs.created }}
+
+runs:
+  using: composite
+  steps:
+    - name: Create issue with dedup check
+      id: create-issue
+      uses: actions/github-script@v7
+      env:
+        INPUT_ISSUE_TITLE: ${{ inputs.issue-title }}
+        INPUT_ISSUE_BODY: ${{ inputs.issue-body }}
+        INPUT_ISSUE_LABELS: ${{ inputs.issue-labels }}
+        INPUT_DEDUP_LABELS: ${{ inputs.dedup-labels || inputs.issue-labels }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const dedupLabels = process.env.INPUT_DEDUP_LABELS;
+
+          // Check for existing open issues matching the dedup labels
+          const { data: existing } = await github.rest.issues.listForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: dedupLabels,
+            state: 'open',
+            per_page: 1
+          });
+
+          const existingIssue = existing.find(item => !item.pull_request);
+
+          if (existingIssue) {
+            core.info(`Skipping: open issue #${existingIssue.number} already exists (dedup labels: ${dedupLabels})`);
+            core.setOutput('issue_number', existingIssue.number);
+            core.setOutput('created', 'false');
+            return;
+          }
+
+          const issueLabels = process.env.INPUT_ISSUE_LABELS.split(',').map(l => l.trim());
+
+          const { data: issue } = await github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: process.env.INPUT_ISSUE_TITLE,
+            body: process.env.INPUT_ISSUE_BODY,
+            labels: issueLabels
+          });
+
+          core.info(`Created issue #${issue.number}`);
+          core.setOutput('issue_number', issue.number);
+          core.setOutput('created', 'true');
+
+    - name: Assign Copilot coding agent
+      if: steps.create-issue.outputs.created == 'true'
+      uses: actions/github-script@v7
+      env:
+        ISSUE_NUMBER: ${{ steps.create-issue.outputs.issue_number }}
+        CUSTOM_INSTRUCTIONS: ${{ inputs.custom-instructions }}
+      with:
+        github-token: ${{ inputs.copilot-assign-token || inputs.github-token }}
+        script: |
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+          const issue_number = parseInt(process.env.ISSUE_NUMBER, 10);
+          const customInstructions = process.env.CUSTOM_INSTRUCTIONS;
+
+          // Get the default branch name
+          const { data: repoData } = await github.rest.repos.get({ owner, repo });
+          const baseBranch = repoData.default_branch;
+
+          try {
+            await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
+              owner,
+              repo,
+              issue_number,
+              assignees: ['copilot-swe-agent[bot]'],
+              agent_assignment: {
+                target_repo: `${owner}/${repo}`,
+                base_branch: baseBranch,
+                custom_instructions: customInstructions,
+                custom_agent: '',
+                model: ''
+              },
+              headers: {
+                'X-GitHub-Api-Version': '2022-11-28'
+              }
+            });
+            core.info(`Assigned copilot-swe-agent[bot] to issue #${issue_number}`);
+          } catch (err) {
+            core.warning(`Assignment with agent_assignment failed: ${err.message}`);
+
+            // Fallback: try plain assignment without agent_assignment
+            let fallbackSucceeded = false;
+            try {
+              await github.rest.issues.addAssignees({
+                owner, repo, issue_number,
+                assignees: ['copilot-swe-agent[bot]']
+              });
+              core.info(`Fallback: assigned copilot-swe-agent[bot] to issue #${issue_number}`);
+              fallbackSucceeded = true;
+            } catch (err2) {
+              core.error(`Fallback assignment also failed: ${err2.message}`);
+            }
+
+            // Post instructions as comment; include manual-assignment note if both methods failed
+            const manualNote = fallbackSucceeded
+              ? ''
+              : '\n\n> ⚠️ Automated assignment failed. A maintainer should manually assign `copilot-swe-agent[bot]` to this issue.';
+            await github.rest.issues.createComment({
+              owner, repo, issue_number,
+              body: `### 🤖 @copilot Instructions\n\n${customInstructions}${manualNote}`
+            });
+          }

--- a/.github/workflows/automated-refactoring.yml
+++ b/.github/workflows/automated-refactoring.yml
@@ -20,9 +20,6 @@ permissions:
 jobs:
   create-refactoring-issue:
     runs-on: ubuntu-latest
-    outputs:
-      issue_number: ${{ steps.create-issue.outputs.issue_number }}
-      should_assign: ${{ steps.create-issue.outputs.should_assign }}
     steps:
       - uses: actions/checkout@v4
 
@@ -33,8 +30,8 @@ jobs:
             -o skill-content.md
           echo "Downloaded skill content ($(wc -c < skill-content.md) bytes)"
 
-      - name: Create refactoring issue
-        id: create-issue
+      - name: Build issue body
+        id: build-body
         uses: actions/github-script@v7
         with:
           script: |
@@ -43,164 +40,77 @@ jobs:
             // Strip YAML frontmatter if present
             const skillContent = rawSkill.replace(/^---[\s\S]*?---\n*/, '');
 
-            // Check for existing open refactoring issues
-            const { data: existing } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: 'automated,refactoring',
-              state: 'open',
-              per_page: 1
-            });
-
-            const existingIssue = existing.find(item => !item.pull_request);
-
-            if (existingIssue) {
-              core.info(`Skipping: open refactoring issue #${existingIssue.number} already exists`);
-              core.setOutput('should_assign', 'false');
-              return;
-            }
-
-            const { data: issue } = await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title: 'Automated code refactoring analysis',
-              body: [
-                '## Automated Refactoring Request',
-                '',
-                'This issue was created automatically by the scheduled refactoring workflow.',
-                '',
-                '### Task',
-                '',
-                'Analyze the codebase for refactoring opportunities using the code-refactorer methodology embedded below.',
-                '',
-                '**Instructions:**',
-                '- Follow the complete refactoring methodology included in this issue',
-                '- Focus on patterns like:',
-                '  - Reducing code duplication',
-                '  - Extracting reusable functions/classes',
-                '  - Simplifying complex logic',
-                '  - Improving naming and structure',
-                '  - Consolidating common patterns across files',
-                '- Apply ONLY refactorings that strictly preserve existing behavior',
-                '- Run all tests before and after to verify no behavior changes',
-                '- Create a PR with clear explanation of what was refactored and why',
-                '',
-                '### Scope',
-                '',
-                'Focus on the TypeScript source files in:',
-                '- `packages/core/src/`',
-                '- `packages/github/src/`',
-                '- `packages/ado/src/`',
-                '- `packages/start-git-work/src/`',
-                '- `packages/ai-reviewer/src/`',
-                '',
-                '### Exit Criteria',
-                '',
-                '- If no refactoring opportunities are found, close this issue with a comment explaining the analysis',
-                '- If refactorings are identified and applied, open a PR with detailed description',
-                '',
-                '### Refactoring Methodology',
-                '',
-                'Follow this complete methodology when analyzing and applying refactoring changes:',
-                '',
-                skillContent,
-                '',
-                '---',
-                '',
-                '_Scheduled refactoring run triggered at ' + new Date().toISOString() + '_'
-              ].join('\n'),
-              labels: ['squad:copilot', 'automated', 'refactoring']
-            });
-
-            core.info(`Created issue #${issue.number}`);
-            core.setOutput('issue_number', issue.number);
-            core.setOutput('should_assign', 'true');
-            return issue.number;
-
-  assign-copilot-agent:
-    needs: create-refactoring-issue
-    if: needs.create-refactoring-issue.outputs.should_assign == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Assign @copilot coding agent
-        uses: actions/github-script@v7
-        env:
-          ISSUE_NUMBER: ${{ needs.create-refactoring-issue.outputs.issue_number }}
-        with:
-          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
-          script: |
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const issue_number = parseInt(process.env.ISSUE_NUMBER, 10);
-
-            // Get the default branch name
-            const { data: repoData } = await github.rest.repos.get({ owner, repo });
-            const baseBranch = repoData.default_branch;
-
-            const customInstructions = [
-              'Follow the complete code-refactorer methodology embedded in the issue body.',
+            const body = [
+              '## Automated Refactoring Request',
               '',
-              'The issue contains the full refactoring workflow including:',
-              '1. Appropriateness Gate — assess whether refactoring is the right response',
-              '2. Context-Adapted Analysis — adapt based on code signals (blast radius, test coverage, coupling)',
-              '3. Standard Refactoring Workflow — analyze, diagnose, plan, execute, verify, summarize',
-              '4. Cross-File Pattern Discovery — find and consolidate patterns across the codebase',
+              'This issue was created automatically by the scheduled refactoring workflow.',
               '',
-              'Key principles:',
-              '- Focus on reducing duplication and improving structure',
-              '- Preserve all existing behavior (no functional changes)',
-              '- Run tests before and after to verify correctness',
-              '- Document what was refactored and why in the PR description',
+              '### Task',
               '',
-              'If you find no refactoring opportunities, close the issue with an explanation.',
-              'If you apply refactorings, create a PR with a clear description.'
+              'Analyze the codebase for refactoring opportunities using the code-refactorer methodology embedded below.',
+              '',
+              '**Instructions:**',
+              '- Follow the complete refactoring methodology included in this issue',
+              '- Focus on patterns like:',
+              '  - Reducing code duplication',
+              '  - Extracting reusable functions/classes',
+              '  - Simplifying complex logic',
+              '  - Improving naming and structure',
+              '  - Consolidating common patterns across files',
+              '- Apply ONLY refactorings that strictly preserve existing behavior',
+              '- Run all tests before and after to verify no behavior changes',
+              '- Create a PR with clear explanation of what was refactored and why',
+              '',
+              '### Scope',
+              '',
+              'Focus on the TypeScript source files in:',
+              '- `packages/core/src/`',
+              '- `packages/github/src/`',
+              '- `packages/ado/src/`',
+              '- `packages/start-git-work/src/`',
+              '- `packages/ai-reviewer/src/`',
+              '',
+              '### Exit Criteria',
+              '',
+              '- If no refactoring opportunities are found, close this issue with a comment explaining the analysis',
+              '- If refactorings are identified and applied, open a PR with detailed description',
+              '',
+              '### Refactoring Methodology',
+              '',
+              'Follow this complete methodology when analyzing and applying refactoring changes:',
+              '',
+              skillContent,
+              '',
+              '---',
+              '',
+              '_Scheduled refactoring run triggered at ' + new Date().toISOString() + '_'
             ].join('\n');
 
-            try {
-              await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
-                owner,
-                repo,
-                issue_number,
-                assignees: ['copilot-swe-agent[bot]'],
-                agent_assignment: {
-                  target_repo: `${owner}/${repo}`,
-                  base_branch: baseBranch,
-                  custom_instructions: customInstructions,
-                  custom_agent: '',
-                  model: ''
-                },
-                headers: {
-                  'X-GitHub-Api-Version': '2022-11-28'
-                }
-              });
-              core.info(`✅ Assigned copilot-swe-agent[bot] to issue #${issue_number} with embedded refactoring methodology`);
-            } catch (err) {
-              core.warning(`Assignment with agent_assignment failed: ${err.message}`);
-              // Fallback: try without agent_assignment
-              try {
-                await github.rest.issues.addAssignees({
-                  owner,
-                  repo,
-                  issue_number,
-                  assignees: ['copilot-swe-agent[bot]']
-                });
-                core.info(`Fallback: assigned copilot-swe-agent[bot] to issue #${issue_number}`);
-                
-                // Post custom instructions as a comment
-                await github.rest.issues.createComment({
-                  owner,
-                  repo,
-                  issue_number,
-                  body: [
-                    '### 🤖 @copilot Instructions',
-                    '',
-                    customInstructions
-                  ].join('\n')
-                });
-              } catch (err2) {
-                core.error(`Both assignment attempts failed: ${err2.message}`);
-                throw err2;
-              }
-            }
+            core.setOutput('body', body);
+
+      - name: Create issue and assign Copilot agent
+        uses: ./.github/actions/create-copilot-issue
+        with:
+          issue-title: 'Automated code refactoring analysis'
+          issue-body: ${{ steps.build-body.outputs.body }}
+          issue-labels: 'squad:copilot,automated,refactoring'
+          dedup-labels: 'automated,refactoring'
+          custom-instructions: |
+            Follow the complete code-refactorer methodology embedded in the issue body.
+
+            The issue contains the full refactoring workflow including:
+            1. Appropriateness Gate — assess whether refactoring is the right response
+            2. Context-Adapted Analysis — adapt based on code signals (blast radius, test coverage, coupling)
+            3. Standard Refactoring Workflow — analyze, diagnose, plan, execute, verify, summarize
+            4. Cross-File Pattern Discovery — find and consolidate patterns across the codebase
+
+            Key principles:
+            - Focus on reducing duplication and improving structure
+            - Preserve all existing behavior (no functional changes)
+            - Run tests before and after to verify correctness
+            - Document what was refactored and why in the PR description
+
+            If you find no refactoring opportunities, close the issue with an explanation.
+            If you apply refactorings, create a PR with a clear description.
+          copilot-assign-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Extract shared composite action for Copilot agent workflows

Extracts the common "create GitHub issue → assign Copilot coding agent" pattern into a reusable composite action at `.github/actions/create-copilot-issue/`.

### What the action does

1. **Dedup check** — Looks for existing open issues matching `dedup-labels` to avoid duplicates
2. **Issue creation** — Creates a new issue with the provided title, body, and labels
3. **Agent assignment** — Assigns `copilot-swe-agent[bot]` via the `agent_assignment` API
4. **Fallback** — If the assignment API fails, tries plain assignment + posts instructions as a comment
5. **Manual fallback** — If both assignment methods fail, posts a note asking for manual assignment

### Inputs

| Input | Required | Description |
|-------|----------|-------------|
| `issue-title` | ✅ | Title for the GitHub issue |
| `issue-body` | ✅ | Body markdown for the issue |
| `issue-labels` | ✅ | Comma-separated labels to apply |
| `dedup-labels` | ❌ | Labels for dedup check (defaults to `issue-labels`) |
| `custom-instructions` | ✅ | Instructions for the Copilot agent |
| `copilot-assign-token` | ❌ | PAT for agent assignment (falls back to `github-token`) |
| `github-token` | ✅ | Token for issue creation and fallback |

### Outputs

| Output | Description |
|--------|-------------|
| `issue-number` | The created or existing issue number |
| `created` | `'true'` if a new issue was created, `'false'` if dedup matched |

### Changes

- **New:** `.github/actions/create-copilot-issue/action.yml` — the composite action
- **Refactored:** `.github/workflows/automated-refactoring.yml` — now uses the composite action, collapsing two jobs into one

### Adoption

PRs #351 (`squad-weekly-review.yml`) and #353 (`weekly-ux-review.yml`) can adopt this action after merge.
