### PR TITLE
Add checkout PR branch action to start-git-work extension

### DIFF
--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -354,11 +354,25 @@ export class StartWorkAction implements DevDocketAction {
         }
       }
 
-      await execFileAsync('git', ['fetch', forkRemoteName, branchName], { cwd: repoPath, timeout: 30_000 });
+      try {
+        await execFileAsync('git', ['fetch', forkRemoteName, branchName], { cwd: repoPath, timeout: 30_000 });
+      } catch {
+        void vscode.window.showErrorMessage(
+          `DevDocket: Could not fetch branch '${branchName}' from fork '${forkOwner}'. The branch may have been deleted.`,
+        );
+        return undefined;
+      }
 
       return { branchName, trackingRef: `${forkRemoteName}/${branchName}` };
     } else {
-      await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: repoPath, timeout: 30_000 });
+      try {
+        await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: repoPath, timeout: 30_000 });
+      } catch {
+        void vscode.window.showErrorMessage(
+          `DevDocket: Could not fetch branch '${branchName}' from origin. The branch may have been deleted.`,
+        );
+        return undefined;
+      }
     }
 
     return { branchName };

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -13,18 +13,45 @@ interface ParsedExternalId {
   itemNumber: string;
 }
 
-const SUPPORTED_PROVIDERS = ['github', 'ado-work-items'];
+const SUPPORTED_PROVIDERS = [
+  'github',
+  'ado-work-items',
+  'github-my-prs',
+  'github-pr-reviews',
+  'ado-pr-reviews',
+];
+
+const PR_PROVIDERS = ['github-my-prs', 'github-pr-reviews', 'ado-pr-reviews'];
+
+type WorkMode = 'checkout' | 'worktree';
+
+interface GitHubPrHead {
+  ref: string;
+  repo: {
+    full_name: string;
+    clone_url: string;
+  };
+}
+
+interface GitHubPrResponse {
+  head: GitHubPrHead;
+  base: {
+    repo: {
+      full_name: string;
+    };
+  };
+}
+
+interface AdoPrResponse {
+  sourceRefName: string;
+}
 
 /**
  * DevDocket action that bootstraps a development environment for a work item.
  *
- * Supports items from both GitHub and Azure DevOps providers.
- * When executed on a work item it:
- * 1. Prompts the user for the local repository path (with cached defaults).
- * 2. Prompts for a base branch (with cached defaults).
- * 3. Creates a feature branch named `issue{num}`.
- * 4. Creates a git worktree at a sibling directory of the repository.
- * 5. Runs any user-configured post-worktree commands.
+ * Supports items from GitHub and Azure DevOps providers (both issues and PRs).
+ * When executed on an issue it creates a new branch and checks out or creates a worktree.
+ * When executed on a PR it fetches the existing PR branch instead of creating one.
  *
  * Only available for items in the `InProgress` state from supported providers.
  */
@@ -49,15 +76,34 @@ export class StartWorkAction implements DevDocketAction {
       return;
     }
 
-    const branchName = `issue${parsed.itemNumber}`;
+    const isPr = PR_PROVIDERS.includes(item.providerId ?? '');
 
     const repoPath = await this.promptForRepoPath(parsed.repoKey);
     if (!repoPath) {
       return;
     }
 
