### PR TITLE
feat: watch PR pipeline runs instead of individual runs

### DIFF
--- a/packages/ado/src/adoPRWatcher.ts
+++ b/packages/ado/src/adoPRWatcher.ts
@@ -152,7 +152,7 @@ export class AdoPRWatcher implements DevDocketPRWatcher {
           providerId: 'ado-pipelines',
           runId: String(build.id),
           displayName,
-          url: `https://dev.azure.com/${org}/${project}/_build/results?buildId=${build.id}`,
+          url: `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(project)}/_build/results?buildId=${build.id}`,
           repo: `${org}/${project}`,
         });
       }

--- a/packages/ado/src/adoPRWatcher.ts
+++ b/packages/ado/src/adoPRWatcher.ts
@@ -94,7 +94,7 @@ export class AdoPRWatcher implements DevDocketPRWatcher {
     try {
       prResponse = await fetch(prUrl, { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
+      if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
         throw new Error(`ADO API request timed out after ${FETCH_TIMEOUT_MS / 1000}s`);
       }
       throw err;

--- a/packages/ado/src/adoPRWatcher.ts
+++ b/packages/ado/src/adoPRWatcher.ts
@@ -127,7 +127,7 @@ export class AdoPRWatcher implements DevDocketPRWatcher {
     try {
       buildsResponse = await fetch(buildsUrl, { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
+      if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
         throw new Error(`ADO builds request timed out after ${FETCH_TIMEOUT_MS / 1000}s for PR ${identifier.prId}`);
       }
       throw err;

--- a/packages/ado/src/adoPRWatcher.ts
+++ b/packages/ado/src/adoPRWatcher.ts
@@ -111,10 +111,9 @@ export class AdoPRWatcher implements DevDocketPRWatcher {
         ? 'merged'
         : 'closed';
 
-    // Update display name with PR title
-    if (prData.title) {
-      identifier.displayName = `PR #${identifier.prId}: ${prData.title}`;
-    }
+    const updatedDisplayName = prData.title
+      ? `PR #${identifier.prId}: ${prData.title}`
+      : undefined;
 
     if (token?.isCancellationRequested) {
       const error = new Error('The operation was aborted.');
@@ -162,6 +161,6 @@ export class AdoPRWatcher implements DevDocketPRWatcher {
       logger.warn(`Failed to fetch builds for PR ${identifier.prId}: ${buildsResponse.status} ${buildsResponse.statusText}`);
     }
 
-    return { prState, runs };
+    return { prState, runs, displayName: updatedDisplayName };
   }
 }

--- a/packages/ado/src/adoPRWatcher.ts
+++ b/packages/ado/src/adoPRWatcher.ts
@@ -124,8 +124,8 @@ export class AdoPRWatcher implements DevDocketPRWatcher {
       throw error;
     }
 
-    // Fetch builds for the PR's source branch
-    const buildsUrl = `https://dev.azure.com/${encodedOrg}/${encodedProject}/_apis/build/builds?reasonFilter=pullRequest&repositoryId=${encodedRepo}&repositoryType=TfsGit&api-version=7.1`;
+    // Fetch builds triggered by this PR via its merge ref branch
+    const buildsUrl = `https://dev.azure.com/${encodedOrg}/${encodedProject}/_apis/build/builds?branchName=refs/pull/${encodedPrId}/merge&api-version=7.1`;
     let buildsResponse: Response;
     try {
       buildsResponse = await fetch(buildsUrl, { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
@@ -138,15 +138,9 @@ export class AdoPRWatcher implements DevDocketPRWatcher {
 
     const runs: RunIdentifier[] = [];
     if (buildsResponse.ok) {
-      const buildsData = await buildsResponse.json() as { value: (AdoBuild & { triggerInfo?: { 'pr.number'?: string } })[] };
+      const buildsData = await buildsResponse.json() as { value: AdoBuild[] };
 
       for (const build of buildsData.value) {
-        // Filter to builds triggered by this specific PR
-        const prNumber = build.triggerInfo?.['pr.number'];
-        if (prNumber !== identifier.prId) {
-          continue;
-        }
-
         const displayName = build.definition?.name
           ? `${build.definition.name} #${build.buildNumber}`
           : `Build ${build.buildNumber}`;

--- a/packages/ado/src/adoPRWatcher.ts
+++ b/packages/ado/src/adoPRWatcher.ts
@@ -128,8 +128,7 @@ export class AdoPRWatcher implements DevDocketPRWatcher {
       buildsResponse = await fetch(buildsUrl, { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
-        logger.warn(`ADO builds request timed out for PR ${identifier.prId}`);
-        return { prState, runs: [] };
+        throw new Error(`ADO builds request timed out after ${FETCH_TIMEOUT_MS / 1000}s for PR ${identifier.prId}`);
       }
       throw err;
     }

--- a/packages/ado/src/adoPRWatcher.ts
+++ b/packages/ado/src/adoPRWatcher.ts
@@ -1,0 +1,167 @@
+import type {
+  DevDocketPRWatcher,
+  PRIdentifier,
+  PRRunsSnapshot,
+  PRState,
+  RunIdentifier,
+  CancellationTokenLike,
+} from '@devdocket/shared';
+import { safeDecodeComponent } from '@devdocket/shared';
+import { getAdoHeaders, throwAdoApiError } from './adoAuth';
+import { logger } from './logger';
+
+interface AdoPullRequest {
+  pullRequestId: number;
+  title: string;
+  status: 'active' | 'completed' | 'abandoned';
+  mergeStatus: string;
+  lastMergeSourceCommit?: { commitId: string };
+}
+
+interface AdoBuild {
+  id: number;
+  buildNumber: string;
+  definition: { name: string };
+  status: string;
+  result: string | null;
+}
+
+const FETCH_TIMEOUT_MS = 30_000;
+const ADO_PR_URL_RE = /^\/([^/]+)\/([^/]+)\/_git\/([^/]+)\/pullrequest\/(\d+)\/?$/;
+
+/**
+ * Watcher for Azure DevOps pull request pipeline runs.
+ * Resolves PR URLs to their associated ADO pipeline builds.
+ */
+export class AdoPRWatcher implements DevDocketPRWatcher {
+  readonly id = 'ado-pr';
+  readonly label = 'Azure DevOps Pull Requests';
+
+  canWatch(url: string): boolean {
+    try {
+      const u = new URL(url);
+      return (u.protocol === 'https:' || u.protocol === 'http:')
+        && u.hostname === 'dev.azure.com'
+        && ADO_PR_URL_RE.test(u.pathname);
+    } catch {
+      return false;
+    }
+  }
+
+  parsePRUrl(url: string): PRIdentifier {
+    const u = new URL(url);
+    const match = u.pathname.match(ADO_PR_URL_RE);
+    if (!match) {
+      throw new Error('Invalid Azure DevOps PR URL');
+    }
+
+    const [, rawOrg, rawProject, rawRepo, prId] = match;
+    const org = safeDecodeComponent(rawOrg);
+    const project = safeDecodeComponent(rawProject);
+    const repo = safeDecodeComponent(rawRepo);
+
+    return {
+      providerId: this.id,
+      prId,
+      displayName: `PR #${prId}`,
+      url,
+      repo: `${org}/${project}/${repo}`,
+    };
+  }
+
+  async getPRRunsSnapshot(
+    identifier: PRIdentifier,
+    token?: CancellationTokenLike,
+  ): Promise<PRRunsSnapshot> {
+    const repoParts = identifier.repo.split('/');
+    const [org, project, repo] = repoParts;
+    const encodedOrg = encodeURIComponent(org);
+    const encodedProject = encodeURIComponent(project);
+    const encodedRepo = encodeURIComponent(repo);
+    const encodedPrId = encodeURIComponent(identifier.prId);
+
+    const headers = await getAdoHeaders();
+
+    if (token?.isCancellationRequested) {
+      const error = new Error('The operation was aborted.');
+      error.name = 'AbortError';
+      throw error;
+    }
+
+    // Fetch PR details
+    const prUrl = `https://dev.azure.com/${encodedOrg}/${encodedProject}/_apis/git/repositories/${encodedRepo}/pullrequests/${encodedPrId}?api-version=7.1`;
+    let prResponse: Response;
+    try {
+      prResponse = await fetch(prUrl, { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new Error(`ADO API request timed out after ${FETCH_TIMEOUT_MS / 1000}s`);
+      }
+      throw err;
+    }
+    if (!prResponse.ok) {
+      throwAdoApiError(prResponse, `PR ${identifier.prId}`);
+    }
+    const prData = await prResponse.json() as AdoPullRequest;
+
+    // Map ADO PR status to PRState
+    const prState: PRState = prData.status === 'active'
+      ? 'open'
+      : prData.status === 'completed'
+        ? 'merged'
+        : 'closed';
+
+    // Update display name with PR title
+    if (prData.title) {
+      identifier.displayName = `PR #${identifier.prId}: ${prData.title}`;
+    }
+
+    if (token?.isCancellationRequested) {
+      const error = new Error('The operation was aborted.');
+      error.name = 'AbortError';
+      throw error;
+    }
+
+    // Fetch builds for the PR's source branch
+    const buildsUrl = `https://dev.azure.com/${encodedOrg}/${encodedProject}/_apis/build/builds?reasonFilter=pullRequest&repositoryId=${encodedRepo}&repositoryType=TfsGit&api-version=7.1`;
+    let buildsResponse: Response;
+    try {
+      buildsResponse = await fetch(buildsUrl, { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        logger.warn(`ADO builds request timed out for PR ${identifier.prId}`);
+        return { prState, runs: [] };
+      }
+      throw err;
+    }
+
+    const runs: RunIdentifier[] = [];
+    if (buildsResponse.ok) {
+      const buildsData = await buildsResponse.json() as { value: (AdoBuild & { triggerInfo?: { 'pr.number'?: string } })[] };
+
+      for (const build of buildsData.value) {
+        // Filter to builds triggered by this specific PR
+        const prNumber = build.triggerInfo?.['pr.number'];
+        if (prNumber !== identifier.prId) {
+          continue;
+        }
+
+        const displayName = build.definition?.name
+          ? `${build.definition.name} #${build.buildNumber}`
+          : `Build ${build.buildNumber}`;
+
+        runs.push({
+          providerId: 'ado-pipelines',
+          runId: String(build.id),
+          displayName,
+          url: `https://dev.azure.com/${org}/${project}/_build/results?buildId=${build.id}`,
+          repo: `${org}/${project}`,
+        });
+      }
+    } else {
+      logger.warn(`Failed to fetch builds for PR ${identifier.prId}: ${buildsResponse.status} ${buildsResponse.statusText}`);
+    }
+
+    return { prState, runs };
+  }
+}

--- a/packages/ado/src/adoPRWatcher.ts
+++ b/packages/ado/src/adoPRWatcher.ts
@@ -74,6 +74,9 @@ export class AdoPRWatcher implements DevDocketPRWatcher {
     token?: CancellationTokenLike,
   ): Promise<PRRunsSnapshot> {
     const repoParts = identifier.repo.split('/');
+    if (repoParts.length !== 3 || repoParts.some(p => !p)) {
+      throw new Error(`Invalid ADO repo format: expected "org/project/repo" but got "${identifier.repo}"`);
+    }
     const [org, project, repo] = repoParts;
     const encodedOrg = encodeURIComponent(org);
     const encodedProject = encodeURIComponent(project);

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { AdoWorkItemProvider } from './adoWorkItemProvider';
 import { AdoPrReviewProvider } from './adoPrReviewProvider';
 import { AdoPipelineWatcher } from './adoPipelineWatcher';
+import { AdoPRWatcher } from './adoPRWatcher';
 import { parseAdoProjectsConfig } from './configParser';
 import { validateRefreshInterval } from '@devdocket/shared';
 import { initLogger, setLogLevel, logger, resolveLogLevel } from './logger';
@@ -11,6 +12,7 @@ let prProvider: AdoPrReviewProvider | undefined;
 let workItemRegistration: vscode.Disposable | undefined;
 let prRegistration: vscode.Disposable | undefined;
 let watcherRegistration: vscode.Disposable | undefined;
+let prWatcherRegistration: vscode.Disposable | undefined;
 let orgWarningShown = false;
 
 export async function activate(_context: vscode.ExtensionContext): Promise<void> {
@@ -119,9 +121,17 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
     if (typeof api.registerRunWatcher === 'function') {
       watcherRegistration?.dispose();
       watcherRegistration = api.registerRunWatcher(new AdoPipelineWatcher());
+    }
+
+    // Register ADO PR watcher (if core supports it)
+    if (typeof api.registerPRWatcher === 'function') {
+      prWatcherRegistration?.dispose();
+      prWatcherRegistration = api.registerPRWatcher(new AdoPRWatcher());
+      logger.info('Registered 2 ADO providers + 1 watcher + 1 PR watcher');
+    } else if (watcherRegistration) {
       logger.info('Registered 2 ADO providers + 1 watcher');
     } else {
-      logger.info('Registered 2 ADO providers (run watcher API not available)');
+      logger.info('Registered 2 ADO providers');
     }
   };
 
@@ -146,6 +156,7 @@ export function deactivate(): void {
   workItemRegistration?.dispose();
   prRegistration?.dispose();
   watcherRegistration?.dispose();
+  prWatcherRegistration?.dispose();
   workItemProvider?.dispose();
   prProvider?.dispose();
   logger.info('DevDocket ADO deactivated');

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -127,12 +127,12 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
     if (typeof api.registerPRWatcher === 'function') {
       prWatcherRegistration?.dispose();
       prWatcherRegistration = api.registerPRWatcher(new AdoPRWatcher());
-      logger.info('Registered 2 ADO providers + 1 watcher + 1 PR watcher');
-    } else if (watcherRegistration) {
-      logger.info('Registered 2 ADO providers + 1 watcher');
-    } else {
-      logger.info('Registered 2 ADO providers');
     }
+
+    const parts = ['2 ADO providers'];
+    if (watcherRegistration) { parts.push('1 watcher'); }
+    if (prWatcherRegistration) { parts.push('1 PR watcher'); }
+    logger.info(`Registered ${parts.join(' + ')}`);
   };
 
   configureProviders();

--- a/packages/ado/src/test/adoPRWatcher.test.ts
+++ b/packages/ado/src/test/adoPRWatcher.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { AdoPRWatcher } from '../adoPRWatcher';
+
+vi.mock('../adoAuth', () => ({
+  getAdoHeaders: vi.fn().mockResolvedValue({ Accept: 'application/json', Authorization: 'Bearer mock-token' }),
+  throwAdoApiError: vi.fn((response: any, label: string) => {
+    throw new Error(`${label} not found`);
+  }),
+}));
+
+describe('AdoPRWatcher', () => {
+  let watcher: AdoPRWatcher;
+
+  beforeEach(() => {
+    watcher = new AdoPRWatcher();
+    vi.restoreAllMocks();
+  });
+
+  it('has expected id and label', () => {
+    expect(watcher.id).toBe('ado-pr');
+    expect(watcher.label).toBe('Azure DevOps Pull Requests');
+  });
+
+  describe('canWatch', () => {
+    it('returns true for valid ADO PR URL', () => {
+      expect(watcher.canWatch('https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/123')).toBe(true);
+    });
+
+    it('returns true for URL with trailing slash', () => {
+      expect(watcher.canWatch('https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/123/')).toBe(true);
+    });
+
+    it('returns false for non-ADO URL', () => {
+      expect(watcher.canWatch('https://github.com/owner/repo/pull/42')).toBe(false);
+    });
+
+    it('returns false for ADO URL that is not a PR', () => {
+      expect(watcher.canWatch('https://dev.azure.com/myorg/myproject/_build/results?buildId=123')).toBe(false);
+    });
+
+    it('returns false for invalid URL', () => {
+      expect(watcher.canWatch('not-a-url')).toBe(false);
+    });
+
+    it('returns false for empty string', () => {
+      expect(watcher.canWatch('')).toBe(false);
+    });
+  });
+
+  describe('parsePRUrl', () => {
+    const validUrl = 'https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/123';
+
+    it('extracts org, project, repo, and prId correctly', () => {
+      const result = watcher.parsePRUrl(validUrl);
+      expect(result.prId).toBe('123');
+    });
+
+    it('sets providerId to ado-pr', () => {
+      const result = watcher.parsePRUrl(validUrl);
+      expect(result.providerId).toBe('ado-pr');
+    });
+
+    it('sets displayName to PR #123', () => {
+      const result = watcher.parsePRUrl(validUrl);
+      expect(result.displayName).toBe('PR #123');
+    });
+
+    it('preserves original URL', () => {
+      const result = watcher.parsePRUrl(validUrl);
+      expect(result.url).toBe(validUrl);
+    });
+
+    it('sets repo to org/project/repo', () => {
+      const result = watcher.parsePRUrl(validUrl);
+      expect(result.repo).toBe('myorg/myproject/myrepo');
+    });
+
+    it('throws for invalid URL format', () => {
+      expect(() => watcher.parsePRUrl('https://dev.azure.com/myorg/myproject/_build/results?buildId=123')).toThrow('Invalid');
+    });
+  });
+
+  describe('getPRRunsSnapshot', () => {
+    const identifier = {
+      providerId: 'ado-pr',
+      prId: '42',
+      displayName: 'PR #42',
+      url: 'https://dev.azure.com/myorg/myproject/_git/myrepo/pullrequest/42',
+      repo: 'myorg/myproject/myrepo',
+    };
+
+    it('maps active PR status to open', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ pullRequestId: 42, title: 'Fix bug', status: 'active', mergeStatus: 'succeeded' }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [] }),
+        } as Response);
+
+      const result = await watcher.getPRRunsSnapshot(identifier);
+      expect(result.prState).toBe('open');
+
+      fetchSpy.mockRestore();
+    });
+
+    it('maps completed PR status to merged', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ pullRequestId: 42, title: 'Add feature', status: 'completed', mergeStatus: 'succeeded' }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [] }),
+        } as Response);
+
+      const result = await watcher.getPRRunsSnapshot(identifier);
+      expect(result.prState).toBe('merged');
+
+      fetchSpy.mockRestore();
+    });
+
+    it('maps abandoned PR status to closed', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ pullRequestId: 42, title: 'Stale PR', status: 'abandoned', mergeStatus: 'conflicts' }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [] }),
+        } as Response);
+
+      const result = await watcher.getPRRunsSnapshot(identifier);
+      expect(result.prState).toBe('closed');
+
+      fetchSpy.mockRestore();
+    });
+
+    it('updates displayName with PR title', async () => {
+      const id = { ...identifier };
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ pullRequestId: 42, title: 'Fix login flow', status: 'active', mergeStatus: 'succeeded' }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [] }),
+        } as Response);
+
+      await watcher.getPRRunsSnapshot(id);
+      expect(id.displayName).toBe('PR #42: Fix login flow');
+
+      fetchSpy.mockRestore();
+    });
+
+    it('filters builds to only those triggered by the specific PR', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ pullRequestId: 42, title: 'My PR', status: 'active', mergeStatus: 'succeeded' }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            value: [
+              { id: 100, buildNumber: '20240101.1', definition: { name: 'CI' }, status: 'completed', result: 'succeeded', triggerInfo: { 'pr.number': '42' } },
+              { id: 200, buildNumber: '20240101.2', definition: { name: 'CI' }, status: 'completed', result: 'failed', triggerInfo: { 'pr.number': '99' } },
+              { id: 300, buildNumber: '20240101.3', definition: { name: 'Nightly' }, status: 'completed', result: 'succeeded', triggerInfo: {} },
+            ],
+          }),
+        } as Response);
+
+      const result = await watcher.getPRRunsSnapshot(identifier);
+      expect(result.runs).toHaveLength(1);
+      expect(result.runs[0].runId).toBe('100');
+      expect(result.runs[0].displayName).toBe('CI #20240101.1');
+      expect(result.runs[0].providerId).toBe('ado-pipelines');
+
+      fetchSpy.mockRestore();
+    });
+
+    it('returns empty runs array when no builds found', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ pullRequestId: 42, title: 'Empty PR', status: 'active', mergeStatus: 'succeeded' }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ value: [] }),
+        } as Response);
+
+      const result = await watcher.getPRRunsSnapshot(identifier);
+      expect(result.runs).toEqual([]);
+
+      fetchSpy.mockRestore();
+    });
+  });
+});

--- a/packages/ado/src/test/adoPRWatcher.test.ts
+++ b/packages/ado/src/test/adoPRWatcher.test.ts
@@ -140,7 +140,7 @@ describe('AdoPRWatcher', () => {
       fetchSpy.mockRestore();
     });
 
-    it('updates displayName with PR title', async () => {
+    it('returns displayName with PR title in snapshot', async () => {
       const id = { ...identifier };
       const fetchSpy = vi.spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce({
@@ -152,8 +152,8 @@ describe('AdoPRWatcher', () => {
           json: async () => ({ value: [] }),
         } as Response);
 
-      await watcher.getPRRunsSnapshot(id);
-      expect(id.displayName).toBe('PR #42: Fix login flow');
+      const snapshot = await watcher.getPRRunsSnapshot(id);
+      expect(snapshot.displayName).toBe('PR #42: Fix login flow');
 
       fetchSpy.mockRestore();
     });

--- a/packages/ado/src/test/adoPRWatcher.test.ts
+++ b/packages/ado/src/test/adoPRWatcher.test.ts
@@ -168,18 +168,24 @@ describe('AdoPRWatcher', () => {
           ok: true,
           json: async () => ({
             value: [
-              { id: 100, buildNumber: '20240101.1', definition: { name: 'CI' }, status: 'completed', result: 'succeeded', triggerInfo: { 'pr.number': '42' } },
-              { id: 200, buildNumber: '20240101.2', definition: { name: 'CI' }, status: 'completed', result: 'failed', triggerInfo: { 'pr.number': '99' } },
-              { id: 300, buildNumber: '20240101.3', definition: { name: 'Nightly' }, status: 'completed', result: 'succeeded', triggerInfo: {} },
+              { id: 100, buildNumber: '20240101.1', definition: { name: 'CI' }, status: 'completed', result: 'succeeded' },
+              { id: 200, buildNumber: '20240101.2', definition: { name: 'Deploy' }, status: 'completed', result: 'failed' },
             ],
           }),
         } as Response);
 
       const result = await watcher.getPRRunsSnapshot(identifier);
-      expect(result.runs).toHaveLength(1);
+      expect(result.runs).toHaveLength(2);
       expect(result.runs[0].runId).toBe('100');
       expect(result.runs[0].displayName).toBe('CI #20240101.1');
       expect(result.runs[0].providerId).toBe('ado-pipelines');
+      expect(result.runs[1].runId).toBe('200');
+      expect(result.runs[1].displayName).toBe('Deploy #20240101.2');
+
+      // Verify the builds URL uses branchName filter instead of repositoryId
+      const buildsCallUrl = (fetchSpy.mock.calls[1][0] as string);
+      expect(buildsCallUrl).toContain('branchName=refs/pull/42/merge');
+      expect(buildsCallUrl).not.toContain('repositoryId');
 
       fetchSpy.mockRestore();
     });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -831,12 +831,12 @@
         },
         {
           "command": "devdocket.dismissWatch",
-          "when": "view == devdocket.watches && viewItem =~ /^watchedRun/",
+          "when": "view == devdocket.watches && viewItem =~ /^watchedRun|^watchedPR/",
           "group": "inline"
         },
         {
           "command": "devdocket.openWatchUrl",
-          "when": "view == devdocket.watches && viewItem =~ /^watchedRun/",
+          "when": "view == devdocket.watches && viewItem =~ /^watchedRun|^watchedPR/",
           "group": "1_actions"
         }
       ]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,7 @@
     "onCommand:devdocket.clearHistory",
     "onView:devdocket.watches",
     "onCommand:devdocket.watchRun",
