### PR TITLE
Suppress version resurfacing for items in Queue/Focus

### DIFF
--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -305,7 +305,7 @@ export class AdoPrReviewProvider extends BaseProvider {
         group: `${projectName}/${repoName}`,
         reason: 'review_requested',
         ...(pr.status ? { state: pr.status } : {}),
-        version: resurfaceOnNewVersion ? pr.lastMergeSourceCommit?.commitId : undefined,
+        resurfaceVersion: resurfaceOnNewVersion ? pr.lastMergeSourceCommit?.commitId : undefined,
       };
     });
 

--- a/packages/ado/src/test/adoPrReviewProvider.extended.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.extended.test.ts
@@ -464,7 +464,7 @@ describe('AdoPrReviewProvider — extended', () => {
       } as any);
     });
 
-    it('omits version when resurfaceOnNewVersion is false', async () => {
+    it('omits resurfaceVersion when resurfaceOnNewVersion is false', async () => {
       const { workspace } = await import('vscode');
       vi.mocked(workspace.getConfiguration).mockReturnValue({
         get: vi.fn((key: string, defaultValue?: any) => {
@@ -493,10 +493,10 @@ describe('AdoPrReviewProvider — extended', () => {
 
       const items = listener.mock.calls[0][0];
       expect(items).toHaveLength(1);
-      expect(items[0].version).toBeUndefined();
+      expect(items[0].resurfaceVersion).toBeUndefined();
     });
 
-    it('includes version when resurfaceOnNewVersion is true (default)', async () => {
+    it('includes resurfaceVersion when resurfaceOnNewVersion is true (default)', async () => {
       const prWithCommit = {
         ...createMockPr(1, 'PR with commit'),
         lastMergeSourceCommit: { commitId: 'abc123' },
@@ -515,7 +515,7 @@ describe('AdoPrReviewProvider — extended', () => {
 
       const items = listener.mock.calls[0][0];
       expect(items).toHaveLength(1);
-      expect(items[0].version).toBe('abc123');
+      expect(items[0].resurfaceVersion).toBe('abc123');
     });
   });
 

--- a/packages/core/src/commands/commandUtils.ts
+++ b/packages/core/src/commands/commandUtils.ts
@@ -106,6 +106,16 @@ export async function batchAcceptItems(
   for (const item of items) {
     const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
     if (existing) {
+      // Re-open items in terminal states so resurfaced items return to Queue
+      if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+        try {
+          await workGraph.transitionState(existing.id, WorkItemState.New);
+        } catch (err: unknown) {
+          failed++;
+          logger.error(`Failed to re-open ${logLabel} "${item.title}"`, err);
+          continue;
+        }
+      }
       stateUpdates.push({ providerId: item.providerId, externalId: item.externalId, state: 'accepted' });
       continue;
     }

--- a/packages/core/src/commands/commandUtils.ts
+++ b/packages/core/src/commands/commandUtils.ts
@@ -101,6 +101,8 @@ export async function batchAcceptItems(
 ): Promise<void> {
   const stateUpdates: Array<{ providerId: string; externalId: string; state: InboxState }> = [];
   const createdIds: string[] = [];
+  // Track re-opened items so we can roll back on setStates failure
+  const reopenedItems: Array<{ id: string; originalState: WorkItemState }> = [];
   let failed = 0;
 
   for (const item of items) {
@@ -108,8 +110,10 @@ export async function batchAcceptItems(
     if (existing) {
       // Re-open items in terminal states so resurfaced items return to Queue
       if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+        const originalState = existing.state;
         try {
           await workGraph.transitionState(existing.id, WorkItemState.New);
+          reopenedItems.push({ id: existing.id, originalState });
         } catch (err: unknown) {
           failed++;
           logger.error(`Failed to re-open ${logLabel} "${item.title}"`, err);
@@ -139,6 +143,11 @@ export async function batchAcceptItems(
       for (const id of createdIds) {
         try { await workGraph.deleteItem(id); } catch (rollbackErr: unknown) {
           logger.error('Failed to roll back created item after batch setStates failure', rollbackErr);
+        }
+      }
+      for (const { id, originalState } of reopenedItems) {
+        try { await workGraph.transitionState(id, originalState); } catch (rollbackErr: unknown) {
+          logger.error('Failed to roll back re-opened item after batch setStates failure', rollbackErr);
         }
       }
       handleCommandError('Failed to update states after accepting items', err);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -781,6 +781,7 @@ async function batchAcceptToFocusItems(
   const stateUpdates: Array<{ providerId: string; externalId: string; state: InboxState }> = [];
   const createdIds: string[] = [];
   const allIds: string[] = [];
+  const reopenedItems: Array<{ id: string; originalState: WorkItemState }> = [];
   let failed = 0;
   let skipped = 0;
 
@@ -794,8 +795,10 @@ async function batchAcceptToFocusItems(
         continue;
       }
       if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+        const originalState = existing.state;
         try {
           await workGraph.transitionState(existing.id, WorkItemState.New);
+          reopenedItems.push({ id: existing.id, originalState });
         } catch (err: unknown) {
           failed++;
           logger.error(`Failed to re-open "${item.title}"`, err);
@@ -833,6 +836,11 @@ async function batchAcceptToFocusItems(
       for (const id of createdIds) {
         try { await workGraph.deleteItem(id); } catch (rollbackErr: unknown) {
           logger.error('Failed to roll back created item after batch setStates failure', rollbackErr);
+        }
+      }
+      for (const { id, originalState } of reopenedItems) {
+        try { await workGraph.transitionState(id, originalState); } catch (rollbackErr: unknown) {
+          logger.error('Failed to roll back re-opened item after batch setStates failure', rollbackErr);
         }
       }
       handleCommandError('Failed to update states after accepting items', err);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -718,19 +718,32 @@ async function acceptToFocusSingleInboxItem(
       return;
     }
     if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+      const originalState = existing.state;
       try {
         await workGraph.transitionState(existing.id, WorkItemState.New);
       } catch (err: unknown) {
         handleCommandError('Failed to re-open item', err);
         return;
       }
-    }
-    workItemId = existing.id;
-    try {
-      await stateStore.setState(item.providerId, item.externalId, 'accepted');
-    } catch (err: unknown) {
-      handleCommandError('Failed to update state for existing accepted item', err);
-      return;
+      // Roll back if setState fails to keep workGraph and discovered state consistent
+      workItemId = existing.id;
+      try {
+        await stateStore.setState(item.providerId, item.externalId, 'accepted');
+      } catch (err: unknown) {
+        try { await workGraph.transitionState(existing.id, originalState); } catch (rollbackErr: unknown) {
+          logger.error('Failed to roll back re-opened item after setState failure', rollbackErr);
+        }
+        handleCommandError('Failed to update state for re-opened item', err);
+        return;
+      }
+    } else {
+      workItemId = existing.id;
+      try {
+        await stateStore.setState(item.providerId, item.externalId, 'accepted');
+      } catch (err: unknown) {
+        handleCommandError('Failed to update state for existing accepted item', err);
+        return;
+      }
     }
   } else {
     const group = item.group?.trim();

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -975,6 +975,7 @@ async function acceptSingleSourceItem(
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {
         handleCommandError('Failed to update state for re-opened item', err);
+        return;
       }
       await propagateStateToCanonicalPeers(item, providerRegistry, stateStore, 'accepted');
       void revealer?.revealInQueue(existing.id);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -169,6 +169,16 @@ async function batchAcceptItems(
   for (const item of items) {
     const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
     if (existing) {
+      // Re-open items in terminal states so resurfaced items return to Queue
+      if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+        try {
+          await workGraph.transitionState(existing.id, WorkItemState.New);
+        } catch (err: unknown) {
+          failed++;
+          logger.error(`Failed to re-open ${logLabel} "${item.title}"`, err);
+          continue;
+        }
+      }
       stateUpdates.push({ providerId: item.providerId, externalId: item.externalId, state: 'accepted' });
       continue;
     }
@@ -526,6 +536,22 @@ async function acceptSingleInboxItem(
   logger.info(`Accepting inbox item: ${item.externalId} from ${item.providerId}`);
   const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
   if (existing) {
+    // Re-open items in terminal states so resurfaced items return to Queue
+    if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+      try {
+        await workGraph.transitionState(existing.id, WorkItemState.New);
+      } catch (err: unknown) {
+        handleCommandError('Failed to re-open completed item', err);
+        return;
+      }
+      try {
+        await stateStore.setState(item.providerId, item.externalId, 'accepted');
+      } catch (err: unknown) {
+        handleCommandError('Failed to update state for re-opened item', err);
+      }
+      void revealer?.revealInQueue(existing.id);
+      return;
+    }
     void vscode.window.showInformationMessage(
       `DevDocket: Item already accepted as "${existing.title}"`
     );
@@ -589,15 +615,11 @@ async function acceptToFocusSingleInboxItem(
     }
     if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
       try {
-        await stateStore.setState(item.providerId, item.externalId, 'accepted');
+        await workGraph.transitionState(existing.id, WorkItemState.New);
       } catch (err: unknown) {
-        handleCommandError('Failed to update state for existing completed item', err);
+        handleCommandError('Failed to re-open completed item', err);
         return;
       }
-      void vscode.window.showWarningMessage(
-        `DevDocket: Item is ${existing.state} and cannot be moved to Focus`,
-      );
-      return;
     }
     workItemId = existing.id;
     try {
@@ -666,10 +688,13 @@ async function batchAcceptToFocusItems(
         continue;
       }
       if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
-        logger.info(`Skipping "${item.title}" — item is ${existing.state} and cannot be moved to Focus`);
-        stateUpdates.push({ providerId: item.providerId, externalId: item.externalId, state: 'accepted' });
-        skipped++;
-        continue;
+        try {
+          await workGraph.transitionState(existing.id, WorkItemState.New);
+        } catch (err: unknown) {
+          failed++;
+          logger.error(`Failed to re-open "${item.title}"`, err);
+          continue;
+        }
       }
       stateUpdates.push({ providerId: item.providerId, externalId: item.externalId, state: 'accepted' });
       allIds.push(existing.id);
@@ -826,6 +851,22 @@ async function acceptSingleSourceItem(
   logger.info(`Accepting sources item: ${item.externalId}`);
   const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
   if (existing) {
+    // Re-open items in terminal states so resurfaced items return to Queue
+    if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+      try {
+        await workGraph.transitionState(existing.id, WorkItemState.New);
+      } catch (err: unknown) {
+        handleCommandError('Failed to re-open completed item', err);
+        return;
+      }
+      try {
+        await stateStore.setState(item.providerId, item.externalId, 'accepted');
+      } catch (err: unknown) {
+        handleCommandError('Failed to update state for re-opened item', err);
+      }
+      void revealer?.revealInQueue(existing.id);
+      return;
+    }
     try {
       await stateStore.setState(item.providerId, item.externalId, 'accepted');
     } catch (err: unknown) {

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -635,6 +635,7 @@ async function acceptSingleInboxItem(
   if (existing) {
     // Re-open items in terminal states so resurfaced items return to Queue
     if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+      const originalState = existing.state;
       try {
         await workGraph.transitionState(existing.id, WorkItemState.New);
       } catch (err: unknown) {
@@ -644,6 +645,9 @@ async function acceptSingleInboxItem(
       try {
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {
+        try { await workGraph.transitionState(existing.id, originalState); } catch (rollbackErr: unknown) {
+          logger.error('Failed to roll back re-opened item after setState failure', rollbackErr);
+        }
         handleCommandError('Failed to update state for re-opened item', err);
         return;
       }
@@ -995,6 +999,7 @@ async function acceptSingleSourceItem(
   if (existing) {
     // Re-open items in terminal states so resurfaced items return to Queue
     if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+      const originalState = existing.state;
       try {
         await workGraph.transitionState(existing.id, WorkItemState.New);
       } catch (err: unknown) {
@@ -1004,6 +1009,9 @@ async function acceptSingleSourceItem(
       try {
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {
+        try { await workGraph.transitionState(existing.id, originalState); } catch (rollbackErr: unknown) {
+          logger.error('Failed to roll back re-opened item after setState failure', rollbackErr);
+        }
         handleCommandError('Failed to update state for re-opened item', err);
         return;
       }

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -638,7 +638,7 @@ async function acceptSingleInboxItem(
       try {
         await workGraph.transitionState(existing.id, WorkItemState.New);
       } catch (err: unknown) {
-        handleCommandError('Failed to re-open completed item', err);
+        handleCommandError('Failed to re-open item', err);
         return;
       }
       try {
@@ -721,7 +721,7 @@ async function acceptToFocusSingleInboxItem(
       try {
         await workGraph.transitionState(existing.id, WorkItemState.New);
       } catch (err: unknown) {
-        handleCommandError('Failed to re-open completed item', err);
+        handleCommandError('Failed to re-open item', err);
         return;
       }
     }
@@ -977,7 +977,7 @@ async function acceptSingleSourceItem(
       try {
         await workGraph.transitionState(existing.id, WorkItemState.New);
       } catch (err: unknown) {
-        handleCommandError('Failed to re-open completed item', err);
+        handleCommandError('Failed to re-open item', err);
         return;
       }
       try {

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -636,6 +636,7 @@ async function acceptSingleInboxItem(
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {
         handleCommandError('Failed to update state for re-opened item', err);
+        return;
       }
       await propagateStateToCanonicalPeers(item, providerRegistry, stateStore, 'accepted');
       void revealer?.revealInQueue(existing.id);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -246,6 +246,8 @@ async function batchAcceptItems(
 ): Promise<void> {
   const stateUpdates: Array<{ providerId: string; externalId: string; state: InboxState }> = [];
   const createdIds: string[] = [];
+  // Track re-opened items so we can roll back on setStates failure
+  const reopenedItems: Array<{ id: string; originalState: WorkItemState }> = [];
   let failed = 0;
 
   for (const item of items) {
@@ -253,8 +255,10 @@ async function batchAcceptItems(
     if (existing) {
       // Re-open items in terminal states so resurfaced items return to Queue
       if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+        const originalState = existing.state;
         try {
           await workGraph.transitionState(existing.id, WorkItemState.New);
+          reopenedItems.push({ id: existing.id, originalState });
         } catch (err: unknown) {
           failed++;
           logger.error(`Failed to re-open ${logLabel} "${item.title}"`, err);
@@ -284,6 +288,11 @@ async function batchAcceptItems(
       for (const id of createdIds) {
         try { await workGraph.deleteItem(id); } catch (rollbackErr: unknown) {
           logger.error('Failed to roll back created item after batch setStates failure', rollbackErr);
+        }
+      }
+      for (const { id, originalState } of reopenedItems) {
+        try { await workGraph.transitionState(id, originalState); } catch (rollbackErr: unknown) {
+          logger.error('Failed to roll back re-opened item after batch setStates failure', rollbackErr);
         }
       }
       handleCommandError('Failed to update states after accepting items', err);

--- a/packages/core/src/commands/inboxCommands.ts
+++ b/packages/core/src/commands/inboxCommands.ts
@@ -46,6 +46,22 @@ async function acceptSingleInboxItem(
   logger.info(`Accepting inbox item: ${item.externalId} from ${item.providerId}`);
   const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
   if (existing) {
+    // Re-open items in terminal states so resurfaced items return to Queue
+    if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+      try {
+        await workGraph.transitionState(existing.id, WorkItemState.New);
+      } catch (err: unknown) {
+        handleCommandError('Failed to re-open completed item', err);
+        return;
+      }
+      try {
+        await stateStore.setState(item.providerId, item.externalId, 'accepted');
+      } catch (err: unknown) {
+        handleCommandError('Failed to update state for re-opened item', err);
+      }
+      void revealer?.revealInQueue(existing.id);
+      return;
+    }
     void vscode.window.showInformationMessage(
       `DevDocket: Item already accepted as "${existing.title}"`
     );
@@ -108,15 +124,11 @@ async function acceptToFocusSingleInboxItem(
     }
     if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
       try {
-        await stateStore.setState(item.providerId, item.externalId, 'accepted');
+        await workGraph.transitionState(existing.id, WorkItemState.New);
       } catch (err: unknown) {
-        handleCommandError('Failed to update state for existing completed item', err);
+        handleCommandError('Failed to re-open completed item', err);
         return;
       }
-      void vscode.window.showWarningMessage(
-        `DevDocket: Item is ${existing.state} and cannot be moved to Focus`,
-      );
-      return;
     }
     workItemId = existing.id;
     try {
@@ -185,10 +197,13 @@ async function batchAcceptToFocusItems(
         continue;
       }
       if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
-        logger.info(`Skipping "${item.title}" — item is ${existing.state} and cannot be moved to Focus`);
-        stateUpdates.push({ providerId: item.providerId, externalId: item.externalId, state: 'accepted' });
-        skipped++;
-        continue;
+        try {
+          await workGraph.transitionState(existing.id, WorkItemState.New);
+        } catch (err: unknown) {
+          failed++;
+          logger.error(`Failed to re-open "${item.title}"`, err);
+          continue;
+        }
       }
       stateUpdates.push({ providerId: item.providerId, externalId: item.externalId, state: 'accepted' });
       allIds.push(existing.id);

--- a/packages/core/src/commands/inboxCommands.ts
+++ b/packages/core/src/commands/inboxCommands.ts
@@ -51,7 +51,7 @@ async function acceptSingleInboxItem(
       try {
         await workGraph.transitionState(existing.id, WorkItemState.New);
       } catch (err: unknown) {
-        handleCommandError('Failed to re-open completed item', err);
+        handleCommandError('Failed to re-open item', err);
         return;
       }
       try {
@@ -127,7 +127,7 @@ async function acceptToFocusSingleInboxItem(
       try {
         await workGraph.transitionState(existing.id, WorkItemState.New);
       } catch (err: unknown) {
-        handleCommandError('Failed to re-open completed item', err);
+        handleCommandError('Failed to re-open item', err);
         return;
       }
     }

--- a/packages/core/src/commands/inboxCommands.ts
+++ b/packages/core/src/commands/inboxCommands.ts
@@ -58,6 +58,7 @@ async function acceptSingleInboxItem(
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {
         handleCommandError('Failed to update state for re-opened item', err);
+        return;
       }
       void revealer?.revealInQueue(existing.id);
       return;

--- a/packages/core/src/commands/inboxCommands.ts
+++ b/packages/core/src/commands/inboxCommands.ts
@@ -48,6 +48,7 @@ async function acceptSingleInboxItem(
   if (existing) {
     // Re-open items in terminal states so resurfaced items return to Queue
     if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+      const originalState = existing.state;
       try {
         await workGraph.transitionState(existing.id, WorkItemState.New);
       } catch (err: unknown) {
@@ -57,6 +58,9 @@ async function acceptSingleInboxItem(
       try {
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {
+        try { await workGraph.transitionState(existing.id, originalState); } catch (rollbackErr: unknown) {
+          logger.error('Failed to roll back re-opened item after setState failure', rollbackErr);
+        }
         handleCommandError('Failed to update state for re-opened item', err);
         return;
       }
@@ -124,19 +128,31 @@ async function acceptToFocusSingleInboxItem(
       return;
     }
     if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+      const originalState = existing.state;
       try {
         await workGraph.transitionState(existing.id, WorkItemState.New);
       } catch (err: unknown) {
         handleCommandError('Failed to re-open item', err);
         return;
       }
-    }
-    workItemId = existing.id;
-    try {
-      await stateStore.setState(item.providerId, item.externalId, 'accepted');
-    } catch (err: unknown) {
-      handleCommandError('Failed to update state for existing accepted item', err);
-      return;
+      workItemId = existing.id;
+      try {
+        await stateStore.setState(item.providerId, item.externalId, 'accepted');
+      } catch (err: unknown) {
+        try { await workGraph.transitionState(existing.id, originalState); } catch (rollbackErr: unknown) {
+          logger.error('Failed to roll back re-opened item after setState failure', rollbackErr);
+        }
+        handleCommandError('Failed to update state for re-opened item', err);
+        return;
+      }
+    } else {
+      workItemId = existing.id;
+      try {
+        await stateStore.setState(item.providerId, item.externalId, 'accepted');
+      } catch (err: unknown) {
+        handleCommandError('Failed to update state for existing accepted item', err);
+        return;
+      }
     }
   } else {
     const group = item.group?.trim();
@@ -185,6 +201,7 @@ async function batchAcceptToFocusItems(
   const stateUpdates: Array<{ providerId: string; externalId: string; state: InboxState }> = [];
   const createdIds: string[] = [];
   const allIds: string[] = [];
+  const reopenedItems: Array<{ id: string; originalState: WorkItemState }> = [];
   let failed = 0;
   let skipped = 0;
 
@@ -198,8 +215,10 @@ async function batchAcceptToFocusItems(
         continue;
       }
       if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+        const originalState = existing.state;
         try {
           await workGraph.transitionState(existing.id, WorkItemState.New);
+          reopenedItems.push({ id: existing.id, originalState });
         } catch (err: unknown) {
           failed++;
           logger.error(`Failed to re-open "${item.title}"`, err);
@@ -237,6 +256,11 @@ async function batchAcceptToFocusItems(
       for (const id of createdIds) {
         try { await workGraph.deleteItem(id); } catch (rollbackErr: unknown) {
           logger.error('Failed to roll back created item after batch setStates failure', rollbackErr);
+        }
+      }
+      for (const { id, originalState } of reopenedItems) {
+        try { await workGraph.transitionState(id, originalState); } catch (rollbackErr: unknown) {
+          logger.error('Failed to roll back re-opened item after batch setStates failure', rollbackErr);
         }
       }
       handleCommandError('Failed to update states after accepting items', err);

--- a/packages/core/src/commands/sourcesCommands.ts
+++ b/packages/core/src/commands/sourcesCommands.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import { type SourceItemNode, type SourcesElement } from '../views/sourcesTreeProvider';
@@ -38,6 +39,22 @@ async function acceptSingleSourceItem(
   logger.info(`Accepting sources item: ${item.externalId}`);
   const existing = workGraph.findItemByProvenance(item.providerId, item.externalId);
   if (existing) {
+    // Re-open items in terminal states so resurfaced items return to Queue
+    if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+      try {
+        await workGraph.transitionState(existing.id, WorkItemState.New);
+      } catch (err: unknown) {
+        handleCommandError('Failed to re-open completed item', err);
+        return;
+      }
+      try {
+        await stateStore.setState(item.providerId, item.externalId, 'accepted');
+      } catch (err: unknown) {
+        handleCommandError('Failed to update state for re-opened item', err);
+      }
+      void revealer?.revealInQueue(existing.id);
+      return;
+    }
     try {
       await stateStore.setState(item.providerId, item.externalId, 'accepted');
     } catch (err: unknown) {

--- a/packages/core/src/commands/sourcesCommands.ts
+++ b/packages/core/src/commands/sourcesCommands.ts
@@ -51,6 +51,7 @@ async function acceptSingleSourceItem(
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {
         handleCommandError('Failed to update state for re-opened item', err);
+        return;
       }
       void revealer?.revealInQueue(existing.id);
       return;

--- a/packages/core/src/commands/sourcesCommands.ts
+++ b/packages/core/src/commands/sourcesCommands.ts
@@ -44,7 +44,7 @@ async function acceptSingleSourceItem(
       try {
         await workGraph.transitionState(existing.id, WorkItemState.New);
       } catch (err: unknown) {
-        handleCommandError('Failed to re-open completed item', err);
+        handleCommandError('Failed to re-open item', err);
         return;
       }
       try {

--- a/packages/core/src/commands/sourcesCommands.ts
+++ b/packages/core/src/commands/sourcesCommands.ts
@@ -41,6 +41,7 @@ async function acceptSingleSourceItem(
   if (existing) {
     // Re-open items in terminal states so resurfaced items return to Queue
     if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
+      const originalState = existing.state;
       try {
         await workGraph.transitionState(existing.id, WorkItemState.New);
       } catch (err: unknown) {
@@ -50,6 +51,9 @@ async function acceptSingleSourceItem(
       try {
         await stateStore.setState(item.providerId, item.externalId, 'accepted');
       } catch (err: unknown) {
+        try { await workGraph.transitionState(existing.id, originalState); } catch (rollbackErr: unknown) {
+          logger.error('Failed to roll back re-opened item after setState failure', rollbackErr);
+        }
         handleCommandError('Failed to update state for re-opened item', err);
         return;
       }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -28,6 +28,7 @@ import { initLogger, setLogLevel, logger, resolveLogLevel } from './services/log
 import { getInboxUnseenCount } from './services/inboxBadge';
 import { syncProviderTitles } from './services/titleSync';
 import { getViewLayout, ViewId } from './views/viewLayout';
+import { ActivityType } from '@devdocket/shared';
 import { performance } from 'perf_hooks';
 
 export type { DevDocketApi, DevDocketProvider, DevDocketAction, DiscoveredItem, Disposable, ActivityLogEntry, ActivityType, StateTransitionEvent } from './api/types';
@@ -390,7 +391,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const { workGraph: wg, stateStore: ss, readStateStore, labelCache } = await loadStores(storagePath);
   await migrateDiscoveredState(wg, ss);
 
-  const pr = new ProviderRegistry(ss, labelCache);
+  const pr = new ProviderRegistry(
+    ss, labelCache,
+    (providerId, externalId) => wg.findItemByProvenance(providerId, externalId)?.state,
+    async (providerId, externalId, type, detail) => {
+      const item = wg.findItemByProvenance(providerId, externalId);
+      if (item) { await wg.addActivity(item.id, type as ActivityType, detail); }
+    },
+  );
   const ar = new ActionRegistry();
   const wr = new WatcherRegistry(logger);
   const watchStore = new WatchStore(storagePath);

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -396,7 +396,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     (providerId, externalId) => wg.findItemByProvenance(providerId, externalId)?.state,
     async (providerId, externalId, type, detail) => {
       const item = wg.findItemByProvenance(providerId, externalId);
-      if (item) { await wg.addActivity(item.id, type as ActivityType, detail); }
+      if (item) { await wg.addActivity(item.id, type, detail); }
     },
   );
   const ar = new ActionRegistry();

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -28,7 +28,6 @@ import { initLogger, setLogLevel, logger, resolveLogLevel } from './services/log
 import { getInboxUnseenCount } from './services/inboxBadge';
 import { syncProviderTitles } from './services/titleSync';
 import { getViewLayout, ViewId } from './views/viewLayout';
-import { ActivityType } from '@devdocket/shared';
 import { performance } from 'perf_hooks';
 
 export type { DevDocketApi, DevDocketProvider, DevDocketAction, DiscoveredItem, Disposable, ActivityLogEntry, ActivityType, StateTransitionEvent } from './api/types';

--- a/packages/core/src/models/activityLog.ts
+++ b/packages/core/src/models/activityLog.ts
@@ -10,7 +10,7 @@ import type { ActivityType } from '@devdocket/shared';
 export const MAX_ACTIVITY_LOG_ENTRIES = 100;
 
 /** All valid activity type values, for runtime validation. */
-export const ACTIVITY_TYPES = ['created', 'state-changed', 'updated', 'action-executed', 'auto-completed', 'work-started', 'cleanup', 'cleanup-dismissed'] as const satisfies readonly ActivityType[];
+export const ACTIVITY_TYPES = ['created', 'state-changed', 'updated', 'action-executed', 'auto-completed', 'work-started', 'cleanup', 'cleanup-dismissed', 'version-updated'] as const satisfies readonly ActivityType[];
 
 // Compile-time exhaustiveness check: fails if a new ActivityType is added to
 // @devdocket/shared without updating ACTIVITY_TYPES above.

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -440,17 +440,22 @@ export class ProviderRegistry {
         if (!this._disposed && newUnseenUpdates.length > 0) {
           this._onDidAddNewUnseenItems.fire(newUnseenUpdates.length);
         }
+
+        // Log activity only after state was successfully persisted
+        if (this.addActivity && activityEntries.length > 0) {
+          const results = await Promise.allSettled(
+            activityEntries.map(entry =>
+              this.addActivity!(entry.providerId, entry.externalId, 'version-updated'),
+            ),
+          );
+          for (const result of results) {
+            if (result.status === 'rejected') {
+              logger.error('Failed to log version-updated activity', result.reason);
+            }
+          }
+        }
       } catch (err) {
         logger.error('Failed to persist discovered states', err);
-      }
-    }
-
-    // Log activity for suppressed version changes
-    if (this.addActivity && activityEntries.length > 0) {
-      for (const entry of activityEntries) {
-        this.addActivity(entry.providerId, entry.externalId, 'version-updated').catch(err => {
-          logger.error('Failed to log version-updated activity', err);
-        });
       }
     }
     if (!this._disposed) {

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -3,7 +3,8 @@ import { DevDocketProvider, DiscoveredItem, type ResolvedItem } from '../api/typ
 import { DiscoveredStateStore, InboxState } from '../storage/discoveredStateStore';
 import { ProviderLabelCache } from '../storage/providerLabelCache';
 import { logger } from './logger';
-import { WorkItemState, type ActivityType } from '@devdocket/shared';
+import { WorkItemState } from '../models/workItem';
+import { type ActivityType } from '../models/activityLog';
 
 /** Health status of a single provider's most recent refresh attempt. */
 export interface ProviderHealthStatus {

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -3,6 +3,7 @@ import { DevDocketProvider, DiscoveredItem, type ResolvedItem } from '../api/typ
 import { DiscoveredStateStore, InboxState } from '../storage/discoveredStateStore';
 import { ProviderLabelCache } from '../storage/providerLabelCache';
 import { logger } from './logger';
+import { WorkItemState } from '@devdocket/shared';
 
 /** Health status of a single provider's most recent refresh attempt. */
 export interface ProviderHealthStatus {
@@ -73,6 +74,8 @@ export class ProviderRegistry {
   constructor(
     private readonly stateStore: DiscoveredStateStore,
     private readonly labelCache?: ProviderLabelCache,
+    private readonly getWorkItemState?: (providerId: string, externalId: string) => WorkItemState | undefined,
+    private readonly addActivity?: (providerId: string, externalId: string, type: string, detail?: string) => Promise<void>,
   ) {}
 
   /**
@@ -355,6 +358,7 @@ export class ProviderRegistry {
 
     const newUnseenUpdates: Array<{ providerId: string; externalId: string; state: 'unseen'; version?: string; resurfaceVersion?: string }> = [];
     const versionBackfills: Array<{ providerId: string; externalId: string; state: InboxState; version?: string; resurfaceVersion?: string }> = [];
+    const activityEntries: Array<{ providerId: string; externalId: string }> = [];
 
     for (const item of items) {
       const existing = this.stateStore.getState(providerId, item.externalId);
@@ -364,13 +368,14 @@ export class ProviderRegistry {
         if (item.resurfaceVersion !== undefined) { update.resurfaceVersion = item.resurfaceVersion; }
         newUnseenUpdates.push(update);
       } else if (existing === 'accepted') {
-        let shouldResurface = false;
+        let versionTriggered = false;
+        let resurfaceVersionTriggered = false;
         let needsBackfill = false;
 
         if (item.version !== undefined) {
           const storedVersion = this.stateStore.getVersion(providerId, item.externalId);
           if (storedVersion !== undefined && storedVersion !== item.version) {
-            shouldResurface = true;
+            versionTriggered = true;
           } else if (storedVersion === undefined) {
             needsBackfill = true;
           }
@@ -379,9 +384,22 @@ export class ProviderRegistry {
         if (item.resurfaceVersion !== undefined) {
           const storedRV = this.stateStore.getResurfaceVersion(providerId, item.externalId);
           if (storedRV !== undefined && storedRV !== item.resurfaceVersion) {
-            shouldResurface = true;
+            resurfaceVersionTriggered = true;
           } else if (storedRV === undefined) {
             needsBackfill = true;
+          }
+        }
+
+        // resurfaceVersion always resurfaces (hard); version checks work item state (soft)
+        let shouldResurface = resurfaceVersionTriggered;
+        let suppressedVersionChange = false;
+        if (versionTriggered && !shouldResurface) {
+          const wiState = this.getWorkItemState?.(providerId, item.externalId);
+          if (wiState === WorkItemState.New || wiState === WorkItemState.InProgress || wiState === WorkItemState.Paused) {
+            // Suppress: backfill version instead of resurfacing
+            suppressedVersionChange = true;
+          } else {
+            shouldResurface = true;
           }
         }
 
@@ -390,11 +408,14 @@ export class ProviderRegistry {
           if (item.version !== undefined) { update.version = item.version; }
           if (item.resurfaceVersion !== undefined) { update.resurfaceVersion = item.resurfaceVersion; }
           newUnseenUpdates.push(update);
-        } else if (needsBackfill) {
+        } else if (suppressedVersionChange || needsBackfill) {
           const update: typeof versionBackfills[number] = { providerId, externalId: item.externalId, state: 'accepted' };
           if (item.version !== undefined) { update.version = item.version; }
           if (item.resurfaceVersion !== undefined) { update.resurfaceVersion = item.resurfaceVersion; }
           versionBackfills.push(update);
+          if (suppressedVersionChange) {
+            activityEntries.push({ providerId, externalId: item.externalId });
+          }
         }
       } else if (existing === 'unseen') {
         if (item.version !== undefined || item.resurfaceVersion !== undefined) {
@@ -421,6 +442,15 @@ export class ProviderRegistry {
         }
       } catch (err) {
         logger.error('Failed to persist discovered states', err);
+      }
+    }
+
+    // Log activity for suppressed version changes
+    if (this.addActivity && activityEntries.length > 0) {
+      for (const entry of activityEntries) {
+        this.addActivity(entry.providerId, entry.externalId, 'version-updated').catch(err => {
+          logger.error('Failed to log version-updated activity', err);
+        });
       }
     }
     if (!this._disposed) {

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -442,7 +442,7 @@ export class ProviderRegistry {
         }
 
         // Log activity only after state was successfully persisted
-        if (this.addActivity && activityEntries.length > 0) {
+        if (!this._disposed && this.addActivity && activityEntries.length > 0) {
           const results = await Promise.allSettled(
             activityEntries.map(entry =>
               this.addActivity!(entry.providerId, entry.externalId, 'version-updated'),

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -3,7 +3,7 @@ import { DevDocketProvider, DiscoveredItem, type ResolvedItem } from '../api/typ
 import { DiscoveredStateStore, InboxState } from '../storage/discoveredStateStore';
 import { ProviderLabelCache } from '../storage/providerLabelCache';
 import { logger } from './logger';
-import { WorkItemState } from '@devdocket/shared';
+import { WorkItemState, type ActivityType } from '@devdocket/shared';
 
 /** Health status of a single provider's most recent refresh attempt. */
 export interface ProviderHealthStatus {
@@ -75,7 +75,7 @@ export class ProviderRegistry {
     private readonly stateStore: DiscoveredStateStore,
     private readonly labelCache?: ProviderLabelCache,
     private readonly getWorkItemState?: (providerId: string, externalId: string) => WorkItemState | undefined,
-    private readonly addActivity?: (providerId: string, externalId: string, type: string, detail?: string) => Promise<void>,
+    private readonly addActivity?: (providerId: string, externalId: string, type: ActivityType, detail?: string) => Promise<void>,
   ) {}
 
   /**

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -759,6 +759,41 @@ describe('registerCommands', () => {
       expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
     });
 
+    it('re-opens Done item back to Queue when accepting resurfaced item', async () => {
+      const existing = createWorkItem({ id: 'wc-done', title: 'Done Item', state: WorkItemState.Done });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+
+      await invoke('devdocket.acceptFromInbox', makeInboxItem());
+
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-done', WorkItemState.New);
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
+      expect(workGraph.createItem).not.toHaveBeenCalled();
+    });
+
+    it('re-opens Archived item back to Queue when accepting resurfaced item', async () => {
+      const existing = createWorkItem({ id: 'wc-arch', title: 'Archived Item', state: WorkItemState.Archived });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+
+      await invoke('devdocket.acceptFromInbox', makeInboxItem());
+
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-arch', WorkItemState.New);
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
+      expect(workGraph.createItem).not.toHaveBeenCalled();
+    });
+
+    it('shows error when transitionState fails for re-opening Done item', async () => {
+      const existing = createWorkItem({ id: 'wc-done', title: 'Done Item', state: WorkItemState.Done });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+      workGraph.transitionState.mockRejectedValue(new Error('transition error'));
+
+      await invoke('devdocket.acceptFromInbox', makeInboxItem());
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'DevDocket: Failed to re-open completed item — transition error',
+      );
+      expect(stateStore.setState).not.toHaveBeenCalled();
+    });
+
     it('shows error when setState fails for existing accepted item', async () => {
       const existing = createWorkItem({ title: 'Already There' });
       workGraph.findItemByProvenance.mockReturnValue(existing);
@@ -1194,28 +1229,26 @@ describe('registerCommands', () => {
       expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
     });
 
-    it('shows warning and does not transition when item is Done', async () => {
+    it('re-opens Done item and transitions to Focus', async () => {
       const existing = createWorkItem({ id: 'wc-done', state: WorkItemState.Done });
       workGraph.findItemByProvenance.mockReturnValue(existing);
 
       await invoke('devdocket.acceptToFocusFromInbox', makeInboxItem());
 
-      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
-        'DevDocket: Item is Done and cannot be moved to Focus',
-      );
-      expect(workGraph.transitionState).not.toHaveBeenCalled();
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-done', WorkItemState.New);
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-done', WorkItemState.InProgress);
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
     });
 
-    it('shows warning and does not transition when item is Archived', async () => {
+    it('re-opens Archived item and transitions to Focus', async () => {
       const existing = createWorkItem({ id: 'wc-arch', state: WorkItemState.Archived });
       workGraph.findItemByProvenance.mockReturnValue(existing);
 
       await invoke('devdocket.acceptToFocusFromInbox', makeInboxItem());
 
-      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
-        'DevDocket: Item is Archived and cannot be moved to Focus',
-      );
-      expect(workGraph.transitionState).not.toHaveBeenCalled();
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-arch', WorkItemState.New);
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-arch', WorkItemState.InProgress);
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
     });
 
     it('returns early with no errors for empty selection', async () => {
@@ -1317,32 +1350,30 @@ describe('registerCommands', () => {
       expect(workGraph.transitionState).not.toHaveBeenCalled();
     });
 
-    it('returns early with error when setState fails for Done item', async () => {
+    it('returns early with error when transitionState fails for Done item', async () => {
       const existing = createWorkItem({ id: 'wc-done-err', state: WorkItemState.Done });
       workGraph.findItemByProvenance.mockReturnValue(existing);
-      stateStore.setState.mockRejectedValue(new Error('state error'));
+      workGraph.transitionState.mockRejectedValue(new Error('transition error'));
 
       await invoke('devdocket.acceptToFocusFromInbox', makeInboxItem());
 
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: Failed to update state for existing completed item — state error',
+        'DevDocket: Failed to re-open completed item — transition error',
       );
-      expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
-      expect(workGraph.transitionState).not.toHaveBeenCalled();
+      expect(stateStore.setState).not.toHaveBeenCalled();
     });
 
-    it('returns early with error when setState fails for Archived item', async () => {
+    it('returns early with error when transitionState fails for Archived item', async () => {
       const existing = createWorkItem({ id: 'wc-arch-err', state: WorkItemState.Archived });
       workGraph.findItemByProvenance.mockReturnValue(existing);
-      stateStore.setState.mockRejectedValue(new Error('state error'));
+      workGraph.transitionState.mockRejectedValue(new Error('transition error'));
 
       await invoke('devdocket.acceptToFocusFromInbox', makeInboxItem());
 
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: Failed to update state for existing completed item — state error',
+        'DevDocket: Failed to re-open completed item — transition error',
       );
-      expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
-      expect(workGraph.transitionState).not.toHaveBeenCalled();
+      expect(stateStore.setState).not.toHaveBeenCalled();
     });
 
     it('returns early with error when setState fails for existing New item', async () => {
@@ -1464,7 +1495,7 @@ describe('registerCommands', () => {
       );
     });
 
-    it('skips existing items in non-transitionable states', async () => {
+    it('re-opens Done/Archived items and skips InProgress items', async () => {
       const items = [
         makeInboxItem({ externalId: 'ext-1', title: 'Issue 1' }),
         makeInboxItem({ externalId: 'ext-2', title: 'Issue 2' }),
@@ -1479,11 +1510,12 @@ describe('registerCommands', () => {
       await invoke('devdocket.acceptToFocusFromInbox', items[0], items);
 
       expect(workGraph.createItem).toHaveBeenCalledTimes(1);
-      // Only wc-3 should be transitioned; wc-1 (InProgress) and wc-2 (Done) are skipped
-      expect(workGraph.transitionState).toHaveBeenCalledTimes(1);
+      // wc-2 re-opened (Done→New), then both wc-2 and wc-3 transitioned to InProgress
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-2', WorkItemState.New);
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-2', WorkItemState.InProgress);
       expect(workGraph.transitionState).toHaveBeenCalledWith('wc-3', WorkItemState.InProgress);
       expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
-        'Accepted 1 item to Focus; 2 items already in Focus or cannot be moved',
+        'Accepted 2 items to Focus; 1 item already in Focus or cannot be moved',
       );
     });
   });
@@ -1930,6 +1962,28 @@ describe('registerCommands', () => {
       expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
         'DevDocket: Item already accepted as "Existing"',
       );
+    });
+
+    it('re-opens Done item back to Queue when accepting from sources', async () => {
+      const existing = createWorkItem({ id: 'wc-done', title: 'Done Item', state: WorkItemState.Done });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+
+      await invoke('devdocket.acceptFromSources', makeSourceItem());
+
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-done', WorkItemState.New);
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-2', 'accepted');
+      expect(workGraph.createItem).not.toHaveBeenCalled();
+    });
+
+    it('re-opens Archived item back to Queue when accepting from sources', async () => {
+      const existing = createWorkItem({ id: 'wc-arch', title: 'Archived Item', state: WorkItemState.Archived });
+      workGraph.findItemByProvenance.mockReturnValue(existing);
+
+      await invoke('devdocket.acceptFromSources', makeSourceItem());
+
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-arch', WorkItemState.New);
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-2', 'accepted');
+      expect(workGraph.createItem).not.toHaveBeenCalled();
     });
 
     it('shows error when setState fails for existing item', async () => {

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -793,7 +793,7 @@ describe('registerCommands', () => {
       await invoke('devdocket.acceptFromInbox', makeInboxItem());
 
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: Failed to re-open completed item — transition error',
+        'DevDocket: Failed to re-open item — transition error',
       );
       expect(stateStore.setState).not.toHaveBeenCalled();
     });
@@ -1362,7 +1362,7 @@ describe('registerCommands', () => {
       await invoke('devdocket.acceptToFocusFromInbox', makeInboxItem());
 
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: Failed to re-open completed item — transition error',
+        'DevDocket: Failed to re-open item — transition error',
       );
       expect(stateStore.setState).not.toHaveBeenCalled();
     });
@@ -1375,7 +1375,7 @@ describe('registerCommands', () => {
       await invoke('devdocket.acceptToFocusFromInbox', makeInboxItem());
 
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: Failed to re-open completed item — transition error',
+        'DevDocket: Failed to re-open item — transition error',
       );
       expect(stateStore.setState).not.toHaveBeenCalled();
     });

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -1664,6 +1664,101 @@ describe('ProviderRegistry', () => {
     });
   });
 
+  describe('accepted items without version fields', () => {
+    it('does not resurface accepted item re-emitted with no version or resurfaceVersion', async () => {
+      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.Done);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+
+      const listener = vi.fn();
+      reg.onDidAddNewUnseenItems(listener);
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1' },
+      ]);
+
+      // Allow handleDiscoveredItems to process
+      await vi.waitFor(() => expect(reg.getDiscoveredItems('gh')).toHaveLength(1));
+      // No state updates should have been made
+      expect(stateStore.setStates).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+
+      reg.dispose();
+    });
+
+    it('does not resurface accepted Done item re-emitted with no version after being in History', async () => {
+      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.Done);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+
+      const listener = vi.fn();
+      reg.onDidAddNewUnseenItems(listener);
+
+      // Re-emit same item multiple times (simulating repeated refreshes with no version)
+      provider.fireItems([{ externalId: 'pr-1', title: 'PR 1' }]);
+      await vi.waitFor(() => expect(reg.getDiscoveredItems('gh')).toHaveLength(1));
+
+      provider.fireItems([{ externalId: 'pr-1', title: 'PR 1' }]);
+      await vi.waitFor(() => expect(reg.getDiscoveredItems('gh')).toHaveLength(1));
+
+      expect(stateStore.setStates).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+
+      reg.dispose();
+    });
+
+    it('does not resurface accepted Archived item re-emitted with no version', async () => {
+      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.Archived);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+
+      const listener = vi.fn();
+      reg.onDidAddNewUnseenItems(listener);
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1' },
+      ]);
+
+      await vi.waitFor(() => expect(reg.getDiscoveredItems('gh')).toHaveLength(1));
+      expect(stateStore.setStates).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+
+      reg.dispose();
+    });
+
+    it('does not resurface accepted item with no work item when no version set', async () => {
+      // Work item was deleted (e.g., clearOldHistory) — getWorkItemState returns undefined
+      const getWorkItemState = vi.fn().mockReturnValue(undefined);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+
+      const listener = vi.fn();
+      reg.onDidAddNewUnseenItems(listener);
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1' },
+      ]);
+
+      await vi.waitFor(() => expect(reg.getDiscoveredItems('gh')).toHaveLength(1));
+      expect(stateStore.setStates).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+
+      reg.dispose();
+    });
+  });
+
   describe('resolveUrl', () => {
     function nextTick(): Promise<void> {
       return new Promise(resolve => setTimeout(resolve, 0));

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -1426,6 +1426,244 @@ describe('ProviderRegistry', () => {
     });
   });
 
+  describe('soft version resurfacing with work item state', () => {
+    it('suppresses version resurfacing when work item is InProgress', async () => {
+      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.InProgress);
+      const addActivityFn = vi.fn().mockResolvedValue(undefined);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState, addActivityFn);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+      stateStore._setVersion('gh', 'pr-1', 'sha-old');
+
+      const listener = vi.fn();
+      reg.onDidAddNewUnseenItems(listener);
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      // Should backfill version, not resurface
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'accepted', version: 'sha-new' },
+      ]);
+      expect(listener).not.toHaveBeenCalled();
+      expect(getWorkItemState).toHaveBeenCalledWith('gh', 'pr-1');
+      // Activity log should be called
+      await vi.waitFor(() => expect(addActivityFn).toHaveBeenCalledWith('gh', 'pr-1', 'version-updated'));
+
+      reg.dispose();
+    });
+
+    it('suppresses version resurfacing when work item is Paused', async () => {
+      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.Paused);
+      const addActivityFn = vi.fn().mockResolvedValue(undefined);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState, addActivityFn);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+      stateStore._setVersion('gh', 'pr-1', 'sha-old');
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'accepted', version: 'sha-new' },
+      ]);
+
+      reg.dispose();
+    });
+
+    it('suppresses version resurfacing when work item is New', async () => {
+      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.New);
+      const addActivityFn = vi.fn().mockResolvedValue(undefined);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState, addActivityFn);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+      stateStore._setVersion('gh', 'pr-1', 'sha-old');
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'accepted', version: 'sha-new' },
+      ]);
+
+      reg.dispose();
+    });
+
+    it('resurfaces when version changes and work item is Done', async () => {
+      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.Done);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+      stateStore._setVersion('gh', 'pr-1', 'sha-old');
+
+      const listener = vi.fn();
+      reg.onDidAddNewUnseenItems(listener);
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'unseen', version: 'sha-new' },
+      ]);
+      await vi.waitFor(() => expect(listener).toHaveBeenCalledWith(1));
+
+      reg.dispose();
+    });
+
+    it('resurfaces when version changes and work item is Archived', async () => {
+      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.Archived);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+      stateStore._setVersion('gh', 'pr-1', 'sha-old');
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'unseen', version: 'sha-new' },
+      ]);
+
+      reg.dispose();
+    });
+
+    it('resurfaces when version changes and no work item exists', async () => {
+      const getWorkItemState = vi.fn().mockReturnValue(undefined);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+      stateStore._setVersion('gh', 'pr-1', 'sha-old');
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'unseen', version: 'sha-new' },
+      ]);
+
+      reg.dispose();
+    });
+
+    it('resurfaceVersion always resurfaces even when work item is InProgress', async () => {
+      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.InProgress);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+      stateStore._setResurfaceVersion('gh', 'pr-1', 'rr-old');
+
+      const listener = vi.fn();
+      reg.onDidAddNewUnseenItems(listener);
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', resurfaceVersion: 'rr-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'unseen', resurfaceVersion: 'rr-new' },
+      ]);
+      await vi.waitFor(() => expect(listener).toHaveBeenCalledWith(1));
+
+      reg.dispose();
+    });
+
+    it('resurfaceVersion overrides suppressed version change', async () => {
+      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.InProgress);
+      const addActivityFn = vi.fn().mockResolvedValue(undefined);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState, addActivityFn);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+      stateStore._setVersion('gh', 'pr-1', 'sha-old');
+      stateStore._setResurfaceVersion('gh', 'pr-1', 'rr-old');
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new', resurfaceVersion: 'rr-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      // resurfaceVersion change should trigger full resurface
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'unseen', version: 'sha-new', resurfaceVersion: 'rr-new' },
+      ]);
+      // No activity logged — item resurfaced, not suppressed
+      expect(addActivityFn).not.toHaveBeenCalled();
+
+      reg.dispose();
+    });
+
+    it('still works without getWorkItemState callback (backward compatible)', async () => {
+      // No callback provided — behaves as before (version change resurfaces)
+      const reg = new ProviderRegistry(stateStore);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+      stateStore._setVersion('gh', 'pr-1', 'sha-old');
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'unseen', version: 'sha-new' },
+      ]);
+
+      reg.dispose();
+    });
+
+    it('logs activity error gracefully without breaking flow', async () => {
+      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.InProgress);
+      const addActivityFn = vi.fn().mockRejectedValue(new Error('activity fail'));
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState, addActivityFn);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+      stateStore._setVersion('gh', 'pr-1', 'sha-old');
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      // Should still backfill version even though activity fails
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'accepted', version: 'sha-new' },
+      ]);
+
+      reg.dispose();
+    });
+  });
+
   describe('resolveUrl', () => {
     function nextTick(): Promise<void> {
       return new Promise(resolve => setTimeout(resolve, 0));

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -64,14 +64,14 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
         reason: 'review_requested',
       };
       if (pr.state) { item.state = pr.state; }
-      // Both signals use soft resurfacing (version) — items only resurface from
-      // History (Done/Archived), never from Queue or Focus.
+      // Head SHA uses soft resurfacing (version) — only resurfaces from
+      // Done/Archived, not from Queue or Focus.
       const headSha = headShas.get(pr.html_url);
+      if (headSha !== undefined) { item.version = headSha; }
+      // Re-request time uses hard resurfacing (resurfaceVersion) — always
+      // resurfaces regardless of work item state.
       const reRequestTime = reRequestTimes.get(pr.html_url);
-      const versionParts: string[] = [];
-      if (headSha !== undefined) { versionParts.push(headSha); }
-      if (reRequestTime !== undefined) { versionParts.push(reRequestTime); }
-      if (versionParts.length > 0) { item.version = versionParts.join('::'); }
+      if (reRequestTime !== undefined) { item.resurfaceVersion = reRequestTime; }
       return item;
     });
 

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -65,8 +65,8 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
         canonicalId: `github:pull:${repoName}#${pr.number}`,
       };
       if (pr.state) { item.state = pr.state; }
-      // Head SHA uses soft resurfacing (version) — only resurfaces from
-      // Done/Archived, not from Queue or Focus.
+      // Head SHA uses soft resurfacing (version) — resurfaces from
+      // Done/Archived or when no work item exists, but not from Queue or Focus.
       const headSha = headShas.get(pr.html_url);
       if (headSha !== undefined) { item.version = headSha; }
       // Re-request time uses hard resurfacing (resurfaceVersion) — always

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -64,14 +64,14 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
         reason: 'review_requested',
       };
       if (pr.state) { item.state = pr.state; }
-      // Both settings produce hard resurfacing (resurfaceVersion) since the user
-      // explicitly opted in. Combine both signals so either change triggers it.
+      // Both signals use soft resurfacing (version) — items only resurface from
+      // History (Done/Archived), never from Queue or Focus.
       const headSha = headShas.get(pr.html_url);
       const reRequestTime = reRequestTimes.get(pr.html_url);
-      const resurfaceParts: string[] = [];
-      if (headSha !== undefined) { resurfaceParts.push(headSha); }
-      if (reRequestTime !== undefined) { resurfaceParts.push(reRequestTime); }
-      if (resurfaceParts.length > 0) { item.resurfaceVersion = resurfaceParts.join('::'); }
+      const versionParts: string[] = [];
+      if (headSha !== undefined) { versionParts.push(headSha); }
+      if (reRequestTime !== undefined) { versionParts.push(reRequestTime); }
+      if (versionParts.length > 0) { item.version = versionParts.join('::'); }
       return item;
     });
 

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -64,10 +64,14 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
         reason: 'review_requested',
       };
       if (pr.state) { item.state = pr.state; }
+      // Both settings produce hard resurfacing (resurfaceVersion) since the user
+      // explicitly opted in. Combine both signals so either change triggers it.
       const headSha = headShas.get(pr.html_url);
-      if (headSha !== undefined) { item.version = headSha; }
       const reRequestTime = reRequestTimes.get(pr.html_url);
-      if (reRequestTime !== undefined) { item.resurfaceVersion = reRequestTime; }
+      const resurfaceParts: string[] = [];
+      if (headSha !== undefined) { resurfaceParts.push(headSha); }
+      if (reRequestTime !== undefined) { resurfaceParts.push(reRequestTime); }
+      if (resurfaceParts.length > 0) { item.resurfaceVersion = resurfaceParts.join('::'); }
       return item;
     });
 

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -644,10 +644,11 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].version).toBe('2024-01-15T10:30:00Z');
+      expect(items[0].version).toBeUndefined();
+      expect(items[0].resurfaceVersion).toBe('2024-01-15T10:30:00Z');
     });
 
-    it('combines commit SHA and re-request time when both settings enabled', async () => {
+    it('sets version and resurfaceVersion independently when both settings enabled', async () => {
       mockConfig({ resurfaceOnNewVersion: true, resurfaceOnReRequestedReview: true });
 
       mockFetch
@@ -685,10 +686,11 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].version).toBe('abc123::2024-01-15T10:30:00Z');
+      expect(items[0].version).toBe('abc123');
+      expect(items[0].resurfaceVersion).toBe('2024-01-15T10:30:00Z');
     });
 
-    it('uses latest review_requested event for version', async () => {
+    it('uses latest review_requested event for resurfaceVersion', async () => {
       mockConfig({ resurfaceOnNewVersion: false, resurfaceOnReRequestedReview: true });
 
       mockFetch
@@ -723,7 +725,7 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].version).toBe('2024-01-15T10:30:00Z');
+      expect(items[0].resurfaceVersion).toBe('2024-01-15T10:30:00Z');
     });
 
     it('ignores review_requested events for other users', async () => {
@@ -756,7 +758,7 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].version).toBeUndefined();
+      expect(items[0].resurfaceVersion).toBeUndefined();
     });
 
     it('skips timeline fetch when fetchCurrentUser fails', async () => {
@@ -777,7 +779,7 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].version).toBeUndefined();
+      expect(items[0].resurfaceVersion).toBeUndefined();
       // 2 calls: search + failed /user. No timeline call.
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
@@ -804,7 +806,7 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].version).toBeUndefined();
+      expect(items[0].resurfaceVersion).toBeUndefined();
     });
 
     it('caches current user login across refreshes', async () => {
@@ -877,7 +879,7 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].version).toBe('2024-01-15T10:30:00Z');
+      expect(items[0].resurfaceVersion).toBe('2024-01-15T10:30:00Z');
     });
   });
 

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -584,6 +584,7 @@ describe('GitHubPrReviewProvider', () => {
       const items = listener.mock.calls[0][0];
       expect(items).toHaveLength(1);
       expect(items[0].version).toBeUndefined();
+      expect(items[0].resurfaceVersion).toBeUndefined();
       // Only 1 fetch call (search), no head SHA or timeline calls
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
@@ -608,7 +609,8 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].version).toBe('abc123');
+      expect(items[0].version).toBeUndefined();
+      expect(items[0].resurfaceVersion).toBe('abc123');
     });
 
     it('fetches timeline when resurfaceOnReRequestedReview is true', async () => {
@@ -644,8 +646,49 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].version).toBeUndefined();
       expect(items[0].resurfaceVersion).toBe('2024-01-15T10:30:00Z');
+    });
+
+    it('combines commit SHA and re-request time when both settings enabled', async () => {
+      mockConfig({ resurfaceOnNewVersion: true, resurfaceOnReRequestedReview: true });
+
+      mockFetch
+        // Search API
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            items: [createMockPrWithApi(1, 'PR 1')],
+          }),
+        })
+        // Head SHA
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ head: { sha: 'abc123' } }),
+        })
+        // GET /user
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ login: 'testuser' }),
+        })
+        // Timeline
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ([
+            {
+              event: 'review_requested',
+              created_at: '2024-01-15T10:30:00Z',
+              requested_reviewer: { login: 'testuser' },
+            },
+          ]),
+        });
+
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+      await provider.refresh();
+
+      const items = listener.mock.calls[0][0];
+      expect(items[0].version).toBeUndefined();
+      expect(items[0].resurfaceVersion).toBe('abc123::2024-01-15T10:30:00Z');
     });
 
     it('uses latest review_requested event for resurfaceVersion', async () => {

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -584,7 +584,6 @@ describe('GitHubPrReviewProvider', () => {
       const items = listener.mock.calls[0][0];
       expect(items).toHaveLength(1);
       expect(items[0].version).toBeUndefined();
-      expect(items[0].resurfaceVersion).toBeUndefined();
       // Only 1 fetch call (search), no head SHA or timeline calls
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
@@ -609,8 +608,7 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].version).toBeUndefined();
-      expect(items[0].resurfaceVersion).toBe('abc123');
+      expect(items[0].version).toBe('abc123');
     });
 
     it('fetches timeline when resurfaceOnReRequestedReview is true', async () => {
@@ -646,7 +644,7 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].resurfaceVersion).toBe('2024-01-15T10:30:00Z');
+      expect(items[0].version).toBe('2024-01-15T10:30:00Z');
     });
 
     it('combines commit SHA and re-request time when both settings enabled', async () => {
@@ -687,11 +685,10 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].version).toBeUndefined();
-      expect(items[0].resurfaceVersion).toBe('abc123::2024-01-15T10:30:00Z');
+      expect(items[0].version).toBe('abc123::2024-01-15T10:30:00Z');
     });
 
-    it('uses latest review_requested event for resurfaceVersion', async () => {
+    it('uses latest review_requested event for version', async () => {
       mockConfig({ resurfaceOnNewVersion: false, resurfaceOnReRequestedReview: true });
 
       mockFetch
@@ -726,7 +723,7 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].resurfaceVersion).toBe('2024-01-15T10:30:00Z');
+      expect(items[0].version).toBe('2024-01-15T10:30:00Z');
     });
 
     it('ignores review_requested events for other users', async () => {
@@ -759,7 +756,7 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].resurfaceVersion).toBeUndefined();
+      expect(items[0].version).toBeUndefined();
     });
 
     it('skips timeline fetch when fetchCurrentUser fails', async () => {
@@ -780,7 +777,7 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].resurfaceVersion).toBeUndefined();
+      expect(items[0].version).toBeUndefined();
       // 2 calls: search + failed /user. No timeline call.
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
@@ -807,7 +804,7 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].resurfaceVersion).toBeUndefined();
+      expect(items[0].version).toBeUndefined();
     });
 
     it('caches current user login across refreshes', async () => {
@@ -880,7 +877,7 @@ describe('GitHubPrReviewProvider', () => {
       await provider.refresh();
 
       const items = listener.mock.calls[0][0];
-      expect(items[0].resurfaceVersion).toBe('2024-01-15T10:30:00Z');
+      expect(items[0].version).toBe('2024-01-15T10:30:00Z');
     });
   });
 

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -30,17 +30,18 @@ export interface DiscoveredItem {
   /** Optional upstream state from the provider (e.g. `"open"`, `"closed"`, `"Active"`). */
   state?: string;
   /**
-   * Optional version identifier that changes when the item needs re-attention.
+   * Optional version identifier for "soft" resurfacing.
    * When a previously accepted item reappears with a different version,
-   * it is resurfaced in the Inbox as unseen. Useful for PR reviews where
-   * new commits should create a new inbox cycle.
+   * it is resurfaced in the Inbox as unseen **unless** the linked work item
+   * is currently in Queue or Focus (New, InProgress, Paused), in which case
+   * the version is silently updated and a `version-updated` activity is logged.
    */
   version?: string;
   /**
-   * Optional secondary version that independently triggers resurfacing.
-   * Behaves the same as `version` but is tracked separately, allowing
-   * providers to detect multiple independent change signals (e.g. new
-   * commits via `version` and re-requested reviews via `resurfaceVersion`).
+   * Optional secondary version for "hard" resurfacing.
+   * When a previously accepted item reappears with a different
+   * resurfaceVersion, it is **always** resurfaced in the Inbox as unseen,
+   * regardless of the linked work item's state.
    */
   resurfaceVersion?: string;
 }

--- a/packages/shared/src/workItem.ts
+++ b/packages/shared/src/workItem.ts
@@ -9,8 +9,9 @@
  * - `work-started` — a branch and/or worktree was created for this item.
  * - `cleanup` — git branch and/or worktree was cleaned up.
  * - `cleanup-dismissed` — user declined cleanup prompt for this item.
+ * - `version-updated` — a provider version change was suppressed because the item is in Queue or Focus.
  */
-export type ActivityType = 'created' | 'state-changed' | 'updated' | 'action-executed' | 'auto-completed' | 'work-started' | 'cleanup' | 'cleanup-dismissed';
+export type ActivityType = 'created' | 'state-changed' | 'updated' | 'action-executed' | 'auto-completed' | 'work-started' | 'cleanup' | 'cleanup-dismissed' | 'version-updated';
 
 /**
  * A single, immutable entry in a work item's activity log.


### PR DESCRIPTION
Fixes #357

## Summary

Introduces "soft" vs "hard" version resurfacing for discovered items to prevent PR review items from resurfacing in the Inbox when the user is actively working on them in Queue or Focus.

Also fixes a bug where resurfaced items in Done/Archived state could not be re-accepted because the accept logic treated any existing work item as "already accepted". Items in terminal states are now re-opened (transitioned back to New) when accepted, with proper rollback if state persistence fails.

## Changes

### Soft resurfacing (`version`)
When an accepted item's `version` changes, the system now checks the linked work item's state:
- **Queue/Focus** (New, InProgress, Paused): version is silently updated (backfilled) and a `version-updated` activity is logged — the item does NOT resurface.
- **Done/Archived/not found**: item resurfaces as before.

### Hard resurfacing (`resurfaceVersion`)
`resurfaceVersion` changes **always** resurface the item regardless of work item state. This is used for explicit signals like re-requested reviews.

### Re-accepting resurfaced items
When a user accepts an item that has an existing work item in Done or Archived state:
- The work item is transitioned back to New (re-opened) so it appears in Queue
- The discovered state is updated to `accepted`
- If state persistence fails, the re-open transition is rolled back
- Accept-to-Focus also works: Done/Archived → New → InProgress

This applies to all accept paths: single inbox accept, single sources accept, batch accept, and accept-to-Focus (single and batch).

### ADO provider alignment
Renamed `version` → `resurfaceVersion` in `AdoPrReviewProvider` so ADO PR commit changes always hard-resurface (matching the original behavior for that provider).

### New `version-updated` activity type
Added to track when a version change was suppressed for items in Queue/Focus.

## Migration Notes

This PR adds a new `'version-updated'` literal to the exported `ActivityType` union in `packages/shared/src/workItem.ts`.

**What changed:** `ActivityType` now includes `'version-updated'` in addition to the existing values (`'created'`, `'state-changed'`, `'updated'`, `'action-executed'`, `'auto-completed'`, `'work-started'`, `'cleanup'`, `'cleanup-dismissed'`).

**Impact on provider extensions:** If your extension performs exhaustive `switch` or `if`/`else` checks over `ActivityType` values (e.g., using a TypeScript `never` check for exhaustiveness), you will get a compile-time error until you handle the new `'version-updated'` case.

**How to update:**
- Add a `case 'version-updated':` to any exhaustive `switch` statement over `ActivityType`.
- Alternatively, add a `default:` case to gracefully handle unknown activity types going forward.

This is an additive change — existing code that does not exhaustively match on `ActivityType` (e.g., uses `if` checks for specific types) will continue to work without modification.