+    if (isPr) {
+      await this.runPrFlow(item, parsed, repoPath);
+    } else {
+      await this.runIssueFlow(item, parsed, repoPath);
+    }
+  }
+
+  private async runIssueFlow(
+    item: Readonly<WorkItem>,
+    parsed: ParsedExternalId,
+    repoPath: string,
+  ): Promise<void> {
+    const branchName = `issue${parsed.itemNumber}`;
+
     const baseBranch = await this.promptForBaseBranch(parsed.repoKey);
     if (!baseBranch) {
+      return;
+    }
+
+    const workMode = await this.promptForWorkMode();
+    if (!workMode) {
       return;
     }
 
@@ -69,95 +115,401 @@ export class StartWorkAction implements DevDocketAction {
           cancellable: false,
         },
         async (progress) => {
-          const repoBaseName = path.basename(repoPath);
-          const worktreeDirName = `${repoBaseName}-issue${parsed.itemNumber}`;
-          const worktreePath = path.join(path.dirname(repoPath), worktreeDirName);
-
-          // Fail fast if worktree directory already exists (before creating branch)
-          if (fs.existsSync(worktreePath)) {
-            void vscode.window.showErrorMessage(`DevDocket: Directory "${worktreePath}" already exists.`);
-            return;
+          if (workMode === 'worktree') {
+            await this.issueWorktreeFlow(item, parsed, repoPath, branchName, baseBranch, progress);
+          } else {
+            await this.issueCheckoutFlow(item, parsed, repoPath, branchName, baseBranch, progress);
           }
-
-          progress.report({ message: 'Creating branch...' });
-
-          // Check if branch already exists
-          const { stdout: branchList } = await execFileAsync('git', ['branch', '--list', branchName], { cwd: repoPath, timeout: 30_000 });
-          if (branchList.trim()) {
-            void vscode.window.showErrorMessage(`DevDocket: Branch "${branchName}" already exists.`);
-            return;
-          }
-
-          await execFileAsync('git', ['branch', branchName, baseBranch], { cwd: repoPath, timeout: 30_000 });
-          logger.info(`Starting work: creating branch ${branchName}`);
-
-          progress.report({ message: 'Creating worktree...' });
-
-          try {
-            await execFileAsync('git', ['worktree', 'add', worktreePath, branchName], {
-              cwd: repoPath,
-              timeout: 30_000,
-            });
-          } catch (worktreeErr) {
-            // Rollback: delete the branch we just created
-            try {
-              await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath, timeout: 30_000 });
-            } catch (rollbackErr) {
-              const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
-              void vscode.window.showWarningMessage(`DevDocket: Failed to delete branch during rollback — ${rollbackMessage}`);
-            }
-
-            const errMsg = worktreeErr instanceof Error ? worktreeErr.message : String(worktreeErr);
-            const errStderr = (worktreeErr as any)?.stderr ?? '';
-            if (errMsg.includes('already exists') || errStderr.includes('already exists')) {
-              void vscode.window.showErrorMessage(`DevDocket: Directory "${worktreePath}" already exists.`);
-              return;
-            }
-            throw worktreeErr;
-          }
-
-          logger.info(`Created worktree at ${worktreePath}`);
-
-          // Log branch and worktree info to the work item's activity log
-          try {
-            const detail = JSON.stringify({ branchName, worktreePath, repoPath });
-            await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-started', detail);
-          } catch (activityErr) {
-            logger.error('Failed to log work-started activity', activityErr);
-            void vscode.window.showWarningMessage(
-              `DevDocket: Worktree created but failed to log activity — cleanup prompt may not work`,
-            );
-          }
-
-          // Run user-configured post-worktree commands
-          const commands = vscode.workspace.getConfiguration('devdocketStartGitWork')
-            .get<{ command: string; args?: string[] }[]>('commands', []);
-
-          for (const cmd of commands) {
-            progress.report({ message: `Running ${cmd.command}...` });
-            const resolvedArgs = (cmd.args ?? []).map(
-              arg => arg.replace(/\{path\}/g, worktreePath),
-            );
-            try {
-              await execFileAsync(cmd.command, resolvedArgs, { cwd: worktreePath, timeout: 60_000 });
-            } catch (cmdErr) {
-              const cmdMessage = cmdErr instanceof Error ? cmdErr.message : String(cmdErr);
-              logger.error(`Post-worktree command failed: ${cmd.command}`, cmdErr);
-              void vscode.window.showWarningMessage(
-                `DevDocket: Command "${cmd.command}" failed — ${cmdMessage}`,
-              );
-            }
-          }
-
-          void vscode.window.showInformationMessage(
-            `DevDocket: Created worktree for ${branchName}`,
-          );
         },
       );
     } catch (err: unknown) {
       logger.error('Failed to start work', err);
       const message = err instanceof Error ? err.message : String(err);
       void vscode.window.showErrorMessage(`DevDocket: Failed to start work — ${message}`);
+    }
+  }
+
+  private async issueWorktreeFlow(
+    item: Readonly<WorkItem>,
+    parsed: ParsedExternalId,
+    repoPath: string,
+    branchName: string,
+    baseBranch: string,
+    progress: vscode.Progress<{ message?: string }>,
+  ): Promise<void> {
+    const repoBaseName = path.basename(repoPath);
+    const worktreeDirName = `${repoBaseName}-issue${parsed.itemNumber}`;
+    const worktreePath = path.join(path.dirname(repoPath), worktreeDirName);
+
+    if (fs.existsSync(worktreePath)) {
+      void vscode.window.showErrorMessage(`DevDocket: Directory "${worktreePath}" already exists.`);
+      return;
+    }
+
+    progress.report({ message: 'Creating branch...' });
+
+    const { stdout: branchList } = await execFileAsync('git', ['branch', '--list', branchName], { cwd: repoPath, timeout: 30_000 });
+    if (branchList.trim()) {
+      void vscode.window.showErrorMessage(`DevDocket: Branch "${branchName}" already exists.`);
+      return;
+    }
+
+    await execFileAsync('git', ['branch', branchName, baseBranch], { cwd: repoPath, timeout: 30_000 });
+    logger.info(`Starting work: creating branch ${branchName}`);
+
+    progress.report({ message: 'Creating worktree...' });
+
+    try {
+      await execFileAsync('git', ['worktree', 'add', worktreePath, branchName], {
+        cwd: repoPath,
+        timeout: 30_000,
+      });
+    } catch (worktreeErr) {
+      try {
+        await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath, timeout: 30_000 });
+      } catch (rollbackErr) {
+        const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
+        void vscode.window.showWarningMessage(`DevDocket: Failed to delete branch during rollback — ${rollbackMessage}`);
+      }
+
+      const errMsg = worktreeErr instanceof Error ? worktreeErr.message : String(worktreeErr);
+      const errStderr = (worktreeErr as any)?.stderr ?? '';
+      if (errMsg.includes('already exists') || errStderr.includes('already exists')) {
+        void vscode.window.showErrorMessage(`DevDocket: Directory "${worktreePath}" already exists.`);
+        return;
+      }
+      throw worktreeErr;
+    }
+
+    logger.info(`Created worktree at ${worktreePath}`);
+
+    try {
+      const detail = JSON.stringify({ branchName, worktreePath, repoPath });
+      await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-started', detail);
+    } catch (activityErr) {
+      logger.error('Failed to log work-started activity', activityErr);
+      void vscode.window.showWarningMessage(
+        `DevDocket: Worktree created but failed to log activity — cleanup prompt may not work`,
+      );
+    }
+
+    await this.runPostWorktreeCommands(worktreePath, progress);
+
+    void vscode.window.showInformationMessage(
+      `DevDocket: Created worktree for ${branchName}`,
+    );
+  }
+
+  private async issueCheckoutFlow(
+    item: Readonly<WorkItem>,
+    parsed: ParsedExternalId,
+    repoPath: string,
+    branchName: string,
+    baseBranch: string,
+    progress: vscode.Progress<{ message?: string }>,
+  ): Promise<void> {
+    const canProceed = await this.checkDirtyTree(repoPath);
+    if (!canProceed) {
+      return;
+    }
+
+    progress.report({ message: 'Creating and checking out branch...' });
+
+    await execFileAsync('git', ['checkout', '-b', branchName, baseBranch], { cwd: repoPath, timeout: 30_000 });
+    logger.info(`Starting work: checked out new branch ${branchName}`);
+
+    try {
+      const detail = JSON.stringify({ branchName, repoPath });
+      await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-started', detail);
+    } catch (activityErr) {
+      logger.error('Failed to log work-started activity', activityErr);
+      void vscode.window.showWarningMessage(
+        `DevDocket: Branch checked out but failed to log activity — cleanup prompt may not work`,
+      );
+    }
+
+    void vscode.window.showInformationMessage(
+      `DevDocket: Checked out branch ${branchName}`,
+    );
+  }
+
+  private async runPrFlow(
+    item: Readonly<WorkItem>,
+    parsed: ParsedExternalId,
+    repoPath: string,
+  ): Promise<void> {
+    const workMode = await this.promptForWorkMode();
+    if (!workMode) {
+      return;
+    }
+
+    try {
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: `Starting git work for PR #${parsed.itemNumber}`,
+          cancellable: false,
+        },
+        async (progress) => {
+          progress.report({ message: 'Fetching PR branch...' });
+
+          const isGitHubPr = item.providerId === 'github-my-prs' || item.providerId === 'github-pr-reviews';
+          const branchName = isGitHubPr
+            ? await this.fetchGitHubPrBranch(parsed, repoPath)
+            : await this.fetchAdoPrBranch(parsed, repoPath);
+
+          if (!branchName) {
+            return;
+          }
+
+          if (workMode === 'worktree') {
+            await this.prWorktreeFlow(item, parsed, repoPath, branchName, progress);
+          } else {
+            await this.prCheckoutFlow(item, repoPath, branchName, progress);
+          }
+        },
+      );
+    } catch (err: unknown) {
+      logger.error('Failed to start work', err);
+      const message = err instanceof Error ? err.message : String(err);
+      void vscode.window.showErrorMessage(`DevDocket: Failed to start work — ${message}`);
+    }
+  }
+
+  /**
+   * Fetches the branch name for a GitHub PR and ensures it is available locally.
+   * Handles fork detection — adds a remote for the fork owner if needed.
+   */
+  private async fetchGitHubPrBranch(parsed: ParsedExternalId, repoPath: string): Promise<string | undefined> {
+    const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: true });
+    if (!session) {
+      void vscode.window.showErrorMessage('DevDocket: GitHub authentication required.');
+      return undefined;
+    }
+
+    const [owner, repo] = parsed.repoKey.split('/');
+    const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${parsed.itemNumber}`;
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${session.accessToken}`,
+        Accept: 'application/vnd.github+json',
+      },
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        void vscode.window.showErrorMessage(`DevDocket: Could not find PR #${parsed.itemNumber}`);
+      } else {
+        void vscode.window.showErrorMessage(`DevDocket: GitHub API error (${response.status})`);
+      }
+      return undefined;
+    }
+
+    const pr = await response.json() as GitHubPrResponse;
+    const branchName = pr.head.ref;
+    const isFork = pr.head.repo.full_name !== pr.base.repo.full_name;
+
+    if (isFork) {
+      const forkOwner = pr.head.repo.full_name.split('/')[0];
+      const cloneUrl = pr.head.repo.clone_url;
+
+      // Add remote if it doesn't already exist
+      try {
+        await execFileAsync('git', ['remote', 'add', forkOwner, cloneUrl], { cwd: repoPath, timeout: 30_000 });
+      } catch {
+        // Remote already exists — that's fine
+      }
+
+      await execFileAsync('git', ['fetch', forkOwner, branchName], { cwd: repoPath, timeout: 30_000 });
+    } else {
+      await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: repoPath, timeout: 30_000 });
+    }
+
+    return branchName;
+  }
+
+  /**
+   * Fetches the branch name for an ADO PR.
+   * Strips the `refs/heads/` prefix from `sourceRefName`.
+   */
+  private async fetchAdoPrBranch(parsed: ParsedExternalId, repoPath: string): Promise<string | undefined> {
+    const session = await vscode.authentication.getSession(
+      'microsoft',
+      ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+      { createIfNone: true },
+    );
+    if (!session) {
+      void vscode.window.showErrorMessage('DevDocket: Microsoft authentication required.');
+      return undefined;
+    }
+
+    // ADO PR externalId format: org/project/repo/id
+    const parts = parsed.repoKey.split('/');
+    const org = parts[0];
+    const project = parts[1];
+    const adoRepo = parts[2];
+    const url = `https://dev.azure.com/${org}/${project}/_apis/git/repositories/${adoRepo}/pullrequests/${parsed.itemNumber}?api-version=7.1`;
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${session.accessToken}`,
+        Accept: 'application/json',
+      },
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        void vscode.window.showErrorMessage(`DevDocket: Could not find PR #${parsed.itemNumber}`);
+      } else {
+        void vscode.window.showErrorMessage(`DevDocket: ADO API error (${response.status})`);
+      }
+      return undefined;
+    }
+
+    const pr = await response.json() as AdoPrResponse;
+    const branchName = pr.sourceRefName.replace(/^refs\/heads\//, '');
+
+    await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: repoPath, timeout: 30_000 });
+
+    return branchName;
+  }
+
+  private async prWorktreeFlow(
+    item: Readonly<WorkItem>,
+    parsed: ParsedExternalId,
+    repoPath: string,
+    branchName: string,
+    progress: vscode.Progress<{ message?: string }>,
+  ): Promise<void> {
+    const repoBaseName = path.basename(repoPath);
+    const worktreeDirName = `${repoBaseName}-pr${parsed.itemNumber}`;
+    const worktreePath = path.join(path.dirname(repoPath), worktreeDirName);
+
+    if (fs.existsSync(worktreePath)) {
+      void vscode.window.showErrorMessage(`DevDocket: Directory "${worktreePath}" already exists.`);
+      return;
+    }
+
+    progress.report({ message: 'Creating worktree...' });
+
+    await execFileAsync('git', ['worktree', 'add', worktreePath, branchName], {
+      cwd: repoPath,
+      timeout: 30_000,
+    });
+
+    logger.info(`Created worktree at ${worktreePath} for PR branch ${branchName}`);
+
+    try {
+      const detail = JSON.stringify({ branchName, worktreePath, repoPath });
+      await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-started', detail);
+    } catch (activityErr) {
+      logger.error('Failed to log work-started activity', activityErr);
+      void vscode.window.showWarningMessage(
+        `DevDocket: Worktree created but failed to log activity — cleanup prompt may not work`,
+      );
+    }
+
+    await this.runPostWorktreeCommands(worktreePath, progress);
+
+    void vscode.window.showInformationMessage(
+      `DevDocket: Created worktree for ${branchName}`,
+    );
+  }
+
+  private async prCheckoutFlow(
+    item: Readonly<WorkItem>,
+    repoPath: string,
+    branchName: string,
+    progress: vscode.Progress<{ message?: string }>,
+  ): Promise<void> {
+    const canProceed = await this.checkDirtyTree(repoPath);
+    if (!canProceed) {
+      return;
+    }
+
+    progress.report({ message: 'Checking out branch...' });
+
+    await execFileAsync('git', ['checkout', branchName], { cwd: repoPath, timeout: 30_000 });
+    logger.info(`Checked out PR branch ${branchName}`);
+
+    try {
+      const detail = JSON.stringify({ branchName, repoPath });
+      await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-started', detail);
+    } catch (activityErr) {
+      logger.error('Failed to log work-started activity', activityErr);
+      void vscode.window.showWarningMessage(
+        `DevDocket: Branch checked out but failed to log activity — cleanup prompt may not work`,
+      );
+    }
+
+    void vscode.window.showInformationMessage(
+      `DevDocket: Checked out branch ${branchName}`,
+    );
+  }
+
+  /**
+   * Checks if the working tree is dirty and prompts the user for confirmation.
+   * Returns true if work can proceed (clean tree or user confirmed).
+   */
+  private async checkDirtyTree(repoPath: string): Promise<boolean> {
+    const { stdout: statusOutput } = await execFileAsync('git', ['status', '--porcelain'], { cwd: repoPath, timeout: 30_000 });
+    if (statusOutput.trim()) {
+      const answer = await vscode.window.showWarningMessage(
+        'Working tree has uncommitted changes. Checkout anyway?',
+        { modal: true },
+        'Yes',
+      );
+      if (answer !== 'Yes') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Prompts the user to choose between checkout and worktree modes.
+   */
+  private async promptForWorkMode(): Promise<WorkMode | undefined> {
+    const choice = await vscode.window.showQuickPick(
+      [
+        { label: 'Checkout branch', value: 'checkout' as WorkMode },
+        { label: 'Create worktree', value: 'worktree' as WorkMode },
+      ],
+      {
+        placeHolder: 'How would you like to work on this?',
+        ignoreFocusOut: true,
+      },
+    );
+    return choice?.value;
+  }
+
+  /**
+   * Runs user-configured post-worktree commands.
+   */
+  private async runPostWorktreeCommands(
+    worktreePath: string,
+    progress: vscode.Progress<{ message?: string }>,
+  ): Promise<void> {
+    const commands = vscode.workspace.getConfiguration('devdocketStartGitWork')
+      .get<{ command: string; args?: string[] }[]>('commands', []);
+
+    for (const cmd of commands) {
+      progress.report({ message: `Running ${cmd.command}...` });
+      const resolvedArgs = (cmd.args ?? []).map(
+        arg => arg.replace(/\{path\}/g, worktreePath),
+      );
+      try {
+        await execFileAsync(cmd.command, resolvedArgs, { cwd: worktreePath, timeout: 60_000 });
+      } catch (cmdErr) {
+        const cmdMessage = cmdErr instanceof Error ? cmdErr.message : String(cmdErr);
+        logger.error(`Post-worktree command failed: ${cmd.command}`, cmdErr);
+        void vscode.window.showWarningMessage(
+          `DevDocket: Command "${cmd.command}" failed — ${cmdMessage}`,
+        );
+      }
     }
   }
 

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -57,14 +57,15 @@ interface PrBranchInfo {
  * DevDocket action that bootstraps a development environment for a work item.
  *
  * Supports items from GitHub and Azure DevOps providers (both issues and PRs).
- * When executed on an issue it creates a new branch and checks out or creates a worktree.
+ * When executed on an issue it creates a new branch and either checks out
+ * or creates a worktree for it, based on user preference.
  * When executed on a PR it fetches the existing PR branch instead of creating one.
  *
  * Only available for items in the `InProgress` state from supported providers.
  */
 export class StartWorkAction implements DevDocketAction {
   readonly id = 'startGitWork';
-  readonly label = 'Start Git Work (Branch + Worktree)';
+  readonly label = 'Start Git Work';
 
   private readonly globalState: vscode.Memento;
 
@@ -294,14 +295,19 @@ export class StartWorkAction implements DevDocketAction {
       return undefined;
     }
 
-    const [owner, repo] = parsed.repoKey.split('/');
-    const url = `https://api.github.com/repos/${owner}/${repo}/pulls/${parsed.itemNumber}`;
+    const repoKeyParts = parsed.repoKey.split('/');
+    if (repoKeyParts.length !== 2 || !repoKeyParts[0] || !repoKeyParts[1]) {
+      void vscode.window.showErrorMessage(`DevDocket: Invalid GitHub repository key "${parsed.repoKey}".`);
+      return undefined;
+    }
+    const [owner, repo] = repoKeyParts;
+    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${parsed.itemNumber}`;
 
     const response = await fetch(url, {
       headers: {
         Authorization: `Bearer ${session.accessToken}`,
         Accept: 'application/vnd.github+json',
-        'User-Agent': 'devdocket-start-git-work',
+        'User-Agent': 'DevDocket-VSCode',
         'X-GitHub-Api-Version': '2022-11-28',
       },
       signal: AbortSignal.timeout(30_000),

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -126,7 +126,7 @@ export class StartWorkAction implements DevDocketAction {
           if (workMode === 'worktree') {
             await this.issueWorktreeFlow(item, parsed, repoPath, branchName, baseBranch, progress);
           } else {
-            await this.issueCheckoutFlow(item, parsed, repoPath, branchName, baseBranch, progress);
+            await this.issueCheckoutFlow(item, repoPath, branchName, baseBranch, progress);
           }
         },
       );
@@ -210,7 +210,6 @@ export class StartWorkAction implements DevDocketAction {
 
   private async issueCheckoutFlow(
     item: Readonly<WorkItem>,
-    parsed: ParsedExternalId,
     repoPath: string,
     branchName: string,
     baseBranch: string,

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -261,6 +261,7 @@ export class StartWorkAction implements DevDocketAction {
           progress.report({ message: 'Fetching PR branch...' });
 
           const isGitHubPr = GITHUB_PR_PROVIDERS.includes(item.providerId ?? '');
+          logger.info(`PR flow: provider=${item.providerId}, type=${isGitHubPr ? 'GitHub' : 'ADO'}, repoKey=${parsed.repoKey}, itemNumber=${parsed.itemNumber}`);
           const branchInfo = isGitHubPr
             ? await this.fetchGitHubPrBranch(parsed, repoPath)
             : await this.fetchAdoPrBranch(parsed, repoPath);
@@ -302,6 +303,7 @@ export class StartWorkAction implements DevDocketAction {
     }
     const [owner, repo] = repoKeyParts;
     const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${parsed.itemNumber}`;
+    logger.debug(`GitHub PR API: ${url}`);
 
     const response = await fetch(url, {
       headers: {
@@ -314,6 +316,7 @@ export class StartWorkAction implements DevDocketAction {
     });
 
     if (!response.ok) {
+      logger.info(`GitHub PR API returned ${response.status} for PR #${parsed.itemNumber}`);
       if (response.status === 404) {
         void vscode.window.showErrorMessage(`DevDocket: Could not find PR #${parsed.itemNumber}`);
       } else {
@@ -324,8 +327,11 @@ export class StartWorkAction implements DevDocketAction {
 
     const pr = await response.json() as GitHubPrResponse;
     const branchName = pr.head.ref;
+    const isFork = pr.head.repo ? pr.head.repo.full_name !== pr.base.repo.full_name : false;
+    logger.debug(`GitHub PR #${parsed.itemNumber}: head.ref=${branchName}, head.repo=${pr.head.repo?.full_name ?? 'null'}, base.repo=${pr.base.repo.full_name}, isFork=${isFork}`);
 
     if (!pr.head.repo) {
+      logger.info(`PR #${parsed.itemNumber}: source repository has been deleted`);
       void vscode.window.showErrorMessage(
         `DevDocket: The source repository for PR #${parsed.itemNumber} has been deleted.`,
       );
@@ -333,14 +339,19 @@ export class StartWorkAction implements DevDocketAction {
     }
 
     const headCloneUrl = pr.head.repo.clone_url;
+    logger.debug(`Looking up remote for clone URL: ${headCloneUrl}`);
     const remoteName = await this.findOrAddRemote(headCloneUrl, pr.head.repo.full_name, repoPath);
 
     // Full fetch to ensure all refs (including the PR branch) are available
+    logger.info(`Fetching all refs from remote "${remoteName}"`);
     await execFileAsync('git', ['fetch', remoteName], { cwd: repoPath, timeout: 30_000 });
+    logger.debug(`Fetch complete for remote "${remoteName}"`);
 
     if (remoteName === 'origin') {
+      logger.info(`PR branch "${branchName}" available on origin`);
       return { branchName };
     }
+    logger.info(`PR branch available as ${remoteName}/${branchName}`);
     return { branchName, trackingRef: `${remoteName}/${branchName}` };
   }
 
@@ -353,6 +364,7 @@ export class StartWorkAction implements DevDocketAction {
     for (const line of stdout.split('\n')) {
       const match = line.match(/^(\S+)\t(\S+)\s+\(fetch\)$/);
       if (match && match[2] === cloneUrl) {
+        logger.info(`Found existing remote "${match[1]}" matching ${cloneUrl}`);
         return match[1];
       }
     }
@@ -360,15 +372,19 @@ export class StartWorkAction implements DevDocketAction {
     // No existing remote matches — add a DevDocket-managed one
     const forkOwner = fullName.split('/')[0];
     const forkRemoteName = `devdocket-fork-${forkOwner}`;
+    logger.debug(`No remote found for ${cloneUrl}, adding "${forkRemoteName}"`);
 
     try {
       await execFileAsync('git', ['remote', 'add', forkRemoteName, cloneUrl], { cwd: repoPath, timeout: 30_000 });
+      logger.info(`Added remote "${forkRemoteName}" → ${cloneUrl}`);
     } catch (err) {
       try {
         const { stdout: existingUrl } = await execFileAsync('git', ['remote', 'get-url', forkRemoteName], { cwd: repoPath, timeout: 30_000 });
         if (existingUrl.trim() !== cloneUrl) {
           logger.info(`Remote "${forkRemoteName}" exists with different URL, updating to "${cloneUrl}".`);
           await execFileAsync('git', ['remote', 'set-url', forkRemoteName, cloneUrl], { cwd: repoPath, timeout: 30_000 });
+        } else {
+          logger.debug(`Remote "${forkRemoteName}" already exists with correct URL`);
         }
       } catch {
         throw err;
@@ -403,6 +419,7 @@ export class StartWorkAction implements DevDocketAction {
     const project = parts[1];
     const adoRepo = parts[2];
     const url = `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(adoRepo)}/pullrequests/${parsed.itemNumber}?api-version=7.1`;
+    logger.debug(`ADO PR API: ${url}`);
 
     const response = await fetch(url, {
       headers: {
@@ -414,6 +431,7 @@ export class StartWorkAction implements DevDocketAction {
     });
 
     if (!response.ok) {
+      logger.info(`ADO PR API returned ${response.status} for PR #${parsed.itemNumber}`);
       if (response.status === 404) {
         void vscode.window.showErrorMessage(`DevDocket: Could not find PR #${parsed.itemNumber}`);
       } else {
@@ -424,10 +442,14 @@ export class StartWorkAction implements DevDocketAction {
 
     const pr = await response.json() as AdoPrResponse;
     const branchName = pr.sourceRefName.replace(/^refs\/heads\//, '');
+    logger.debug(`ADO PR #${parsed.itemNumber}: sourceRefName=${pr.sourceRefName}, branchName=${branchName}`);
 
+    logger.info(`Fetching branch "${branchName}" from origin`);
     try {
       await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: repoPath, timeout: 30_000 });
+      logger.debug(`Fetch complete for origin/${branchName}`);
     } catch {
+      logger.info(`Failed to fetch branch "${branchName}" from origin`);
       void vscode.window.showErrorMessage(
         `DevDocket: Could not fetch branch '${branchName}' from origin. The branch may have been deleted.`,
       );

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -337,25 +337,26 @@ export class StartWorkAction implements DevDocketAction {
     if (isFork) {
       const forkOwner = pr.head.repo.full_name.split('/')[0];
       const cloneUrl = pr.head.repo.clone_url;
+      const forkRemoteName = `devdocket-fork-${forkOwner}`;
 
-      // Add remote if it doesn't already exist; update URL if it points elsewhere
+      // Add or update only the DevDocket-managed fork remote to avoid mutating user remotes
       try {
-        await execFileAsync('git', ['remote', 'add', forkOwner, cloneUrl], { cwd: repoPath, timeout: 30_000 });
+        await execFileAsync('git', ['remote', 'add', forkRemoteName, cloneUrl], { cwd: repoPath, timeout: 30_000 });
       } catch (err) {
         try {
-          const { stdout } = await execFileAsync('git', ['remote', 'get-url', forkOwner], { cwd: repoPath, timeout: 30_000 });
+          const { stdout } = await execFileAsync('git', ['remote', 'get-url', forkRemoteName], { cwd: repoPath, timeout: 30_000 });
           if (stdout.trim() !== cloneUrl) {
-            logger.info(`Remote "${forkOwner}" exists with different URL, updating to "${cloneUrl}".`);
-            await execFileAsync('git', ['remote', 'set-url', forkOwner, cloneUrl], { cwd: repoPath, timeout: 30_000 });
+            logger.info(`Remote "${forkRemoteName}" exists with different URL, updating to "${cloneUrl}".`);
+            await execFileAsync('git', ['remote', 'set-url', forkRemoteName, cloneUrl], { cwd: repoPath, timeout: 30_000 });
           }
         } catch {
           throw err;
         }
       }
 
-      await execFileAsync('git', ['fetch', forkOwner, branchName], { cwd: repoPath, timeout: 30_000 });
+      await execFileAsync('git', ['fetch', forkRemoteName, branchName], { cwd: repoPath, timeout: 30_000 });
 
-      return { branchName, trackingRef: `${forkOwner}/${branchName}` };
+      return { branchName, trackingRef: `${forkRemoteName}/${branchName}` };
     } else {
       await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: repoPath, timeout: 30_000 });
     }

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -22,6 +22,7 @@ const SUPPORTED_PROVIDERS = [
 ];
 
 const PR_PROVIDERS = ['github-my-prs', 'github-pr-reviews', 'ado-pr-reviews'];
+const GITHUB_PR_PROVIDERS = ['github-my-prs', 'github-pr-reviews'];
 
 type WorkMode = 'checkout' | 'worktree';
 
@@ -78,7 +79,7 @@ export class StartWorkAction implements DevDocketAction {
   async run(item: Readonly<WorkItem>): Promise<void> {
     const parsed = this.parseExternalId(item.externalId);
     if (!parsed) {
-      void vscode.window.showErrorMessage('Could not determine issue number.');
+      void vscode.window.showErrorMessage('Could not determine work item number.');
       return;
     }
 
@@ -259,7 +260,7 @@ export class StartWorkAction implements DevDocketAction {
         async (progress) => {
           progress.report({ message: 'Fetching PR branch...' });
 
-          const isGitHubPr = item.providerId === 'github-my-prs' || item.providerId === 'github-pr-reviews';
+          const isGitHubPr = GITHUB_PR_PROVIDERS.includes(item.providerId ?? '');
           const branchInfo = isGitHubPr
             ? await this.fetchGitHubPrBranch(parsed, repoPath)
             : await this.fetchAdoPrBranch(parsed, repoPath);

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -441,6 +441,7 @@ export class StartWorkAction implements DevDocketAction {
     // For same-repo PRs, the branch may only exist as origin/<branch> after fetch.
     const hasLocalBranch = await this.localBranchExists(branchName, repoPath);
     const worktreeSourceRef = trackingRef ?? `origin/${branchName}`;
+    let createdBranch = false;
 
     if (hasLocalBranch && trackingRef) {
       // Fork PR with an existing local branch — the local branch may be stale or
@@ -486,12 +487,19 @@ export class StartWorkAction implements DevDocketAction {
         cwd: repoPath,
         timeout: 30_000,
       });
+      createdBranch = true;
     }
 
     logger.info(`Created worktree at ${worktreePath} for PR branch ${branchName}`);
 
     try {
-      const detail = JSON.stringify({ branchName, worktreePath, repoPath });
+      // Only include branchName when this action created the branch, so cleanup
+      // won't accidentally delete a pre-existing user branch.
+      const detail = JSON.stringify({
+        ...(createdBranch ? { branchName } : {}),
+        worktreePath,
+        repoPath,
+      });
       await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-started', detail);
     } catch (activityErr) {
       logger.error('Failed to log work-started activity', activityErr);
@@ -528,14 +536,19 @@ export class StartWorkAction implements DevDocketAction {
     // point at the tracking ref to avoid silently checking out stale/unrelated code.
     const hasLocalBranch = await this.localBranchExists(branchName, repoPath);
     let checkoutArgs: string[];
+    // Track whether this action created/reset the branch (for safe cleanup later)
+    let createdBranch = false;
     if (hasLocalBranch && trackingRef) {
       checkoutArgs = ['checkout', '-B', branchName, trackingRef];
+      createdBranch = true; // force-reset counts as owning the branch
     } else if (hasLocalBranch) {
       checkoutArgs = ['checkout', branchName];
     } else if (trackingRef) {
       checkoutArgs = ['checkout', '-b', branchName, trackingRef];
+      createdBranch = true;
     } else {
       checkoutArgs = ['checkout', '-b', branchName, '--track', `origin/${branchName}`];
+      createdBranch = true;
     }
 
     try {
@@ -554,7 +567,12 @@ export class StartWorkAction implements DevDocketAction {
     logger.info(`Checked out PR branch ${branchName}`);
 
     try {
-      const detail = JSON.stringify({ branchName, repoPath });
+      // Only include branchName when this action created/reset the branch, so cleanup
+      // won't accidentally delete a pre-existing user branch.
+      const detail = JSON.stringify({
+        ...(createdBranch ? { branchName } : {}),
+        repoPath,
+      });
       await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-started', detail);
     } catch (activityErr) {
       logger.error('Failed to log work-started activity', activityErr);

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -395,7 +395,14 @@ export class StartWorkAction implements DevDocketAction {
     const pr = await response.json() as AdoPrResponse;
     const branchName = pr.sourceRefName.replace(/^refs\/heads\//, '');
 
-    await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: repoPath, timeout: 30_000 });
+    try {
+      await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: repoPath, timeout: 30_000 });
+    } catch {
+      void vscode.window.showErrorMessage(
+        `DevDocket: Could not fetch branch '${branchName}' from origin. The branch may have been deleted.`,
+      );
+      return undefined;
+    }
 
     return { branchName };
   }

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -434,12 +434,25 @@ export class StartWorkAction implements DevDocketAction {
     progress.report({ message: 'Creating worktree...' });
 
     // Determine worktree strategy based on whether a local branch already exists.
-    // For fork PRs, always create from the remote tracking ref.
+    // For fork PRs, always create from the remote tracking ref (detached if local branch
+    // exists, to avoid using a stale/unrelated same-named local branch).
     // For same-repo PRs, the branch may only exist as origin/<branch> after fetch.
     const hasLocalBranch = await this.localBranchExists(branchName, repoPath);
     const worktreeSourceRef = trackingRef ?? `origin/${branchName}`;
 
-    if (hasLocalBranch) {
+    if (hasLocalBranch && trackingRef) {
+      // Fork PR with an existing local branch — the local branch may be stale or
+      // tracking a different remote. Create a detached worktree from the fork ref.
+      logger.info(
+        `Local branch ${branchName} exists, but PR uses tracking ref ${trackingRef}; creating detached worktree from tracking ref`,
+      );
+      progress.report({ message: 'Creating detached worktree from PR tracking ref...' });
+
+      await execFileAsync('git', ['worktree', 'add', '--detach', worktreePath, trackingRef], {
+        cwd: repoPath,
+        timeout: 30_000,
+      });
+    } else if (hasLocalBranch) {
       try {
         await execFileAsync('git', ['worktree', 'add', worktreePath, branchName], {
           cwd: repoPath,

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -49,7 +49,7 @@ interface AdoPrResponse {
 
 interface PrBranchInfo {
   branchName: string;
-  /** Fully-qualified remote tracking ref for fork PRs (e.g. "contributor/fix-bug"). */
+  /** Fully-qualified remote tracking ref for fork PRs (e.g. "devdocket-fork-contributor/fix-bug"). */
   trackingRef?: string;
 }
 
@@ -532,8 +532,8 @@ export class StartWorkAction implements DevDocketAction {
     // Check if the branch already exists locally to pick the right checkout strategy.
     // For fork PRs without a local branch, create from the remote tracking ref.
     // For same-repo PRs without a local branch, create from origin/<branch>.
-    // When a fork trackingRef is set and a local branch exists, force-update it to
-    // point at the tracking ref to avoid silently checking out stale/unrelated code.
+    // When a fork trackingRef is set and a local branch exists, use a detached checkout
+    // to avoid destructively modifying the user's existing branch.
     const hasLocalBranch = await this.localBranchExists(branchName, repoPath);
     let checkoutArgs: string[];
     // Track whether this action created the branch (for safe cleanup later)
@@ -568,7 +568,7 @@ export class StartWorkAction implements DevDocketAction {
     logger.info(`Checked out PR branch ${branchName}`);
 
     try {
-      // Only include branchName when this action created/reset the branch, so cleanup
+      // Only include branchName when this action created the branch, so cleanup
       // won't accidentally delete a pre-existing user branch.
       const detail = JSON.stringify({
         ...(createdBranch ? { branchName } : {}),

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -374,10 +374,14 @@ export class StartWorkAction implements DevDocketAction {
 
     // ADO PR externalId format: org/project/repo/id
     const parts = parsed.repoKey.split('/');
+    if (parts.length < 3) {
+      void vscode.window.showErrorMessage(`DevDocket: Invalid ADO repo key "${parsed.repoKey}".`);
+      return undefined;
+    }
     const org = parts[0];
     const project = parts[1];
     const adoRepo = parts[2];
-    const url = `https://dev.azure.com/${org}/${project}/_apis/git/repositories/${adoRepo}/pullrequests/${parsed.itemNumber}?api-version=7.1`;
+    const url = `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(adoRepo)}/pullrequests/${parsed.itemNumber}?api-version=7.1`;
 
     const response = await fetch(url, {
       headers: {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -394,6 +394,7 @@ export class StartWorkAction implements DevDocketAction {
       headers: {
         Authorization: `Bearer ${session.accessToken}`,
         Accept: 'application/json',
+        'User-Agent': 'DevDocket-VSCode',
       },
       signal: AbortSignal.timeout(30_000),
     });
@@ -537,7 +538,19 @@ export class StartWorkAction implements DevDocketAction {
       checkoutArgs = ['checkout', '-b', branchName, '--track', `origin/${branchName}`];
     }
 
-    await execFileAsync('git', checkoutArgs, { cwd: repoPath, timeout: 30_000 });
+    try {
+      await execFileAsync('git', checkoutArgs, { cwd: repoPath, timeout: 30_000 });
+    } catch (error) {
+      const gitError = error as { stderr?: string; stdout?: string; message?: string };
+      const gitErrorText = `${gitError.stderr ?? ''}\n${gitError.stdout ?? ''}\n${gitError.message ?? ''}`;
+      if (gitErrorText.includes('already checked out') || gitErrorText.includes('already used by worktree')) {
+        void vscode.window.showErrorMessage(
+          `DevDocket: Branch "${branchName}" is already checked out in another worktree. Use worktree mode instead, or remove the conflicting worktree first.`,
+        );
+        return;
+      }
+      throw error;
+    }
     logger.info(`Checked out PR branch ${branchName}`);
 
     try {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -300,6 +300,8 @@ export class StartWorkAction implements DevDocketAction {
       headers: {
         Authorization: `Bearer ${session.accessToken}`,
         Accept: 'application/vnd.github+json',
+        'User-Agent': 'devdocket-start-git-work',
+        'X-GitHub-Api-Version': '2022-11-28',
       },
       signal: AbortSignal.timeout(30_000),
     });
@@ -329,11 +331,19 @@ export class StartWorkAction implements DevDocketAction {
       const forkOwner = pr.head.repo.full_name.split('/')[0];
       const cloneUrl = pr.head.repo.clone_url;
 
-      // Add remote if it doesn't already exist
+      // Add remote if it doesn't already exist; update URL if it points elsewhere
       try {
         await execFileAsync('git', ['remote', 'add', forkOwner, cloneUrl], { cwd: repoPath, timeout: 30_000 });
       } catch (err) {
-        logger.info(`Remote "${forkOwner}" may already exist: ${err instanceof Error ? err.message : String(err)}`);
+        try {
+          const { stdout } = await execFileAsync('git', ['remote', 'get-url', forkOwner], { cwd: repoPath, timeout: 30_000 });
+          if (stdout.trim() !== cloneUrl) {
+            logger.info(`Remote "${forkOwner}" exists with different URL, updating to "${cloneUrl}".`);
+            await execFileAsync('git', ['remote', 'set-url', forkOwner, cloneUrl], { cwd: repoPath, timeout: 30_000 });
+          }
+        } catch {
+          throw err;
+        }
       }
 
       await execFileAsync('git', ['fetch', forkOwner, branchName], { cwd: repoPath, timeout: 30_000 });
@@ -412,10 +422,20 @@ export class StartWorkAction implements DevDocketAction {
 
     progress.report({ message: 'Creating worktree...' });
 
-    // For fork PRs, use -b to create a local branch from the remote tracking ref
-    const worktreeArgs = trackingRef
-      ? ['worktree', 'add', '-b', branchName, worktreePath, trackingRef]
-      : ['worktree', 'add', worktreePath, branchName];
+    // Determine worktree args based on whether a local branch already exists.
+    // For fork PRs, always create from the remote tracking ref.
+    // For same-repo PRs, the branch may only exist as origin/<branch> after fetch.
+    const hasLocalBranch = await this.localBranchExists(branchName, repoPath);
+    let worktreeArgs: string[];
+    if (trackingRef) {
+      worktreeArgs = hasLocalBranch
+        ? ['worktree', 'add', worktreePath, branchName]
+        : ['worktree', 'add', '-b', branchName, worktreePath, trackingRef];
+    } else {
+      worktreeArgs = hasLocalBranch
+        ? ['worktree', 'add', worktreePath, branchName]
+        : ['worktree', 'add', '-b', branchName, worktreePath, `origin/${branchName}`];
+    }
 
     await execFileAsync('git', worktreeArgs, {
       cwd: repoPath,
@@ -455,10 +475,18 @@ export class StartWorkAction implements DevDocketAction {
 
     progress.report({ message: 'Checking out branch...' });
 
-    // For fork PRs, create a local branch from the remote tracking ref to avoid ambiguity
-    const checkoutArgs = trackingRef
-      ? ['checkout', '-b', branchName, trackingRef]
-      : ['checkout', branchName];
+    // Check if the branch already exists locally to pick the right checkout strategy.
+    // For fork PRs without a local branch, create from the remote tracking ref.
+    // For same-repo PRs without a local branch, create from origin/<branch>.
+    const hasLocalBranch = await this.localBranchExists(branchName, repoPath);
+    let checkoutArgs: string[];
+    if (hasLocalBranch) {
+      checkoutArgs = ['checkout', branchName];
+    } else if (trackingRef) {
+      checkoutArgs = ['checkout', '-b', branchName, trackingRef];
+    } else {
+      checkoutArgs = ['checkout', '-b', branchName, '--track', `origin/${branchName}`];
+    }
 
     await execFileAsync('git', checkoutArgs, { cwd: repoPath, timeout: 30_000 });
     logger.info(`Checked out PR branch ${branchName}`);
@@ -495,6 +523,16 @@ export class StartWorkAction implements DevDocketAction {
       }
     }
     return true;
+  }
+
+  /** Checks whether a local branch with the given name already exists. */
+  private async localBranchExists(branchName: string, repoPath: string): Promise<boolean> {
+    try {
+      await execFileAsync('git', ['rev-parse', '--verify', `refs/heads/${branchName}`], { cwd: repoPath, timeout: 30_000 });
+      return true;
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -536,11 +536,12 @@ export class StartWorkAction implements DevDocketAction {
     // point at the tracking ref to avoid silently checking out stale/unrelated code.
     const hasLocalBranch = await this.localBranchExists(branchName, repoPath);
     let checkoutArgs: string[];
-    // Track whether this action created/reset the branch (for safe cleanup later)
+    // Track whether this action created the branch (for safe cleanup later)
     let createdBranch = false;
     if (hasLocalBranch && trackingRef) {
-      checkoutArgs = ['checkout', '-B', branchName, trackingRef];
-      createdBranch = true; // force-reset counts as owning the branch
+      // Fork PR with existing local branch — use detached checkout to avoid
+      // destructively resetting the user's branch.
+      checkoutArgs = ['checkout', '--detach', trackingRef];
     } else if (hasLocalBranch) {
       checkoutArgs = ['checkout', branchName];
     } else if (trackingRef) {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -49,7 +49,7 @@ interface AdoPrResponse {
 
 interface PrBranchInfo {
   branchName: string;
-  /** Fully-qualified remote tracking ref for fork PRs (e.g. "devdocket-fork-contributor/fix-bug"). */
+  /** Local ref for fork PRs fetched via GitHub's PR refs (e.g. "refs/devdocket/pr/42"). */
   trackingRef?: string;
 }
 
@@ -286,7 +286,7 @@ export class StartWorkAction implements DevDocketAction {
 
   /**
    * Fetches the branch name for a GitHub PR and ensures it is available locally.
-   * Handles fork detection — adds a remote for the fork owner if needed.
+   * For fork PRs, fetches via GitHub's PR refs on origin (no fork remote needed).
    */
   private async fetchGitHubPrBranch(parsed: ParsedExternalId, repoPath: string): Promise<PrBranchInfo | undefined> {
     const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: true });
@@ -335,44 +335,14 @@ export class StartWorkAction implements DevDocketAction {
     const isFork = pr.head.repo.full_name !== pr.base.repo.full_name;
 
     if (isFork) {
-      const forkOwner = pr.head.repo.full_name.split('/')[0];
-      const cloneUrl = pr.head.repo.clone_url;
-      const forkRemoteName = `devdocket-fork-${forkOwner}`;
+      // Fetch fork PR via GitHub's special PR refs on the base repo.
+      // This avoids adding a remote for the fork (which may lack auth for private forks).
+      const prRef = `refs/devdocket/pr/${parsed.itemNumber}`;
+      await execFileAsync('git', ['fetch', 'origin', `pull/${parsed.itemNumber}/head:${prRef}`], { cwd: repoPath, timeout: 30_000 });
 
-      // Add or update only the DevDocket-managed fork remote to avoid mutating user remotes
-      try {
-        await execFileAsync('git', ['remote', 'add', forkRemoteName, cloneUrl], { cwd: repoPath, timeout: 30_000 });
-      } catch (err) {
-        try {
-          const { stdout } = await execFileAsync('git', ['remote', 'get-url', forkRemoteName], { cwd: repoPath, timeout: 30_000 });
-          if (stdout.trim() !== cloneUrl) {
-            logger.info(`Remote "${forkRemoteName}" exists with different URL, updating to "${cloneUrl}".`);
-            await execFileAsync('git', ['remote', 'set-url', forkRemoteName, cloneUrl], { cwd: repoPath, timeout: 30_000 });
-          }
-        } catch {
-          throw err;
-        }
-      }
-
-      try {
-        await execFileAsync('git', ['fetch', forkRemoteName, branchName], { cwd: repoPath, timeout: 30_000 });
-      } catch {
-        void vscode.window.showErrorMessage(
-          `DevDocket: Could not fetch branch '${branchName}' from fork '${forkOwner}'. The branch may have been deleted.`,
-        );
-        return undefined;
-      }
-
-      return { branchName, trackingRef: `${forkRemoteName}/${branchName}` };
+      return { branchName, trackingRef: prRef };
     } else {
-      try {
-        await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: repoPath, timeout: 30_000 });
-      } catch {
-        void vscode.window.showErrorMessage(
-          `DevDocket: Could not fetch branch '${branchName}' from origin. The branch may have been deleted.`,
-        );
-        return undefined;
-      }
+      await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: repoPath, timeout: 30_000 });
     }
 
     return { branchName };
@@ -459,7 +429,7 @@ export class StartWorkAction implements DevDocketAction {
 
     if (hasLocalBranch && trackingRef) {
       // Fork PR with an existing local branch — the local branch may be stale or
-      // tracking a different remote. Create a detached worktree from the fork ref.
+      // tracking a different remote. Create a detached worktree from the PR ref.
       logger.info(
         `Local branch ${branchName} exists, but PR uses tracking ref ${trackingRef}; creating detached worktree from tracking ref`,
       );

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -49,7 +49,7 @@ interface AdoPrResponse {
 
 interface PrBranchInfo {
   branchName: string;
-  /** Local ref for fork PRs fetched via GitHub's PR refs (e.g. "refs/devdocket/pr/42"). */
+  /** Remote tracking ref when branch is on a non-origin remote (e.g. "devdocket-fork-contributor/fix-bug"). */
   trackingRef?: string;
 }
 
@@ -285,7 +285,8 @@ export class StartWorkAction implements DevDocketAction {
 
   /**
    * Fetches the branch name for a GitHub PR and ensures it is available locally.
-   * For fork PRs, fetches via GitHub's PR refs on origin (no fork remote needed).
+   * Finds (or adds) the remote whose URL matches the PR head repo, then does a
+   * full fetch so all refs are available for checkout/worktree creation.
    */
   private async fetchGitHubPrBranch(parsed: ParsedExternalId, repoPath: string): Promise<PrBranchInfo | undefined> {
     const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: true });
@@ -331,20 +332,50 @@ export class StartWorkAction implements DevDocketAction {
       return undefined;
     }
 
-    const isFork = pr.head.repo.full_name !== pr.base.repo.full_name;
+    const headCloneUrl = pr.head.repo.clone_url;
+    const remoteName = await this.findOrAddRemote(headCloneUrl, pr.head.repo.full_name, repoPath);
 
-    if (isFork) {
-      // Fetch fork PR via GitHub's special PR refs on the base repo.
-      // This avoids adding a remote for the fork (which may lack auth for private forks).
-      const prRef = `refs/devdocket/pr/${parsed.itemNumber}`;
-      await execFileAsync('git', ['fetch', 'origin', `pull/${parsed.itemNumber}/head:${prRef}`], { cwd: repoPath, timeout: 30_000 });
+    // Full fetch to ensure all refs (including the PR branch) are available
+    await execFileAsync('git', ['fetch', remoteName], { cwd: repoPath, timeout: 30_000 });
 
-      return { branchName, trackingRef: prRef };
-    } else {
-      await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: repoPath, timeout: 30_000 });
+    if (remoteName === 'origin') {
+      return { branchName };
+    }
+    return { branchName, trackingRef: `${remoteName}/${branchName}` };
+  }
+
+  /**
+   * Finds a local remote whose fetch URL matches {@link cloneUrl}, or adds a
+   * new `devdocket-fork-{owner}` remote pointing to it.
+   */
+  private async findOrAddRemote(cloneUrl: string, fullName: string, repoPath: string): Promise<string> {
+    const { stdout } = await execFileAsync('git', ['remote', '-v'], { cwd: repoPath, timeout: 30_000 });
+    for (const line of stdout.split('\n')) {
+      const match = line.match(/^(\S+)\t(\S+)\s+\(fetch\)$/);
+      if (match && match[2] === cloneUrl) {
+        return match[1];
+      }
     }
 
-    return { branchName };
+    // No existing remote matches — add a DevDocket-managed one
+    const forkOwner = fullName.split('/')[0];
+    const forkRemoteName = `devdocket-fork-${forkOwner}`;
+
+    try {
+      await execFileAsync('git', ['remote', 'add', forkRemoteName, cloneUrl], { cwd: repoPath, timeout: 30_000 });
+    } catch (err) {
+      try {
+        const { stdout: existingUrl } = await execFileAsync('git', ['remote', 'get-url', forkRemoteName], { cwd: repoPath, timeout: 30_000 });
+        if (existingUrl.trim() !== cloneUrl) {
+          logger.info(`Remote "${forkRemoteName}" exists with different URL, updating to "${cloneUrl}".`);
+          await execFileAsync('git', ['remote', 'set-url', forkRemoteName, cloneUrl], { cwd: repoPath, timeout: 30_000 });
+        }
+      } catch {
+        throw err;
+      }
+    }
+
+    return forkRemoteName;
   }
 
   /**
@@ -434,7 +465,7 @@ export class StartWorkAction implements DevDocketAction {
     let createdBranch = false;
 
     if (hasLocalBranch && trackingRef) {
-      // Fork PR with an existing local branch — the local branch may be stale or
+      // PR with an existing local branch — the local branch may be stale or
       // tracking a different remote. Create a detached worktree from the PR ref.
       logger.info(
         `Local branch ${branchName} exists, but PR uses tracking ref ${trackingRef}; creating detached worktree from tracking ref`,

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -509,9 +509,13 @@ export class StartWorkAction implements DevDocketAction {
     // Check if the branch already exists locally to pick the right checkout strategy.
     // For fork PRs without a local branch, create from the remote tracking ref.
     // For same-repo PRs without a local branch, create from origin/<branch>.
+    // When a fork trackingRef is set and a local branch exists, force-update it to
+    // point at the tracking ref to avoid silently checking out stale/unrelated code.
     const hasLocalBranch = await this.localBranchExists(branchName, repoPath);
     let checkoutArgs: string[];
-    if (hasLocalBranch) {
+    if (hasLocalBranch && trackingRef) {
+      checkoutArgs = ['checkout', '-B', branchName, trackingRef];
+    } else if (hasLocalBranch) {
       checkoutArgs = ['checkout', branchName];
     } else if (trackingRef) {
       checkoutArgs = ['checkout', '-b', branchName, trackingRef];

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -30,7 +30,7 @@ interface GitHubPrHead {
   repo: {
     full_name: string;
     clone_url: string;
-  };
+  } | null;
 }
 
 interface GitHubPrResponse {
@@ -44,6 +44,12 @@ interface GitHubPrResponse {
 
 interface AdoPrResponse {
   sourceRefName: string;
+}
+
+interface PrBranchInfo {
+  branchName: string;
+  /** Fully-qualified remote tracking ref for fork PRs (e.g. "contributor/fix-bug"). */
+  trackingRef?: string;
 }
 
 /**
@@ -254,18 +260,18 @@ export class StartWorkAction implements DevDocketAction {
           progress.report({ message: 'Fetching PR branch...' });
 
           const isGitHubPr = item.providerId === 'github-my-prs' || item.providerId === 'github-pr-reviews';
-          const branchName = isGitHubPr
+          const branchInfo = isGitHubPr
             ? await this.fetchGitHubPrBranch(parsed, repoPath)
             : await this.fetchAdoPrBranch(parsed, repoPath);
 
-          if (!branchName) {
+          if (!branchInfo) {
             return;
           }
 
           if (workMode === 'worktree') {
-            await this.prWorktreeFlow(item, parsed, repoPath, branchName, progress);
+            await this.prWorktreeFlow(item, parsed, repoPath, branchInfo, progress);
           } else {
-            await this.prCheckoutFlow(item, repoPath, branchName, progress);
+            await this.prCheckoutFlow(item, repoPath, branchInfo, progress);
           }
         },
       );
@@ -280,7 +286,7 @@ export class StartWorkAction implements DevDocketAction {
    * Fetches the branch name for a GitHub PR and ensures it is available locally.
    * Handles fork detection — adds a remote for the fork owner if needed.
    */
-  private async fetchGitHubPrBranch(parsed: ParsedExternalId, repoPath: string): Promise<string | undefined> {
+  private async fetchGitHubPrBranch(parsed: ParsedExternalId, repoPath: string): Promise<PrBranchInfo | undefined> {
     const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: true });
     if (!session) {
       void vscode.window.showErrorMessage('DevDocket: GitHub authentication required.');
@@ -309,6 +315,14 @@ export class StartWorkAction implements DevDocketAction {
 
     const pr = await response.json() as GitHubPrResponse;
     const branchName = pr.head.ref;
+
+    if (!pr.head.repo) {
+      void vscode.window.showErrorMessage(
+        `DevDocket: The source repository for PR #${parsed.itemNumber} has been deleted.`,
+      );
+      return undefined;
+    }
+
     const isFork = pr.head.repo.full_name !== pr.base.repo.full_name;
 
     if (isFork) {
@@ -318,23 +332,25 @@ export class StartWorkAction implements DevDocketAction {
       // Add remote if it doesn't already exist
       try {
         await execFileAsync('git', ['remote', 'add', forkOwner, cloneUrl], { cwd: repoPath, timeout: 30_000 });
-      } catch {
-        // Remote already exists — that's fine
+      } catch (err) {
+        logger.info(`Remote "${forkOwner}" may already exist: ${err instanceof Error ? err.message : String(err)}`);
       }
 
       await execFileAsync('git', ['fetch', forkOwner, branchName], { cwd: repoPath, timeout: 30_000 });
+
+      return { branchName, trackingRef: `${forkOwner}/${branchName}` };
     } else {
       await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: repoPath, timeout: 30_000 });
     }
 
-    return branchName;
+    return { branchName };
   }
 
   /**
    * Fetches the branch name for an ADO PR.
    * Strips the `refs/heads/` prefix from `sourceRefName`.
    */
-  private async fetchAdoPrBranch(parsed: ParsedExternalId, repoPath: string): Promise<string | undefined> {
+  private async fetchAdoPrBranch(parsed: ParsedExternalId, repoPath: string): Promise<PrBranchInfo | undefined> {
     const session = await vscode.authentication.getSession(
       'microsoft',
       ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
@@ -374,16 +390,17 @@ export class StartWorkAction implements DevDocketAction {
 
     await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: repoPath, timeout: 30_000 });
 
-    return branchName;
+    return { branchName };
   }
 
   private async prWorktreeFlow(
     item: Readonly<WorkItem>,
     parsed: ParsedExternalId,
     repoPath: string,
-    branchName: string,
+    branchInfo: PrBranchInfo,
     progress: vscode.Progress<{ message?: string }>,
   ): Promise<void> {
+    const { branchName, trackingRef } = branchInfo;
     const repoBaseName = path.basename(repoPath);
     const worktreeDirName = `${repoBaseName}-pr${parsed.itemNumber}`;
     const worktreePath = path.join(path.dirname(repoPath), worktreeDirName);
@@ -395,7 +412,12 @@ export class StartWorkAction implements DevDocketAction {
 
     progress.report({ message: 'Creating worktree...' });
 
-    await execFileAsync('git', ['worktree', 'add', worktreePath, branchName], {
+    // For fork PRs, use -b to create a local branch from the remote tracking ref
+    const worktreeArgs = trackingRef
+      ? ['worktree', 'add', '-b', branchName, worktreePath, trackingRef]
+      : ['worktree', 'add', worktreePath, branchName];
+
+    await execFileAsync('git', worktreeArgs, {
       cwd: repoPath,
       timeout: 30_000,
     });
@@ -422,9 +444,10 @@ export class StartWorkAction implements DevDocketAction {
   private async prCheckoutFlow(
     item: Readonly<WorkItem>,
     repoPath: string,
-    branchName: string,
+    branchInfo: PrBranchInfo,
     progress: vscode.Progress<{ message?: string }>,
   ): Promise<void> {
+    const { branchName, trackingRef } = branchInfo;
     const canProceed = await this.checkDirtyTree(repoPath);
     if (!canProceed) {
       return;
@@ -432,7 +455,12 @@ export class StartWorkAction implements DevDocketAction {
 
     progress.report({ message: 'Checking out branch...' });
 
-    await execFileAsync('git', ['checkout', branchName], { cwd: repoPath, timeout: 30_000 });
+    // For fork PRs, create a local branch from the remote tracking ref to avoid ambiguity
+    const checkoutArgs = trackingRef
+      ? ['checkout', '-b', branchName, trackingRef]
+      : ['checkout', branchName];
+
+    await execFileAsync('git', checkoutArgs, { cwd: repoPath, timeout: 30_000 });
     logger.info(`Checked out PR branch ${branchName}`);
 
     try {
@@ -515,9 +543,10 @@ export class StartWorkAction implements DevDocketAction {
 
   /**
    * Parses the externalId into repoKey and itemNumber.
-   * Supports two formats:
-   *   GitHub:  "owner/repo#123"       → repoKey="owner/repo", itemNumber="123"
-   *   ADO:    "org/project/123"       → repoKey="org/project", itemNumber="123"
+   * Supports three formats:
+   *   GitHub:      "owner/repo#123"           → repoKey="owner/repo", itemNumber="123"
+   *   ADO Issue:   "org/project/123"           → repoKey="org/project", itemNumber="123"
+   *   ADO PR:      "org/project/repo/101"      → repoKey="org/project/repo", itemNumber="101"
    */
   private parseExternalId(externalId: string | undefined): ParsedExternalId | undefined {
     if (!externalId) {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -427,25 +427,45 @@ export class StartWorkAction implements DevDocketAction {
 
     progress.report({ message: 'Creating worktree...' });
 
-    // Determine worktree args based on whether a local branch already exists.
+    // Determine worktree strategy based on whether a local branch already exists.
     // For fork PRs, always create from the remote tracking ref.
     // For same-repo PRs, the branch may only exist as origin/<branch> after fetch.
     const hasLocalBranch = await this.localBranchExists(branchName, repoPath);
-    let worktreeArgs: string[];
-    if (trackingRef) {
-      worktreeArgs = hasLocalBranch
-        ? ['worktree', 'add', worktreePath, branchName]
-        : ['worktree', 'add', '-b', branchName, worktreePath, trackingRef];
-    } else {
-      worktreeArgs = hasLocalBranch
-        ? ['worktree', 'add', worktreePath, branchName]
-        : ['worktree', 'add', '-b', branchName, worktreePath, `origin/${branchName}`];
-    }
+    const worktreeSourceRef = trackingRef ?? `origin/${branchName}`;
 
-    await execFileAsync('git', worktreeArgs, {
-      cwd: repoPath,
-      timeout: 30_000,
-    });
+    if (hasLocalBranch) {
+      try {
+        await execFileAsync('git', ['worktree', 'add', worktreePath, branchName], {
+          cwd: repoPath,
+          timeout: 30_000,
+        });
+      } catch (error) {
+        const gitError = error as { stderr?: string; stdout?: string; message?: string };
+        const gitErrorText = `${gitError.stderr ?? ''}\n${gitError.stdout ?? ''}\n${gitError.message ?? ''}`;
+        const branchAlreadyCheckedOut =
+          gitErrorText.includes('already checked out') &&
+          gitErrorText.includes(branchName);
+
+        if (!branchAlreadyCheckedOut) {
+          throw error;
+        }
+
+        logger.info(
+          `Branch ${branchName} is already checked out in another worktree; creating detached worktree from ${worktreeSourceRef}`,
+        );
+        progress.report({ message: 'Branch already checked out elsewhere; creating detached worktree...' });
+
+        await execFileAsync('git', ['worktree', 'add', '--detach', worktreePath, worktreeSourceRef], {
+          cwd: repoPath,
+          timeout: 30_000,
+        });
+      }
+    } else {
+      await execFileAsync('git', ['worktree', 'add', '-b', branchName, worktreePath, worktreeSourceRef], {
+        cwd: repoPath,
+        timeout: 30_000,
+      });
+    }
 
     logger.info(`Created worktree at ${worktreePath} for PR branch ${branchName}`);
 

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -896,6 +896,36 @@ describe('StartWorkAction', () => {
       ]);
     });
 
+    it('creates detached worktree from tracking ref when local branch exists (fork PR)', async () => {
+      mockFetchResponse(createGitHubPrResponse({
+        head: {
+          ref: 'fix/something',
+          repo: {
+            full_name: 'contributor/repo',
+            clone_url: 'https://github.com/contributor/repo.git',
+          },
+        },
+      }));
+      mockQuickPickWorktree();
+      // Local branch exists — should create detached worktree from tracking ref
+
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      const worktreeCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'worktree',
+      );
+      expect(worktreeCall).toBeDefined();
+      expect(worktreeCall![1]).toEqual([
+        'worktree', 'add', '--detach',
+        path.join('/mock', 'workspace-pr42'),
+        'contributor/fix/something',
+      ]);
+    });
+
     it('uses checkout -b with tracking ref for fork PRs in checkout mode', async () => {
       mockFetchResponse(createGitHubPrResponse({
         head: {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -1150,7 +1150,7 @@ describe('StartWorkAction', () => {
         'devdocket.addActivity',
         item.id,
         'work-started',
-        JSON.stringify({ branchName: 'feature/my-branch', worktreePath: expectedWorktreePath, repoPath: '/mock/workspace' }),
+        JSON.stringify({ worktreePath: expectedWorktreePath, repoPath: '/mock/workspace' }),
       );
     });
 
@@ -1167,7 +1167,7 @@ describe('StartWorkAction', () => {
         'devdocket.addActivity',
         item.id,
         'work-started',
-        JSON.stringify({ branchName: 'feature/my-branch', repoPath: '/mock/workspace' }),
+        JSON.stringify({ repoPath: '/mock/workspace' }),
       );
     });
 

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -427,7 +427,7 @@ describe('StartWorkAction', () => {
       await action.run(item);
 
       expect(window.showErrorMessage).toHaveBeenCalledWith(
-        'Could not determine issue number.',
+        'Could not determine work item number.',
       );
     });
 
@@ -436,7 +436,7 @@ describe('StartWorkAction', () => {
       await action.run(item);
 
       expect(window.showErrorMessage).toHaveBeenCalledWith(
-        'Could not determine issue number.',
+        'Could not determine work item number.',
       );
     });
 

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -922,6 +922,31 @@ describe('StartWorkAction', () => {
       expect(checkoutCall![1]).toEqual(['checkout', '-b', 'fix/something', 'contributor/fix/something']);
     });
 
+    it('force-updates local branch to fork tracking ref in checkout mode', async () => {
+      mockFetchResponse(createGitHubPrResponse({
+        head: {
+          ref: 'fix/something',
+          repo: {
+            full_name: 'contributor/repo',
+            clone_url: 'https://github.com/contributor/repo.git',
+          },
+        },
+      }));
+      mockQuickPickCheckout();
+      // Local branch exists — should use -B to reset it to tracking ref
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      const checkoutCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'checkout',
+      );
+      expect(checkoutCall).toBeDefined();
+      expect(checkoutCall![1]).toEqual(['checkout', '-B', 'fix/something', 'contributor/fix/something']);
+    });
+
     it('shows error when fork repository has been deleted', async () => {
       mockFetchResponse(createGitHubPrResponse({
         head: {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -21,13 +21,7 @@ vi.mock('child_process', () => {
           resolve({ stdout, stderr });
         }
       };
-      // Determine if last user arg is options or if there are only positional args
-      const lastArg = promiseArgs[promiseArgs.length - 1];
-      if (typeof lastArg === 'object' && lastArg !== null) {
-        fn(...promiseArgs, cb);
-      } else {
-        fn(...promiseArgs, cb);
-      }
+      fn(...promiseArgs, cb);
     });
   };
   return { execFile: fn };

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -952,7 +952,7 @@ describe('StartWorkAction', () => {
       expect(checkoutCall![1]).toEqual(['checkout', '-b', 'fix/something', 'devdocket-fork-contributor/fix/something']);
     });
 
-    it('force-updates local branch to fork tracking ref in checkout mode', async () => {
+    it('uses detached checkout for fork PR when local branch exists', async () => {
       mockFetchResponse(createGitHubPrResponse({
         head: {
           ref: 'fix/something',
@@ -963,7 +963,7 @@ describe('StartWorkAction', () => {
         },
       }));
       mockQuickPickCheckout();
-      // Local branch exists — should use -B to reset it to tracking ref
+      // Local branch exists — should use --detach to avoid resetting user's branch
       const item = createWorkItem({
         providerId: 'github-my-prs',
         externalId: 'owner/repo#42',
@@ -974,7 +974,7 @@ describe('StartWorkAction', () => {
         (call: any[]) => call[1]?.[0] === 'checkout',
       );
       expect(checkoutCall).toBeDefined();
-      expect(checkoutCall![1]).toEqual(['checkout', '-B', 'fix/something', 'devdocket-fork-contributor/fix/something']);
+      expect(checkoutCall![1]).toEqual(['checkout', '--detach', 'devdocket-fork-contributor/fix/something']);
     });
 
     it('shows error when fork repository has been deleted', async () => {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -1257,6 +1257,33 @@ describe('StartWorkAction', () => {
       expect(checkoutCall![1]).toEqual(['checkout', 'feature/ado-branch']);
     });
 
+    it('shows error when ADO branch fetch fails', async () => {
+      mockQuickPickWorktree();
+
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'fetch') {
+          cb(new Error("fatal: couldn't find remote ref feature/ado-branch"), '', '');
+          return;
+        }
+        cb(null, '', '');
+      }) as any);
+
+      const item = createWorkItem({
+        providerId: 'ado-pr-reviews',
+        externalId: 'org/project/repo/101',
+      });
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        "DevDocket: Could not fetch branch 'feature/ado-branch' from origin. The branch may have been deleted.",
+      );
+
+      const worktreeCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'worktree',
+      );
+      expect(worktreeCall).toBeUndefined();
+    });
+
     it('shows error for 404 ADO PR response', async () => {
       mockFetchResponse({}, 404);
       mockQuickPickWorktree();

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -67,6 +67,17 @@ function mockQuickPickCheckout() {
   vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Checkout branch', value: 'checkout' } as any);
 }
 
+/** Mocks execFile to fail for local branch existence checks (rev-parse --verify refs/heads/*). */
+function mockNoLocalBranch() {
+  vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+    if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2]?.startsWith('refs/heads/')) {
+      cb(new Error('not a valid ref'), { stdout: '', stderr: '' }, '');
+      return;
+    }
+    cb(null, { stdout: '', stderr: '' }, '');
+  }) as any);
+}
+
 function mockFetchResponse(body: any, status = 200) {
   const mockResponse = {
     ok: status >= 200 && status < 300,
@@ -832,6 +843,7 @@ describe('StartWorkAction', () => {
         },
       }));
       mockQuickPickWorktree();
+      mockNoLocalBranch();
 
       const item = createWorkItem({
         providerId: 'github-my-prs',
@@ -873,6 +885,7 @@ describe('StartWorkAction', () => {
         },
       }));
       mockQuickPickCheckout();
+      mockNoLocalBranch();
 
       const item = createWorkItem({
         providerId: 'github-my-prs',
@@ -919,10 +932,14 @@ describe('StartWorkAction', () => {
       }));
       mockQuickPickWorktree();
 
-      // Make remote add fail (already exists), but fetch succeeds
+      // Make remote add fail (already exists); get-url returns the same URL
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         if (args[0] === 'remote' && args[1] === 'add') {
           cb(new Error('remote contributor already exists'), { stdout: '', stderr: '' }, '');
+          return;
+        }
+        if (args[0] === 'remote' && args[1] === 'get-url') {
+          cb(null, { stdout: 'https://github.com/contributor/repo.git\n', stderr: '' }, '');
           return;
         }
         cb(null, { stdout: '', stderr: '' }, '');
@@ -974,6 +991,42 @@ describe('StartWorkAction', () => {
       );
       expect(checkoutCall).toBeDefined();
       expect(checkoutCall![1]).toEqual(['checkout', 'feature/my-branch']);
+    });
+
+    it('creates local branch from origin when no local branch exists (worktree)', async () => {
+      mockQuickPickWorktree();
+      mockNoLocalBranch();
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      const worktreeCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'worktree',
+      );
+      expect(worktreeCall).toBeDefined();
+      expect(worktreeCall![1]).toEqual([
+        'worktree', 'add', '-b', 'feature/my-branch',
+        path.join('/mock', 'workspace-pr42'),
+        'origin/feature/my-branch',
+      ]);
+    });
+
+    it('creates local branch from origin when no local branch exists (checkout)', async () => {
+      mockQuickPickCheckout();
+      mockNoLocalBranch();
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      const checkoutCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'checkout',
+      );
+      expect(checkoutCall).toBeDefined();
+      expect(checkoutCall![1]).toEqual(['checkout', '-b', 'feature/my-branch', '--track', 'origin/feature/my-branch']);
     });
 
     it('shows error for 404 PR response', async () => {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -83,9 +83,16 @@ function mockQuickPickCheckout() {
   vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Checkout branch', value: 'checkout' } as any);
 }
 
+/** Default git remote -v output — origin points at the default PR response's repo. */
+const ORIGIN_REMOTE_V = 'origin\thttps://github.com/owner/repo.git (fetch)\norigin\thttps://github.com/owner/repo.git (push)\n';
+
 /** Mocks execFile to fail for local branch existence checks (rev-parse --verify refs/heads/*). */
 function mockNoLocalBranch() {
   vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+    if (args[0] === 'remote' && args[1] === '-v') {
+      cb(null, ORIGIN_REMOTE_V, '');
+      return;
+    }
     if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2]?.startsWith('refs/heads/')) {
       cb(new Error('not a valid ref'), '', '');
       return;
@@ -142,8 +149,12 @@ describe('StartWorkAction', () => {
       get: vi.fn((key: string, defaultValue?: any) => defaultValue),
     } as any);
 
-    // Reset execFile mock to succeed with empty output
+    // Reset execFile mock to succeed with empty output; includes git remote -v
     vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+      if (args[0] === 'remote' && args[1] === '-v') {
+        cb(null, ORIGIN_REMOTE_V, '');
+        return;
+      }
       cb(null, '', '');
     }) as any);
 
@@ -845,10 +856,10 @@ describe('StartWorkAction', () => {
         (call: any[]) => call[1]?.[0] === 'fetch',
       );
       expect(fetchCall).toBeDefined();
-      expect(fetchCall![1]).toEqual(['fetch', 'origin', 'feature/my-branch']);
+      expect(fetchCall![1]).toEqual(['fetch', 'origin']);
     });
 
-    it('fetches fork PR via PR ref from origin', async () => {
+    it('adds fork remote and full-fetches for fork PRs', async () => {
       mockFetchResponse(createGitHubPrResponse({
         head: {
           ref: 'fix/something',
@@ -867,18 +878,25 @@ describe('StartWorkAction', () => {
       });
       await action.run(item);
 
-      // Should NOT add a fork remote
+      // Should look up remotes
+      const remoteVCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'remote' && call[1]?.[1] === '-v',
+      );
+      expect(remoteVCall).toBeDefined();
+
+      // Should add a fork remote (origin URL doesn't match fork URL)
       const remoteAddCall = vi.mocked(execFile).mock.calls.find(
         (call: any[]) => call[1]?.[0] === 'remote' && call[1]?.[1] === 'add',
       );
-      expect(remoteAddCall).toBeUndefined();
+      expect(remoteAddCall).toBeDefined();
+      expect(remoteAddCall![1]).toEqual(['remote', 'add', 'devdocket-fork-contributor', 'https://github.com/contributor/repo.git']);
 
-      // Should fetch via GitHub's PR ref on origin
+      // Should do a full fetch (no branch specified)
       const fetchCall = vi.mocked(execFile).mock.calls.find(
         (call: any[]) => call[1]?.[0] === 'fetch',
       );
       expect(fetchCall).toBeDefined();
-      expect(fetchCall![1]).toEqual(['fetch', 'origin', 'pull/42/head:refs/devdocket/pr/42']);
+      expect(fetchCall![1]).toEqual(['fetch', 'devdocket-fork-contributor']);
 
       const worktreeCall = vi.mocked(execFile).mock.calls.find(
         (call: any[]) => call[1]?.[0] === 'worktree',
@@ -887,8 +905,99 @@ describe('StartWorkAction', () => {
       expect(worktreeCall![1]).toEqual([
         'worktree', 'add', '-b', 'fix/something',
         path.join('/mock', 'workspace-pr42'),
-        'refs/devdocket/pr/42',
+        'devdocket-fork-contributor/fix/something',
       ]);
+    });
+
+    it('uses existing remote when it matches fork URL', async () => {
+      mockFetchResponse(createGitHubPrResponse({
+        head: {
+          ref: 'fix/something',
+          repo: {
+            full_name: 'contributor/repo',
+            clone_url: 'https://github.com/contributor/repo.git',
+          },
+        },
+      }));
+      mockQuickPickWorktree();
+
+      // git remote -v returns a user remote that matches the fork URL
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'remote' && args[1] === '-v') {
+          cb(null, 'origin\thttps://github.com/owner/repo.git (fetch)\norigin\thttps://github.com/owner/repo.git (push)\nmy-fork\thttps://github.com/contributor/repo.git (fetch)\nmy-fork\thttps://github.com/contributor/repo.git (push)\n', '');
+          return;
+        }
+        cb(null, '', '');
+      }) as any);
+
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      // Should NOT add a new remote
+      const remoteAddCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'remote' && call[1]?.[1] === 'add',
+      );
+      expect(remoteAddCall).toBeUndefined();
+
+      // Should fetch from the existing remote
+      const fetchCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'fetch',
+      );
+      expect(fetchCall).toBeDefined();
+      expect(fetchCall![1]).toEqual(['fetch', 'my-fork']);
+    });
+
+    it('updates existing devdocket-fork remote with different URL', async () => {
+      mockFetchResponse(createGitHubPrResponse({
+        head: {
+          ref: 'fix/something',
+          repo: {
+            full_name: 'contributor/repo',
+            clone_url: 'https://github.com/contributor/repo.git',
+          },
+        },
+      }));
+      mockQuickPickWorktree();
+
+      // remote add fails (already exists); get-url returns a different URL
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'remote' && args[1] === '-v') {
+          cb(null, ORIGIN_REMOTE_V, '');
+          return;
+        }
+        if (args[0] === 'remote' && args[1] === 'add') {
+          cb(new Error('remote devdocket-fork-contributor already exists'), '', '');
+          return;
+        }
+        if (args[0] === 'remote' && args[1] === 'get-url') {
+          cb(null, 'https://github.com/old-contributor/repo.git\n', '');
+          return;
+        }
+        cb(null, '', '');
+      }) as any);
+
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      // Should update the URL
+      const setUrlCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'remote' && call[1]?.[1] === 'set-url',
+      );
+      expect(setUrlCall).toBeDefined();
+      expect(setUrlCall![1]).toEqual(['remote', 'set-url', 'devdocket-fork-contributor', 'https://github.com/contributor/repo.git']);
+
+      // Should still fetch
+      const fetchCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'fetch',
+      );
+      expect(fetchCall).toBeDefined();
+      expect(fetchCall![1]).toEqual(['fetch', 'devdocket-fork-contributor']);
     });
 
     it('creates detached worktree from tracking ref when local branch exists (fork PR)', async () => {
@@ -917,7 +1026,7 @@ describe('StartWorkAction', () => {
       expect(worktreeCall![1]).toEqual([
         'worktree', 'add', '--detach',
         path.join('/mock', 'workspace-pr42'),
-        'refs/devdocket/pr/42',
+        'devdocket-fork-contributor/fix/something',
       ]);
     });
 
@@ -944,7 +1053,7 @@ describe('StartWorkAction', () => {
         (call: any[]) => call[1]?.[0] === 'checkout',
       );
       expect(checkoutCall).toBeDefined();
-      expect(checkoutCall![1]).toEqual(['checkout', '-b', 'fix/something', 'refs/devdocket/pr/42']);
+      expect(checkoutCall![1]).toEqual(['checkout', '-b', 'fix/something', 'devdocket-fork-contributor/fix/something']);
     });
 
     it('uses detached checkout for fork PR when local branch exists', async () => {
@@ -969,7 +1078,7 @@ describe('StartWorkAction', () => {
         (call: any[]) => call[1]?.[0] === 'checkout',
       );
       expect(checkoutCall).toBeDefined();
-      expect(checkoutCall![1]).toEqual(['checkout', '--detach', 'refs/devdocket/pr/42']);
+      expect(checkoutCall![1]).toEqual(['checkout', '--detach', 'devdocket-fork-contributor/fix/something']);
     });
 
     it('shows error when fork repository has been deleted', async () => {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -850,6 +850,61 @@ describe('StartWorkAction', () => {
       );
       expect(fetchCall).toBeDefined();
       expect(fetchCall![1]).toEqual(['fetch', 'contributor', 'fix/something']);
+
+      const worktreeCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'worktree',
+      );
+      expect(worktreeCall).toBeDefined();
+      expect(worktreeCall![1]).toEqual([
+        'worktree', 'add', '-b', 'fix/something',
+        path.join('/mock', 'workspace-pr42'),
+        'contributor/fix/something',
+      ]);
+    });
+
+    it('uses checkout -b with tracking ref for fork PRs in checkout mode', async () => {
+      mockFetchResponse(createGitHubPrResponse({
+        head: {
+          ref: 'fix/something',
+          repo: {
+            full_name: 'contributor/repo',
+            clone_url: 'https://github.com/contributor/repo.git',
+          },
+        },
+      }));
+      mockQuickPickCheckout();
+
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      const checkoutCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'checkout',
+      );
+      expect(checkoutCall).toBeDefined();
+      expect(checkoutCall![1]).toEqual(['checkout', '-b', 'fix/something', 'contributor/fix/something']);
+    });
+
+    it('shows error when fork repository has been deleted', async () => {
+      mockFetchResponse(createGitHubPrResponse({
+        head: {
+          ref: 'fix/something',
+          repo: null,
+        },
+      }));
+      mockQuickPickWorktree();
+
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        'DevDocket: The source repository for PR #42 has been deleted.',
+      );
     });
 
     it('handles existing fork remote gracefully', async () => {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -991,6 +991,74 @@ describe('StartWorkAction', () => {
       );
     });
 
+    it('shows error when fork branch fetch fails', async () => {
+      mockFetchResponse(createGitHubPrResponse({
+        head: {
+          ref: 'fix/something',
+          repo: {
+            full_name: 'contributor/repo',
+            clone_url: 'https://github.com/contributor/repo.git',
+          },
+        },
+      }));
+      mockQuickPickWorktree();
+
+      // Make fetch fail (branch deleted on fork)
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'fetch') {
+          cb(new Error("fatal: couldn't find remote ref fix/something"), '', '');
+          return;
+        }
+        cb(null, '', '');
+      }) as any);
+
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        "DevDocket: Could not fetch branch 'fix/something' from fork 'contributor'. The branch may have been deleted.",
+      );
+
+      // Should not create worktree
+      const worktreeCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'worktree',
+      );
+      expect(worktreeCall).toBeUndefined();
+    });
+
+    it('shows error when origin branch fetch fails', async () => {
+      mockFetchResponse(createGitHubPrResponse());
+      mockQuickPickWorktree();
+
+      // Make fetch fail (branch deleted on origin)
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'fetch') {
+          cb(new Error("fatal: couldn't find remote ref feature/my-branch"), '', '');
+          return;
+        }
+        cb(null, '', '');
+      }) as any);
+
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        "DevDocket: Could not fetch branch 'feature/my-branch' from origin. The branch may have been deleted.",
+      );
+
+      // Should not create worktree
+      const worktreeCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'worktree',
+      );
+      expect(worktreeCall).toBeUndefined();
+    });
+
     it('handles existing fork remote gracefully', async () => {
       mockFetchResponse(createGitHubPrResponse({
         head: {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -3,13 +3,35 @@ import { window, workspace, authentication } from 'vscode';
 import { StartWorkAction } from '../startWorkAction';
 import * as path from 'path';
 
-// Mock child_process
-vi.mock('child_process', () => ({
-  execFile: vi.fn((cmd: string, args: string[], optsOrCb: any, cb?: Function) => {
+// Mock child_process with custom promisify so util.promisify(execFile) returns { stdout, stderr }
+vi.mock('child_process', () => {
+  const fn = vi.fn((cmd: string, args: string[], optsOrCb: any, cb?: Function) => {
     const callback = typeof optsOrCb === 'function' ? optsOrCb : cb;
     callback?.(null, '', '');
-  }),
-}));
+  });
+  const customSymbol = Symbol.for('nodejs.util.promisify.custom');
+  (fn as any)[customSymbol] = (...promiseArgs: any[]) => {
+    return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      const cb = (err: Error | null, stdout: string, stderr: string) => {
+        if (err) {
+          (err as any).stdout = stdout;
+          (err as any).stderr = stderr;
+          reject(err);
+        } else {
+          resolve({ stdout, stderr });
+        }
+      };
+      // Determine if last user arg is options or if there are only positional args
+      const lastArg = promiseArgs[promiseArgs.length - 1];
+      if (typeof lastArg === 'object' && lastArg !== null) {
+        fn(...promiseArgs, cb);
+      } else {
+        fn(...promiseArgs, cb);
+      }
+    });
+  };
+  return { execFile: fn };
+});
 
 // Mock fs
 vi.mock('fs', () => ({
@@ -71,10 +93,10 @@ function mockQuickPickCheckout() {
 function mockNoLocalBranch() {
   vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
     if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2]?.startsWith('refs/heads/')) {
-      cb(new Error('not a valid ref'), { stdout: '', stderr: '' }, '');
+      cb(new Error('not a valid ref'), '', '');
       return;
     }
-    cb(null, { stdout: '', stderr: '' }, '');
+    cb(null, '', '');
   }) as any);
 }
 
@@ -128,7 +150,7 @@ describe('StartWorkAction', () => {
 
     // Reset execFile mock to succeed with empty output
     vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-      cb(null, { stdout: '', stderr: '' }, '');
+      cb(null, '', '');
     }) as any);
 
     // Return true for .git paths (repo validation), false otherwise (worktree check)
@@ -273,7 +295,7 @@ describe('StartWorkAction', () => {
       mockInputBox('/cached/path', 'origin/dev');
       mockQuickPickWorktree();
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-        cb(null, { stdout: '', stderr: '' }, '');
+        cb(null, '', '');
       }) as any);
       vi.mocked(fs.existsSync).mockImplementation((p: any) => p.toString().endsWith('.git'));
 
@@ -391,9 +413,9 @@ describe('StartWorkAction', () => {
     it('shows error when branch already exists', async () => {
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         if (args[0] === 'branch' && args[1] === '--list') {
-          cb(null, { stdout: '  issue123\n', stderr: '' }, '');
+          cb(null, '  issue123\n', '');
         } else {
-          cb(null, { stdout: '', stderr: '' }, '');
+          cb(null, '', '');
         }
       }) as any);
 
@@ -486,10 +508,10 @@ describe('StartWorkAction', () => {
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], optsOrCb: any, cb?: Function) => {
         const callback = typeof optsOrCb === 'function' ? optsOrCb : cb;
         if (cmd === 'bad-cmd') {
-          callback?.(new Error('command not found'), { stdout: '', stderr: '' }, '');
+          callback?.(new Error('command not found'), '', '');
           return;
         }
-        callback?.(null, { stdout: '', stderr: '' }, '');
+        callback?.(null, '', '');
       }) as any);
 
       const item = createWorkItem();
@@ -505,10 +527,10 @@ describe('StartWorkAction', () => {
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         callCount++;
         if (args[0] === 'worktree') {
-          cb(new Error('worktree failed'), { stdout: '', stderr: '' }, '');
+          cb(new Error('worktree failed'), '', '');
           return;
         }
-        cb(null, { stdout: '', stderr: '' }, '');
+        cb(null, '', '');
       }) as any);
 
       const item = createWorkItem();
@@ -583,10 +605,10 @@ describe('StartWorkAction', () => {
     it('prompts confirmation when working tree is dirty', async () => {
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         if (args[0] === 'status' && args[1] === '--porcelain') {
-          cb(null, { stdout: ' M file.ts\n', stderr: '' }, '');
+          cb(null, ' M file.ts\n', '');
           return;
         }
-        cb(null, { stdout: '', stderr: '' }, '');
+        cb(null, '', '');
       }) as any);
 
       vi.mocked(window.showWarningMessage).mockResolvedValue('Yes' as any);
@@ -609,10 +631,10 @@ describe('StartWorkAction', () => {
     it('aborts checkout when user declines dirty tree prompt', async () => {
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         if (args[0] === 'status' && args[1] === '--porcelain') {
-          cb(null, { stdout: ' M file.ts\n', stderr: '' }, '');
+          cb(null, ' M file.ts\n', '');
           return;
         }
-        cb(null, { stdout: '', stderr: '' }, '');
+        cb(null, '', '');
       }) as any);
 
       vi.mocked(window.showWarningMessage).mockResolvedValue(undefined as any);
@@ -759,10 +781,10 @@ describe('StartWorkAction', () => {
     it('handles generic git failure gracefully', async () => {
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         if (args[0] === 'branch' && args[1] !== '--list') {
-          cb(new Error('git error: permission denied'), { stdout: '', stderr: '' }, '');
+          cb(new Error('git error: permission denied'), '', '');
           return;
         }
-        cb(null, { stdout: '', stderr: '' }, '');
+        cb(null, '', '');
       }) as any);
 
       const item = createWorkItem();
@@ -935,14 +957,14 @@ describe('StartWorkAction', () => {
       // Make remote add fail (already exists); get-url returns the same URL
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         if (args[0] === 'remote' && args[1] === 'add') {
-          cb(new Error('remote contributor already exists'), { stdout: '', stderr: '' }, '');
+          cb(new Error('remote contributor already exists'), '', '');
           return;
         }
         if (args[0] === 'remote' && args[1] === 'get-url') {
-          cb(null, { stdout: 'https://github.com/contributor/repo.git\n', stderr: '' }, '');
+          cb(null, 'https://github.com/contributor/repo.git\n', '');
           return;
         }
-        cb(null, { stdout: '', stderr: '' }, '');
+        cb(null, '', '');
       }) as any);
 
       const item = createWorkItem({
@@ -1098,10 +1120,10 @@ describe('StartWorkAction', () => {
       mockQuickPickCheckout();
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         if (args[0] === 'status' && args[1] === '--porcelain') {
-          cb(null, { stdout: ' M dirty.ts\n', stderr: '' }, '');
+          cb(null, ' M dirty.ts\n', '');
           return;
         }
-        cb(null, { stdout: '', stderr: '' }, '');
+        cb(null, '', '');
       }) as any);
       vi.mocked(window.showWarningMessage).mockResolvedValue('Yes' as any);
 

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -848,7 +848,7 @@ describe('StartWorkAction', () => {
       expect(fetchCall![1]).toEqual(['fetch', 'origin', 'feature/my-branch']);
     });
 
-    it('adds fork remote and fetches for fork PRs', async () => {
+    it('fetches fork PR via PR ref from origin', async () => {
       mockFetchResponse(createGitHubPrResponse({
         head: {
           ref: 'fix/something',
@@ -867,17 +867,18 @@ describe('StartWorkAction', () => {
       });
       await action.run(item);
 
+      // Should NOT add a fork remote
       const remoteAddCall = vi.mocked(execFile).mock.calls.find(
         (call: any[]) => call[1]?.[0] === 'remote' && call[1]?.[1] === 'add',
       );
-      expect(remoteAddCall).toBeDefined();
-      expect(remoteAddCall![1]).toEqual(['remote', 'add', 'devdocket-fork-contributor', 'https://github.com/contributor/repo.git']);
+      expect(remoteAddCall).toBeUndefined();
 
+      // Should fetch via GitHub's PR ref on origin
       const fetchCall = vi.mocked(execFile).mock.calls.find(
         (call: any[]) => call[1]?.[0] === 'fetch',
       );
       expect(fetchCall).toBeDefined();
-      expect(fetchCall![1]).toEqual(['fetch', 'devdocket-fork-contributor', 'fix/something']);
+      expect(fetchCall![1]).toEqual(['fetch', 'origin', 'pull/42/head:refs/devdocket/pr/42']);
 
       const worktreeCall = vi.mocked(execFile).mock.calls.find(
         (call: any[]) => call[1]?.[0] === 'worktree',
@@ -886,7 +887,7 @@ describe('StartWorkAction', () => {
       expect(worktreeCall![1]).toEqual([
         'worktree', 'add', '-b', 'fix/something',
         path.join('/mock', 'workspace-pr42'),
-        'devdocket-fork-contributor/fix/something',
+        'refs/devdocket/pr/42',
       ]);
     });
 
@@ -916,7 +917,7 @@ describe('StartWorkAction', () => {
       expect(worktreeCall![1]).toEqual([
         'worktree', 'add', '--detach',
         path.join('/mock', 'workspace-pr42'),
-        'devdocket-fork-contributor/fix/something',
+        'refs/devdocket/pr/42',
       ]);
     });
 
@@ -943,7 +944,7 @@ describe('StartWorkAction', () => {
         (call: any[]) => call[1]?.[0] === 'checkout',
       );
       expect(checkoutCall).toBeDefined();
-      expect(checkoutCall![1]).toEqual(['checkout', '-b', 'fix/something', 'devdocket-fork-contributor/fix/something']);
+      expect(checkoutCall![1]).toEqual(['checkout', '-b', 'fix/something', 'refs/devdocket/pr/42']);
     });
 
     it('uses detached checkout for fork PR when local branch exists', async () => {
@@ -968,7 +969,7 @@ describe('StartWorkAction', () => {
         (call: any[]) => call[1]?.[0] === 'checkout',
       );
       expect(checkoutCall).toBeDefined();
-      expect(checkoutCall![1]).toEqual(['checkout', '--detach', 'devdocket-fork-contributor/fix/something']);
+      expect(checkoutCall![1]).toEqual(['checkout', '--detach', 'refs/devdocket/pr/42']);
     });
 
     it('shows error when fork repository has been deleted', async () => {
@@ -989,113 +990,6 @@ describe('StartWorkAction', () => {
       expect(window.showErrorMessage).toHaveBeenCalledWith(
         'DevDocket: The source repository for PR #42 has been deleted.',
       );
-    });
-
-    it('shows error when fork branch fetch fails', async () => {
-      mockFetchResponse(createGitHubPrResponse({
-        head: {
-          ref: 'fix/something',
-          repo: {
-            full_name: 'contributor/repo',
-            clone_url: 'https://github.com/contributor/repo.git',
-          },
-        },
-      }));
-      mockQuickPickWorktree();
-
-      // Make fetch fail (branch deleted on fork)
-      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-        if (args[0] === 'fetch') {
-          cb(new Error("fatal: couldn't find remote ref fix/something"), '', '');
-          return;
-        }
-        cb(null, '', '');
-      }) as any);
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        "DevDocket: Could not fetch branch 'fix/something' from fork 'contributor'. The branch may have been deleted.",
-      );
-
-      // Should not create worktree
-      const worktreeCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'worktree',
-      );
-      expect(worktreeCall).toBeUndefined();
-    });
-
-    it('shows error when origin branch fetch fails', async () => {
-      mockFetchResponse(createGitHubPrResponse());
-      mockQuickPickWorktree();
-
-      // Make fetch fail (branch deleted on origin)
-      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-        if (args[0] === 'fetch') {
-          cb(new Error("fatal: couldn't find remote ref feature/my-branch"), '', '');
-          return;
-        }
-        cb(null, '', '');
-      }) as any);
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        "DevDocket: Could not fetch branch 'feature/my-branch' from origin. The branch may have been deleted.",
-      );
-
-      // Should not create worktree
-      const worktreeCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'worktree',
-      );
-      expect(worktreeCall).toBeUndefined();
-    });
-
-    it('handles existing fork remote gracefully', async () => {
-      mockFetchResponse(createGitHubPrResponse({
-        head: {
-          ref: 'fix/something',
-          repo: {
-            full_name: 'contributor/repo',
-            clone_url: 'https://github.com/contributor/repo.git',
-          },
-        },
-      }));
-      mockQuickPickWorktree();
-
-      // Make remote add fail (already exists); get-url returns the same URL
-      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-        if (args[0] === 'remote' && args[1] === 'add') {
-          cb(new Error('remote devdocket-fork-contributor already exists'), '', '');
-          return;
-        }
-        if (args[0] === 'remote' && args[1] === 'get-url') {
-          cb(null, 'https://github.com/contributor/repo.git\n', '');
-          return;
-        }
-        cb(null, '', '');
-      }) as any);
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      // Should still fetch
-      const fetchCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'fetch',
-      );
-      expect(fetchCall).toBeDefined();
-      expect(fetchCall![1]).toEqual(['fetch', 'devdocket-fork-contributor', 'fix/something']);
     });
 
     it('creates worktree with pr-prefixed directory name', async () => {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -877,13 +877,13 @@ describe('StartWorkAction', () => {
         (call: any[]) => call[1]?.[0] === 'remote' && call[1]?.[1] === 'add',
       );
       expect(remoteAddCall).toBeDefined();
-      expect(remoteAddCall![1]).toEqual(['remote', 'add', 'contributor', 'https://github.com/contributor/repo.git']);
+      expect(remoteAddCall![1]).toEqual(['remote', 'add', 'devdocket-fork-contributor', 'https://github.com/contributor/repo.git']);
 
       const fetchCall = vi.mocked(execFile).mock.calls.find(
         (call: any[]) => call[1]?.[0] === 'fetch',
       );
       expect(fetchCall).toBeDefined();
-      expect(fetchCall![1]).toEqual(['fetch', 'contributor', 'fix/something']);
+      expect(fetchCall![1]).toEqual(['fetch', 'devdocket-fork-contributor', 'fix/something']);
 
       const worktreeCall = vi.mocked(execFile).mock.calls.find(
         (call: any[]) => call[1]?.[0] === 'worktree',
@@ -892,7 +892,7 @@ describe('StartWorkAction', () => {
       expect(worktreeCall![1]).toEqual([
         'worktree', 'add', '-b', 'fix/something',
         path.join('/mock', 'workspace-pr42'),
-        'contributor/fix/something',
+        'devdocket-fork-contributor/fix/something',
       ]);
     });
 
@@ -922,7 +922,7 @@ describe('StartWorkAction', () => {
       expect(worktreeCall![1]).toEqual([
         'worktree', 'add', '--detach',
         path.join('/mock', 'workspace-pr42'),
-        'contributor/fix/something',
+        'devdocket-fork-contributor/fix/something',
       ]);
     });
 
@@ -949,7 +949,7 @@ describe('StartWorkAction', () => {
         (call: any[]) => call[1]?.[0] === 'checkout',
       );
       expect(checkoutCall).toBeDefined();
-      expect(checkoutCall![1]).toEqual(['checkout', '-b', 'fix/something', 'contributor/fix/something']);
+      expect(checkoutCall![1]).toEqual(['checkout', '-b', 'fix/something', 'devdocket-fork-contributor/fix/something']);
     });
 
     it('force-updates local branch to fork tracking ref in checkout mode', async () => {
@@ -974,7 +974,7 @@ describe('StartWorkAction', () => {
         (call: any[]) => call[1]?.[0] === 'checkout',
       );
       expect(checkoutCall).toBeDefined();
-      expect(checkoutCall![1]).toEqual(['checkout', '-B', 'fix/something', 'contributor/fix/something']);
+      expect(checkoutCall![1]).toEqual(['checkout', '-B', 'fix/something', 'devdocket-fork-contributor/fix/something']);
     });
 
     it('shows error when fork repository has been deleted', async () => {
@@ -1012,7 +1012,7 @@ describe('StartWorkAction', () => {
       // Make remote add fail (already exists); get-url returns the same URL
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         if (args[0] === 'remote' && args[1] === 'add') {
-          cb(new Error('remote contributor already exists'), '', '');
+          cb(new Error('remote devdocket-fork-contributor already exists'), '', '');
           return;
         }
         if (args[0] === 'remote' && args[1] === 'get-url') {
@@ -1033,7 +1033,7 @@ describe('StartWorkAction', () => {
         (call: any[]) => call[1]?.[0] === 'fetch',
       );
       expect(fetchCall).toBeDefined();
-      expect(fetchCall![1]).toEqual(['fetch', 'contributor', 'fix/something']);
+      expect(fetchCall![1]).toEqual(['fetch', 'devdocket-fork-contributor', 'fix/something']);
     });
 
     it('creates worktree with pr-prefixed directory name', async () => {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { window, workspace } from 'vscode';
+import { window, workspace, authentication } from 'vscode';
 import { StartWorkAction } from '../startWorkAction';
 import * as path from 'path';
 
@@ -57,17 +57,58 @@ function mockInputBox(repoPath: string | undefined, baseBranch: string | undefin
   });
 }
 
+/** Sets up showQuickPick to return the worktree option (default for existing tests). */
+function mockQuickPickWorktree() {
+  vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Create worktree', value: 'worktree' } as any);
+}
+
+/** Sets up showQuickPick to return the checkout option. */
+function mockQuickPickCheckout() {
+  vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Checkout branch', value: 'checkout' } as any);
+}
+
+function mockFetchResponse(body: any, status = 200) {
+  const mockResponse = {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  };
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
+}
+
+function createGitHubPrResponse(overrides: Partial<any> = {}) {
+  return {
+    head: {
+      ref: 'feature/my-branch',
+      repo: {
+        full_name: 'owner/repo',
+        clone_url: 'https://github.com/owner/repo.git',
+      },
+    },
+    base: {
+      repo: {
+        full_name: 'owner/repo',
+      },
+    },
+    ...overrides,
+  };
+}
+
 describe('StartWorkAction', () => {
   let action: StartWorkAction;
   let mockMemento: ReturnType<typeof createMockMemento>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
     mockMemento = createMockMemento();
     action = new StartWorkAction(mockMemento as any);
 
     // Default: showInputBox returns repo path and base branch based on prompt
     mockInputBox('/mock/workspace', 'origin/dev');
+
+    // Default: select worktree mode (preserves existing test behavior)
+    mockQuickPickWorktree();
 
     // Default: no post-worktree commands configured
     vi.mocked(workspace.getConfiguration).mockReturnValue({
@@ -93,6 +134,21 @@ describe('StartWorkAction', () => {
 
     it('returns true for ado-work-items provider items in InProgress state', () => {
       const item = createWorkItem({ providerId: 'ado-work-items', state: 'InProgress', externalId: 'org/project/456' });
+      expect(action.canRun(item)).toBe(true);
+    });
+
+    it('returns true for github-my-prs provider items in InProgress state', () => {
+      const item = createWorkItem({ providerId: 'github-my-prs', state: 'InProgress' });
+      expect(action.canRun(item)).toBe(true);
+    });
+
+    it('returns true for github-pr-reviews provider items in InProgress state', () => {
+      const item = createWorkItem({ providerId: 'github-pr-reviews', state: 'InProgress' });
+      expect(action.canRun(item)).toBe(true);
+    });
+
+    it('returns true for ado-pr-reviews provider items in InProgress state', () => {
+      const item = createWorkItem({ providerId: 'ado-pr-reviews', state: 'InProgress', externalId: 'org/project/repo/101' });
       expect(action.canRun(item)).toBe(true);
     });
 
@@ -204,6 +260,7 @@ describe('StartWorkAction', () => {
 
       vi.clearAllMocks();
       mockInputBox('/cached/path', 'origin/dev');
+      mockQuickPickWorktree();
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         cb(null, { stdout: '', stderr: '' }, '');
       }) as any);
@@ -218,7 +275,34 @@ describe('StartWorkAction', () => {
     });
   });
 
-  describe('run', () => {
+  describe('checkout vs worktree prompt', () => {
+    it('shows quick pick with checkout and worktree options for issue items', async () => {
+      const item = createWorkItem();
+      await action.run(item);
+
+      expect(window.showQuickPick).toHaveBeenCalledWith(
+        [
+          { label: 'Checkout branch', value: 'checkout' },
+          { label: 'Create worktree', value: 'worktree' },
+        ],
+        {
+          placeHolder: 'How would you like to work on this?',
+          ignoreFocusOut: true,
+        },
+      );
+    });
+
+    it('aborts when user cancels work mode selection', async () => {
+      vi.mocked(window.showQuickPick).mockResolvedValue(undefined);
+
+      const item = createWorkItem();
+      await action.run(item);
+
+      expect(execFile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('run (worktree mode)', () => {
     it('creates branch and worktree with correct names for GitHub items', async () => {
       const item = createWorkItem({ title: '#123: Fix login redirect bug' });
       await action.run(item);
@@ -426,6 +510,121 @@ describe('StartWorkAction', () => {
       expect(rollbackCall).toBeDefined();
       expect(rollbackCall![1]).toEqual(['branch', '-D', 'issue123']);
     });
+
+    it('logs activity with worktreePath and repoPath', async () => {
+      const { commands } = await import('vscode');
+      const item = createWorkItem();
+      await action.run(item);
+
+      const expectedWorktreePath = path.join('/mock', 'workspace-issue123');
+      expect(commands.executeCommand).toHaveBeenCalledWith(
+        'devdocket.addActivity',
+        item.id,
+        'work-started',
+        JSON.stringify({ branchName: 'issue123', worktreePath: expectedWorktreePath, repoPath: '/mock/workspace' }),
+      );
+    });
+  });
+
+  describe('run (checkout mode)', () => {
+    beforeEach(() => {
+      mockQuickPickCheckout();
+    });
+
+    it('checks out new branch with git checkout -b for issue items', async () => {
+      const item = createWorkItem();
+      await action.run(item);
+
+      // git status --porcelain + git checkout -b
+      expect(execFile).toHaveBeenCalledTimes(2);
+
+      const statusCall = vi.mocked(execFile).mock.calls[0];
+      expect(statusCall[1]).toEqual(['status', '--porcelain']);
+
+      const checkoutCall = vi.mocked(execFile).mock.calls[1];
+      expect(checkoutCall[0]).toBe('git');
+      expect(checkoutCall[1]).toEqual(['checkout', '-b', 'issue123', 'origin/dev']);
+      expect(checkoutCall[2]).toEqual({ cwd: '/mock/workspace', timeout: 30_000 });
+    });
+
+    it('shows success message after checkout', async () => {
+      const item = createWorkItem();
+      await action.run(item);
+
+      expect(window.showInformationMessage).toHaveBeenCalledWith(
+        'DevDocket: Checked out branch issue123',
+      );
+    });
+
+    it('logs activity with branchName and repoPath (no worktreePath)', async () => {
+      const { commands } = await import('vscode');
+      const item = createWorkItem();
+      await action.run(item);
+
+      expect(commands.executeCommand).toHaveBeenCalledWith(
+        'devdocket.addActivity',
+        item.id,
+        'work-started',
+        JSON.stringify({ branchName: 'issue123', repoPath: '/mock/workspace' }),
+      );
+    });
+
+    it('prompts confirmation when working tree is dirty', async () => {
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'status' && args[1] === '--porcelain') {
+          cb(null, { stdout: ' M file.ts\n', stderr: '' }, '');
+          return;
+        }
+        cb(null, { stdout: '', stderr: '' }, '');
+      }) as any);
+
+      vi.mocked(window.showWarningMessage).mockResolvedValue('Yes' as any);
+
+      const item = createWorkItem();
+      await action.run(item);
+
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        'Working tree has uncommitted changes. Checkout anyway?',
+        { modal: true },
+        'Yes',
+      );
+      // Should still proceed
+      const checkoutCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'checkout',
+      );
+      expect(checkoutCall).toBeDefined();
+    });
+
+    it('aborts checkout when user declines dirty tree prompt', async () => {
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'status' && args[1] === '--porcelain') {
+          cb(null, { stdout: ' M file.ts\n', stderr: '' }, '');
+          return;
+        }
+        cb(null, { stdout: '', stderr: '' }, '');
+      }) as any);
+
+      vi.mocked(window.showWarningMessage).mockResolvedValue(undefined as any);
+
+      const item = createWorkItem();
+      await action.run(item);
+
+      const checkoutCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'checkout',
+      );
+      expect(checkoutCall).toBeUndefined();
+    });
+
+    it('does not prompt when working tree is clean', async () => {
+      const item = createWorkItem();
+      await action.run(item);
+
+      expect(window.showWarningMessage).not.toHaveBeenCalledWith(
+        expect.stringContaining('uncommitted changes'),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
   });
 
   describe('base branch prompting', () => {
@@ -560,6 +759,375 @@ describe('StartWorkAction', () => {
 
       expect(window.showErrorMessage).toHaveBeenCalledWith(
         expect.stringContaining('Failed to start work'),
+      );
+    });
+  });
+
+  describe('GitHub PR flow', () => {
+    beforeEach(() => {
+      mockFetchResponse(createGitHubPrResponse());
+    });
+
+    it('fetches PR branch via GitHub API for github-my-prs items', async () => {
+      mockQuickPickWorktree();
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      expect(authentication.getSession).toHaveBeenCalledWith('github', ['repo'], { createIfNone: true });
+      const fetchCalls = vi.mocked(globalThis.fetch).mock.calls;
+      expect(fetchCalls[0][0]).toBe('https://api.github.com/repos/owner/repo/pulls/42');
+    });
+
+    it('fetches PR branch via GitHub API for github-pr-reviews items', async () => {
+      mockQuickPickWorktree();
+      const item = createWorkItem({
+        providerId: 'github-pr-reviews',
+        externalId: 'owner/repo#99',
+      });
+      await action.run(item);
+
+      const fetchCalls = vi.mocked(globalThis.fetch).mock.calls;
+      expect(fetchCalls[0][0]).toBe('https://api.github.com/repos/owner/repo/pulls/99');
+    });
+
+    it('does not prompt for base branch for PR items', async () => {
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      const baseBranchCall = vi.mocked(window.showInputBox).mock.calls.find(
+        (call: any[]) => call[0]?.prompt?.includes('base branch'),
+      );
+      expect(baseBranchCall).toBeUndefined();
+    });
+
+    it('fetches from origin for same-repo PRs', async () => {
+      mockQuickPickWorktree();
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      const fetchCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'fetch',
+      );
+      expect(fetchCall).toBeDefined();
+      expect(fetchCall![1]).toEqual(['fetch', 'origin', 'feature/my-branch']);
+    });
+
+    it('adds fork remote and fetches for fork PRs', async () => {
+      mockFetchResponse(createGitHubPrResponse({
+        head: {
+          ref: 'fix/something',
+          repo: {
+            full_name: 'contributor/repo',
+            clone_url: 'https://github.com/contributor/repo.git',
+          },
+        },
+      }));
+      mockQuickPickWorktree();
+
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      const remoteAddCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'remote' && call[1]?.[1] === 'add',
+      );
+      expect(remoteAddCall).toBeDefined();
+      expect(remoteAddCall![1]).toEqual(['remote', 'add', 'contributor', 'https://github.com/contributor/repo.git']);
+
+      const fetchCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'fetch',
+      );
+      expect(fetchCall).toBeDefined();
+      expect(fetchCall![1]).toEqual(['fetch', 'contributor', 'fix/something']);
+    });
+
+    it('handles existing fork remote gracefully', async () => {
+      mockFetchResponse(createGitHubPrResponse({
+        head: {
+          ref: 'fix/something',
+          repo: {
+            full_name: 'contributor/repo',
+            clone_url: 'https://github.com/contributor/repo.git',
+          },
+        },
+      }));
+      mockQuickPickWorktree();
+
+      // Make remote add fail (already exists), but fetch succeeds
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'remote' && args[1] === 'add') {
+          cb(new Error('remote contributor already exists'), { stdout: '', stderr: '' }, '');
+          return;
+        }
+        cb(null, { stdout: '', stderr: '' }, '');
+      }) as any);
+
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      // Should still fetch
+      const fetchCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'fetch',
+      );
+      expect(fetchCall).toBeDefined();
+      expect(fetchCall![1]).toEqual(['fetch', 'contributor', 'fix/something']);
+    });
+
+    it('creates worktree with pr-prefixed directory name', async () => {
+      mockQuickPickWorktree();
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      const worktreeCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'worktree',
+      );
+      expect(worktreeCall).toBeDefined();
+      expect(worktreeCall![1]).toEqual([
+        'worktree', 'add',
+        path.join('/mock', 'workspace-pr42'),
+        'feature/my-branch',
+      ]);
+    });
+
+    it('checks out PR branch for checkout mode', async () => {
+      mockQuickPickCheckout();
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      const checkoutCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'checkout',
+      );
+      expect(checkoutCall).toBeDefined();
+      expect(checkoutCall![1]).toEqual(['checkout', 'feature/my-branch']);
+    });
+
+    it('shows error for 404 PR response', async () => {
+      mockFetchResponse({}, 404);
+      mockQuickPickWorktree();
+
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#999',
+      });
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        'DevDocket: Could not find PR #999',
+      );
+    });
+
+    it('shows error for non-404 API errors', async () => {
+      mockFetchResponse({}, 500);
+      mockQuickPickWorktree();
+
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        'DevDocket: GitHub API error (500)',
+      );
+    });
+
+    it('logs activity with worktreePath for worktree mode', async () => {
+      const { commands } = await import('vscode');
+      mockQuickPickWorktree();
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      const expectedWorktreePath = path.join('/mock', 'workspace-pr42');
+      expect(commands.executeCommand).toHaveBeenCalledWith(
+        'devdocket.addActivity',
+        item.id,
+        'work-started',
+        JSON.stringify({ branchName: 'feature/my-branch', worktreePath: expectedWorktreePath, repoPath: '/mock/workspace' }),
+      );
+    });
+
+    it('logs activity without worktreePath for checkout mode', async () => {
+      const { commands } = await import('vscode');
+      mockQuickPickCheckout();
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      expect(commands.executeCommand).toHaveBeenCalledWith(
+        'devdocket.addActivity',
+        item.id,
+        'work-started',
+        JSON.stringify({ branchName: 'feature/my-branch', repoPath: '/mock/workspace' }),
+      );
+    });
+
+    it('prompts for dirty tree before checkout', async () => {
+      mockQuickPickCheckout();
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'status' && args[1] === '--porcelain') {
+          cb(null, { stdout: ' M dirty.ts\n', stderr: '' }, '');
+          return;
+        }
+        cb(null, { stdout: '', stderr: '' }, '');
+      }) as any);
+      vi.mocked(window.showWarningMessage).mockResolvedValue('Yes' as any);
+
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        'Working tree has uncommitted changes. Checkout anyway?',
+        { modal: true },
+        'Yes',
+      );
+    });
+
+    it('aborts when user cancels work mode selection for PR', async () => {
+      vi.mocked(window.showQuickPick).mockResolvedValue(undefined);
+
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      // fetch should not have been called (work mode prompt comes before API call)
+      expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
+      expect(execFile).not.toHaveBeenCalled();
+    });
+
+    it('shows error when worktree dir already exists for PR', async () => {
+      mockQuickPickWorktree();
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+        const pathStr = p.toString();
+        return pathStr.endsWith('.git') || pathStr.includes('workspace-pr42');
+      });
+
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+      });
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        expect.stringContaining('already exists'),
+      );
+    });
+  });
+
+  describe('ADO PR flow', () => {
+    beforeEach(() => {
+      mockFetchResponse({ sourceRefName: 'refs/heads/feature/ado-branch' });
+    });
+
+    it('fetches PR branch via ADO API for ado-pr-reviews items', async () => {
+      mockQuickPickWorktree();
+      const item = createWorkItem({
+        providerId: 'ado-pr-reviews',
+        externalId: 'org/project/repo/101',
+      });
+      await action.run(item);
+
+      expect(authentication.getSession).toHaveBeenCalledWith(
+        'microsoft',
+        ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+        { createIfNone: true },
+      );
+      const fetchCalls = vi.mocked(globalThis.fetch).mock.calls;
+      expect(fetchCalls[0][0]).toBe(
+        'https://dev.azure.com/org/project/_apis/git/repositories/repo/pullrequests/101?api-version=7.1',
+      );
+    });
+
+    it('strips refs/heads/ prefix from sourceRefName', async () => {
+      mockQuickPickWorktree();
+      const item = createWorkItem({
+        providerId: 'ado-pr-reviews',
+        externalId: 'org/project/repo/101',
+      });
+      await action.run(item);
+
+      const fetchCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'fetch',
+      );
+      expect(fetchCall).toBeDefined();
+      expect(fetchCall![1]).toEqual(['fetch', 'origin', 'feature/ado-branch']);
+    });
+
+    it('creates worktree with pr-prefixed directory for ADO PRs', async () => {
+      mockQuickPickWorktree();
+      const item = createWorkItem({
+        providerId: 'ado-pr-reviews',
+        externalId: 'org/project/repo/101',
+      });
+      await action.run(item);
+
+      const worktreeCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'worktree',
+      );
+      expect(worktreeCall).toBeDefined();
+      expect(worktreeCall![1]).toEqual([
+        'worktree', 'add',
+        path.join('/mock', 'workspace-pr101'),
+        'feature/ado-branch',
+      ]);
+    });
+
+    it('checks out ADO PR branch for checkout mode', async () => {
+      mockQuickPickCheckout();
+      const item = createWorkItem({
+        providerId: 'ado-pr-reviews',
+        externalId: 'org/project/repo/101',
+      });
+      await action.run(item);
+
+      const checkoutCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'checkout',
+      );
+      expect(checkoutCall).toBeDefined();
+      expect(checkoutCall![1]).toEqual(['checkout', 'feature/ado-branch']);
+    });
+
+    it('shows error for 404 ADO PR response', async () => {
+      mockFetchResponse({}, 404);
+      mockQuickPickWorktree();
+
+      const item = createWorkItem({
+        providerId: 'ado-pr-reviews',
+        externalId: 'org/project/repo/999',
+      });
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        'DevDocket: Could not find PR #999',
       );
     });
   });


### PR DESCRIPTION
## Summary

Closes #363

Adds PR branch checkout support to the `start-git-work` extension. When a user invokes "Start Git Work" on a PR work item, the action now fetches the PR's branch and either checks it out or creates a worktree — instead of creating a new branch like the issue flow does.

## Changes

### `packages/start-git-work/src/startWorkAction.ts`
- **PR provider support**: Added `github-my-prs`, `github-pr-reviews`, and `ado-pr-reviews` to `SUPPORTED_PROVIDERS`. Introduced `PR_PROVIDERS` to distinguish PR items from issue items.
- **PR flow**: New `runPrFlow` method that skips the base-branch prompt (PR branches already exist) and delegates to `fetchGitHubPrBranch` or `fetchAdoPrBranch`.
- **GitHub PR branch fetch**: Calls `GET /repos/{owner}/{repo}/pulls/{number}` to get `head.ref`. Uses `git remote -v` to find a local remote matching the head repo's clone URL. If no match, adds a `devdocket-fork-{owner}` remote (with URL update if it already exists with a different URL). Performs a **full fetch** (`git fetch {remote}` with no branch) to ensure all refs are available, then uses `{remote}/{branch}` as the tracking ref for non-origin remotes.
- **ADO PR branch fetch**: Calls the ADO PR API to get `sourceRefName`, strips `refs/heads/`, and fetches from origin. Handles fetch failures with a user-friendly error.
- **Fork safety**: Guards against `head.repo: null` (deleted fork) with a descriptive error. Uses `checkout -b` / `worktree add -b` with tracking ref for fork PRs to avoid ambiguity when branch names shadow across remotes.
- **Work mode**: Both checkout and worktree modes are supported for PR items, consistent with the issue flow.

### `packages/start-git-work/src/test/startWorkAction.test.ts`
- New tests cover: GitHub PR API calls for both providers, same-repo full-fetch, fork remote add + full-fetch, reusing existing remote matching fork URL, updating stale devdocket-fork remote URL, fork worktree with tracking ref, fork checkout with tracking ref, deleted fork error, worktree/checkout flows, 404/500 errors, user cancellation, dirty tree, worktree conflict, activity logging, ADO PR flow, and ADO fetch failure.

## No API Surface Changes

This PR only modifies internal action implementation files (`packages/start-git-work/`). No changes to `packages/core/src/api/`, `packages/shared/src/`, or `packages/core/src/models/`.