+    "onCommand:devdocket.watchPR",
     "onCommand:devdocket.dismissWatch",
     "onCommand:devdocket.dismissAllCompletedWatches",
     "onCommand:devdocket.openWatchUrl",
@@ -241,7 +242,7 @@
       },
       {
         "view": "devdocket.watches",
-        "contents": "No pipeline runs being watched.\n[Watch Pipeline Run](command:devdocket.watchRun)"
+        "contents": "No pipeline runs being watched.\n[Watch Pipeline Run](command:devdocket.watchRun)\n[Watch Pull Request](command:devdocket.watchPR)"
       }
     ],
     "commands": [
@@ -495,6 +496,12 @@
         "title": "DevDocket: Watch Pipeline Run",
         "category": "DevDocket",
         "icon": "$(add)"
+      },
+      {
+        "command": "devdocket.watchPR",
+        "title": "DevDocket: Watch Pull Request",
+        "category": "DevDocket",
+        "icon": "$(git-pull-request)"
       },
       {
         "command": "devdocket.dismissWatch",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -242,7 +242,7 @@
       },
       {
         "view": "devdocket.watches",
-        "contents": "No pipeline runs being watched.\n[Watch Pipeline Run](command:devdocket.watchRun)\n[Watch Pull Request](command:devdocket.watchPR)"
+        "contents": "No watches yet.\n[Watch Pipeline Run](command:devdocket.watchRun)\n[Watch Pull Request](command:devdocket.watchPR)"
       }
     ],
     "commands": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "onView:devdocket.watches",
     "onCommand:devdocket.watchRun",
     "onCommand:devdocket.watchPR",
+    "onCommand:devdocket.watchPRFromItem",
     "onCommand:devdocket.dismissWatch",
     "onCommand:devdocket.dismissAllCompletedWatches",
     "onCommand:devdocket.openWatchUrl",
@@ -504,6 +505,12 @@
         "icon": "$(git-pull-request)"
       },
       {
+        "command": "devdocket.watchPRFromItem",
+        "title": "Watch CI",
+        "category": "DevDocket",
+        "icon": "$(eye)"
+      },
+      {
         "command": "devdocket.dismissWatch",
         "title": "Dismiss Watch",
         "category": "DevDocket",
@@ -701,6 +708,10 @@
         {
           "command": "devdocket.addActivity",
           "when": "false"
+        },
+        {
+          "command": "devdocket.watchPRFromItem",
+          "when": "false"
         }
       ],
       "view/item/context": [
@@ -767,6 +778,16 @@
         {
           "command": "devdocket.openInBrowser",
           "when": "viewItem =~ /hasUrl/ && !listMultiSelection",
+          "group": "2_links"
+        },
+        {
+          "command": "devdocket.watchPRFromItem",
+          "when": "view == devdocket.focus && viewItem =~ /hasUrl/ && !listMultiSelection",
+          "group": "2_links"
+        },
+        {
+          "command": "devdocket.watchPRFromItem",
+          "when": "view == devdocket.queue && viewItem =~ /hasUrl/ && !listMultiSelection",
           "group": "2_links"
         },
         {

--- a/packages/core/src/api/devDocketApi.ts
+++ b/packages/core/src/api/devDocketApi.ts
@@ -1,8 +1,9 @@
-import { DevDocketApi, DevDocketProvider, DevDocketAction, DevDocketRunWatcher, Disposable, type ActivityType, type StateTransitionEvent } from './types';
+import { DevDocketApi, DevDocketProvider, DevDocketAction, DevDocketRunWatcher, DevDocketPRWatcher, Disposable, type ActivityType, type StateTransitionEvent } from './types';
 import type { Event } from '@devdocket/shared';
 import { ProviderRegistry } from '../services/providerRegistry';
 import { ActionRegistry } from '../services/actionRegistry';
 import { WatcherRegistry } from '../services/watcherRegistry';
+import { PRWatcherRegistry } from '../services/prWatcherRegistry';
 import { WorkGraph } from '../services/workGraph';
 
 export class DevDocketApiImpl implements DevDocketApi {
@@ -12,6 +13,7 @@ export class DevDocketApiImpl implements DevDocketApi {
     private readonly providerRegistry: ProviderRegistry,
     private readonly actionRegistry: ActionRegistry,
     private readonly watcherRegistry: WatcherRegistry,
+    private readonly prWatcherRegistry: PRWatcherRegistry,
     private readonly workGraph: WorkGraph,
   ) {
     this.onDidTransitionState = workGraph.onDidTransitionState;
@@ -27,6 +29,10 @@ export class DevDocketApiImpl implements DevDocketApi {
 
   registerRunWatcher(watcher: DevDocketRunWatcher): Disposable {
     return this.watcherRegistry.register(watcher);
+  }
+
+  registerPRWatcher(watcher: DevDocketPRWatcher): Disposable {
+    return this.prWatcherRegistry.register(watcher);
   }
 
   async addActivity(itemId: string, type: ActivityType, detail?: string): Promise<void> {

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -1,5 +1,5 @@
 // Canonical type declarations live in @devdocket/shared; re-export for
 // existing intra-core imports (e.g. `from '../api/types'`).
-export type { Disposable, Event, DiscoveredItem, ResolvedItem, DevDocketRunWatcher } from '@devdocket/shared';
+export type { Disposable, Event, DiscoveredItem, ResolvedItem, DevDocketRunWatcher, DevDocketPRWatcher } from '@devdocket/shared';
 export type { ActivityLogEntry, ActivityType } from '@devdocket/shared';
 export type { StateTransitionEvent, DevDocketProvider, DevDocketAction, DevDocketApi } from '@devdocket/shared';

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -13,10 +13,10 @@ import { logger } from '../services/logger';
 import type { ResolvedItem } from '../api/types';
 import { toggleViewLayout, setViewLayout } from '../views/viewLayout';
 import type { ViewRevealer } from '../services/viewRevealer';
-import { WatcherService, type WatchedRun, type WatchedPR } from '../services/watcherService';
+import { WatcherService } from '../services/watcherService';
 import { WatcherRegistry } from '../services/watcherRegistry';
 import { PRWatcherRegistry } from '../services/prWatcherRegistry';
-import { showWatchesQuickPick } from '../views/watchesStatusBar';
+import { registerWatchCommands } from './watchCommands';
 import { showProviderHealthQuickPick } from '../views/providerHealthStatusBar';
 import { isSafeUrl } from '../utils/url';
 
@@ -897,190 +897,6 @@ async function handleDismissFromSources(
 }
 
 // ---------------------------------------------------------------------------
-// Watch Pipeline Commands
-// ---------------------------------------------------------------------------
-
-async function handleWatchRun(watcherRegistry: WatcherRegistry, prWatcherRegistry: PRWatcherRegistry, watcherService: WatcherService): Promise<void> {
-  const url = await vscode.window.showInputBox({
-    prompt: 'Enter a pipeline run URL',
-    placeHolder: 'https://github.com/owner/repo/actions/runs/123456789',
-    validateInput: (value) => {
-      const trimmed = value.trim();
-      if (!trimmed) {
-        return 'URL cannot be empty';
-      }
-      if (!isSafeUrl(trimmed)) {
-        return 'Only http(s) URLs are supported.';
-      }
-      const watcher = watcherRegistry.findWatcherForUrl(trimmed);
-      const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmed);
-      if (!watcher && !prWatcher) {
-        return 'Unsupported URL format. No registered watcher recognizes this URL.';
-      }
-      return undefined;
-    },
-  });
-
-  if (!url) {
-    return; // User cancelled
-  }
-
-  const trimmedUrl = url.trim();
-
-  // If a PR watcher recognizes the URL, redirect to PR watch flow
-  const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmedUrl);
-  if (prWatcher) {
-    try {
-      const identifier = prWatcher.parsePRUrl(trimmedUrl);
-      await watcherService.startPRWatch(identifier);
-      void vscode.window.showInformationMessage(`Now watching PR: ${identifier.displayName}`);
-    } catch (err: unknown) {
-      handleCommandError('Failed to watch PR', err);
-    }
-    return;
-  }
-
-  try {
-    const watcher = watcherRegistry.findWatcherForUrl(trimmedUrl);
-    if (!watcher) {
-      void vscode.window.showErrorMessage('Unsupported URL format. No registered watcher recognizes this URL.');
-      return;
-    }
-
-    const identifier = watcher.parseRunUrl(trimmedUrl);
-    await watcherService.startWatch(identifier);
-    
-    void vscode.window.showInformationMessage(`Now watching: ${identifier.displayName}`);
-  } catch (err: unknown) {
-    handleCommandError('Failed to watch pipeline run', err);
-  }
-}
-
-async function handleWatchPR(prWatcherRegistry: PRWatcherRegistry, watcherService: WatcherService): Promise<void> {
-  const url = await vscode.window.showInputBox({
-    prompt: 'Enter a pull request URL',
-    placeHolder: 'https://github.com/owner/repo/pull/42',
-    validateInput: (value) => {
-      const trimmed = value.trim();
-      if (!trimmed) {
-        return 'URL cannot be empty';
-      }
-      if (!isSafeUrl(trimmed)) {
-        return 'Only http(s) URLs are supported.';
-      }
-      const watcher = prWatcherRegistry.findWatcherForUrl(trimmed);
-      if (!watcher) {
-        return 'Unsupported URL format. No registered PR watcher recognizes this URL.';
-      }
-      return undefined;
-    },
-  });
-
-  if (!url) {
-    return;
-  }
-
-  const trimmedUrl = url.trim();
-
-  try {
-    const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmedUrl);
-    if (!prWatcher) {
-      void vscode.window.showErrorMessage('Unsupported URL format. No registered PR watcher recognizes this URL.');
-      return;
-    }
-
-    const identifier = prWatcher.parsePRUrl(trimmedUrl);
-    await watcherService.startPRWatch(identifier);
-    void vscode.window.showInformationMessage(`Now watching PR: ${identifier.displayName}`);
-  } catch (err: unknown) {
-    handleCommandError('Failed to watch PR', err);
-  }
-}
-
-// Normalize argument: context menu passes WatchedRunNode, inline click passes WatchedRun
-function resolveWatchedRun(arg: unknown): WatchedRun | undefined {
-  if (!arg || typeof arg !== 'object') {
-    return undefined;
-  }
-  if ('watchedRun' in arg) {
-    return (arg as { watchedRun: WatchedRun }).watchedRun;
-  }
-  if ('identifier' in arg && 'status' in arg) {
-    return arg as WatchedRun;
-  }
-  return undefined;
-}
-
-// Normalize argument: context menu passes WatchedPRNode, inline click passes WatchedPR
-function resolveWatchedPR(arg: unknown): WatchedPR | undefined {
-  if (!arg || typeof arg !== 'object') {
-    return undefined;
-  }
-  if ('watchedPR' in arg) {
-    return (arg as { watchedPR: WatchedPR }).watchedPR;
-  }
-  if ('identifier' in arg && 'prState' in arg) {
-    return arg as WatchedPR;
-  }
-  return undefined;
-}
-
-async function handleDismissWatch(arg: unknown, watcherService: WatcherService): Promise<void> {
-  try {
-    const watchedPR = resolveWatchedPR(arg);
-    if (watchedPR) {
-      watcherService.dismissPRWatch(watchedPR.identifier);
-      return;
-    }
-    const watchedRun = resolveWatchedRun(arg);
-    if (!watchedRun) {
-      void vscode.window.showInformationMessage('Select a watch from the Watches view to dismiss.');
-      return;
-    }
-    watcherService.dismissWatch(watchedRun.identifier);
-  } catch (err: unknown) {
-    handleCommandError('Failed to dismiss watch', err);
-  }
-}
-
-async function handleDismissAllCompletedWatches(watcherService: WatcherService): Promise<void> {
-  try {
-    watcherService.dismissAllCompleted();
-  } catch (err: unknown) {
-    handleCommandError('Failed to dismiss all completed watches', err);
-  }
-}
-
-async function handleOpenWatchUrl(arg: unknown): Promise<void> {
-  try {
-    const watchedPR = resolveWatchedPR(arg);
-    if (watchedPR) {
-      const safeUrl = isSafeUrl(watchedPR.identifier.url);
-      if (!safeUrl) {
-        void vscode.window.showWarningMessage('Can only open http(s) URLs in the browser.');
-        return;
-      }
-      await vscode.env.openExternal(vscode.Uri.parse(safeUrl.href));
-      return;
-    }
-
-    const watchedRun = resolveWatchedRun(arg);
-    if (!watchedRun) {
-      void vscode.window.showInformationMessage('Select a watch from the Watches view to open.');
-      return;
-    }
-    const safeUrl = isSafeUrl(watchedRun.identifier.url);
-    if (!safeUrl) {
-      void vscode.window.showWarningMessage('Can only open http(s) URLs in the browser.');
-      return;
-    }
-    await vscode.env.openExternal(vscode.Uri.parse(safeUrl.href));
-  } catch (err: unknown) {
-    handleCommandError('Failed to open URL', err);
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Registration
 // ---------------------------------------------------------------------------
 
@@ -1180,19 +996,6 @@ export function registerCommands(
       wrapCommand('Failed to switch watches layout', () => setViewLayout('watches', 'flat'))),
     vscode.commands.registerCommand('devdocket.toggleWatchesLayout',
       wrapCommand('Failed to switch watches layout', () => toggleViewLayout('watches'))),
-    // Watch pipeline commands
-    vscode.commands.registerCommand('devdocket.watchRun',
-      wrapCommand('Failed to watch pipeline run', () => handleWatchRun(watcherRegistry, prWatcherRegistry, watcherService))),
-    vscode.commands.registerCommand('devdocket.watchPR',
-      wrapCommand('Failed to watch PR', () => handleWatchPR(prWatcherRegistry, watcherService))),
-    vscode.commands.registerCommand('devdocket.dismissWatch',
-      wrapCommand('Failed to dismiss watch', (arg: unknown) => handleDismissWatch(arg, watcherService))),
-    vscode.commands.registerCommand('devdocket.dismissAllCompletedWatches',
-      wrapCommand('Failed to dismiss all completed watches', () => handleDismissAllCompletedWatches(watcherService))),
-    vscode.commands.registerCommand('devdocket.openWatchUrl',
-      wrapCommand('Failed to open watch URL', (arg: unknown) => handleOpenWatchUrl(arg))),
-    vscode.commands.registerCommand('devdocket.showWatchesQuickPick',
-      wrapCommand('Failed to show watches quick pick', () => showWatchesQuickPick(watcherService))),
     vscode.commands.registerCommand('devdocket.showProviderHealthQuickPick',
       wrapCommand('Failed to show provider health quick pick', () => showProviderHealthQuickPick(providerRegistry))),
     vscode.commands.registerCommand('devdocket.addActivity',
@@ -1206,4 +1009,6 @@ export function registerCommands(
         return workGraph.addActivity(itemId, type as ActivityType, detail);
       }),
   );
+
+  registerWatchCommands(context, watcherRegistry, prWatcherRegistry, watcherService);
 }

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -13,8 +13,9 @@ import { logger } from '../services/logger';
 import type { ResolvedItem } from '../api/types';
 import { toggleViewLayout, setViewLayout } from '../views/viewLayout';
 import type { ViewRevealer } from '../services/viewRevealer';
-import { WatcherService, type WatchedRun } from '../services/watcherService';
+import { WatcherService, type WatchedRun, type WatchedPR } from '../services/watcherService';
 import { WatcherRegistry } from '../services/watcherRegistry';
+import { PRWatcherRegistry } from '../services/prWatcherRegistry';
 import { showWatchesQuickPick } from '../views/watchesStatusBar';
 import { showProviderHealthQuickPick } from '../views/providerHealthStatusBar';
 import { isSafeUrl } from '../utils/url';
@@ -899,7 +900,7 @@ async function handleDismissFromSources(
 // Watch Pipeline Commands
 // ---------------------------------------------------------------------------
 
-async function handleWatchRun(watcherRegistry: WatcherRegistry, watcherService: WatcherService): Promise<void> {
+async function handleWatchRun(watcherRegistry: WatcherRegistry, prWatcherRegistry: PRWatcherRegistry, watcherService: WatcherService): Promise<void> {
   const url = await vscode.window.showInputBox({
     prompt: 'Enter a pipeline run URL',
     placeHolder: 'https://github.com/owner/repo/actions/runs/123456789',
@@ -912,7 +913,8 @@ async function handleWatchRun(watcherRegistry: WatcherRegistry, watcherService: 
         return 'Only http(s) URLs are supported.';
       }
       const watcher = watcherRegistry.findWatcherForUrl(trimmed);
-      if (!watcher) {
+      const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmed);
+      if (!watcher && !prWatcher) {
         return 'Unsupported URL format. No registered watcher recognizes this URL.';
       }
       return undefined;
@@ -924,6 +926,19 @@ async function handleWatchRun(watcherRegistry: WatcherRegistry, watcherService: 
   }
 
   const trimmedUrl = url.trim();
+
+  // If a PR watcher recognizes the URL, redirect to PR watch flow
+  const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmedUrl);
+  if (prWatcher) {
+    try {
+      const identifier = prWatcher.parsePRUrl(trimmedUrl);
+      await watcherService.startPRWatch(identifier);
+      void vscode.window.showInformationMessage(`Now watching PR: ${identifier.displayName}`);
+    } catch (err: unknown) {
+      handleCommandError('Failed to watch PR', err);
+    }
+    return;
+  }
 
   try {
     const watcher = watcherRegistry.findWatcherForUrl(trimmedUrl);
@@ -941,6 +956,47 @@ async function handleWatchRun(watcherRegistry: WatcherRegistry, watcherService: 
   }
 }
 
+async function handleWatchPR(prWatcherRegistry: PRWatcherRegistry, watcherService: WatcherService): Promise<void> {
+  const url = await vscode.window.showInputBox({
+    prompt: 'Enter a pull request URL',
+    placeHolder: 'https://github.com/owner/repo/pull/42',
+    validateInput: (value) => {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return 'URL cannot be empty';
+      }
+      if (!isSafeUrl(trimmed)) {
+        return 'Only http(s) URLs are supported.';
+      }
+      const watcher = prWatcherRegistry.findWatcherForUrl(trimmed);
+      if (!watcher) {
+        return 'Unsupported URL format. No registered PR watcher recognizes this URL.';
+      }
+      return undefined;
+    },
+  });
+
+  if (!url) {
+    return;
+  }
+
+  const trimmedUrl = url.trim();
+
+  try {
+    const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmedUrl);
+    if (!prWatcher) {
+      void vscode.window.showErrorMessage('Unsupported URL format. No registered PR watcher recognizes this URL.');
+      return;
+    }
+
+    const identifier = prWatcher.parsePRUrl(trimmedUrl);
+    await watcherService.startPRWatch(identifier);
+    void vscode.window.showInformationMessage(`Now watching PR: ${identifier.displayName}`);
+  } catch (err: unknown) {
+    handleCommandError('Failed to watch PR', err);
+  }
+}
+
 // Normalize argument: context menu passes WatchedRunNode, inline click passes WatchedRun
 function resolveWatchedRun(arg: unknown): WatchedRun | undefined {
   if (!arg || typeof arg !== 'object') {
@@ -955,8 +1011,27 @@ function resolveWatchedRun(arg: unknown): WatchedRun | undefined {
   return undefined;
 }
 
+// Normalize argument: context menu passes WatchedPRNode, inline click passes WatchedPR
+function resolveWatchedPR(arg: unknown): WatchedPR | undefined {
+  if (!arg || typeof arg !== 'object') {
+    return undefined;
+  }
+  if ('watchedPR' in arg) {
+    return (arg as { watchedPR: WatchedPR }).watchedPR;
+  }
+  if ('identifier' in arg && 'prState' in arg) {
+    return arg as WatchedPR;
+  }
+  return undefined;
+}
+
 async function handleDismissWatch(arg: unknown, watcherService: WatcherService): Promise<void> {
   try {
+    const watchedPR = resolveWatchedPR(arg);
+    if (watchedPR) {
+      watcherService.dismissPRWatch(watchedPR.identifier);
+      return;
+    }
     const watchedRun = resolveWatchedRun(arg);
     if (!watchedRun) {
       void vscode.window.showInformationMessage('Select a watch from the Watches view to dismiss.');
@@ -978,6 +1053,17 @@ async function handleDismissAllCompletedWatches(watcherService: WatcherService):
 
 async function handleOpenWatchUrl(arg: unknown): Promise<void> {
   try {
+    const watchedPR = resolveWatchedPR(arg);
+    if (watchedPR) {
+      const safeUrl = isSafeUrl(watchedPR.identifier.url);
+      if (!safeUrl) {
+        void vscode.window.showWarningMessage('Can only open http(s) URLs in the browser.');
+        return;
+      }
+      await vscode.env.openExternal(vscode.Uri.parse(safeUrl.href));
+      return;
+    }
+
     const watchedRun = resolveWatchedRun(arg);
     if (!watchedRun) {
       void vscode.window.showInformationMessage('Select a watch from the Watches view to open.');
@@ -1006,6 +1092,7 @@ export function registerCommands(
   providerRegistry: ProviderRegistry,
   labelCache: ProviderLabelCache,
   watcherRegistry: WatcherRegistry,
+  prWatcherRegistry: PRWatcherRegistry,
   watcherService: WatcherService,
   revealer?: ViewRevealer,
 ): void {
@@ -1095,7 +1182,9 @@ export function registerCommands(
       wrapCommand('Failed to switch watches layout', () => toggleViewLayout('watches'))),
     // Watch pipeline commands
     vscode.commands.registerCommand('devdocket.watchRun',
-      wrapCommand('Failed to watch pipeline run', () => handleWatchRun(watcherRegistry, watcherService))),
+      wrapCommand('Failed to watch pipeline run', () => handleWatchRun(watcherRegistry, prWatcherRegistry, watcherService))),
+    vscode.commands.registerCommand('devdocket.watchPR',
+      wrapCommand('Failed to watch PR', () => handleWatchPR(prWatcherRegistry, watcherService))),
     vscode.commands.registerCommand('devdocket.dismissWatch',
       wrapCommand('Failed to dismiss watch', (arg: unknown) => handleDismissWatch(arg, watcherService))),
     vscode.commands.registerCommand('devdocket.dismissAllCompletedWatches',

--- a/packages/core/src/commands/watchCommands.ts
+++ b/packages/core/src/commands/watchCommands.ts
@@ -131,6 +131,44 @@ function resolveWatchedPR(arg: unknown): WatchedPR | undefined {
   return undefined;
 }
 
+async function handleWatchPRFromItem(
+  prWatcherRegistry: PRWatcherRegistry,
+  watcherService: WatcherService,
+  arg: unknown,
+): Promise<void> {
+  const url = extractItemUrl(arg);
+  if (!url) {
+    void vscode.window.showWarningMessage('DevDocket: Select an item with a URL to watch its CI.');
+    return;
+  }
+
+  const safeUrl = isSafeUrl(url);
+  if (!safeUrl) {
+    void vscode.window.showWarningMessage('DevDocket: Only http(s) URLs are supported.');
+    return;
+  }
+
+  const prWatcher = prWatcherRegistry.findWatcherForUrl(safeUrl.href);
+  if (!prWatcher) {
+    void vscode.window.showWarningMessage('DevDocket: This item\'s URL is not recognized as a pull request.');
+    return;
+  }
+
+  const identifier = prWatcher.parsePRUrl(safeUrl.href);
+  await watcherService.startPRWatch(identifier);
+  void vscode.window.showInformationMessage(`Now watching PR: ${identifier.displayName}`);
+}
+
+function extractItemUrl(arg: unknown): string | undefined {
+  if (!arg || typeof arg !== 'object') {
+    return undefined;
+  }
+  if ('url' in arg && typeof (arg as { url: unknown }).url === 'string') {
+    return (arg as { url: string }).url;
+  }
+  return undefined;
+}
+
 async function handleDismissWatch(arg: unknown, watcherService: WatcherService): Promise<void> {
   try {
     // Try PR first
@@ -205,6 +243,8 @@ export function registerWatchCommands(
       wrapCommand('Failed to watch pipeline run', () => handleWatchRun(watcherRegistry, prWatcherRegistry, watcherService))),
     vscode.commands.registerCommand('devdocket.watchPR',
       wrapCommand('Failed to watch PR', () => handleWatchPR(prWatcherRegistry, watcherService))),
+    vscode.commands.registerCommand('devdocket.watchPRFromItem',
+      wrapCommand('Failed to watch PR from item', (arg: unknown) => handleWatchPRFromItem(prWatcherRegistry, watcherService, arg))),
     vscode.commands.registerCommand('devdocket.dismissWatch',
       wrapCommand('Failed to dismiss watch', (arg: unknown) => handleDismissWatch(arg, watcherService))),
     vscode.commands.registerCommand('devdocket.dismissAllCompletedWatches',

--- a/packages/core/src/commands/watchCommands.ts
+++ b/packages/core/src/commands/watchCommands.ts
@@ -1,11 +1,12 @@
 import * as vscode from 'vscode';
-import { WatcherService, type WatchedRun } from '../services/watcherService';
+import { WatcherService, type WatchedRun, type WatchedPR } from '../services/watcherService';
 import { WatcherRegistry } from '../services/watcherRegistry';
+import { PRWatcherRegistry } from '../services/prWatcherRegistry';
 import { showWatchesQuickPick } from '../views/watchesStatusBar';
 import { isSafeUrl } from '../utils/url';
 import { wrapCommand, handleCommandError } from './commandUtils';
 
-async function handleWatchRun(watcherRegistry: WatcherRegistry, watcherService: WatcherService): Promise<void> {
+async function handleWatchRun(watcherRegistry: WatcherRegistry, prWatcherRegistry: PRWatcherRegistry, watcherService: WatcherService): Promise<void> {
   const url = await vscode.window.showInputBox({
     prompt: 'Enter a pipeline run URL',
     placeHolder: 'https://github.com/owner/repo/actions/runs/123456789',
@@ -18,7 +19,8 @@ async function handleWatchRun(watcherRegistry: WatcherRegistry, watcherService: 
         return 'Only http(s) URLs are supported.';
       }
       const watcher = watcherRegistry.findWatcherForUrl(trimmed);
-      if (!watcher) {
+      const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmed);
+      if (!watcher && !prWatcher) {
         return 'Unsupported URL format. No registered watcher recognizes this URL.';
       }
       return undefined;
@@ -30,6 +32,19 @@ async function handleWatchRun(watcherRegistry: WatcherRegistry, watcherService: 
   }
 
   const trimmedUrl = url.trim();
+
+  // If a PR watcher recognizes the URL, redirect to PR watch flow
+  const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmedUrl);
+  if (prWatcher) {
+    try {
+      const identifier = prWatcher.parsePRUrl(trimmedUrl);
+      await watcherService.startPRWatch(identifier);
+      void vscode.window.showInformationMessage(`Now watching PR: ${identifier.displayName}`);
+    } catch (err: unknown) {
+      handleCommandError('Failed to watch PR', err);
+    }
+    return;
+  }
 
   try {
     const watcher = watcherRegistry.findWatcherForUrl(trimmedUrl);
@@ -47,6 +62,47 @@ async function handleWatchRun(watcherRegistry: WatcherRegistry, watcherService: 
   }
 }
 
+async function handleWatchPR(prWatcherRegistry: PRWatcherRegistry, watcherService: WatcherService): Promise<void> {
+  const url = await vscode.window.showInputBox({
+    prompt: 'Enter a pull request URL',
+    placeHolder: 'https://github.com/owner/repo/pull/42',
+    validateInput: (value) => {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return 'URL cannot be empty';
+      }
+      if (!isSafeUrl(trimmed)) {
+        return 'Only http(s) URLs are supported.';
+      }
+      const watcher = prWatcherRegistry.findWatcherForUrl(trimmed);
+      if (!watcher) {
+        return 'Unsupported URL format. No registered PR watcher recognizes this URL.';
+      }
+      return undefined;
+    },
+  });
+
+  if (!url) {
+    return;
+  }
+
+  const trimmedUrl = url.trim();
+
+  try {
+    const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmedUrl);
+    if (!prWatcher) {
+      void vscode.window.showErrorMessage('Unsupported URL format. No registered PR watcher recognizes this URL.');
+      return;
+    }
+
+    const identifier = prWatcher.parsePRUrl(trimmedUrl);
+    await watcherService.startPRWatch(identifier);
+    void vscode.window.showInformationMessage(`Now watching PR: ${identifier.displayName}`);
+  } catch (err: unknown) {
+    handleCommandError('Failed to watch PR', err);
+  }
+}
+
 // Normalize argument: context menu passes WatchedRunNode, inline click passes WatchedRun
 function resolveWatchedRun(arg: unknown): WatchedRun | undefined {
   if (!arg || typeof arg !== 'object') {
@@ -61,8 +117,28 @@ function resolveWatchedRun(arg: unknown): WatchedRun | undefined {
   return undefined;
 }
 
+// Normalize argument: context menu passes WatchedPRNode, inline click passes WatchedPR
+function resolveWatchedPR(arg: unknown): WatchedPR | undefined {
+  if (!arg || typeof arg !== 'object') {
+    return undefined;
+  }
+  if ('watchedPR' in arg) {
+    return (arg as { watchedPR: WatchedPR }).watchedPR;
+  }
+  if ('identifier' in arg && 'prState' in arg) {
+    return arg as WatchedPR;
+  }
+  return undefined;
+}
+
 async function handleDismissWatch(arg: unknown, watcherService: WatcherService): Promise<void> {
   try {
+    // Try PR first
+    const watchedPR = resolveWatchedPR(arg);
+    if (watchedPR) {
+      watcherService.dismissPRWatch(watchedPR.identifier);
+      return;
+    }
     const watchedRun = resolveWatchedRun(arg);
     if (!watchedRun) {
       void vscode.window.showInformationMessage('Select a watch from the Watches view to dismiss.');
@@ -84,6 +160,21 @@ async function handleDismissAllCompletedWatches(watcherService: WatcherService):
 
 async function handleOpenWatchUrl(arg: unknown): Promise<void> {
   try {
+    // Try PR first
+    const watchedPR = resolveWatchedPR(arg);
+    if (watchedPR) {
+      const safeUrl = isSafeUrl(watchedPR.identifier.url);
+      if (!safeUrl) {
+        void vscode.window.showWarningMessage('Can only open http(s) URLs in the browser.');
+        return;
+      }
+      const opened = await vscode.env.openExternal(vscode.Uri.parse(safeUrl.href));
+      if (!opened) {
+        void vscode.window.showWarningMessage('Failed to open URL in the browser.');
+      }
+      return;
+    }
+
     const watchedRun = resolveWatchedRun(arg);
     if (!watchedRun) {
       void vscode.window.showInformationMessage('Select a watch from the Watches view to open.');
@@ -106,11 +197,14 @@ async function handleOpenWatchUrl(arg: unknown): Promise<void> {
 export function registerWatchCommands(
   context: vscode.ExtensionContext,
   watcherRegistry: WatcherRegistry,
+  prWatcherRegistry: PRWatcherRegistry,
   watcherService: WatcherService,
 ): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('devdocket.watchRun',
-      wrapCommand('Failed to watch pipeline run', () => handleWatchRun(watcherRegistry, watcherService))),
+      wrapCommand('Failed to watch pipeline run', () => handleWatchRun(watcherRegistry, prWatcherRegistry, watcherService))),
+    vscode.commands.registerCommand('devdocket.watchPR',
+      wrapCommand('Failed to watch PR', () => handleWatchPR(prWatcherRegistry, watcherService))),
     vscode.commands.registerCommand('devdocket.dismissWatch',
       wrapCommand('Failed to dismiss watch', (arg: unknown) => handleDismissWatch(arg, watcherService))),
     vscode.commands.registerCommand('devdocket.dismissAllCompletedWatches',

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -10,6 +10,7 @@ import { ProviderRegistry } from './services/providerRegistry';
 import { checkAutoComplete, showAutoCompleteNotification } from './services/autoComplete';
 import { ActionRegistry } from './services/actionRegistry';
 import { WatcherRegistry } from './services/watcherRegistry';
+import { PRWatcherRegistry } from './services/prWatcherRegistry';
 import { WatcherService } from './services/watcherService';
 import { WatchStore } from './storage/watchStore';
 import { InboxTreeProvider } from './views/inboxTreeProvider';
@@ -30,7 +31,7 @@ import { syncProviderTitles } from './services/titleSync';
 import { getViewLayout, ViewId } from './views/viewLayout';
 import { performance } from 'perf_hooks';
 
-export type { DevDocketApi, DevDocketProvider, DevDocketAction, DiscoveredItem, Disposable, ActivityLogEntry, ActivityType, StateTransitionEvent } from './api/types';
+export type { DevDocketApi, DevDocketProvider, DevDocketAction, DiscoveredItem, Disposable, ActivityLogEntry, ActivityType, StateTransitionEvent, DevDocketPRWatcher } from './api/types';
 export { logger } from './services/logger';
 
 /** Wrap an event callback so unhandled errors (sync or async) are logged instead of crashing. */
@@ -393,9 +394,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const pr = new ProviderRegistry(ss, labelCache);
   const ar = new ActionRegistry();
   const wr = new WatcherRegistry(logger);
+  const pwr = new PRWatcherRegistry(logger);
   const watchStore = new WatchStore(storagePath);
-  const ws = new WatcherService(wr, watchStore, logger);
-  const api = new DevDocketApiImpl(pr, ar, wr, wg);
+  const ws = new WatcherService(wr, pwr, watchStore, logger);
+  const api = new DevDocketApiImpl(pr, ar, wr, pwr, wg);
   logger.info(`Store + service init took ${Math.round(performance.now() - initStart)}ms`);
 
   const treeViewStart = performance.now();
@@ -436,6 +438,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     { dispose: () => ss.dispose() },
     { dispose: () => ws.dispose() },
     { dispose: () => wr.dispose() },
+    { dispose: () => pwr.dispose() },
     { dispose: () => providers.inboxProvider.dispose() },
     { dispose: () => providers.queueProvider.dispose() },
     { dispose: () => providers.focusProvider.dispose() },
@@ -448,7 +451,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
 
   const commandRegStart = performance.now();
   const revealer = new ViewRevealer(wg, views.queueTreeView, views.focusTreeView, views.historyTreeView);
-  registerCommands(context, wg, ar, ss, pr, labelCache, wr, ws, revealer);
+  registerCommands(context, wg, ar, ss, pr, labelCache, wr, pwr, ws, revealer);
   logger.info(`Command registration took ${Math.round(performance.now() - commandRegStart)}ms`);
 
   // Set context keys and listen for layout changes

--- a/packages/core/src/services/prWatcherRegistry.ts
+++ b/packages/core/src/services/prWatcherRegistry.ts
@@ -1,0 +1,70 @@
+import * as vscode from 'vscode';
+import type { DevDocketPRWatcher } from '@devdocket/shared';
+
+/**
+ * Registry for DevDocketPRWatcher instances.
+ * Manages registration, lookup, and lifecycle of PR watchers.
+ */
+export class PRWatcherRegistry {
+  private watchers = new Map<string, DevDocketPRWatcher>();
+
+  constructor(private logger: { info: (msg: string) => void; warn: (msg: string) => void }) {}
+
+  /**
+   * Register a PR watcher.
+   * @param watcher - The watcher to register
+   * @returns Disposable that unregisters the watcher when disposed
+   * @throws If a watcher with the same ID is already registered
+   */
+  register(watcher: DevDocketPRWatcher): vscode.Disposable {
+    if (this.watchers.has(watcher.id)) {
+      const msg = `PR watcher with id '${watcher.id}' is already registered`;
+      this.logger.warn(msg);
+      throw new Error(msg);
+    }
+    this.watchers.set(watcher.id, watcher);
+    this.logger.info(`Registered PR watcher: ${watcher.id} (${watcher.label})`);
+
+    return new vscode.Disposable(() => {
+      if (this.watchers.get(watcher.id) === watcher) {
+        this.watchers.delete(watcher.id);
+        this.logger.info(`Unregistered PR watcher: ${watcher.id}`);
+      }
+    });
+  }
+
+  /**
+   * Get a watcher by ID.
+   */
+  get(id: string): DevDocketPRWatcher | undefined {
+    return this.watchers.get(id);
+  }
+
+  /**
+   * Find a watcher that can handle the given URL.
+   * @returns The first watcher that returns true from canWatch, or undefined
+   */
+  findWatcherForUrl(url: string): DevDocketPRWatcher | undefined {
+    for (const watcher of this.watchers.values()) {
+      try {
+        if (watcher.canWatch(url)) {
+          return watcher;
+        }
+      } catch (err) {
+        this.logger.warn(`PR watcher ${watcher.id} threw error in canWatch: ${err}`);
+      }
+    }
+    return undefined;
+  }
+
+  /**
+   * Get all registered watchers.
+   */
+  getAll(): DevDocketPRWatcher[] {
+    return Array.from(this.watchers.values());
+  }
+
+  dispose(): void {
+    this.watchers.clear();
+  }
+}

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -313,7 +313,7 @@ export class ProviderRegistry {
     const prev = this.healthStatus.get(providerId);
     const next: ProviderHealthStatus = {
       status,
-      lastRefreshTime: status === 'healthy' ? new Date(Date.now()) : prev?.lastRefreshTime,
+      lastRefreshTime: status === 'healthy' ? new Date() : prev?.lastRefreshTime,
       lastError: status === 'unhealthy' ? lastError : undefined,
     };
     this.healthStatus.set(providerId, next);

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -313,7 +313,7 @@ export class ProviderRegistry {
     const prev = this.healthStatus.get(providerId);
     const next: ProviderHealthStatus = {
       status,
-      lastRefreshTime: status === 'healthy' ? new Date() : prev?.lastRefreshTime,
+      lastRefreshTime: status === 'healthy' ? new Date(Date.now()) : prev?.lastRefreshTime,
       lastError: status === 'unhealthy' ? lastError : undefined,
     };
     this.healthStatus.set(providerId, next);

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -618,12 +618,11 @@ export class WatcherService implements vscode.Disposable {
     try {
       const existing = this.watches.get(runKey);
       if (existing && !existing.dismissed) {
-        // Already watched — just link to the PR
-        if (!existing.parentPRKey) {
-          existing.parentPRKey = prKey;
-        }
-        if (!prWatch.childRunKeys.includes(runKey)) {
-          prWatch.childRunKeys.push(runKey);
+        // Already watched as standalone or by another PR — don't re-parent
+        if (existing.parentPRKey === prKey) {
+          if (!prWatch.childRunKeys.includes(runKey)) {
+            prWatch.childRunKeys.push(runKey);
+          }
         }
         return;
       }

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -332,9 +332,22 @@ export class WatcherService implements vscode.Disposable {
    * Get active child runs for a PR watch.
    */
   getChildRuns(prKey: string): WatchedRun[] {
-    return Array.from(this.watches.values()).filter(
-      w => !w.dismissed && w.parentPRKey === prKey
-    );
+    const childRuns = new Map<string, WatchedRun>();
+    // Include runs tracked via childRunKeys (covers linked standalone watches)
+    const prWatch = this.prWatches.get(prKey);
+    for (const childRunKey of prWatch?.childRunKeys ?? []) {
+      const watch = this.watches.get(childRunKey);
+      if (watch && !watch.dismissed) {
+        childRuns.set(childRunKey, watch);
+      }
+    }
+    // Also include any runs explicitly parented by this PR
+    for (const [watchKey, watch] of this.watches.entries()) {
+      if (!watch.dismissed && watch.parentPRKey === prKey) {
+        childRuns.set(watchKey, watch);
+      }
+    }
+    return Array.from(childRuns.values());
   }
 
   /**

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -122,9 +122,9 @@ export class WatcherService implements vscode.Disposable {
     const key = this.getWatchKey(identifier);
     const existing = this.watches.get(key);
     if (existing && !existing.dismissed) {
-      // If being re-added by a PR watcher, just update parentPRKey
-      if (parentPRKey && !existing.parentPRKey) {
-        existing.parentPRKey = parentPRKey;
+      // If being re-added by a PR watcher, keep existing ownership unchanged
+      // to avoid converting a standalone watch into a PR-owned watch.
+      if (parentPRKey) {
         return existing;
       }
       throw new Error(`Already watching run: ${existing.identifier.displayName}`);
@@ -325,7 +325,18 @@ export class WatcherService implements vscode.Disposable {
    * Get active standalone watches (not dismissed, no parent PR).
    */
   getActiveStandaloneWatches(): WatchedRun[] {
-    return Array.from(this.watches.values()).filter(w => !w.dismissed && !w.parentPRKey);
+    // Collect run keys linked by any active PR
+    const prLinkedKeys = new Set<string>();
+    for (const prWatch of this.prWatches.values()) {
+      if (!prWatch.dismissed) {
+        for (const childKey of prWatch.childRunKeys) {
+          prLinkedKeys.add(childKey);
+        }
+      }
+    }
+    return Array.from(this.watches.values()).filter(
+      w => !w.dismissed && !w.parentPRKey && !prLinkedKeys.has(this.getWatchKey(w.identifier))
+    );
   }
 
   /**
@@ -378,7 +389,7 @@ export class WatcherService implements vscode.Disposable {
    * Get a unique key for a PR watch.
    */
   getPRWatchKey(identifier: PRIdentifier): string {
-    return `${identifier.providerId}:${identifier.repo}:${identifier.prId}`;
+    return `pr:${identifier.providerId}:${identifier.repo}:${identifier.prId}`;
   }
 
   /**
@@ -656,18 +667,13 @@ export class WatcherService implements vscode.Disposable {
     try {
       const existing = this.watches.get(runKey);
       if (existing && !existing.dismissed) {
-        let changed = false;
-        // Re-parent unowned standalone watches so they don't appear
-        // in both the standalone list and the PR's child list.
-        if (!existing.parentPRKey) {
-          existing.parentPRKey = prKey;
-          changed = true;
-        }
+        // Preserve ownership of existing watches. Standalone watches remain
+        // standalone even when linked from a PR watch.
         if (!prWatch.childRunKeys.includes(runKey)) {
           prWatch.childRunKeys.push(runKey);
-          changed = true;
+          return true;
         }
-        return changed;
+        return false;
       }
 
       await this.startWatch(runIdentifier, prKey, options);

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
-import type { RunIdentifier, RunStatus, JobStatus } from '@devdocket/shared';
+import type { RunIdentifier, RunStatus, JobStatus, PRIdentifier, PRState } from '@devdocket/shared';
 import { WatcherRegistry } from './watcherRegistry';
+import { PRWatcherRegistry } from './prWatcherRegistry';
 import { WatchStore } from '../storage/watchStore';
 
 /**
@@ -16,14 +17,33 @@ export interface WatchedRun {
   hasWarning?: boolean;
   /** Error message from last failed poll */
   errorMessage?: string;
+  /** Key of the parent PR watch, if this run is a child of a PR watch */
+  parentPRKey?: string;
 }
 
 /**
- * Service that manages watching pipeline runs.
+ * A watched pull request with its lifecycle state.
+ */
+export interface WatchedPR {
+  identifier: PRIdentifier;
+  prState: PRState;
+  childRunKeys: string[];
+  watchedAt: string; // ISO 8601 timestamp
+  lastPolledAt: string; // ISO 8601 timestamp
+  dismissed: boolean;
+  /** Set to true after 3 consecutive failures */
+  hasWarning?: boolean;
+  /** Error message from last failed poll */
+  errorMessage?: string;
+}
+
+/**
+ * Service that manages watching pipeline runs and pull requests.
  * Polls for status changes, detects job failures, and fires events.
  */
 export class WatcherService implements vscode.Disposable {
   private watches = new Map<string, WatchedRun>();
+  private prWatches = new Map<string, WatchedPR>();
   private pollTimer: NodeJS.Timeout | undefined;
   private isPollInFlight = false;
   private consecutiveFailures = new Map<string, number>();
@@ -37,8 +57,15 @@ export class WatcherService implements vscode.Disposable {
   private readonly _onDidCompleteRun = new vscode.EventEmitter<WatchedRun>();
   readonly onDidCompleteRun = this._onDidCompleteRun.event;
 
+  private readonly _onDidChangePRWatches = new vscode.EventEmitter<void>();
+  readonly onDidChangePRWatches = this._onDidChangePRWatches.event;
+
+  private readonly _onDidCompletePR = new vscode.EventEmitter<WatchedPR>();
+  readonly onDidCompletePR = this._onDidCompletePR.event;
+
   constructor(
     private watcherRegistry: WatcherRegistry,
+    private prWatcherRegistry: PRWatcherRegistry,
     private watchStore: WatchStore,
     private logger: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void }
   ) {}
@@ -47,19 +74,32 @@ export class WatcherService implements vscode.Disposable {
    * Load persisted watches from disk and resume polling for active ones.
    */
   async loadPersistedWatches(): Promise<void> {
-    const watches = await this.watchStore.loadAll();
-    // Only restore non-dismissed watches
+    const { runs: watches, prs } = await this.watchStore.loadAll();
+    // Restore non-dismissed run watches
     const restored = watches.filter(w => !w.dismissed);
     for (const watch of restored) {
       const key = this.getWatchKey(watch.identifier);
       this.watches.set(key, watch);
     }
-    if (restored.length > 0) {
-      this.logger.info(`Restored ${restored.length} persisted watch(es)`);
+
+    // Restore non-dismissed PR watches
+    const restoredPRs = prs.filter(pr => !pr.dismissed);
+    for (const pr of restoredPRs) {
+      const key = this.getPRWatchKey(pr.identifier);
+      this.prWatches.set(key, pr);
+    }
+
+    if (restored.length > 0 || restoredPRs.length > 0) {
+      this.logger.info(`Restored ${restored.length} run watch(es) and ${restoredPRs.length} PR watch(es)`);
       this._onDidChangeWatchedRuns.fire(this.getAllWatches());
+      if (restoredPRs.length > 0) {
+        this._onDidChangePRWatches.fire();
+      }
       // Resume polling for any that are still in progress
       const hasPollable = restored.some(
         w => w.status.overallState !== 'completed' && !w.hasWarning
+      ) || restoredPRs.some(
+        pr => pr.prState === 'open' && !pr.hasWarning
       );
       if (hasPollable) {
         this.ensurePollingActive();
@@ -70,13 +110,19 @@ export class WatcherService implements vscode.Disposable {
   /**
    * Start watching a pipeline run.
    * @param identifier - Run identifier from parseRunUrl
+   * @param parentPRKey - Optional key of the parent PR watch
    * @returns The newly watched run
    * @throws If run is already being watched or watcher not found
    */
-  async startWatch(identifier: RunIdentifier): Promise<WatchedRun> {
+  async startWatch(identifier: RunIdentifier, parentPRKey?: string): Promise<WatchedRun> {
     const key = this.getWatchKey(identifier);
     const existing = this.watches.get(key);
     if (existing && !existing.dismissed) {
+      // If being re-added by a PR watcher, just update parentPRKey
+      if (parentPRKey && !existing.parentPRKey) {
+        existing.parentPRKey = parentPRKey;
+        return existing;
+      }
       throw new Error(`Already watching run: ${existing.identifier.displayName}`);
     }
     // Remove dismissed watch to allow re-watching
@@ -103,6 +149,7 @@ export class WatcherService implements vscode.Disposable {
       watchedAt: now,
       lastPolledAt: now,
       dismissed: false,
+      parentPRKey,
     };
 
     this.watches.set(key, watchedRun);
@@ -121,6 +168,60 @@ export class WatcherService implements vscode.Disposable {
   }
 
   /**
+   * Start watching a pull request.
+   * @param identifier - PR identifier from parsePRUrl
+   * @returns The newly watched PR
+   * @throws If PR is already being watched
+   */
+  async startPRWatch(identifier: PRIdentifier): Promise<WatchedPR> {
+    const key = this.getPRWatchKey(identifier);
+    const existing = this.prWatches.get(key);
+    if (existing && !existing.dismissed) {
+      throw new Error(`Already watching PR: ${existing.identifier.displayName}`);
+    }
+    if (existing) {
+      this.prWatches.delete(key);
+    }
+
+    const prWatcher = this.prWatcherRegistry.get(identifier.providerId);
+    if (!prWatcher) {
+      throw new Error(`No PR watcher registered for provider: ${identifier.providerId}`);
+    }
+
+    // Fetch initial snapshot
+    const snapshot = await prWatcher.getPRRunsSnapshot(identifier);
+    const now = new Date().toISOString();
+
+    const watchedPR: WatchedPR = {
+      identifier,
+      prState: snapshot.prState,
+      childRunKeys: [],
+      watchedAt: now,
+      lastPolledAt: now,
+      dismissed: false,
+    };
+
+    this.prWatches.set(key, watchedPR);
+    this.consecutiveFailures.delete(key);
+    this.logger.info(`Started watching PR: ${identifier.displayName} (${identifier.providerId})`);
+
+    // Add initial runs as child watches
+    for (const runId of snapshot.runs) {
+      await this.addChildRun(key, watchedPR, runId);
+    }
+
+    this._onDidChangePRWatches.fire();
+    this._onDidChangeWatchedRuns.fire(this.getAllWatches());
+
+    if (snapshot.prState === 'open') {
+      this.ensurePollingActive();
+    }
+
+    this.persistWatches();
+    return watchedPR;
+  }
+
+  /**
    * Dismiss a watched run (hides it from the tree).
    */
   dismissWatch(identifier: RunIdentifier): void {
@@ -129,6 +230,28 @@ export class WatcherService implements vscode.Disposable {
     if (watch) {
       watch.dismissed = true;
       this.logger.info(`Dismissed watch: ${identifier.displayName}`);
+      this._onDidChangeWatchedRuns.fire(this.getAllWatches());
+      this.persistWatches();
+    }
+  }
+
+  /**
+   * Dismiss a watched PR and all its child runs.
+   */
+  dismissPRWatch(identifier: PRIdentifier): void {
+    const key = this.getPRWatchKey(identifier);
+    const prWatch = this.prWatches.get(key);
+    if (prWatch) {
+      prWatch.dismissed = true;
+      // Dismiss all child runs
+      for (const childKey of prWatch.childRunKeys) {
+        const childWatch = this.watches.get(childKey);
+        if (childWatch) {
+          childWatch.dismissed = true;
+        }
+      }
+      this.logger.info(`Dismissed PR watch: ${identifier.displayName}`);
+      this._onDidChangePRWatches.fire();
       this._onDidChangeWatchedRuns.fire(this.getAllWatches());
       this.persistWatches();
     }
@@ -145,8 +268,23 @@ export class WatcherService implements vscode.Disposable {
         dismissedCount++;
       }
     }
+    for (const prWatch of this.prWatches.values()) {
+      if ((prWatch.prState === 'merged' || prWatch.prState === 'closed') && !prWatch.dismissed) {
+        prWatch.dismissed = true;
+        // Dismiss child runs too
+        for (const childKey of prWatch.childRunKeys) {
+          const childWatch = this.watches.get(childKey);
+          if (childWatch && !childWatch.dismissed) {
+            childWatch.dismissed = true;
+            dismissedCount++;
+          }
+        }
+        dismissedCount++;
+      }
+    }
     if (dismissedCount > 0) {
       this.logger.info(`Dismissed ${dismissedCount} completed watch(es)`);
+      this._onDidChangePRWatches.fire();
       this._onDidChangeWatchedRuns.fire(this.getAllWatches());
       this.persistWatches();
     }
@@ -160,11 +298,36 @@ export class WatcherService implements vscode.Disposable {
   }
 
   /**
+   * Get all active PR watches (not dismissed).
+   */
+  getActivePRWatches(): WatchedPR[] {
+    return Array.from(this.prWatches.values()).filter(pr => !pr.dismissed);
+  }
+
+  /**
+   * Get active standalone watches (not dismissed, no parent PR).
+   */
+  getActiveStandaloneWatches(): WatchedRun[] {
+    return Array.from(this.watches.values()).filter(w => !w.dismissed && !w.parentPRKey);
+  }
+
+  /**
+   * Get active child runs for a PR watch.
+   */
+  getChildRuns(prKey: string): WatchedRun[] {
+    return Array.from(this.watches.values()).filter(
+      w => !w.dismissed && w.parentPRKey === prKey
+    );
+  }
+
+  /**
    * Get a human-friendly label for a provider by looking up its registered watcher.
    */
   getProviderLabel(providerId: string): string | undefined {
     const watcher = this.watcherRegistry.get(providerId);
-    return watcher?.label;
+    if (watcher) return watcher.label;
+    const prWatcher = this.prWatcherRegistry.get(providerId);
+    return prWatcher?.label;
   }
 
   /**
@@ -172,6 +335,20 @@ export class WatcherService implements vscode.Disposable {
    */
   getAllWatches(): WatchedRun[] {
     return Array.from(this.watches.values());
+  }
+
+  /**
+   * Get all PR watches including dismissed.
+   */
+  getAllPRWatches(): WatchedPR[] {
+    return Array.from(this.prWatches.values());
+  }
+
+  /**
+   * Get a unique key for a PR watch.
+   */
+  getPRWatchKey(identifier: PRIdentifier): string {
+    return `${identifier.providerId}:${identifier.repo}:${identifier.prId}`;
   }
 
   /**
@@ -222,102 +399,232 @@ export class WatcherService implements vscode.Disposable {
       return;
     }
 
-    const activeWatches = this.getActiveWatches();
-    // Only poll watches that are still in progress and haven't hit the failure threshold.
-    // Completed watches stay visible until dismissed; warned watches need manual re-watch.
-    const pollableWatches = activeWatches.filter(
-      w => w.status.overallState !== 'completed' && !w.hasWarning
-    );
-    if (pollableWatches.length === 0) {
-      this.stopPolling();
-      return;
-    }
-
     this.isPollInFlight = true;
     try {
       let anyChanged = false;
-      
-      for (const watch of pollableWatches) {
 
-        try {
-          const watcher = this.watcherRegistry.get(watch.identifier.providerId);
-          if (!watcher) {
-            throw new Error(`Watcher '${watch.identifier.providerId}' is no longer registered`);
-          }
+      // Phase 1: Poll PR watches first — may add/remove child runs
+      const prChanged = await this.pollPRWatches();
+      anyChanged = anyChanged || prChanged;
 
-          const newStatus = await watcher.getRunStatus(watch.identifier);
-          watch.lastPolledAt = new Date().toISOString();
-          
-          // Reset failure count on success
-          const key = this.getWatchKey(watch.identifier);
-          this.consecutiveFailures.delete(key);
-          watch.hasWarning = false;
-          watch.errorMessage = undefined;
-
-          // Snapshot old status for comparison, then update immediately
-          // so event subscribers always see current data.
-          const oldStatus = watch.status;
-          const statusChanged = oldStatus.overallState !== newStatus.overallState
-            || oldStatus.conclusion !== newStatus.conclusion
-            || oldStatus.jobs.length !== newStatus.jobs.length
-            || newStatus.jobs.some(newJob => {
-              const oldJob = newJob.id
-                ? oldStatus.jobs.find(j => j.id === newJob.id)
-                : oldStatus.jobs.find(j => j.name === newJob.name);
-              return !oldJob || oldJob.state !== newJob.state || oldJob.conclusion !== newJob.conclusion;
-            });
-          watch.status = newStatus;
-          // Update display name if the watcher returned one
-          if (newStatus.displayName && newStatus.displayName !== watch.identifier.displayName) {
-            watch.identifier.displayName = newStatus.displayName;
-            anyChanged = true;
-          }
-          if (statusChanged) {
-            anyChanged = true;
-          }
-
-          // Detect job failures (while run is still in progress)
-          if (newStatus.overallState !== 'completed') {
-            for (const newJob of newStatus.jobs) {
-              if (newJob.state === 'completed' && newJob.conclusion === 'failure') {
-                const oldJob = newJob.id
-                  ? oldStatus.jobs.find(j => j.id === newJob.id)
-                  : oldStatus.jobs.find(j => j.name === newJob.name);
-                if (!oldJob || oldJob.state !== 'completed' || oldJob.conclusion !== 'failure') {
-                  this._onDidDetectJobFailure.fire({ run: watch, job: newJob });
-                }
-              }
-            }
-          }
-
-          // Check if run just completed
-          if (oldStatus.overallState !== 'completed' && newStatus.overallState === 'completed') {
-            this._onDidCompleteRun.fire(watch);
-          }
-
-        } catch (err) {
-          const key = this.getWatchKey(watch.identifier);
-          const failures = (this.consecutiveFailures.get(key) || 0) + 1;
-          this.consecutiveFailures.set(key, failures);
-          
-          if (failures >= 3) {
-            watch.hasWarning = true;
-            watch.errorMessage = err instanceof Error ? err.message : String(err);
-            anyChanged = true;
-            this.logger.warn(`3 consecutive failures for ${watch.identifier.displayName}, marking with warning`);
-          } else {
-            this.logger.warn(`Poll failed for ${watch.identifier.displayName} (attempt ${failures}/3): ${err}`);
-          }
-        }
-      }
+      // Phase 2: Poll run watches (including newly added child runs)
+      const runChanged = await this.pollRunWatches();
+      anyChanged = anyChanged || runChanged;
 
       if (anyChanged) {
         this._onDidChangeWatchedRuns.fire(this.getAllWatches());
         this.persistWatches();
       }
 
+      // Check if anything is still pollable
+      const hasPollableRuns = this.getActiveWatches().some(
+        w => w.status.overallState !== 'completed' && !w.hasWarning
+      );
+      const hasPollablePRs = this.getActivePRWatches().some(
+        pr => pr.prState === 'open' && !pr.hasWarning
+      );
+      if (!hasPollableRuns && !hasPollablePRs) {
+        this.stopPolling();
+      }
     } finally {
       this.isPollInFlight = false;
+    }
+  }
+
+  /**
+   * Poll PR watches for state changes and run updates.
+   */
+  private async pollPRWatches(): Promise<boolean> {
+    const activePRs = this.getActivePRWatches().filter(
+      pr => pr.prState === 'open' && !pr.hasWarning
+    );
+    if (activePRs.length === 0) return false;
+
+    let anyChanged = false;
+
+    for (const prWatch of activePRs) {
+      const key = this.getPRWatchKey(prWatch.identifier);
+      try {
+        const prWatcher = this.prWatcherRegistry.get(prWatch.identifier.providerId);
+        if (!prWatcher) {
+          throw new Error(`PR watcher '${prWatch.identifier.providerId}' is no longer registered`);
+        }
+
+        const snapshot = await prWatcher.getPRRunsSnapshot(prWatch.identifier);
+        prWatch.lastPolledAt = new Date().toISOString();
+
+        // Reset failure count
+        this.consecutiveFailures.delete(key);
+        prWatch.hasWarning = false;
+        prWatch.errorMessage = undefined;
+
+        // Handle new/removed runs
+        const currentRunKeys = new Set(prWatch.childRunKeys);
+        const newRunKeys = new Set<string>();
+        for (const runId of snapshot.runs) {
+          const runKey = this.getWatchKey(runId);
+          newRunKeys.add(runKey);
+          if (!currentRunKeys.has(runKey)) {
+            // New run discovered
+            await this.addChildRun(key, prWatch, runId);
+            anyChanged = true;
+          }
+        }
+
+        // Remove orphaned child runs
+        for (const childKey of currentRunKeys) {
+          if (!newRunKeys.has(childKey)) {
+            const childWatch = this.watches.get(childKey);
+            if (childWatch && !childWatch.dismissed) {
+              childWatch.dismissed = true;
+              anyChanged = true;
+            }
+            prWatch.childRunKeys = prWatch.childRunKeys.filter(k => k !== childKey);
+          }
+        }
+
+        // Check PR state transitions
+        if (snapshot.prState !== prWatch.prState) {
+          prWatch.prState = snapshot.prState;
+          anyChanged = true;
+          if (snapshot.prState === 'merged' || snapshot.prState === 'closed') {
+            this._onDidCompletePR.fire(prWatch);
+          }
+          this._onDidChangePRWatches.fire();
+        }
+
+      } catch (err) {
+        const failures = (this.consecutiveFailures.get(key) || 0) + 1;
+        this.consecutiveFailures.set(key, failures);
+
+        if (failures >= 3) {
+          prWatch.hasWarning = true;
+          prWatch.errorMessage = err instanceof Error ? err.message : String(err);
+          anyChanged = true;
+          this._onDidChangePRWatches.fire();
+          this.logger.warn(`3 consecutive failures for PR ${prWatch.identifier.displayName}, marking with warning`);
+        } else {
+          this.logger.warn(`PR poll failed for ${prWatch.identifier.displayName} (attempt ${failures}/3): ${err}`);
+        }
+      }
+    }
+
+    return anyChanged;
+  }
+
+  /**
+   * Poll run watches for status updates.
+   */
+  private async pollRunWatches(): Promise<boolean> {
+    const activeWatches = this.getActiveWatches();
+    const pollableWatches = activeWatches.filter(
+      w => w.status.overallState !== 'completed' && !w.hasWarning
+    );
+    if (pollableWatches.length === 0) return false;
+
+    let anyChanged = false;
+
+    for (const watch of pollableWatches) {
+
+      try {
+        const watcher = this.watcherRegistry.get(watch.identifier.providerId);
+        if (!watcher) {
+          throw new Error(`Watcher '${watch.identifier.providerId}' is no longer registered`);
+        }
+
+        const newStatus = await watcher.getRunStatus(watch.identifier);
+        watch.lastPolledAt = new Date().toISOString();
+        
+        // Reset failure count on success
+        const key = this.getWatchKey(watch.identifier);
+        this.consecutiveFailures.delete(key);
+        watch.hasWarning = false;
+        watch.errorMessage = undefined;
+
+        // Snapshot old status for comparison, then update immediately
+        // so event subscribers always see current data.
+        const oldStatus = watch.status;
+        const statusChanged = oldStatus.overallState !== newStatus.overallState
+          || oldStatus.conclusion !== newStatus.conclusion
+          || oldStatus.jobs.length !== newStatus.jobs.length
+          || newStatus.jobs.some(newJob => {
+            const oldJob = newJob.id
+              ? oldStatus.jobs.find(j => j.id === newJob.id)
+              : oldStatus.jobs.find(j => j.name === newJob.name);
+            return !oldJob || oldJob.state !== newJob.state || oldJob.conclusion !== newJob.conclusion;
+          });
+        watch.status = newStatus;
+        // Update display name if the watcher returned one
+        if (newStatus.displayName && newStatus.displayName !== watch.identifier.displayName) {
+          watch.identifier.displayName = newStatus.displayName;
+          anyChanged = true;
+        }
+        if (statusChanged) {
+          anyChanged = true;
+        }
+
+        // Detect job failures (while run is still in progress)
+        if (newStatus.overallState !== 'completed') {
+          for (const newJob of newStatus.jobs) {
+            if (newJob.state === 'completed' && newJob.conclusion === 'failure') {
+              const oldJob = newJob.id
+                ? oldStatus.jobs.find(j => j.id === newJob.id)
+                : oldStatus.jobs.find(j => j.name === newJob.name);
+              if (!oldJob || oldJob.state !== 'completed' || oldJob.conclusion !== 'failure') {
+                this._onDidDetectJobFailure.fire({ run: watch, job: newJob });
+              }
+            }
+          }
+        }
+
+        // Check if run just completed
+        if (oldStatus.overallState !== 'completed' && newStatus.overallState === 'completed') {
+          this._onDidCompleteRun.fire(watch);
+        }
+
+      } catch (err) {
+        const key = this.getWatchKey(watch.identifier);
+        const failures = (this.consecutiveFailures.get(key) || 0) + 1;
+        this.consecutiveFailures.set(key, failures);
+        
+        if (failures >= 3) {
+          watch.hasWarning = true;
+          watch.errorMessage = err instanceof Error ? err.message : String(err);
+          anyChanged = true;
+          this.logger.warn(`3 consecutive failures for ${watch.identifier.displayName}, marking with warning`);
+        } else {
+          this.logger.warn(`Poll failed for ${watch.identifier.displayName} (attempt ${failures}/3): ${err}`);
+        }
+      }
+    }
+
+    return anyChanged;
+  }
+
+  /**
+   * Add a child run to a PR watch, starting a new watch for it.
+   */
+  private async addChildRun(prKey: string, prWatch: WatchedPR, runIdentifier: RunIdentifier): Promise<void> {
+    const runKey = this.getWatchKey(runIdentifier);
+    try {
+      const existing = this.watches.get(runKey);
+      if (existing && !existing.dismissed) {
+        // Already watched — just link to the PR
+        if (!existing.parentPRKey) {
+          existing.parentPRKey = prKey;
+        }
+        if (!prWatch.childRunKeys.includes(runKey)) {
+          prWatch.childRunKeys.push(runKey);
+        }
+        return;
+      }
+
+      await this.startWatch(runIdentifier, prKey);
+      if (!prWatch.childRunKeys.includes(runKey)) {
+        prWatch.childRunKeys.push(runKey);
+      }
+    } catch (err) {
+      this.logger.warn(`Failed to add child run ${runIdentifier.displayName} for PR ${prWatch.identifier.displayName}: ${err}`);
     }
   }
 
@@ -331,7 +638,7 @@ export class WatcherService implements vscode.Disposable {
   }
 
   private persistWatches(): void {
-    this.watchStore.saveAll(this.getAllWatches()).catch(err => {
+    this.watchStore.saveAll(this.getAllWatches(), this.getAllPRWatches()).catch(err => {
       this.logger.error(`Failed to persist watches: ${err}`);
     });
   }
@@ -341,7 +648,10 @@ export class WatcherService implements vscode.Disposable {
     this._onDidChangeWatchedRuns.dispose();
     this._onDidDetectJobFailure.dispose();
     this._onDidCompleteRun.dispose();
+    this._onDidChangePRWatches.dispose();
+    this._onDidCompletePR.dispose();
     this.watches.clear();
+    this.prWatches.clear();
     this.consecutiveFailures.clear();
   }
 }

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -114,7 +114,11 @@ export class WatcherService implements vscode.Disposable {
    * @returns The newly watched run
    * @throws If run is already being watched or watcher not found
    */
-  async startWatch(identifier: RunIdentifier, parentPRKey?: string): Promise<WatchedRun> {
+  async startWatch(
+    identifier: RunIdentifier,
+    parentPRKey?: string,
+    options?: { suppressEvents?: boolean; suppressPersist?: boolean },
+  ): Promise<WatchedRun> {
     const key = this.getWatchKey(identifier);
     const existing = this.watches.get(key);
     if (existing && !existing.dismissed) {
@@ -156,14 +160,18 @@ export class WatcherService implements vscode.Disposable {
     this.consecutiveFailures.delete(key);
     this.logger.info(`Started watching: ${identifier.displayName} (${identifier.providerId})`);
     
-    this._onDidChangeWatchedRuns.fire(this.getAllWatches());
+    if (!options?.suppressEvents) {
+      this._onDidChangeWatchedRuns.fire(this.getAllWatches());
+    }
     
     // Start polling if the watch is pollable (not already completed)
     if (watchedRun.status.overallState !== 'completed') {
       this.ensurePollingActive();
     }
     
-    this.persistWatches();
+    if (!options?.suppressPersist) {
+      this.persistWatches();
+    }
     return watchedRun;
   }
 
@@ -208,9 +216,12 @@ export class WatcherService implements vscode.Disposable {
     this.consecutiveFailures.delete(key);
     this.logger.info(`Started watching PR: ${identifier.displayName} (${identifier.providerId})`);
 
-    // Add initial runs as child watches
+    // Add initial runs as child watches (batched — single event/persist after)
     for (const runId of snapshot.runs) {
-      await this.addChildRun(key, watchedPR, runId);
+      await this.addChildRun(key, watchedPR, runId, {
+        suppressEvents: true,
+        suppressPersist: true,
+      });
     }
 
     this._onDidChangePRWatches.fire();
@@ -407,18 +418,18 @@ export class WatcherService implements vscode.Disposable {
       let anyChanged = false;
 
       // Phase 1: Poll PR watches first — may add/remove child runs
-      const prChanged = await this.pollPRWatches();
-      anyChanged = anyChanged || prChanged;
+      const prResult = await this.pollPRWatches();
+      anyChanged = anyChanged || prResult.prChanged || prResult.childRunChanged;
 
       // Phase 2: Poll run watches (including newly added child runs)
       const runChanged = await this.pollRunWatches();
       anyChanged = anyChanged || runChanged;
 
-      if (prChanged) {
+      if (prResult.prChanged) {
         this._onDidChangePRWatches.fire();
       }
 
-      if (runChanged) {
+      if (runChanged || prResult.childRunChanged) {
         this._onDidChangeWatchedRuns.fire(this.getAllWatches());
       }
 
@@ -443,14 +454,16 @@ export class WatcherService implements vscode.Disposable {
 
   /**
    * Poll PR watches for state changes and run updates.
+   * @returns Object indicating whether PR metadata or child runs changed
    */
-  private async pollPRWatches(): Promise<boolean> {
+  private async pollPRWatches(): Promise<{ prChanged: boolean; childRunChanged: boolean }> {
     const activePRs = this.getActivePRWatches().filter(
       pr => pr.prState === 'open' && !pr.hasWarning
     );
-    if (activePRs.length === 0) return false;
+    if (activePRs.length === 0) return { prChanged: false, childRunChanged: false };
 
-    let anyChanged = false;
+    let prChanged = false;
+    let childRunChanged = false;
 
     for (const prWatch of activePRs) {
       const key = this.getPRWatchKey(prWatch.identifier);
@@ -466,7 +479,7 @@ export class WatcherService implements vscode.Disposable {
         // Apply updated display name from snapshot
         if (snapshot.displayName && snapshot.displayName !== prWatch.identifier.displayName) {
           prWatch.identifier.displayName = snapshot.displayName;
-          anyChanged = true;
+          prChanged = true;
         }
 
         // Reset failure count
@@ -481,9 +494,10 @@ export class WatcherService implements vscode.Disposable {
           const runKey = this.getWatchKey(runId);
           newRunKeys.add(runKey);
           if (!currentRunKeys.has(runKey)) {
-            // New run discovered
-            await this.addChildRun(key, prWatch, runId);
-            anyChanged = true;
+            const added = await this.addChildRun(key, prWatch, runId);
+            if (added) {
+              childRunChanged = true;
+            }
           }
         }
 
@@ -493,7 +507,7 @@ export class WatcherService implements vscode.Disposable {
             const childWatch = this.watches.get(childKey);
             if (childWatch && !childWatch.dismissed) {
               childWatch.dismissed = true;
-              anyChanged = true;
+              childRunChanged = true;
             }
             prWatch.childRunKeys = prWatch.childRunKeys.filter(k => k !== childKey);
           }
@@ -502,7 +516,7 @@ export class WatcherService implements vscode.Disposable {
         // Check PR state transitions
         if (snapshot.prState !== prWatch.prState) {
           prWatch.prState = snapshot.prState;
-          anyChanged = true;
+          prChanged = true;
           if (snapshot.prState === 'merged' || snapshot.prState === 'closed') {
             this._onDidCompletePR.fire(prWatch);
           }
@@ -515,7 +529,7 @@ export class WatcherService implements vscode.Disposable {
         if (failures >= 3) {
           prWatch.hasWarning = true;
           prWatch.errorMessage = err instanceof Error ? err.message : String(err);
-          anyChanged = true;
+          prChanged = true;
           this.logger.warn(`3 consecutive failures for PR ${prWatch.identifier.displayName}, marking with warning`);
         } else {
           this.logger.warn(`PR poll failed for ${prWatch.identifier.displayName} (attempt ${failures}/3): ${err}`);
@@ -523,7 +537,7 @@ export class WatcherService implements vscode.Disposable {
       }
     }
 
-    return anyChanged;
+    return { prChanged, childRunChanged };
   }
 
   /**
@@ -617,27 +631,35 @@ export class WatcherService implements vscode.Disposable {
 
   /**
    * Add a child run to a PR watch, starting a new watch for it.
+   * @returns true if the PR's child run list actually changed
    */
-  private async addChildRun(prKey: string, prWatch: WatchedPR, runIdentifier: RunIdentifier): Promise<void> {
+  private async addChildRun(
+    prKey: string,
+    prWatch: WatchedPR,
+    runIdentifier: RunIdentifier,
+    options?: { suppressEvents?: boolean; suppressPersist?: boolean },
+  ): Promise<boolean> {
     const runKey = this.getWatchKey(runIdentifier);
     try {
       const existing = this.watches.get(runKey);
       if (existing && !existing.dismissed) {
-        // Already watched as standalone or by another PR — don't re-parent
-        if (existing.parentPRKey === prKey) {
-          if (!prWatch.childRunKeys.includes(runKey)) {
-            prWatch.childRunKeys.push(runKey);
-          }
+        // Already watched — record association without re-parenting
+        if (!prWatch.childRunKeys.includes(runKey)) {
+          prWatch.childRunKeys.push(runKey);
+          return true;
         }
-        return;
+        return false;
       }
 
-      await this.startWatch(runIdentifier, prKey);
+      await this.startWatch(runIdentifier, prKey, options);
       if (!prWatch.childRunKeys.includes(runKey)) {
         prWatch.childRunKeys.push(runKey);
+        return true;
       }
+      return false;
     } catch (err) {
       this.logger.warn(`Failed to add child run ${runIdentifier.displayName} for PR ${prWatch.identifier.displayName}: ${err}`);
+      return false;
     }
   }
 

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -190,6 +190,9 @@ export class WatcherService implements vscode.Disposable {
 
     // Fetch initial snapshot
     const snapshot = await prWatcher.getPRRunsSnapshot(identifier);
+    if (snapshot.displayName) {
+      identifier.displayName = snapshot.displayName;
+    }
     const now = new Date().toISOString();
 
     const watchedPR: WatchedPR = {
@@ -452,6 +455,12 @@ export class WatcherService implements vscode.Disposable {
 
         const snapshot = await prWatcher.getPRRunsSnapshot(prWatch.identifier);
         prWatch.lastPolledAt = new Date().toISOString();
+
+        // Apply updated display name from snapshot
+        if (snapshot.displayName && snapshot.displayName !== prWatch.identifier.displayName) {
+          prWatch.identifier.displayName = snapshot.displayName;
+          anyChanged = true;
+        }
 
         // Reset failure count
         this.consecutiveFailures.delete(key);

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -286,11 +286,12 @@ export class WatcherService implements vscode.Disposable {
     }
     for (const prWatch of this.prWatches.values()) {
       if ((prWatch.prState === 'merged' || prWatch.prState === 'closed') && !prWatch.dismissed) {
+        const key = this.getPRWatchKey(prWatch.identifier);
         prWatch.dismissed = true;
-        // Dismiss child runs too
+        // Only dismiss child runs actually owned by this PR
         for (const childKey of prWatch.childRunKeys) {
           const childWatch = this.watches.get(childKey);
-          if (childWatch && !childWatch.dismissed) {
+          if (childWatch && !childWatch.dismissed && childWatch.parentPRKey === key) {
             childWatch.dismissed = true;
             dismissedCount++;
           }

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -715,11 +715,15 @@ export class WatcherService implements vscode.Disposable {
 
     const watcher = this.watcherRegistry.findWatcherForUrl(identifier.url);
     if (watcher) {
-      const parsed = watcher.parseRunUrl(identifier.url);
-      return {
-        ...parsed,
-        displayName: identifier.displayName || parsed.displayName,
-      };
+      try {
+        const parsed = watcher.parseRunUrl(identifier.url);
+        return {
+          ...parsed,
+          displayName: identifier.displayName || parsed.displayName,
+        };
+      } catch (err) {
+        this.logger.warn(`URL matched watcher '${watcher.id}' but parseRunUrl failed for ${identifier.url}: ${err}`);
+      }
     }
 
     return identifier;

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -415,15 +415,11 @@ export class WatcherService implements vscode.Disposable {
 
     this.isPollInFlight = true;
     try {
-      let anyChanged = false;
-
       // Phase 1: Poll PR watches first — may add/remove child runs
       const prResult = await this.pollPRWatches();
-      anyChanged = anyChanged || prResult.prChanged || prResult.childRunChanged;
 
       // Phase 2: Poll run watches (including newly added child runs)
       const runChanged = await this.pollRunWatches();
-      anyChanged = anyChanged || runChanged;
 
       if (prResult.prChanged) {
         this._onDidChangePRWatches.fire();
@@ -433,6 +429,7 @@ export class WatcherService implements vscode.Disposable {
         this._onDidChangeWatchedRuns.fire(this.getAllWatches());
       }
 
+      const anyChanged = prResult.prChanged || prResult.childRunChanged || runChanged;
       if (anyChanged) {
         this.persistWatches();
       }

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -656,12 +656,18 @@ export class WatcherService implements vscode.Disposable {
     try {
       const existing = this.watches.get(runKey);
       if (existing && !existing.dismissed) {
-        // Already watched — record association without re-parenting
+        let changed = false;
+        // Re-parent unowned standalone watches so they don't appear
+        // in both the standalone list and the PR's child list.
+        if (!existing.parentPRKey) {
+          existing.parentPRKey = prKey;
+          changed = true;
+        }
         if (!prWatch.childRunKeys.includes(runKey)) {
           prWatch.childRunKeys.push(runKey);
-          return true;
+          changed = true;
         }
-        return false;
+        return changed;
       }
 
       await this.startWatch(runIdentifier, prKey, options);

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -218,7 +218,8 @@ export class WatcherService implements vscode.Disposable {
 
     // Add initial runs as child watches (batched — single event/persist after)
     for (const runId of snapshot.runs) {
-      await this.addChildRun(key, watchedPR, runId, {
+      const resolved = this.resolveRunIdentifier(runId);
+      await this.addChildRun(key, watchedPR, resolved, {
         suppressEvents: true,
         suppressPersist: true,
       });
@@ -515,10 +516,11 @@ export class WatcherService implements vscode.Disposable {
         const currentRunKeys = new Set(prWatch.childRunKeys);
         const newRunKeys = new Set<string>();
         for (const runId of snapshot.runs) {
-          const runKey = this.getWatchKey(runId);
+          const resolved = this.resolveRunIdentifier(runId);
+          const runKey = this.getWatchKey(resolved);
           newRunKeys.add(runKey);
           if (!currentRunKeys.has(runKey)) {
-            const added = await this.addChildRun(key, prWatch, runId);
+            const added = await this.addChildRun(key, prWatch, resolved);
             if (added) {
               childRunChanged = true;
             }
@@ -695,6 +697,29 @@ export class WatcherService implements vscode.Disposable {
     return identifier.repo
       ? `${identifier.providerId}:${identifier.repo}:${identifier.runId}`
       : `${identifier.providerId}:${identifier.runId}`;
+  }
+
+  /**
+   * Resolve a run identifier to one backed by a registered watcher.
+   * If the identifier's providerId matches a registered watcher directly, returns as-is.
+   * Otherwise, tries URL-based matching against all registered run watchers.
+   * Returns the resolved identifier, or the original if no resolution is possible.
+   */
+  private resolveRunIdentifier(identifier: RunIdentifier): RunIdentifier {
+    if (this.watcherRegistry.get(identifier.providerId)) {
+      return identifier;
+    }
+
+    const watcher = this.watcherRegistry.findWatcherForUrl(identifier.url);
+    if (watcher) {
+      const parsed = watcher.parseRunUrl(identifier.url);
+      return {
+        ...parsed,
+        displayName: identifier.displayName || parsed.displayName,
+      };
+    }
+
+    return identifier;
   }
 
   private persistWatches(): void {

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -250,17 +250,19 @@ export class WatcherService implements vscode.Disposable {
   }
 
   /**
-   * Dismiss a watched PR and all its child runs.
+   * Dismiss a watched PR and its owned child runs.
+   * Runs not owned by this PR (standalone or owned by another PR) are
+   * unlinked but not dismissed.
    */
   dismissPRWatch(identifier: PRIdentifier): void {
     const key = this.getPRWatchKey(identifier);
     const prWatch = this.prWatches.get(key);
     if (prWatch) {
       prWatch.dismissed = true;
-      // Dismiss all child runs
+      // Only dismiss child runs actually owned by this PR
       for (const childKey of prWatch.childRunKeys) {
         const childWatch = this.watches.get(childKey);
-        if (childWatch) {
+        if (childWatch && childWatch.parentPRKey === key) {
           childWatch.dismissed = true;
         }
       }
@@ -498,11 +500,11 @@ export class WatcherService implements vscode.Disposable {
           }
         }
 
-        // Remove orphaned child runs
+        // Remove orphaned child runs (only dismiss runs owned by this PR)
         for (const childKey of currentRunKeys) {
           if (!newRunKeys.has(childKey)) {
             const childWatch = this.watches.get(childKey);
-            if (childWatch && !childWatch.dismissed) {
+            if (childWatch && !childWatch.dismissed && childWatch.parentPRKey === key) {
               childWatch.dismissed = true;
               childRunChanged = true;
             }

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -414,8 +414,15 @@ export class WatcherService implements vscode.Disposable {
       const runChanged = await this.pollRunWatches();
       anyChanged = anyChanged || runChanged;
 
-      if (anyChanged) {
+      if (prChanged) {
+        this._onDidChangePRWatches.fire();
+      }
+
+      if (runChanged) {
         this._onDidChangeWatchedRuns.fire(this.getAllWatches());
+      }
+
+      if (anyChanged) {
         this.persistWatches();
       }
 

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -506,7 +506,6 @@ export class WatcherService implements vscode.Disposable {
           if (snapshot.prState === 'merged' || snapshot.prState === 'closed') {
             this._onDidCompletePR.fire(prWatch);
           }
-          this._onDidChangePRWatches.fire();
         }
 
       } catch (err) {
@@ -517,7 +516,6 @@ export class WatcherService implements vscode.Disposable {
           prWatch.hasWarning = true;
           prWatch.errorMessage = err instanceof Error ? err.message : String(err);
           anyChanged = true;
-          this._onDidChangePRWatches.fire();
           this.logger.warn(`3 consecutive failures for PR ${prWatch.identifier.displayName}, marking with warning`);
         } else {
           this.logger.warn(`PR poll failed for ${prWatch.identifier.displayName} (attempt ${failures}/3): ${err}`);

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -520,7 +520,10 @@ export class WatcherService implements vscode.Disposable {
           const runKey = this.getWatchKey(resolved);
           newRunKeys.add(runKey);
           if (!currentRunKeys.has(runKey)) {
-            const added = await this.addChildRun(key, prWatch, resolved);
+            const added = await this.addChildRun(key, prWatch, resolved, {
+              suppressEvents: true,
+              suppressPersist: true,
+            });
             if (added) {
               childRunChanged = true;
             }

--- a/packages/core/src/storage/watchStore.ts
+++ b/packages/core/src/storage/watchStore.ts
@@ -1,14 +1,25 @@
 import * as path from 'path';
 import { logger } from '../services/logger';
 import { SerializedJsonStore } from './serializedJsonStore';
-import type { WatchedRun } from '../services/watcherService';
+import type { WatchedRun, WatchedPR } from '../services/watcherService';
 
 const WATCHES_FILE = 'watches.json';
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
 
 /**
- * Persists watched pipeline runs as a JSON array on disk.
+ * On-disk shape: either a legacy plain array of WatchedRun, or the
+ * new envelope with separate `runs` and `prs` arrays.
+ */
+interface WatchStoreData {
+  runs: WatchedRun[];
+  prs: WatchedPR[];
+}
+
+/**
+ * Persists watched pipeline runs and PR watches as JSON on disk.
  * Extends SerializedJsonStore for write-queue serialization and JSON helpers.
+ *
+ * Migrates legacy files (plain JSON array) to the new envelope format.
  */
 export class WatchStore extends SerializedJsonStore {
   private readonly filePath: string;
@@ -19,40 +30,65 @@ export class WatchStore extends SerializedJsonStore {
   }
 
   /**
-   * Load all persisted watches from disk.
-   * Returns empty array if file doesn't exist or is invalid.
+   * Load all persisted data from disk.
+   * Returns empty arrays if file doesn't exist or is invalid.
+   * Transparently migrates legacy plain-array format.
    */
-  async loadAll(): Promise<WatchedRun[]> {
+  async loadAll(): Promise<WatchStoreData> {
     let parsed: unknown;
     try {
       parsed = await this.readJson(this.filePath, MAX_FILE_SIZE);
     } catch (err) {
-      // Swallow non-ENOENT errors (e.g. permission issues) gracefully
       logger.warn('Failed to load watches', err);
-      return [];
+      return { runs: [], prs: [] };
     }
     if (parsed === undefined) {
-      return [];
+      return { runs: [], prs: [] };
     }
-    if (!Array.isArray(parsed)) {
-      logger.warn(`Invalid watches data in ${this.filePath}: expected a JSON array`);
+
+    // Legacy migration: plain array → envelope
+    if (Array.isArray(parsed)) {
+      const runs = parsed.filter((item: unknown) => {
+        if (typeof item !== 'object' || item === null) return false;
+        const obj = item as Record<string, unknown>;
+        return obj.identifier && obj.status && typeof obj.watchedAt === 'string';
+      }) as WatchedRun[];
+      return { runs, prs: [] };
+    }
+
+    if (typeof parsed !== 'object' || parsed === null) {
+      logger.warn(`Invalid watches data in ${this.filePath}: expected an object or array`);
       await this.backupFile(this.filePath);
-      return [];
+      return { runs: [], prs: [] };
     }
-    // Basic validation: each entry must have identifier and status
-    return parsed.filter((item: unknown) => {
-      if (typeof item !== 'object' || item === null) return false;
-      const obj = item as Record<string, unknown>;
-      return obj.identifier && obj.status && typeof obj.watchedAt === 'string';
-    }) as WatchedRun[];
+
+    const data = parsed as Record<string, unknown>;
+    const runs = Array.isArray(data.runs)
+      ? (data.runs as unknown[]).filter((item: unknown) => {
+          if (typeof item !== 'object' || item === null) return false;
+          const obj = item as Record<string, unknown>;
+          return obj.identifier && obj.status && typeof obj.watchedAt === 'string';
+        }) as WatchedRun[]
+      : [];
+
+    const prs = Array.isArray(data.prs)
+      ? (data.prs as unknown[]).filter((item: unknown) => {
+          if (typeof item !== 'object' || item === null) return false;
+          const obj = item as Record<string, unknown>;
+          return obj.identifier && typeof obj.watchedAt === 'string' && typeof obj.prState === 'string';
+        }) as WatchedPR[]
+      : [];
+
+    return { runs, prs };
   }
 
   /**
    * Save all watches to disk (serialized through write queue).
    */
-  async saveAll(watches: WatchedRun[]): Promise<void> {
+  async saveAll(runs: WatchedRun[], prs: WatchedPR[]): Promise<void> {
     return this.enqueue(async () => {
-      await this.writeJson(this.filePath, watches);
+      const data: WatchStoreData = { runs, prs };
+      await this.writeJson(this.filePath, data);
     });
   }
 }

--- a/packages/core/src/storage/watchStore.ts
+++ b/packages/core/src/storage/watchStore.ts
@@ -32,7 +32,7 @@ export class WatchStore extends SerializedJsonStore {
   /**
    * Load all persisted data from disk.
    * Returns empty arrays if file doesn't exist or is invalid.
-   * Transparently migrates legacy plain-array format.
+   * Transparently supports the legacy plain-array format (runs only).
    */
   async loadAll(): Promise<WatchStoreData> {
     let parsed: unknown;

--- a/packages/core/src/storage/watchStore.ts
+++ b/packages/core/src/storage/watchStore.ts
@@ -19,7 +19,9 @@ interface WatchStoreData {
  * Persists watched pipeline runs and PR watches as JSON on disk.
  * Extends SerializedJsonStore for write-queue serialization and JSON helpers.
  *
- * Migrates legacy files (plain JSON array) to the new envelope format.
+ * Supports the legacy plain-array format (runs only); legacy data is
+ * transparently converted on read and written in the new envelope format
+ * on the next save.
  */
 export class WatchStore extends SerializedJsonStore {
   private readonly filePath: string;

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -9,6 +9,7 @@ import type { ProviderRegistry } from '../services/providerRegistry';
 import type { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import type { ProviderLabelCache } from '../storage/providerLabelCache';
 import type { WatcherRegistry } from '../services/watcherRegistry';
+import type { PRWatcherRegistry } from '../services/prWatcherRegistry';
 import type { WatcherService } from '../services/watcherService';
 import type { InboxItem, InboxProviderNode, InboxGroupNode } from '../views/inboxTreeProvider';
 import type { SourceItemNode, SourceProviderNode, SourceGroupNode } from '../views/sourcesTreeProvider';
@@ -152,7 +153,7 @@ describe('registerCommands', () => {
     labelCache = createMockLabelCache();
     ctx = createMockContext();
 
-    registerCommands(ctx, workGraph as any, actionRegistry as any, stateStore as any, providerRegistry as any, labelCache as any, {} as WatcherRegistry, {} as WatcherService);
+    registerCommands(ctx, workGraph as any, actionRegistry as any, stateStore as any, providerRegistry as any, labelCache as any, {} as WatcherRegistry, {} as PRWatcherRegistry, {} as WatcherService);
   });
 
   // helper to invoke a registered command

--- a/packages/core/src/test/devDocketApi.test.ts
+++ b/packages/core/src/test/devDocketApi.test.ts
@@ -3,6 +3,7 @@ import { DevDocketProvider, DevDocketAction, DiscoveredItem } from '../api/types
 import { ProviderRegistry } from '../services/providerRegistry';
 import { ActionRegistry } from '../services/actionRegistry';
 import { WatcherRegistry } from '../services/watcherRegistry';
+import { PRWatcherRegistry } from '../services/prWatcherRegistry';
 import { WorkGraph } from '../services/workGraph';
 import { ITaskStore } from '../storage/taskStore';
 import * as vscode from 'vscode';
@@ -67,6 +68,7 @@ describe('DevDocketApiImpl', () => {
   let providerRegistry: ProviderRegistry;
   let actionRegistry: ActionRegistry;
   let watcherRegistry: WatcherRegistry;
+  let prWatcherRegistry: PRWatcherRegistry;
   let workGraph: WorkGraph;
 
   beforeEach(async () => {
@@ -74,9 +76,10 @@ describe('DevDocketApiImpl', () => {
     providerRegistry = new ProviderRegistry(stateStore);
     actionRegistry = new ActionRegistry();
     watcherRegistry = new WatcherRegistry({ info: vi.fn(), warn: vi.fn() });
+    prWatcherRegistry = new PRWatcherRegistry({ info: vi.fn(), warn: vi.fn() });
     workGraph = new WorkGraph(createMockStore());
     await workGraph.load();
-    api = new DevDocketApiImpl(providerRegistry, actionRegistry, watcherRegistry, workGraph);
+    api = new DevDocketApiImpl(providerRegistry, actionRegistry, watcherRegistry, prWatcherRegistry, workGraph);
   });
 
   describe('registerProvider', () => {

--- a/packages/core/src/test/devDocketApi.test.ts
+++ b/packages/core/src/test/devDocketApi.test.ts
@@ -201,6 +201,40 @@ describe('DevDocketApiImpl', () => {
     });
   });
 
+  describe('registerPRWatcher', () => {
+    it('delegates to prWatcherRegistry.register', () => {
+      const watcher = {
+        id: 'test-pr-watcher',
+        label: 'Test PR Watcher',
+        canWatch: vi.fn(),
+        parsePRUrl: vi.fn(),
+        getPRRunsSnapshot: vi.fn(),
+      };
+      const spy = vi.spyOn(prWatcherRegistry, 'register');
+
+      api.registerPRWatcher(watcher);
+
+      expect(spy).toHaveBeenCalledWith(watcher);
+    });
+
+    it('returns a Disposable that unregisters the watcher', () => {
+      const watcher = {
+        id: 'test-pr-watcher',
+        label: 'Test PR Watcher',
+        canWatch: vi.fn(),
+        parsePRUrl: vi.fn(),
+        getPRRunsSnapshot: vi.fn(),
+      };
+      const disposable = api.registerPRWatcher(watcher);
+
+      expect(prWatcherRegistry.get('test-pr-watcher')).toBeDefined();
+
+      disposable.dispose();
+
+      expect(prWatcherRegistry.get('test-pr-watcher')).toBeUndefined();
+    });
+  });
+
   describe('addActivity', () => {
     it('delegates to workGraph.addActivity', async () => {
       const item = await workGraph.createItem({ title: 'Test' });

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -1376,23 +1376,24 @@ describe('ProviderRegistry', () => {
     });
 
     it('fires onDidChangeProviderHealth when lastRefreshTime changes even if status is same', async () => {
-      const provider = createMockProvider('stable');
-      registry.register(provider);
-      // First refresh resolves immediately → healthy
-      await nextTick();
-
-      const listener = vi.fn();
-      registry.onDidChangeProviderHealth(listener);
-
-      // Guarantee a different timestamp on next refresh
-      const spy = vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 1000);
+      vi.useFakeTimers();
       try {
-        await registry.refreshAll();
-      } finally {
-        spy.mockRestore();
-      }
+        const provider = createMockProvider('stable');
+        registry.register(provider);
+        // First refresh resolves immediately → healthy
+        await vi.advanceTimersByTimeAsync(0);
 
-      expect(listener).toHaveBeenCalledWith('stable');
+        const listener = vi.fn();
+        registry.onDidChangeProviderHealth(listener);
+
+        // Advance faked clock to guarantee a different timestamp
+        vi.setSystemTime(Date.now() + 1000);
+        await registry.refreshAll();
+
+        expect(listener).toHaveBeenCalledWith('stable');
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('clears health status when provider is unregistered', async () => {

--- a/packages/core/src/test/watchStore.test.ts
+++ b/packages/core/src/test/watchStore.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { WatchStore } from '../storage/watchStore';
-import type { WatchedRun } from '../services/watcherService';
+import type { WatchedRun, WatchedPR } from '../services/watcherService';
 
 vi.mock('../services/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -25,6 +25,24 @@ function createTestWatch(overrides?: Partial<WatchedRun>): WatchedRun {
   };
 }
 
+function createTestPRWatch(overrides?: Partial<WatchedPR>): WatchedPR {
+  return {
+    identifier: {
+      providerId: 'github-pr',
+      prId: '42',
+      displayName: 'PR #42',
+      url: 'https://github.com/owner/repo/pull/42',
+      repo: 'owner/repo',
+    },
+    prState: 'open',
+    childRunKeys: [],
+    watchedAt: '2026-01-01T00:00:00Z',
+    lastPolledAt: '2026-01-01T00:00:00Z',
+    dismissed: false,
+    ...overrides,
+  };
+}
+
 describe('WatchStore', () => {
   const testDir = path.join(process.cwd(), '.test-watch-store-' + process.pid);
   let store: WatchStore;
@@ -39,12 +57,28 @@ describe('WatchStore', () => {
   });
 
   describe('loadAll', () => {
-    it('returns empty array when file does not exist', async () => {
+    it('returns empty arrays when file does not exist', async () => {
       const result = await store.loadAll();
-      expect(result).toEqual([]);
+      expect(result).toEqual({ runs: [], prs: [] });
     });
 
-    it('loads valid watches from disk', async () => {
+    it('loads valid watches from new envelope format', async () => {
+      const watch = createTestWatch();
+      const prWatch = createTestPRWatch();
+      await fs.writeFile(
+        path.join(testDir, 'watches.json'),
+        JSON.stringify({ runs: [watch], prs: [prWatch] }),
+        'utf-8',
+      );
+
+      const result = await store.loadAll();
+      expect(result.runs).toHaveLength(1);
+      expect(result.runs[0].identifier.runId).toBe('123');
+      expect(result.prs).toHaveLength(1);
+      expect(result.prs[0].identifier.prId).toBe('42');
+    });
+
+    it('migrates legacy plain array format', async () => {
       const watch = createTestWatch();
       await fs.writeFile(
         path.join(testDir, 'watches.json'),
@@ -53,22 +87,23 @@ describe('WatchStore', () => {
       );
 
       const result = await store.loadAll();
-      expect(result).toHaveLength(1);
-      expect(result[0].identifier.runId).toBe('123');
+      expect(result.runs).toHaveLength(1);
+      expect(result.runs[0].identifier.runId).toBe('123');
+      expect(result.prs).toEqual([]);
     });
 
-    it('returns empty array for non-array JSON', async () => {
+    it('returns empty arrays for non-object/non-array JSON', async () => {
       await fs.writeFile(
         path.join(testDir, 'watches.json'),
-        '{"not": "an array"}',
+        '"just a string"',
         'utf-8',
       );
 
       const result = await store.loadAll();
-      expect(result).toEqual([]);
+      expect(result).toEqual({ runs: [], prs: [] });
     });
 
-    it('returns empty array for invalid JSON', async () => {
+    it('returns empty arrays for invalid JSON', async () => {
       await fs.writeFile(
         path.join(testDir, 'watches.json'),
         'not valid json {{{',
@@ -76,7 +111,7 @@ describe('WatchStore', () => {
       );
 
       const result = await store.loadAll();
-      expect(result).toEqual([]);
+      expect(result).toEqual({ runs: [], prs: [] });
     });
 
     it('filters out entries missing required fields', async () => {
@@ -84,33 +119,36 @@ describe('WatchStore', () => {
       const invalid = { foo: 'bar' };
       await fs.writeFile(
         path.join(testDir, 'watches.json'),
-        JSON.stringify([valid, invalid]),
+        JSON.stringify({ runs: [valid, invalid], prs: [] }),
         'utf-8',
       );
 
       const result = await store.loadAll();
-      expect(result).toHaveLength(1);
+      expect(result.runs).toHaveLength(1);
     });
   });
 
   describe('saveAll', () => {
-    it('saves watches to disk', async () => {
+    it('saves watches to disk in envelope format', async () => {
       const watch = createTestWatch();
-      await store.saveAll([watch]);
+      const prWatch = createTestPRWatch();
+      await store.saveAll([watch], [prWatch]);
 
       const data = await fs.readFile(path.join(testDir, 'watches.json'), 'utf-8');
       const parsed = JSON.parse(data);
-      expect(parsed).toHaveLength(1);
-      expect(parsed[0].identifier.runId).toBe('123');
+      expect(parsed.runs).toHaveLength(1);
+      expect(parsed.runs[0].identifier.runId).toBe('123');
+      expect(parsed.prs).toHaveLength(1);
+      expect(parsed.prs[0].identifier.prId).toBe('42');
     });
 
     it('creates directory if it does not exist', async () => {
       const nestedDir = path.join(testDir, 'nested', 'dir');
       const nestedStore = new WatchStore(nestedDir);
-      await nestedStore.saveAll([createTestWatch()]);
+      await nestedStore.saveAll([createTestWatch()], []);
 
       const data = await fs.readFile(path.join(nestedDir, 'watches.json'), 'utf-8');
-      expect(JSON.parse(data)).toHaveLength(1);
+      expect(JSON.parse(data).runs).toHaveLength(1);
     });
 
     it('serializes concurrent writes', async () => {
@@ -119,27 +157,31 @@ describe('WatchStore', () => {
 
       // Fire two saves concurrently — both should succeed without corruption
       await Promise.all([
-        store.saveAll([watch1]),
-        store.saveAll([watch1, watch2]),
+        store.saveAll([watch1], []),
+        store.saveAll([watch1, watch2], []),
       ]);
 
       const data = await fs.readFile(path.join(testDir, 'watches.json'), 'utf-8');
       const parsed = JSON.parse(data);
       // Second write should win (it was queued after the first)
-      expect(parsed).toHaveLength(2);
+      expect(parsed.runs).toHaveLength(2);
     });
   });
 
   describe('round-trip', () => {
     it('saves and loads watches correctly', async () => {
       const watch = createTestWatch();
-      await store.saveAll([watch]);
+      const prWatch = createTestPRWatch();
+      await store.saveAll([watch], [prWatch]);
 
       const loaded = await store.loadAll();
-      expect(loaded).toHaveLength(1);
-      expect(loaded[0].identifier.runId).toBe('123');
-      expect(loaded[0].status.overallState).toBe('running');
-      expect(loaded[0].dismissed).toBe(false);
+      expect(loaded.runs).toHaveLength(1);
+      expect(loaded.runs[0].identifier.runId).toBe('123');
+      expect(loaded.runs[0].status.overallState).toBe('running');
+      expect(loaded.runs[0].dismissed).toBe(false);
+      expect(loaded.prs).toHaveLength(1);
+      expect(loaded.prs[0].identifier.prId).toBe('42');
+      expect(loaded.prs[0].prState).toBe('open');
     });
   });
 });

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -462,5 +462,64 @@ describe('WatcherService', () => {
       expect(service.getActivePRWatches()).toHaveLength(1);
       expect(service.getActivePRWatches()[0].identifier.prId).toBe('42');
     });
+
+    it('resolves run identifiers via URL matching when providerId is unknown', async () => {
+      // Register a run watcher that recognizes URLs
+      const runWatcher = createMockWatcher('ado-pipelines');
+      (runWatcher.canWatch as ReturnType<typeof vi.fn>).mockImplementation(
+        (url: string) => url.includes('dev.azure.com') && url.includes('_build/results'),
+      );
+      (runWatcher.parseRunUrl as ReturnType<typeof vi.fn>).mockReturnValue({
+        providerId: 'ado-pipelines',
+        runId: '555',
+        displayName: 'Build 555',
+        url: 'https://dev.azure.com/org/project/_build/results?buildId=555',
+        repo: 'org/project',
+      });
+      registry.register(runWatcher);
+
+      // PR watcher returns a run with an unknown providerId but a recognizable URL
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [{
+          providerId: 'azure-pipelines',
+          runId: '10',
+          displayName: 'ADO Pipeline',
+          url: 'https://dev.azure.com/org/project/_build/results?buildId=555',
+          repo: 'owner/repo',
+        }],
+      }));
+      prRegistry.register(prWatcher);
+
+      const result = await service.startPRWatch(createPRIdentifier());
+
+      expect(result.childRunKeys).toHaveLength(1);
+      expect(service.getActiveWatches()).toHaveLength(1);
+      // The resolved identifier should use the watcher's providerId
+      expect(service.getActiveWatches()[0].identifier.providerId).toBe('ado-pipelines');
+      expect(service.getActiveWatches()[0].identifier.runId).toBe('555');
+    });
+
+    it('skips run identifiers when no watcher matches providerId or URL', async () => {
+      // No run watchers registered — unresolvable run
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [{
+          providerId: 'unknown-ci',
+          runId: '99',
+          displayName: 'Unknown CI',
+          url: 'https://unknown-ci.example.com/build/99',
+          repo: 'owner/repo',
+        }],
+      }));
+      prRegistry.register(prWatcher);
+
+      const result = await service.startPRWatch(createPRIdentifier());
+
+      // Child run should not be added (no matching watcher)
+      expect(result.childRunKeys).toHaveLength(0);
+      expect(service.getActiveWatches()).toHaveLength(0);
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to add child run'));
+    });
   });
 });

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -467,7 +467,12 @@ describe('WatcherService', () => {
       // Register a run watcher that recognizes URLs
       const runWatcher = createMockWatcher('ado-pipelines');
       (runWatcher.canWatch as ReturnType<typeof vi.fn>).mockImplementation(
-        (url: string) => url.includes('dev.azure.com') && url.includes('_build/results'),
+        (url: string) => {
+          try {
+            const u = new URL(url);
+            return u.hostname === 'dev.azure.com' && u.pathname.includes('_build/results');
+          } catch { return false; }
+        },
       );
       (runWatcher.parseRunUrl as ReturnType<typeof vi.fn>).mockReturnValue({
         providerId: 'ado-pipelines',

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WatcherService, WatchedRun } from '../services/watcherService';
 import { WatcherRegistry } from '../services/watcherRegistry';
+import { PRWatcherRegistry } from '../services/prWatcherRegistry';
 import { WatchStore } from '../storage/watchStore';
 import type { DevDocketRunWatcher, RunIdentifier, RunStatus } from '@devdocket/shared';
 
@@ -42,7 +43,7 @@ function createIdentifier(providerId: string = 'test'): RunIdentifier {
 
 function createMockWatchStore(): WatchStore {
   return {
-    loadAll: vi.fn().mockResolvedValue([]),
+    loadAll: vi.fn().mockResolvedValue({ runs: [], prs: [] }),
     saveAll: vi.fn().mockResolvedValue(undefined),
   } as unknown as WatchStore;
 }
@@ -50,6 +51,7 @@ function createMockWatchStore(): WatchStore {
 describe('WatcherService', () => {
   let service: WatcherService;
   let registry: WatcherRegistry;
+  let prRegistry: PRWatcherRegistry;
   let logger: ReturnType<typeof createMockLogger>;
   let watchStore: WatchStore;
 
@@ -57,8 +59,9 @@ describe('WatcherService', () => {
     vi.useFakeTimers();
     logger = createMockLogger();
     registry = new WatcherRegistry(logger);
+    prRegistry = new PRWatcherRegistry(logger);
     watchStore = createMockWatchStore();
-    service = new WatcherService(registry, watchStore, logger);
+    service = new WatcherService(registry, prRegistry, watchStore, logger);
   });
 
   afterEach(() => {
@@ -256,12 +259,208 @@ describe('WatcherService', () => {
         lastPolledAt: new Date().toISOString(),
         dismissed: false,
       };
-      (watchStore.loadAll as ReturnType<typeof vi.fn>).mockResolvedValue([persistedWatch]);
+      (watchStore.loadAll as ReturnType<typeof vi.fn>).mockResolvedValue({ runs: [persistedWatch], prs: [] });
       
       await service.loadPersistedWatches();
       
       expect(service.getActiveWatches()).toHaveLength(1);
       expect(service.getActiveWatches()[0].identifier.runId).toBe('run-1');
+    });
+  });
+
+  describe('PR watching', () => {
+    function createMockPRWatcher(id: string = 'test-pr', snapshotFn?: () => Promise<import('@devdocket/shared').PRRunsSnapshot>): import('@devdocket/shared').DevDocketPRWatcher {
+      return {
+        id,
+        label: `PR Watcher ${id}`,
+        canWatch: vi.fn().mockReturnValue(true),
+        parsePRUrl: vi.fn().mockReturnValue({
+          providerId: id,
+          prId: '42',
+          displayName: 'PR #42',
+          url: 'https://example.com/pr/42',
+          repo: 'owner/repo',
+        }),
+        getPRRunsSnapshot: snapshotFn ? vi.fn(snapshotFn) : vi.fn().mockResolvedValue({
+          prState: 'open',
+          runs: [],
+        }),
+      };
+    }
+
+    function createPRIdentifier(providerId: string = 'test-pr'): import('@devdocket/shared').PRIdentifier {
+      return {
+        providerId,
+        prId: '42',
+        displayName: 'PR #42',
+        url: 'https://example.com/pr/42',
+        repo: 'owner/repo',
+      };
+    }
+
+    it('starts a PR watch and fires change events', async () => {
+      const prWatcher = createMockPRWatcher();
+      prRegistry.register(prWatcher);
+      const changeSpy = vi.fn();
+      const prChangeSpy = vi.fn();
+      service.onDidChangeWatchedRuns(changeSpy);
+      service.onDidChangePRWatches(prChangeSpy);
+
+      const result = await service.startPRWatch(createPRIdentifier());
+
+      expect(result.identifier.prId).toBe('42');
+      expect(result.prState).toBe('open');
+      expect(result.dismissed).toBe(false);
+      expect(prChangeSpy).toHaveBeenCalled();
+      expect(changeSpy).toHaveBeenCalled();
+    });
+
+    it('throws if already watching the same PR', async () => {
+      const prWatcher = createMockPRWatcher();
+      prRegistry.register(prWatcher);
+
+      await service.startPRWatch(createPRIdentifier());
+      await expect(service.startPRWatch(createPRIdentifier())).rejects.toThrow('Already watching PR');
+    });
+
+    it('throws if no PR watcher registered for provider', async () => {
+      await expect(service.startPRWatch(createPRIdentifier('unknown'))).rejects.toThrow('No PR watcher registered');
+    });
+
+    it('adds initial runs as child watches', async () => {
+      const runWatcher = createMockWatcher('github-actions');
+      registry.register(runWatcher);
+
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [{
+          providerId: 'github-actions',
+          runId: 'run-1',
+          displayName: 'CI Build',
+          url: 'https://example.com/run/1',
+          repo: 'owner/repo',
+        }],
+      }));
+      prRegistry.register(prWatcher);
+
+      const result = await service.startPRWatch(createPRIdentifier());
+
+      expect(result.childRunKeys).toHaveLength(1);
+      expect(service.getActiveWatches()).toHaveLength(1);
+      expect(service.getActiveWatches()[0].parentPRKey).toBeDefined();
+    });
+
+    it('dismisses PR watch and its child runs', async () => {
+      const runWatcher = createMockWatcher('github-actions');
+      registry.register(runWatcher);
+
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [{
+          providerId: 'github-actions',
+          runId: 'run-1',
+          displayName: 'CI Build',
+          url: 'https://example.com/run/1',
+          repo: 'owner/repo',
+        }],
+      }));
+      prRegistry.register(prWatcher);
+
+      const identifier = createPRIdentifier();
+      await service.startPRWatch(identifier);
+
+      expect(service.getActiveWatches()).toHaveLength(1);
+      expect(service.getActivePRWatches()).toHaveLength(1);
+
+      service.dismissPRWatch(identifier);
+
+      expect(service.getActiveWatches()).toHaveLength(0);
+      expect(service.getActivePRWatches()).toHaveLength(0);
+    });
+
+    it('getActiveStandaloneWatches excludes child runs', async () => {
+      const runWatcher = createMockWatcher('github-actions');
+      registry.register(runWatcher);
+
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [{
+          providerId: 'github-actions',
+          runId: 'run-1',
+          displayName: 'CI Build',
+          url: 'https://example.com/run/1',
+          repo: 'owner/repo',
+        }],
+      }));
+      prRegistry.register(prWatcher);
+
+      await service.startPRWatch(createPRIdentifier());
+
+      // Also start a standalone watch with the run watcher
+      const standaloneIdentifier = { ...createIdentifier('github-actions'), runId: 'run-standalone' };
+      await service.startWatch(standaloneIdentifier);
+
+      expect(service.getActiveWatches()).toHaveLength(2);
+      expect(service.getActiveStandaloneWatches()).toHaveLength(1);
+      expect(service.getActiveStandaloneWatches()[0].identifier.runId).toBe('run-standalone');
+    });
+
+    it('dismissAllCompleted dismisses merged/closed PRs and their child runs', async () => {
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'merged',
+        runs: [],
+      }));
+      prRegistry.register(prWatcher);
+
+      await service.startPRWatch(createPRIdentifier());
+
+      expect(service.getActivePRWatches()).toHaveLength(1);
+      expect(service.getActivePRWatches()[0].prState).toBe('merged');
+
+      service.dismissAllCompleted();
+
+      expect(service.getActivePRWatches()).toHaveLength(0);
+    });
+
+    it('polls PR watches and detects state transitions', async () => {
+      let callCount = 0;
+      const prWatcher = createMockPRWatcher('test-pr', async () => {
+        callCount++;
+        if (callCount === 1) {
+          return { prState: 'open', runs: [] };
+        }
+        return { prState: 'merged', runs: [] };
+      });
+      prRegistry.register(prWatcher);
+
+      await service.startPRWatch(createPRIdentifier());
+      const completeSpy = vi.fn();
+      service.onDidCompletePR(completeSpy);
+
+      await vi.advanceTimersByTimeAsync(60000);
+
+      expect(completeSpy).toHaveBeenCalledTimes(1);
+      expect(service.getActivePRWatches()[0].prState).toBe('merged');
+    });
+
+    it('loads persisted PR watches', async () => {
+      const prWatcher = createMockPRWatcher();
+      prRegistry.register(prWatcher);
+
+      const persistedPR = {
+        identifier: createPRIdentifier(),
+        prState: 'open' as const,
+        childRunKeys: [],
+        watchedAt: new Date().toISOString(),
+        lastPolledAt: new Date().toISOString(),
+        dismissed: false,
+      };
+      (watchStore.loadAll as ReturnType<typeof vi.fn>).mockResolvedValue({ runs: [], prs: [persistedPR] });
+
+      await service.loadPersistedWatches();
+
+      expect(service.getActivePRWatches()).toHaveLength(1);
+      expect(service.getActivePRWatches()[0].identifier.prId).toBe('42');
     });
   });
 });

--- a/packages/core/src/views/watchesTreeProvider.ts
+++ b/packages/core/src/views/watchesTreeProvider.ts
@@ -1,7 +1,63 @@
 import * as vscode from 'vscode';
-import type { RunState, RunConclusion } from '@devdocket/shared';
-import { WatcherService, WatchedRun } from '../services/watcherService';
+import type { RunState, RunConclusion, PRState } from '@devdocket/shared';
+import { WatcherService, WatchedRun, WatchedPR } from '../services/watcherService';
 import { ViewLayout, LayoutState } from './viewLayout';
+
+/**
+ * Tree item for a watched PR.
+ */
+class WatchedPRNode extends vscode.TreeItem {
+  constructor(
+    public readonly watchedPR: WatchedPR,
+    public readonly children: WatchedRunNode[]
+  ) {
+    const label = watchedPR.identifier.displayName;
+    super(label, children.length > 0 ? vscode.TreeItemCollapsibleState.Expanded : vscode.TreeItemCollapsibleState.None);
+
+    this.id = `watch-pr:${watchedPR.identifier.providerId}:${watchedPR.identifier.repo}:${watchedPR.identifier.prId}`;
+    this.tooltip = this.buildTooltip();
+    this.description = this.buildDescription();
+    this.iconPath = this.getIconForPRState(watchedPR.prState, watchedPR.hasWarning);
+    this.contextValue = watchedPR.prState === 'open' ? 'watchedPR.active' : 'watchedPR.completed';
+  }
+
+  private buildTooltip(): string {
+    const pr = this.watchedPR;
+    const lines = [pr.identifier.displayName];
+    lines.push(`Repository: ${pr.identifier.repo}`);
+    lines.push(`PR State: ${pr.prState}`);
+    lines.push(`Child Runs: ${this.children.length}`);
+    if (pr.hasWarning && pr.errorMessage) {
+      lines.push(`Warning: ${pr.errorMessage}`);
+    }
+    return lines.join('\n');
+  }
+
+  private buildDescription(): string {
+    const pr = this.watchedPR;
+    const parts: string[] = [pr.identifier.repo];
+    if (pr.hasWarning) {
+      parts.push('polling failed');
+    } else {
+      parts.push(pr.prState);
+    }
+    return parts.join(' · ');
+  }
+
+  private getIconForPRState(state: PRState, hasWarning?: boolean): vscode.ThemeIcon {
+    if (hasWarning) {
+      return new vscode.ThemeIcon('warning', new vscode.ThemeColor('problemsWarningIcon.foreground'));
+    }
+    if (state === 'open') {
+      return new vscode.ThemeIcon('git-pull-request');
+    }
+    if (state === 'merged') {
+      return new vscode.ThemeIcon('git-merge', new vscode.ThemeColor('testing.iconPassed'));
+    }
+    // closed
+    return new vscode.ThemeIcon('git-pull-request-closed', new vscode.ThemeColor('testing.iconFailed'));
+  }
+}
 
 /**
  * Tree item for a watched run.
@@ -140,15 +196,18 @@ interface WatchProviderGroupNode {
   label: string;
 }
 
+type WatchTreeElement = WatchedPRNode | WatchedRunNode | JobStatusNode | WatchProviderGroupNode;
+
 /**
  * Tree data provider for the Watches view.
  */
-export class WatchesTreeProvider implements vscode.TreeDataProvider<WatchedRunNode | JobStatusNode | WatchProviderGroupNode> {
-  private readonly _onDidChangeTreeData = new vscode.EventEmitter<WatchedRunNode | JobStatusNode | WatchProviderGroupNode | undefined>();
+export class WatchesTreeProvider implements vscode.TreeDataProvider<WatchTreeElement> {
+  private readonly _onDidChangeTreeData = new vscode.EventEmitter<WatchTreeElement | undefined>();
   readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
 
   private readonly _layoutState: LayoutState;
   private watchChangeSub: vscode.Disposable;
+  private prChangeSub: vscode.Disposable;
 
   get layout(): ViewLayout { return this._layoutState.value; }
   set layout(value: ViewLayout) { this._layoutState.value = value; }
@@ -159,57 +218,42 @@ export class WatchesTreeProvider implements vscode.TreeDataProvider<WatchedRunNo
     this.watchChangeSub = watcherService.onDidChangeWatchedRuns(() => {
       this._onDidChangeTreeData.fire(undefined);
     });
+    this.prChangeSub = watcherService.onDidChangePRWatches(() => {
+      this._onDidChangeTreeData.fire(undefined);
+    });
   }
 
-  getTreeItem(element: WatchedRunNode | JobStatusNode | WatchProviderGroupNode): vscode.TreeItem {
+  getTreeItem(element: WatchTreeElement): vscode.TreeItem {
     if ('kind' in element && element.kind === 'watchProviderGroup') {
-      const watches = this.watcherService.getActiveWatches()
+      const allRuns = this.watcherService.getActiveStandaloneWatches()
         .filter(w => w.identifier.providerId === element.providerId);
+      const allPRs = this.watcherService.getActivePRWatches()
+        .filter(pr => pr.identifier.providerId === element.providerId);
       const treeItem = new vscode.TreeItem(element.label, vscode.TreeItemCollapsibleState.Collapsed);
       treeItem.id = `watch-group:${element.providerId}`;
       treeItem.contextValue = 'watchProviderGroup';
       treeItem.iconPath = new vscode.ThemeIcon('plug');
-      treeItem.description = `${watches.length}`;
+      treeItem.description = `${allRuns.length + allPRs.length}`;
       return treeItem;
     }
     return element;
   }
 
-  getChildren(element?: WatchedRunNode | JobStatusNode | WatchProviderGroupNode): vscode.ProviderResult<(WatchedRunNode | JobStatusNode | WatchProviderGroupNode)[]> {
+  getChildren(element?: WatchTreeElement): vscode.ProviderResult<WatchTreeElement[]> {
     if (!element) {
-      const watches = this.watcherService.getActiveWatches();
       if (this._layoutState.value === 'flat') {
-        return watches.map(watch => {
-          const jobNodes = watch.status.jobs.map(
-            job => new JobStatusNode(job.name, job.state, job.conclusion)
-          );
-          return new WatchedRunNode(watch, jobNodes);
-        });
+        return this.buildFlatChildren();
       }
       // Tree mode: group by provider
-      const providers = new Map<string, WatchedRun[]>();
-      for (const watch of watches) {
-        const pid = watch.identifier.providerId;
-        if (!providers.has(pid)) {
-          providers.set(pid, []);
-        }
-        providers.get(pid)!.push(watch);
-      }
-      return Array.from(providers.entries()).map(([pid, _runs]) => {
-        const label = this.watcherService.getProviderLabel(pid) ?? pid;
-        return { kind: 'watchProviderGroup' as const, providerId: pid, label };
-      });
+      return this.buildGroupedRoots();
     }
 
     if ('kind' in element && element.kind === 'watchProviderGroup') {
-      const watches = this.watcherService.getActiveWatches()
-        .filter(w => w.identifier.providerId === element.providerId);
-      return watches.map(watch => {
-        const jobNodes = watch.status.jobs.map(
-          job => new JobStatusNode(job.name, job.state, job.conclusion)
-        );
-        return new WatchedRunNode(watch, jobNodes);
-      });
+      return this.buildProviderChildren(element.providerId);
+    }
+
+    if (element instanceof WatchedPRNode) {
+      return element.children;
     }
 
     if (element instanceof WatchedRunNode) {
@@ -221,12 +265,83 @@ export class WatchesTreeProvider implements vscode.TreeDataProvider<WatchedRunNo
     return [];
   }
 
+  private buildFlatChildren(): WatchTreeElement[] {
+    const result: WatchTreeElement[] = [];
+
+    // Add PR watch nodes
+    const prWatches = this.watcherService.getActivePRWatches();
+    for (const prWatch of prWatches) {
+      result.push(this.buildPRNode(prWatch));
+    }
+
+    // Add standalone run nodes
+    const standaloneWatches = this.watcherService.getActiveStandaloneWatches();
+    for (const watch of standaloneWatches) {
+      const jobNodes = watch.status.jobs.map(
+        job => new JobStatusNode(job.name, job.state, job.conclusion)
+      );
+      result.push(new WatchedRunNode(watch, jobNodes));
+    }
+
+    return result;
+  }
+
+  private buildGroupedRoots(): WatchTreeElement[] {
+    const providers = new Map<string, boolean>();
+    for (const watch of this.watcherService.getActiveStandaloneWatches()) {
+      providers.set(watch.identifier.providerId, true);
+    }
+    for (const prWatch of this.watcherService.getActivePRWatches()) {
+      providers.set(prWatch.identifier.providerId, true);
+    }
+    return Array.from(providers.keys()).map(pid => {
+      const label = this.watcherService.getProviderLabel(pid) ?? pid;
+      return { kind: 'watchProviderGroup' as const, providerId: pid, label };
+    });
+  }
+
+  private buildProviderChildren(providerId: string): WatchTreeElement[] {
+    const result: WatchTreeElement[] = [];
+
+    // PR watches for this provider
+    const prWatches = this.watcherService.getActivePRWatches()
+      .filter(pr => pr.identifier.providerId === providerId);
+    for (const prWatch of prWatches) {
+      result.push(this.buildPRNode(prWatch));
+    }
+
+    // Standalone run watches for this provider
+    const standaloneWatches = this.watcherService.getActiveStandaloneWatches()
+      .filter(w => w.identifier.providerId === providerId);
+    for (const watch of standaloneWatches) {
+      const jobNodes = watch.status.jobs.map(
+        job => new JobStatusNode(job.name, job.state, job.conclusion)
+      );
+      result.push(new WatchedRunNode(watch, jobNodes));
+    }
+
+    return result;
+  }
+
+  private buildPRNode(prWatch: WatchedPR): WatchedPRNode {
+    const prKey = this.watcherService.getPRWatchKey(prWatch.identifier);
+    const childRuns = this.watcherService.getChildRuns(prKey);
+    const childNodes = childRuns.map(run => {
+      const jobNodes = run.status.jobs.map(
+        job => new JobStatusNode(job.name, job.state, job.conclusion)
+      );
+      return new WatchedRunNode(run, jobNodes);
+    });
+    return new WatchedPRNode(prWatch, childNodes);
+  }
+
   refresh(): void {
     this._onDidChangeTreeData.fire(undefined);
   }
 
   dispose(): void {
     this.watchChangeSub.dispose();
+    this.prChangeSub.dispose();
     this._onDidChangeTreeData.dispose();
   }
 }

--- a/packages/github/src/extension.ts
+++ b/packages/github/src/extension.ts
@@ -92,12 +92,12 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
   // Register the GitHub PR watcher
   if (typeof api.registerPRWatcher === 'function') {
     prWatcherRegistration = api.registerPRWatcher(new GitHubPRWatcher());
-    logger.info('DevDocket GitHub activated, registered 3 providers + 1 watcher + 1 PR watcher');
-  } else if (watcherRegistration) {
-    logger.info('DevDocket GitHub activated, registered 3 providers + 1 watcher');
-  } else {
-    logger.info('DevDocket GitHub activated, registered 3 providers');
   }
+
+  const parts = ['3 providers'];
+  if (watcherRegistration) { parts.push('1 watcher'); }
+  if (prWatcherRegistration) { parts.push('1 PR watcher'); }
+  logger.info(`DevDocket GitHub activated, registered ${parts.join(' + ')}`);
 }
 
 export function deactivate(): void {

--- a/packages/github/src/extension.ts
+++ b/packages/github/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { GitHubIssueProvider } from './githubProvider';
 import { GitHubPrReviewProvider } from './githubPrReviewProvider';
 import { GitHubActionsWatcher } from './githubActionsWatcher';
+import { GitHubPRWatcher } from './githubPRWatcher';
 import { GitHubMyPrsProvider } from './githubMyPrsProvider';
 import { validateRefreshInterval } from '@devdocket/shared';
 import { initLogger, setLogLevel, logger, resolveLogLevel } from './logger';
@@ -12,6 +13,7 @@ let myPrsProvider: GitHubMyPrsProvider | undefined;
 let providerRegistration: vscode.Disposable | undefined;
 let prReviewRegistration: vscode.Disposable | undefined;
 let watcherRegistration: vscode.Disposable | undefined;
+let prWatcherRegistration: vscode.Disposable | undefined;
 let myPrsRegistration: vscode.Disposable | undefined;
 
 export async function activate(_context: vscode.ExtensionContext): Promise<void> {
@@ -85,9 +87,16 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
   // Register the GitHub Actions watcher
   if (typeof api.registerRunWatcher === 'function') {
     watcherRegistration = api.registerRunWatcher(new GitHubActionsWatcher());
+  }
+
+  // Register the GitHub PR watcher
+  if (typeof api.registerPRWatcher === 'function') {
+    prWatcherRegistration = api.registerPRWatcher(new GitHubPRWatcher());
+    logger.info('DevDocket GitHub activated, registered 3 providers + 1 watcher + 1 PR watcher');
+  } else if (watcherRegistration) {
     logger.info('DevDocket GitHub activated, registered 3 providers + 1 watcher');
   } else {
-    logger.info('DevDocket GitHub activated, registered 3 providers (run watcher API not available)');
+    logger.info('DevDocket GitHub activated, registered 3 providers');
   }
 }
 
@@ -96,6 +105,7 @@ export function deactivate(): void {
   providerRegistration?.dispose();
   prReviewRegistration?.dispose();
   watcherRegistration?.dispose();
+  prWatcherRegistration?.dispose();
   myPrsRegistration?.dispose();
   issueProvider?.dispose();
   prReviewProvider?.dispose();

--- a/packages/github/src/githubPRWatcher.ts
+++ b/packages/github/src/githubPRWatcher.ts
@@ -7,7 +7,6 @@ import type {
   RunIdentifier,
   CancellationTokenLike,
 } from '@devdocket/shared';
-import { logger } from './logger';
 
 interface GitHubPR {
   number: number;
@@ -23,12 +22,6 @@ interface GitHubCheckRun {
   html_url: string;
   app?: { slug?: string };
   check_suite?: { id: number };
-}
-
-interface GitHubWorkflowRun {
-  id: number;
-  name: string;
-  html_url: string;
 }
 
 const FETCH_TIMEOUT_MS = 30_000;

--- a/packages/github/src/githubPRWatcher.ts
+++ b/packages/github/src/githubPRWatcher.ts
@@ -68,7 +68,11 @@ export class GitHubPRWatcher implements DevDocketPRWatcher {
     identifier: PRIdentifier,
     token?: CancellationTokenLike,
   ): Promise<PRRunsSnapshot> {
-    const [owner, repo] = identifier.repo.split('/');
+    const repoParts = identifier.repo.split('/');
+    if (repoParts.length !== 2 || repoParts.some(p => !p)) {
+      throw new Error(`Invalid GitHub repo format: expected "owner/repo" but got "${identifier.repo}"`);
+    }
+    const [owner, repo] = repoParts;
     const encodedOwner = encodeURIComponent(owner);
     const encodedRepo = encodeURIComponent(repo);
     const encodedPrNumber = encodeURIComponent(identifier.prId);

--- a/packages/github/src/githubPRWatcher.ts
+++ b/packages/github/src/githubPRWatcher.ts
@@ -20,6 +20,7 @@ interface GitHubCheckRun {
   id: number;
   name: string;
   html_url: string;
+  details_url?: string;
   app?: { slug?: string };
   check_suite?: { id: number };
 }
@@ -99,31 +100,38 @@ export class GitHubPRWatcher implements DevDocketPRWatcher {
       token,
     );
 
-    // Deduplicate by check_suite ID to get unique workflow runs
-    const seenSuites = new Set<number>();
     const runs: RunIdentifier[] = [];
+    // Track GitHub Actions workflow runs by run ID to avoid duplicates
+    // (multiple check runs/jobs share the same workflow run)
+    const seenGHARunIds = new Set<string>();
 
     for (const cr of checkRunsData.check_runs) {
-      const suiteId = cr.check_suite?.id;
-      if (suiteId && seenSuites.has(suiteId)) {
-        continue;
-      }
-      if (suiteId) {
-        seenSuites.add(suiteId);
-      }
-
-      // Extract workflow run ID from the check run's html_url
+      // GitHub Actions checks: extract workflow run ID from URL and deduplicate
       const runIdMatch = cr.html_url.match(/\/actions\/runs\/(\d+)/);
-      if (!runIdMatch) {
+      if (runIdMatch) {
+        const runId = runIdMatch[1];
+        if (seenGHARunIds.has(runId)) {
+          continue;
+        }
+        seenGHARunIds.add(runId);
+
+        runs.push({
+          providerId: 'github-actions',
+          runId,
+          displayName: cr.name,
+          url: `https://github.com/${owner}/${repo}/actions/runs/${runId}`,
+          repo: `${owner}/${repo}`,
+        });
         continue;
       }
 
-      const runId = runIdMatch[1];
+      // Non-GitHub-Actions checks: use details_url for run watcher matching
+      const checkUrl = cr.details_url || cr.html_url;
       runs.push({
-        providerId: 'github-actions',
-        runId,
+        providerId: cr.app?.slug || 'check-run',
+        runId: String(cr.id),
         displayName: cr.name,
-        url: `https://github.com/${owner}/${repo}/actions/runs/${runId}`,
+        url: checkUrl,
         repo: `${owner}/${repo}`,
       });
     }

--- a/packages/github/src/githubPRWatcher.ts
+++ b/packages/github/src/githubPRWatcher.ts
@@ -1,0 +1,184 @@
+import * as vscode from 'vscode';
+import type {
+  DevDocketPRWatcher,
+  PRIdentifier,
+  PRRunsSnapshot,
+  PRState,
+  RunIdentifier,
+  CancellationTokenLike,
+} from '@devdocket/shared';
+import { logger } from './logger';
+
+interface GitHubPR {
+  number: number;
+  title: string;
+  state: 'open' | 'closed';
+  merged: boolean;
+  head: { sha: string };
+}
+
+interface GitHubCheckRun {
+  id: number;
+  name: string;
+  html_url: string;
+  app?: { slug?: string };
+  check_suite?: { id: number };
+}
+
+interface GitHubWorkflowRun {
+  id: number;
+  name: string;
+  html_url: string;
+}
+
+const FETCH_TIMEOUT_MS = 30_000;
+const PR_URL_RE = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?$/;
+
+/**
+ * Watcher for GitHub pull request pipeline runs.
+ * Resolves PR URLs to their associated GitHub Actions workflow runs.
+ */
+export class GitHubPRWatcher implements DevDocketPRWatcher {
+  readonly id = 'github-pr';
+  readonly label = 'GitHub Pull Requests';
+
+  canWatch(url: string): boolean {
+    try {
+      const u = new URL(url);
+      return (u.protocol === 'https:' || u.protocol === 'http:')
+        && u.hostname === 'github.com'
+        && PR_URL_RE.test(u.pathname);
+    } catch {
+      return false;
+    }
+  }
+
+  parsePRUrl(url: string): PRIdentifier {
+    const u = new URL(url);
+    const match = u.pathname.match(PR_URL_RE);
+    if (!match) {
+      throw new Error('Invalid GitHub PR URL');
+    }
+
+    const [, owner, repo, prNumber] = match;
+
+    return {
+      providerId: this.id,
+      prId: prNumber,
+      displayName: `PR #${prNumber}`,
+      url,
+      repo: `${owner}/${repo}`,
+    };
+  }
+
+  async getPRRunsSnapshot(
+    identifier: PRIdentifier,
+    token?: CancellationTokenLike,
+  ): Promise<PRRunsSnapshot> {
+    const [owner, repo] = identifier.repo.split('/');
+    const encodedOwner = encodeURIComponent(owner);
+    const encodedRepo = encodeURIComponent(repo);
+    const encodedPrNumber = encodeURIComponent(identifier.prId);
+
+    // Fetch PR details to get state and head SHA
+    const prData = await this.fetchApi<GitHubPR>(
+      `https://api.github.com/repos/${encodedOwner}/${encodedRepo}/pulls/${encodedPrNumber}`,
+      token,
+    );
+
+    const prState: PRState = prData.merged
+      ? 'merged'
+      : prData.state === 'closed'
+        ? 'closed'
+        : 'open';
+
+    // Update display name with PR title
+    if (prData.title) {
+      identifier.displayName = `PR #${identifier.prId}: ${prData.title}`;
+    }
+
+    // Fetch check runs for head commit
+    const checkRunsData = await this.fetchApi<{ check_runs: GitHubCheckRun[] }>(
+      `https://api.github.com/repos/${encodedOwner}/${encodedRepo}/commits/${prData.head.sha}/check-runs?per_page=100`,
+      token,
+    );
+
+    // Deduplicate by check_suite ID to get unique workflow runs
+    const seenSuites = new Set<number>();
+    const runs: RunIdentifier[] = [];
+
+    for (const cr of checkRunsData.check_runs) {
+      const suiteId = cr.check_suite?.id;
+      if (suiteId && seenSuites.has(suiteId)) {
+        continue;
+      }
+      if (suiteId) {
+        seenSuites.add(suiteId);
+      }
+
+      // Extract workflow run ID from the check run's html_url
+      const runIdMatch = cr.html_url.match(/\/actions\/runs\/(\d+)/);
+      if (!runIdMatch) {
+        continue;
+      }
+
+      const runId = runIdMatch[1];
+      runs.push({
+        providerId: 'github-actions',
+        runId,
+        displayName: cr.name,
+        url: `https://github.com/${owner}/${repo}/actions/runs/${runId}`,
+        repo: `${owner}/${repo}`,
+      });
+    }
+
+    return { prState, runs };
+  }
+
+  private async fetchApi<T>(url: string, token?: CancellationTokenLike): Promise<T> {
+    const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: false });
+    if (!session) {
+      throw new Error('No GitHub authentication session available. Sign in to GitHub to watch PR pipelines.');
+    }
+
+    const headers: Record<string, string> = {
+      'Accept': 'application/vnd.github+json',
+      'Authorization': `Bearer ${session.accessToken}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'DevDocket-VSCode',
+    };
+
+    if (token?.isCancellationRequested) {
+      throw new Error('Request cancelled');
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(url, { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw new Error(`GitHub API request timed out after ${FETCH_TIMEOUT_MS / 1000}s`);
+      }
+      throw err;
+    }
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new Error('PR not found or access denied');
+      }
+      if (response.status === 401) {
+        throw new Error('GitHub authentication failed. Please re-authenticate.');
+      }
+      if (response.status === 403) {
+        const rateLimitRemaining = response.headers.get('x-ratelimit-remaining');
+        if (rateLimitRemaining === '0') {
+          throw new Error('GitHub API rate limit exceeded. Please wait and try again.');
+        }
+        throw new Error('GitHub access denied. Check repository permissions.');
+      }
+      throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+    }
+
+    return await response.json() as T;
+  }
+}

--- a/packages/github/src/githubPRWatcher.ts
+++ b/packages/github/src/githubPRWatcher.ts
@@ -148,7 +148,7 @@ export class GitHubPRWatcher implements DevDocketPRWatcher {
     try {
       response = await fetch(url, { headers, signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
+      if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
         throw new Error(`GitHub API request timed out after ${FETCH_TIMEOUT_MS / 1000}s`);
       }
       throw err;

--- a/packages/github/src/githubPRWatcher.ts
+++ b/packages/github/src/githubPRWatcher.ts
@@ -92,10 +92,9 @@ export class GitHubPRWatcher implements DevDocketPRWatcher {
         ? 'closed'
         : 'open';
 
-    // Update display name with PR title
-    if (prData.title) {
-      identifier.displayName = `PR #${identifier.prId}: ${prData.title}`;
-    }
+    const updatedDisplayName = prData.title
+      ? `PR #${identifier.prId}: ${prData.title}`
+      : undefined;
 
     // Fetch check runs for head commit
     const checkRunsData = await this.fetchApi<{ check_runs: GitHubCheckRun[] }>(
@@ -132,7 +131,7 @@ export class GitHubPRWatcher implements DevDocketPRWatcher {
       });
     }
 
-    return { prState, runs };
+    return { prState, runs, displayName: updatedDisplayName };
   }
 
   private async fetchApi<T>(url: string, token?: CancellationTokenLike): Promise<T> {

--- a/packages/github/src/test/githubPRWatcher.test.ts
+++ b/packages/github/src/test/githubPRWatcher.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GitHubPRWatcher } from '../githubPRWatcher';
+
+describe('GitHubPRWatcher', () => {
+  let watcher: GitHubPRWatcher;
+
+  beforeEach(() => {
+    watcher = new GitHubPRWatcher();
+  });
+
+  it('has correct id and label', () => {
+    expect(watcher.id).toBe('github-pr');
+    expect(watcher.label).toBe('GitHub Pull Requests');
+  });
+
+  describe('canWatch', () => {
+    it('returns true for valid GitHub PR URL', () => {
+      expect(watcher.canWatch('https://github.com/owner/repo/pull/42')).toBe(true);
+    });
+
+    it('returns true for PR URL with trailing slash', () => {
+      expect(watcher.canWatch('https://github.com/owner/repo/pull/42/')).toBe(true);
+    });
+
+    it('returns false for non-GitHub URL', () => {
+      expect(watcher.canWatch('https://example.com/owner/repo/pull/42')).toBe(false);
+    });
+
+    it('returns false for GitHub URL that is not a PR', () => {
+      expect(watcher.canWatch('https://github.com/owner/repo/issues/42')).toBe(false);
+      expect(watcher.canWatch('https://github.com/owner/repo/actions/runs/123')).toBe(false);
+    });
+
+    it('returns false for invalid URL', () => {
+      expect(watcher.canWatch('not-a-url')).toBe(false);
+    });
+
+    it('returns false for empty string', () => {
+      expect(watcher.canWatch('')).toBe(false);
+    });
+  });
+
+  describe('parsePRUrl', () => {
+    const url = 'https://github.com/myorg/myrepo/pull/42';
+
+    it('extracts owner, repo, and prNumber correctly', () => {
+      const result = watcher.parsePRUrl(url);
+      expect(result.prId).toBe('42');
+      expect(result.repo).toBe('myorg/myrepo');
+    });
+
+    it('sets providerId to github-pr', () => {
+      const result = watcher.parsePRUrl(url);
+      expect(result.providerId).toBe('github-pr');
+    });
+
+    it('sets displayName to PR #42', () => {
+      const result = watcher.parsePRUrl(url);
+      expect(result.displayName).toBe('PR #42');
+    });
+
+    it('preserves original URL', () => {
+      const result = watcher.parsePRUrl(url);
+      expect(result.url).toBe(url);
+    });
+
+    it('sets repo to owner/repo', () => {
+      const result = watcher.parsePRUrl('https://github.com/owner/repo/pull/7');
+      expect(result.repo).toBe('owner/repo');
+    });
+
+    it('throws for invalid URL format', () => {
+      expect(() => watcher.parsePRUrl('https://github.com/owner/repo/issues/1')).toThrow('Invalid GitHub PR URL');
+    });
+  });
+
+  describe('getPRRunsSnapshot', () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      fetchSpy?.mockRestore();
+    });
+
+    afterEach(() => {
+      fetchSpy?.mockRestore();
+    });
+
+    function makeIdentifier(overrides?: Partial<{ prId: string; repo: string }>) {
+      return {
+        providerId: 'github-pr',
+        prId: overrides?.prId ?? '42',
+        displayName: 'PR #42',
+        url: 'https://github.com/owner/repo/pull/42',
+        repo: overrides?.repo ?? 'owner/repo',
+      };
+    }
+
+    function mockFetchResponses(prData: object, checkRunsData: object) {
+      fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => prData,
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => checkRunsData,
+        } as Response);
+    }
+
+    it('returns open state for open PR', async () => {
+      mockFetchResponses(
+        { number: 42, title: 'My PR', state: 'open', merged: false, head: { sha: 'abc123' } },
+        { check_runs: [] },
+      );
+
+      const result = await watcher.getPRRunsSnapshot(makeIdentifier());
+      expect(result.prState).toBe('open');
+    });
+
+    it('returns merged state for merged PR', async () => {
+      mockFetchResponses(
+        { number: 42, title: 'My PR', state: 'closed', merged: true, head: { sha: 'abc123' } },
+        { check_runs: [] },
+      );
+
+      const result = await watcher.getPRRunsSnapshot(makeIdentifier());
+      expect(result.prState).toBe('merged');
+    });
+
+    it('returns closed state for closed non-merged PR', async () => {
+      mockFetchResponses(
+        { number: 42, title: 'My PR', state: 'closed', merged: false, head: { sha: 'abc123' } },
+        { check_runs: [] },
+      );
+
+      const result = await watcher.getPRRunsSnapshot(makeIdentifier());
+      expect(result.prState).toBe('closed');
+    });
+
+    it('updates displayName with PR title', async () => {
+      const identifier = makeIdentifier();
+      mockFetchResponses(
+        { number: 42, title: 'Fix the widget', state: 'open', merged: false, head: { sha: 'abc123' } },
+        { check_runs: [] },
+      );
+
+      await watcher.getPRRunsSnapshot(identifier);
+      expect(identifier.displayName).toBe('PR #42: Fix the widget');
+    });
+
+    it('deduplicates check runs by check_suite.id', async () => {
+      mockFetchResponses(
+        { number: 42, title: 'My PR', state: 'open', merged: false, head: { sha: 'abc123' } },
+        {
+          check_runs: [
+            {
+              id: 1,
+              name: 'build',
+              html_url: 'https://github.com/owner/repo/actions/runs/100/jobs/1',
+              check_suite: { id: 500 },
+            },
+            {
+              id: 2,
+              name: 'test',
+              html_url: 'https://github.com/owner/repo/actions/runs/100/jobs/2',
+              check_suite: { id: 500 },
+            },
+          ],
+        },
+      );
+
+      const result = await watcher.getPRRunsSnapshot(makeIdentifier());
+      expect(result.runs).toHaveLength(1);
+      expect(result.runs[0].runId).toBe('100');
+    });
+
+    it('extracts workflow run IDs from check run html_url', async () => {
+      mockFetchResponses(
+        { number: 42, title: 'My PR', state: 'open', merged: false, head: { sha: 'abc123' } },
+        {
+          check_runs: [
+            {
+              id: 1,
+              name: 'CI',
+              html_url: 'https://github.com/owner/repo/actions/runs/777/jobs/1',
+              check_suite: { id: 501 },
+            },
+            {
+              id: 2,
+              name: 'Deploy',
+              html_url: 'https://github.com/owner/repo/actions/runs/888/jobs/2',
+              check_suite: { id: 502 },
+            },
+          ],
+        },
+      );
+
+      const result = await watcher.getPRRunsSnapshot(makeIdentifier());
+      expect(result.runs).toHaveLength(2);
+      expect(result.runs[0].runId).toBe('777');
+      expect(result.runs[0].displayName).toBe('CI');
+      expect(result.runs[0].url).toBe('https://github.com/owner/repo/actions/runs/777');
+      expect(result.runs[1].runId).toBe('888');
+      expect(result.runs[1].displayName).toBe('Deploy');
+    });
+
+    it('returns empty runs array when no check runs found', async () => {
+      mockFetchResponses(
+        { number: 42, title: 'My PR', state: 'open', merged: false, head: { sha: 'abc123' } },
+        { check_runs: [] },
+      );
+
+      const result = await watcher.getPRRunsSnapshot(makeIdentifier());
+      expect(result.runs).toHaveLength(0);
+    });
+  });
+});

--- a/packages/github/src/test/githubPRWatcher.test.ts
+++ b/packages/github/src/test/githubPRWatcher.test.ts
@@ -137,15 +137,15 @@ describe('GitHubPRWatcher', () => {
       expect(result.prState).toBe('closed');
     });
 
-    it('updates displayName with PR title', async () => {
+    it('returns displayName with PR title in snapshot', async () => {
       const identifier = makeIdentifier();
       mockFetchResponses(
         { number: 42, title: 'Fix the widget', state: 'open', merged: false, head: { sha: 'abc123' } },
         { check_runs: [] },
       );
 
-      await watcher.getPRRunsSnapshot(identifier);
-      expect(identifier.displayName).toBe('PR #42: Fix the widget');
+      const snapshot = await watcher.getPRRunsSnapshot(identifier);
+      expect(snapshot.displayName).toBe('PR #42: Fix the widget');
     });
 
     it('deduplicates check runs by check_suite.id', async () => {

--- a/packages/github/src/test/githubPRWatcher.test.ts
+++ b/packages/github/src/test/githubPRWatcher.test.ts
@@ -148,7 +148,7 @@ describe('GitHubPRWatcher', () => {
       expect(snapshot.displayName).toBe('PR #42: Fix the widget');
     });
 
-    it('deduplicates check runs by check_suite.id', async () => {
+    it('deduplicates GitHub Actions check runs by workflow run ID', async () => {
       mockFetchResponses(
         { number: 42, title: 'My PR', state: 'open', merged: false, head: { sha: 'abc123' } },
         {
@@ -172,6 +172,7 @@ describe('GitHubPRWatcher', () => {
       const result = await watcher.getPRRunsSnapshot(makeIdentifier());
       expect(result.runs).toHaveLength(1);
       expect(result.runs[0].runId).toBe('100');
+      expect(result.runs[0].providerId).toBe('github-actions');
     });
 
     it('extracts workflow run IDs from check run html_url', async () => {
@@ -202,6 +203,105 @@ describe('GitHubPRWatcher', () => {
       expect(result.runs[0].url).toBe('https://github.com/owner/repo/actions/runs/777');
       expect(result.runs[1].runId).toBe('888');
       expect(result.runs[1].displayName).toBe('Deploy');
+    });
+
+    it('includes non-GitHub-Actions check runs with details_url', async () => {
+      mockFetchResponses(
+        { number: 42, title: 'My PR', state: 'open', merged: false, head: { sha: 'abc123' } },
+        {
+          check_runs: [
+            {
+              id: 10,
+              name: 'CI Pipeline',
+              html_url: 'https://github.com/owner/repo/runs/10',
+              details_url: 'https://dev.azure.com/myorg/myproject/_build/results?buildId=555',
+              app: { slug: 'azure-pipelines' },
+              check_suite: { id: 600 },
+            },
+          ],
+        },
+      );
+
+      const result = await watcher.getPRRunsSnapshot(makeIdentifier());
+      expect(result.runs).toHaveLength(1);
+      expect(result.runs[0].providerId).toBe('azure-pipelines');
+      expect(result.runs[0].runId).toBe('10');
+      expect(result.runs[0].displayName).toBe('CI Pipeline');
+      expect(result.runs[0].url).toBe('https://dev.azure.com/myorg/myproject/_build/results?buildId=555');
+    });
+
+    it('falls back to html_url when details_url is absent for non-GHA checks', async () => {
+      mockFetchResponses(
+        { number: 42, title: 'My PR', state: 'open', merged: false, head: { sha: 'abc123' } },
+        {
+          check_runs: [
+            {
+              id: 20,
+              name: 'External CI',
+              html_url: 'https://github.com/owner/repo/runs/20',
+              app: { slug: 'some-ci' },
+              check_suite: { id: 601 },
+            },
+          ],
+        },
+      );
+
+      const result = await watcher.getPRRunsSnapshot(makeIdentifier());
+      expect(result.runs).toHaveLength(1);
+      expect(result.runs[0].providerId).toBe('some-ci');
+      expect(result.runs[0].url).toBe('https://github.com/owner/repo/runs/20');
+    });
+
+    it('uses check-run as providerId when app slug is missing', async () => {
+      mockFetchResponses(
+        { number: 42, title: 'My PR', state: 'open', merged: false, head: { sha: 'abc123' } },
+        {
+          check_runs: [
+            {
+              id: 30,
+              name: 'Mystery Check',
+              html_url: 'https://github.com/owner/repo/runs/30',
+              check_suite: { id: 602 },
+            },
+          ],
+        },
+      );
+
+      const result = await watcher.getPRRunsSnapshot(makeIdentifier());
+      expect(result.runs).toHaveLength(1);
+      expect(result.runs[0].providerId).toBe('check-run');
+      expect(result.runs[0].runId).toBe('30');
+    });
+
+    it('handles mix of GitHub Actions and external check runs', async () => {
+      mockFetchResponses(
+        { number: 42, title: 'My PR', state: 'open', merged: false, head: { sha: 'abc123' } },
+        {
+          check_runs: [
+            {
+              id: 1,
+              name: 'CI',
+              html_url: 'https://github.com/owner/repo/actions/runs/777/jobs/1',
+              check_suite: { id: 501 },
+            },
+            {
+              id: 10,
+              name: 'ADO Pipeline',
+              html_url: 'https://github.com/owner/repo/runs/10',
+              details_url: 'https://dev.azure.com/myorg/myproject/_build/results?buildId=555',
+              app: { slug: 'azure-pipelines' },
+              check_suite: { id: 600 },
+            },
+          ],
+        },
+      );
+
+      const result = await watcher.getPRRunsSnapshot(makeIdentifier());
+      expect(result.runs).toHaveLength(2);
+      expect(result.runs[0].providerId).toBe('github-actions');
+      expect(result.runs[0].runId).toBe('777');
+      expect(result.runs[1].providerId).toBe('azure-pipelines');
+      expect(result.runs[1].url).toBe('https://dev.azure.com/myorg/myproject/_build/results?buildId=555');
     });
 
     it('returns empty runs array when no check runs found', async () => {

--- a/packages/shared/src/apiTypes.ts
+++ b/packages/shared/src/apiTypes.ts
@@ -1,4 +1,5 @@
 import type { CancellationTokenLike, DevDocketRunWatcher } from './runWatcher';
+import type { DevDocketPRWatcher } from './prWatcher';
 import type { Disposable, Event, DiscoveredItem, ResolvedItem } from './baseProvider';
 import type { WorkItem, ActivityType } from './workItem';
 
@@ -191,6 +192,16 @@ export interface DevDocketApi {
    * @param detail - Optional human-readable detail string.
    */
   addActivity?(itemId: string, type: ActivityType, detail?: string): Promise<void>;
+  /**
+   * Register a PR watcher for tracking pull request pipelines.
+   *
+   * PR watchers resolve PR URLs to their associated pipeline runs,
+   * enabling automatic tracking of all CI/CD runs for a pull request.
+   *
+   * @param watcher - The PR watcher to register.
+   * @returns A {@link Disposable} that unregisters the watcher when disposed.
+   */
+  registerPRWatcher?(watcher: DevDocketPRWatcher): Disposable;
   /**
    * Event fired after a work item changes lifecycle state.
    *

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,6 +9,7 @@ export type { DiscoveredItem, Disposable, Event, EventEmitterLike, ResolvedItem 
 export { isValidUrlSegment, isValidGitHubRepo, isValidRepoSlug, sanitizeUrlSegment, safeDecodeComponent } from './urlValidation';
 export { validateRefreshInterval } from './refreshInterval';
 export type { DevDocketRunWatcher, RunIdentifier, RunStatus, JobStatus, RunState, RunConclusion, CancellationTokenLike } from './runWatcher';
+export type { DevDocketPRWatcher, PRIdentifier, PRState, PRRunsSnapshot } from './prWatcher';
 export { combineSignals } from './signalUtils';
 export { runWorkerPool, runWorkerPoolSettled } from './concurrency';
 export { WorkItemState } from './workItem';

--- a/packages/shared/src/prWatcher.ts
+++ b/packages/shared/src/prWatcher.ts
@@ -27,6 +27,8 @@ export type PRState = 'open' | 'merged' | 'closed';
 export interface PRRunsSnapshot {
   prState: PRState;
   runs: RunIdentifier[];
+  /** Updated display name (e.g. with PR title) to apply to the identifier */
+  displayName?: string;
 }
 
 /**

--- a/packages/shared/src/prWatcher.ts
+++ b/packages/shared/src/prWatcher.ts
@@ -1,0 +1,68 @@
+import type { RunIdentifier, CancellationTokenLike } from './runWatcher';
+
+/**
+ * Identifier for a specific pull request parsed from a URL.
+ */
+export interface PRIdentifier {
+  /** ID of the PR watcher that owns this PR (e.g. 'github-pr', 'ado-pr') */
+  providerId: string;
+  /** Provider-specific PR identifier (e.g. PR number) */
+  prId: string;
+  /** Human-readable display name (e.g. "PR #42: Fix login bug") */
+  displayName: string;
+  /** Original URL */
+  url: string;
+  /** Repository identifier (e.g. "owner/repo") */
+  repo: string;
+}
+
+/**
+ * State of a pull request.
+ */
+export type PRState = 'open' | 'merged' | 'closed';
+
+/**
+ * Snapshot of a PR's current state and associated pipeline runs.
+ */
+export interface PRRunsSnapshot {
+  prState: PRState;
+  runs: RunIdentifier[];
+}
+
+/**
+ * A PR watcher that resolves PR URLs to their associated pipeline runs.
+ * Registered via {@link DevDocketApi.registerPRWatcher}.
+ */
+export interface DevDocketPRWatcher {
+  /** Unique identifier (e.g. 'github-pr', 'ado-pr') */
+  readonly id: string;
+  /** Human-readable display name */
+  readonly label: string;
+
+  /**
+   * Determine whether this watcher can handle the given URL.
+   * @param url - Raw URL string
+   * @returns `true` if this watcher recognizes the URL as a PR
+   */
+  canWatch(url: string): boolean;
+
+  /**
+   * Parse a PR URL into a structured identifier.
+   * @param url - Raw URL string (already validated via canWatch)
+   * @returns Identifier for the PR
+   * @throws If URL cannot be parsed
+   */
+  parsePRUrl(url: string): PRIdentifier;
+
+  /**
+   * Fetch the current PR state and its associated pipeline runs.
+   * @param identifier - PR identifier returned by parsePRUrl
+   * @param token - Optional cancellation token
+   * @returns Current PR state and list of run identifiers
+   * @throws If API call fails or PR not found
+   */
+  getPRRunsSnapshot(
+    identifier: PRIdentifier,
+    token?: CancellationTokenLike
+  ): Promise<PRRunsSnapshot>;
+}


### PR DESCRIPTION
Closes #354

## Summary

Adds PR-level pipeline watching. Users can now target a pull request URL instead of individual pipeline run URLs. The system automatically discovers and tracks all associated CI/CD runs, seamlessly handling re-runs and new pushes.

## Changes

### New: `DevDocketPRWatcher` interface (`@devdocket/shared`)
- `PRIdentifier`, `PRState`, `PRRunsSnapshot` types for PR watching
- `DevDocketPRWatcher` interface with `canWatch()`, `parsePRUrl()`, `getPRRunsSnapshot()`
- `PRRunsSnapshot` returns an optional `displayName` to avoid mutating the identifier

### New: PR watcher implementations
- **`GitHubPRWatcher`** — resolves GitHub PR URLs to Actions workflow runs via check runs API
- **`AdoPRWatcher`** — resolves Azure DevOps PR URLs to pipeline builds via builds API

### Core changes
- **`PRWatcherRegistry`** — manages registered PR watcher instances
- **`WatcherService`** — extended with PR watch lifecycle (start, poll, dismiss, persist)
  - Two-phase polling: PR watches first (discover/remove child runs), then run watches
  - `displayName` from snapshot applied by the service, not mutated by the watcher
- **`WatchStore`** — persists PR watches alongside run watches in `{ runs, prs }` envelope format with legacy migration
- **`WatchesTreeProvider`** — PR watches rendered as collapsible parent nodes with child run nodes
- **`DevDocketApi`** — optional `registerPRWatcher()` method (backward compatible)

### Commands
- `devdocket.watchPR` — dedicated command for PR URL input
- `devdocket.watchRun` — now also detects PR URLs and redirects to PR watch flow
- Watch command handlers consolidated in `watchCommands.ts` (removed duplication from `commands.ts`)

## Testing

- 19 new tests for `AdoPRWatcher` (URL parsing, state mapping, API interaction)
- 16+ new tests for `GitHubPRWatcher` (URL parsing, deduplication, error handling)
- Extended `watcherService.test.ts` with PR watch lifecycle tests
- Extended `watchStore.test.ts` with PR persistence and legacy migration tests
