### PR TITLE
Expand My GitHub PRs to include assigned PRs with cross-provider inbox dedup

### DIFF
--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -142,6 +142,16 @@ interface DiscoveredItem {
    * For example, a GitHub provider might group by repository name.
    */
   group?: string;
+
+  /**
+   * Optional cross-provider deduplication key.
+   * Items from different providers that share the same canonicalId are
+   * grouped in the Inbox (one representative shown). Accept/dismiss/read-state
+   * propagates to all items in the group.
+   * Items without canonicalId always show individually (backward compatible).
+   * Use a consistent format like 'github:pull:owner/repo#42'.
+   */
+  canonicalId?: string;
 }
 ```
 
@@ -152,6 +162,7 @@ interface DiscoveredItem {
 - `DiscoveredItem` data is not stored as a persisted record; DevDocket tracks only the inbox state (`unseen`, `accepted`, `dismissed`) for discovered items in `discovered-state.json`.
 - When a user accepts an item from Inbox/Sources, DevDocket creates and persists a new `WorkItem` in `workitems.json` that includes a snapshot of the item's `title`, along with its `providerId`/`externalId`/`url` as provenance metadata.
 - Use `group` to organize items in the Sources tree. Items with the same group value are nested under a folder.
+- Use `canonicalId` when the same entity might be discovered by multiple providers (e.g., a PR found by both "My PRs" and "PR Reviews"). Items sharing a `canonicalId` are deduplicated in the Inbox — one representative is shown and accept/dismiss propagates to all. Use a consistent format like `github:pull:owner/repo#42`. Items without `canonicalId` show individually (backward compatible). The Sources view is unaffected.
 
 ### Registering a Provider
 
@@ -328,6 +339,7 @@ interface DiscoveredItem {
   description?: string;
   url?: string;
   group?: string;
+  canonicalId?: string;
 }
 
 interface Disposable {

--- a/docs/provider-api.md
+++ b/docs/provider-api.md
@@ -113,6 +113,7 @@ interface DiscoveredItem {
   description?: string;
   url?: string;
   group?: string;
+  canonicalId?: string;
 }
 
 interface DevDocketProvider {
@@ -151,6 +152,7 @@ interface DiscoveredItem {
   description?: string;
   url?: string;
   group?: string;
+  canonicalId?: string;
 }
 
 interface Disposable {
@@ -508,6 +510,26 @@ Each `onDidDiscoverItems` emission **replaces** the provider's entire known item
 
 Set the `group` field on `DiscoveredItem` to organize items under folder nodes in the Inbox and Sources views. For example, a GitHub provider groups issues by repository name.
 
+### Use `canonicalId` for cross-provider deduplication
+
+When the same underlying entity (e.g., a pull request) might be discovered by multiple providers, set `canonicalId` to a shared identifier so DevDocket can deduplicate them in the Inbox.
+
+**How it works:**
+- Items from different providers that share the same `canonicalId` are grouped in the Inbox, and only one representative item is shown.
+- When the user accepts, dismisses, or reads an item, the action propagates to all items in the group.
+- Items without `canonicalId` always show individually — existing providers are unaffected.
+- The Sources view is not affected by `canonicalId` — it continues to show items per provider.
+
+**Format convention:** Use a consistent, deterministic format so that independent providers generate the same `canonicalId` for the same entity. The recommended pattern is `<platform>:<entity-type>:<identifier>`:
+
+| Entity | Example `canonicalId` |
+|--------|----------------------|
+| GitHub PR | `github:pull:octocat/hello-world#42` |
+| GitHub Issue | `github:issue:octocat/hello-world#7` |
+| ADO PR | `ado:pull:myorg/myproject/myrepo#123` |
+
+**When to use it:** If your provider discovers items that another provider might also discover, set `canonicalId`. For example, a "My PRs" provider and a "PR Reviews" provider may both discover the same pull request — giving both items the same `canonicalId` ensures the user sees it only once in their Inbox.
+
 ---
 
 ## API Reference
@@ -640,6 +662,18 @@ interface DiscoveredItem {
    * Items with the same group appear under a folder node.
    */
   group?: string;
+
+  /**
+   * Optional cross-provider deduplication key.
+   * When set, items from different providers that share the same canonicalId
+   * are grouped in the Inbox view and only one representative is shown.
+   * Accept/dismiss/read-state actions propagate to all items in the group.
+   * Items without canonicalId always show individually (backward compatible).
+   *
+   * Use a consistent format so different providers generate matching IDs
+   * for the same entity (e.g., 'github:pull:owner/repo#42').
+   */
+  canonicalId?: string;
 }
 ```
 

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -614,6 +614,7 @@ async function acceptSingleInboxItem(
     } catch (err: unknown) {
       handleCommandError('Failed to update state for existing accepted item', err);
     }
+    await propagateStateToCanonicalPeers(item, providerRegistry, stateStore, 'accepted');
     return;
   }
   const group = item.group?.trim();

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -669,6 +669,7 @@ async function acceptToFocusSingleInboxItem(
         return;
       }
       void vscode.window.showInformationMessage('DevDocket: Item is already in Focus');
+      await propagateStateToCanonicalPeers(item, providerRegistry, stateStore, 'accepted');
       return;
     }
     if (existing.state === WorkItemState.Done || existing.state === WorkItemState.Archived) {
@@ -681,6 +682,7 @@ async function acceptToFocusSingleInboxItem(
       void vscode.window.showWarningMessage(
         `DevDocket: Item is ${existing.state} and cannot be moved to Focus`,
       );
+      await propagateStateToCanonicalPeers(item, providerRegistry, stateStore, 'accepted');
       return;
     }
     workItemId = existing.id;

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -110,12 +110,19 @@ function wrapCommand<T extends unknown[]>(label: string, fn: (...args: T) => Pro
 // Canonical ID dedup helpers
 // ---------------------------------------------------------------------------
 
+/** Item with optional canonicalId — accepted by findCanonicalPeers. */
+interface CanonicalItem {
+  providerId: string;
+  externalId: string;
+  canonicalId?: string;
+}
+
 /**
  * Finds all unseen inbox items from other providers that share the same
  * canonicalId as the given item. Used to propagate accept/dismiss actions.
  */
 function findCanonicalPeers(
-  item: InboxItem,
+  item: CanonicalItem,
   providerRegistry: ProviderRegistry,
   stateStore: DiscoveredStateStore,
 ): Array<{ providerId: string; externalId: string }> {
@@ -135,7 +142,7 @@ function findCanonicalPeers(
 
 /** Propagates an inbox state change to all canonical peers of the given item. */
 async function propagateStateToCanonicalPeers(
-  item: InboxItem,
+  item: CanonicalItem,
   providerRegistry: ProviderRegistry,
   stateStore: DiscoveredStateStore,
   state: 'accepted' | 'dismissed',
@@ -899,6 +906,7 @@ async function handleRefresh(providerRegistry: ProviderRegistry): Promise<void> 
 async function handleAcceptFromSources(
   workGraph: WorkGraph,
   stateStore: DiscoveredStateStore,
+  providerRegistry: ProviderRegistry,
   item?: SourcesElement,
   selectedItems?: SourcesElement[],
   revealer?: ViewRevealer,
@@ -907,16 +915,21 @@ async function handleAcceptFromSources(
   if (items.length === 0) { return; }
 
   if (items.length === 1) {
-    await acceptSingleSourceItem(workGraph, stateStore, items[0], revealer);
+    await acceptSingleSourceItem(workGraph, stateStore, providerRegistry, items[0], revealer);
     return;
   }
 
   await batchAcceptItems(workGraph, stateStore, items, 'source item');
+  // Propagate accepted state to canonical peers of all batch items
+  for (const i of items) {
+    await propagateStateToCanonicalPeers(i, providerRegistry, stateStore, 'accepted');
+  }
 }
 
 async function acceptSingleSourceItem(
   workGraph: WorkGraph,
   stateStore: DiscoveredStateStore,
+  providerRegistry: ProviderRegistry,
   item: SourceItemNode,
   revealer?: ViewRevealer,
 ): Promise<void> {
@@ -928,6 +941,7 @@ async function acceptSingleSourceItem(
     } catch (err: unknown) {
       handleCommandError('Failed to update state for existing item', err);
     }
+    await propagateStateToCanonicalPeers(item, providerRegistry, stateStore, 'accepted');
     void vscode.window.showInformationMessage(
       `DevDocket: Item already accepted as "${existing.title}"`
     );
@@ -961,10 +975,12 @@ async function acceptSingleSourceItem(
     return;
   }
   void revealer?.revealInQueue(createdItem.id);
+  await propagateStateToCanonicalPeers(item, providerRegistry, stateStore, 'accepted');
 }
 
 async function handleDismissFromSources(
   stateStore: DiscoveredStateStore,
+  providerRegistry: ProviderRegistry,
   item?: SourcesElement,
   selectedItems?: SourcesElement[],
 ): Promise<void> {
@@ -975,6 +991,7 @@ async function handleDismissFromSources(
     try {
       logger.info(`Dismissing source item: ${items[0].externalId}`);
       await stateStore.setState(items[0].providerId, items[0].externalId, 'dismissed');
+      await propagateStateToCanonicalPeers(items[0], providerRegistry, stateStore, 'dismissed');
     } catch (err: unknown) {
       handleCommandError('Failed to dismiss item', err);
     }
@@ -986,6 +1003,9 @@ async function handleDismissFromSources(
     await stateStore.setStates(
       items.map(i => ({ providerId: i.providerId, externalId: i.externalId, state: 'dismissed' as const }))
     );
+    for (const i of items) {
+      await propagateStateToCanonicalPeers(i, providerRegistry, stateStore, 'dismissed');
+    }
     void vscode.window.showInformationMessage(`Dismissed ${items.length} items`);
   } catch (err: unknown) {
     handleCommandError('Failed to dismiss items', err);
@@ -1150,9 +1170,9 @@ export function registerCommands(
     vscode.commands.registerCommand('devdocket.dismissFromInbox',
       wrapCommand('Failed to dismiss from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleDismissFromInbox(stateStore, providerRegistry, item, selectedItems))),
     vscode.commands.registerCommand('devdocket.acceptFromSources',
-      wrapCommand('Failed to accept from sources', (item: SourcesElement, selectedItems?: SourcesElement[]) => handleAcceptFromSources(workGraph, stateStore, item, selectedItems, revealer))),
+      wrapCommand('Failed to accept from sources', (item: SourcesElement, selectedItems?: SourcesElement[]) => handleAcceptFromSources(workGraph, stateStore, providerRegistry, item, selectedItems, revealer))),
     vscode.commands.registerCommand('devdocket.dismissFromSources',
-      wrapCommand('Failed to dismiss from sources', (item: SourcesElement, selectedItems?: SourcesElement[]) => handleDismissFromSources(stateStore, item, selectedItems))),
+      wrapCommand('Failed to dismiss from sources', (item: SourcesElement, selectedItems?: SourcesElement[]) => handleDismissFromSources(stateStore, providerRegistry, item, selectedItems))),
     vscode.commands.registerCommand('devdocket.switchInboxToTree',
       wrapCommand('Failed to switch inbox layout', () => setViewLayout('inbox', 'tree'))),
     vscode.commands.registerCommand('devdocket.switchInboxToFlat',

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -107,6 +107,80 @@ function wrapCommand<T extends unknown[]>(label: string, fn: (...args: T) => Pro
 }
 
 // ---------------------------------------------------------------------------
+// Canonical ID dedup helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Finds all unseen inbox items from other providers that share the same
+ * canonicalId as the given item. Used to propagate accept/dismiss actions.
+ */
+function findCanonicalPeers(
+  item: InboxItem,
+  providerRegistry: ProviderRegistry,
+  stateStore: DiscoveredStateStore,
+): Array<{ providerId: string; externalId: string }> {
+  if (!item.canonicalId) { return []; }
+  const peers: Array<{ providerId: string; externalId: string }> = [];
+  for (const [providerId, items] of providerRegistry.getAllDiscoveredItems()) {
+    for (const discovered of items) {
+      if (discovered.canonicalId !== item.canonicalId) { continue; }
+      if (providerId === item.providerId && discovered.externalId === item.externalId) { continue; }
+      const state = stateStore.getState(providerId, discovered.externalId);
+      if (state !== undefined && state !== 'unseen') { continue; }
+      peers.push({ providerId, externalId: discovered.externalId });
+    }
+  }
+  return peers;
+}
+
+/** Propagates an inbox state change to all canonical peers of the given item. */
+async function propagateStateToCanonicalPeers(
+  item: InboxItem,
+  providerRegistry: ProviderRegistry,
+  stateStore: DiscoveredStateStore,
+  state: 'accepted' | 'dismissed',
+): Promise<void> {
+  const peers = findCanonicalPeers(item, providerRegistry, stateStore);
+  if (peers.length === 0) { return; }
+  try {
+    await stateStore.setStates(peers.map(p => ({ ...p, state })));
+  } catch (err: unknown) {
+    logger.error('Failed to propagate state to canonical peers', err);
+  }
+}
+
+/**
+ * Expands a list of inbox items by adding canonical peers that haven't already
+ * been explicitly selected. Ensures accept/dismiss propagates to all duplicates.
+ */
+function expandWithCanonicalPeers(
+  items: InboxItem[],
+  providerRegistry: ProviderRegistry,
+  stateStore: DiscoveredStateStore,
+): InboxItem[] {
+  const keys = new Set(items.map(i => `${i.providerId}::${i.externalId}`));
+  const extra: InboxItem[] = [];
+  for (const item of items) {
+    const peers = findCanonicalPeers(item, providerRegistry, stateStore);
+    for (const peer of peers) {
+      const peerKey = `${peer.providerId}::${peer.externalId}`;
+      if (!keys.has(peerKey)) {
+        keys.add(peerKey);
+        extra.push({
+          kind: 'item',
+          providerId: peer.providerId,
+          externalId: peer.externalId,
+          title: item.title,
+          url: item.url,
+          group: item.group,
+        });
+      }
+    }
+  }
+  return [...items, ...extra];
+}
+
+// ---------------------------------------------------------------------------
 // Individual command handlers
 // ---------------------------------------------------------------------------
 
@@ -502,6 +576,7 @@ async function handleFocusMoveDown(workGraph: WorkGraph, item?: { id?: string })
 async function handleAcceptFromInbox(
   workGraph: WorkGraph,
   stateStore: DiscoveredStateStore,
+  providerRegistry: ProviderRegistry,
   item?: InboxElement,
   selectedItems?: InboxElement[],
   revealer?: ViewRevealer,
@@ -510,16 +585,19 @@ async function handleAcceptFromInbox(
   if (items.length === 0) { return; }
 
   if (items.length === 1) {
-    await acceptSingleInboxItem(workGraph, stateStore, items[0], revealer);
+    await acceptSingleInboxItem(workGraph, stateStore, providerRegistry, items[0], revealer);
     return;
   }
 
-  await batchAcceptItems(workGraph, stateStore, items, 'inbox item');
+  // Expand items with canonical peers for batch accept
+  const expanded = expandWithCanonicalPeers(items, providerRegistry, stateStore);
+  await batchAcceptItems(workGraph, stateStore, expanded, 'inbox item');
 }
 
 async function acceptSingleInboxItem(
   workGraph: WorkGraph,
   stateStore: DiscoveredStateStore,
+  providerRegistry: ProviderRegistry,
   item: InboxItem,
   revealer?: ViewRevealer,
 ): Promise<void> {
@@ -564,12 +642,15 @@ async function acceptSingleInboxItem(
     handleCommandError('Failed to update state after accepting item', err);
     return;
   }
+  // Propagate accept to canonical peers
+  await propagateStateToCanonicalPeers(item, providerRegistry, stateStore, 'accepted');
   void revealer?.revealInQueue(createdItem.id);
 }
 
 async function acceptToFocusSingleInboxItem(
   workGraph: WorkGraph,
   stateStore: DiscoveredStateStore,
+  providerRegistry: ProviderRegistry,
   item: InboxItem,
   revealer?: ViewRevealer,
 ): Promise<void> {
@@ -642,6 +723,8 @@ async function acceptToFocusSingleInboxItem(
     handleCommandError('Failed to move item to Focus', err);
     return;
   }
+  // Propagate accept to canonical peers
+  await propagateStateToCanonicalPeers(item, providerRegistry, stateStore, 'accepted');
   void revealer?.revealInFocus(workItemId);
 }
 
@@ -744,6 +827,7 @@ async function batchAcceptToFocusItems(
 async function handleAcceptToFocusFromInbox(
   workGraph: WorkGraph,
   stateStore: DiscoveredStateStore,
+  providerRegistry: ProviderRegistry,
   item?: InboxElement,
   selectedItems?: InboxElement[],
   revealer?: ViewRevealer,
@@ -752,25 +836,31 @@ async function handleAcceptToFocusFromInbox(
   if (items.length === 0) { return; }
 
   if (items.length === 1) {
-    await acceptToFocusSingleInboxItem(workGraph, stateStore, items[0], revealer);
+    await acceptToFocusSingleInboxItem(workGraph, stateStore, providerRegistry, items[0], revealer);
     return;
   }
 
-  await batchAcceptToFocusItems(workGraph, stateStore, items);
+  // Expand items with canonical peers for batch accept
+  const expanded = expandWithCanonicalPeers(items, providerRegistry, stateStore);
+  await batchAcceptToFocusItems(workGraph, stateStore, expanded);
 }
 
 async function handleDismissFromInbox(
   stateStore: DiscoveredStateStore,
+  providerRegistry: ProviderRegistry,
   item?: InboxElement,
   selectedItems?: InboxElement[],
 ): Promise<void> {
   const items = resolveInboxItems(item, selectedItems);
   if (items.length === 0) { return; }
 
-  if (items.length === 1) {
+  // Expand with canonical peers so dismiss propagates
+  const expanded = expandWithCanonicalPeers(items, providerRegistry, stateStore);
+
+  if (expanded.length === 1) {
     try {
-      logger.info(`Dismissing inbox item: ${items[0].externalId}`);
-      await stateStore.setState(items[0].providerId, items[0].externalId, 'dismissed');
+      logger.info(`Dismissing inbox item: ${expanded[0].externalId}`);
+      await stateStore.setState(expanded[0].providerId, expanded[0].externalId, 'dismissed');
     } catch (err: unknown) {
       handleCommandError('Failed to dismiss item', err);
     }
@@ -778,9 +868,9 @@ async function handleDismissFromInbox(
   }
 
   try {
-    logger.info(`Batch dismissing ${items.length} inbox items`);
+    logger.info(`Batch dismissing ${expanded.length} inbox items`);
     await stateStore.setStates(
-      items.map(i => ({ providerId: i.providerId, externalId: i.externalId, state: 'dismissed' as const }))
+      expanded.map(i => ({ providerId: i.providerId, externalId: i.externalId, state: 'dismissed' as const }))
     );
     void vscode.window.showInformationMessage(`Dismissed ${items.length} items`);
   } catch (err: unknown) {
@@ -1047,11 +1137,11 @@ export function registerCommands(
     vscode.commands.registerCommand('devdocket.moveToQueue',
       wrapCommand('Failed to move item to queue', (item, selectedItems) => handleMoveToQueue(workGraph, item, selectedItems, revealer))),
     vscode.commands.registerCommand('devdocket.acceptFromInbox',
-      wrapCommand('Failed to accept from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleAcceptFromInbox(workGraph, stateStore, item, selectedItems, revealer))),
+      wrapCommand('Failed to accept from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleAcceptFromInbox(workGraph, stateStore, providerRegistry, item, selectedItems, revealer))),
     vscode.commands.registerCommand('devdocket.acceptToFocusFromInbox',
-      wrapCommand('Failed to accept to focus from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleAcceptToFocusFromInbox(workGraph, stateStore, item, selectedItems, revealer))),
+      wrapCommand('Failed to accept to focus from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleAcceptToFocusFromInbox(workGraph, stateStore, providerRegistry, item, selectedItems, revealer))),
     vscode.commands.registerCommand('devdocket.dismissFromInbox',
-      wrapCommand('Failed to dismiss from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleDismissFromInbox(stateStore, item, selectedItems))),
+      wrapCommand('Failed to dismiss from inbox', (item: InboxElement, selectedItems?: InboxElement[]) => handleDismissFromInbox(stateStore, providerRegistry, item, selectedItems))),
     vscode.commands.registerCommand('devdocket.acceptFromSources',
       wrapCommand('Failed to accept from sources', (item: SourcesElement, selectedItems?: SourcesElement[]) => handleAcceptFromSources(workGraph, stateStore, item, selectedItems, revealer))),
     vscode.commands.registerCommand('devdocket.dismissFromSources',

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -589,9 +589,11 @@ async function handleAcceptFromInbox(
     return;
   }
 
-  // Expand items with canonical peers for batch accept
-  const expanded = expandWithCanonicalPeers(items, providerRegistry, stateStore);
-  await batchAcceptItems(workGraph, stateStore, expanded, 'inbox item');
+  await batchAcceptItems(workGraph, stateStore, items, 'inbox item');
+  // Propagate state to canonical peers (state-only, no work items created)
+  for (const batchItem of items) {
+    await propagateStateToCanonicalPeers(batchItem, providerRegistry, stateStore, 'accepted');
+  }
 }
 
 async function acceptSingleInboxItem(
@@ -840,9 +842,11 @@ async function handleAcceptToFocusFromInbox(
     return;
   }
 
-  // Expand items with canonical peers for batch accept
-  const expanded = expandWithCanonicalPeers(items, providerRegistry, stateStore);
-  await batchAcceptToFocusItems(workGraph, stateStore, expanded);
+  await batchAcceptToFocusItems(workGraph, stateStore, items);
+  // Propagate state to canonical peers (state-only, no work items created)
+  for (const batchItem of items) {
+    await propagateStateToCanonicalPeers(batchItem, providerRegistry, stateStore, 'accepted');
+  }
 }
 
 async function handleDismissFromInbox(
@@ -872,7 +876,7 @@ async function handleDismissFromInbox(
     await stateStore.setStates(
       expanded.map(i => ({ providerId: i.providerId, externalId: i.externalId, state: 'dismissed' as const }))
     );
-    void vscode.window.showInformationMessage(`Dismissed ${items.length} items`);
+    void vscode.window.showInformationMessage(`Dismissed ${expanded.length} item${expanded.length === 1 ? '' : 's'}`);
   } catch (err: unknown) {
     handleCommandError('Failed to dismiss items', err);
   }

--- a/packages/core/src/services/canonicalDedup.ts
+++ b/packages/core/src/services/canonicalDedup.ts
@@ -1,0 +1,37 @@
+import { DiscoveredItem } from '../api/types';
+
+/**
+ * Builds a set of `providerId::externalId` keys that should be hidden due to
+ * cross-provider canonicalId dedup. For each group of unseen items sharing the
+ * same canonicalId, the first key alphabetically is the representative;
+ * the rest are hidden.
+ */
+export function buildCanonicalHiddenSet(
+  allItems: Iterable<[string, readonly DiscoveredItem[]]>,
+  getState: (providerId: string, externalId: string) => string | undefined,
+): Set<string> {
+  const hidden = new Set<string>();
+  const groups = new Map<string, string[]>();
+  for (const [providerId, items] of allItems) {
+    for (const item of items) {
+      if (!item.canonicalId) { continue; }
+      const state = getState(providerId, item.externalId);
+      if (state !== undefined && state !== 'unseen') { continue; }
+      const key = `${providerId}::${item.externalId}`;
+      let group = groups.get(item.canonicalId);
+      if (!group) {
+        group = [];
+        groups.set(item.canonicalId, group);
+      }
+      group.push(key);
+    }
+  }
+  for (const members of groups.values()) {
+    if (members.length <= 1) { continue; }
+    members.sort();
+    for (let i = 1; i < members.length; i++) {
+      hidden.add(members[i]);
+    }
+  }
+  return hidden;
+}

--- a/packages/core/src/services/inboxBadge.ts
+++ b/packages/core/src/services/inboxBadge.ts
@@ -6,12 +6,38 @@ export function getInboxUnseenCount(
   stateStore: DiscoveredStateStore,
   seenItems?: ReadonlySet<string>,
 ): number {
+  // Build the canonicalId hidden set for dedup
+  const hidden = new Set<string>();
+  const groups = new Map<string, string[]>();
+  for (const [providerId, items] of providerRegistry.getAllDiscoveredItems()) {
+    for (const item of items) {
+      if (!item.canonicalId) { continue; }
+      const state = stateStore.getState(providerId, item.externalId);
+      if (state !== undefined && state !== 'unseen') { continue; }
+      const key = `${providerId}::${item.externalId}`;
+      let group = groups.get(item.canonicalId);
+      if (!group) {
+        group = [];
+        groups.set(item.canonicalId, group);
+      }
+      group.push(key);
+    }
+  }
+  for (const members of groups.values()) {
+    if (members.length <= 1) { continue; }
+    members.sort();
+    for (let i = 1; i < members.length; i++) {
+      hidden.add(members[i]);
+    }
+  }
+
   let count = 0;
   for (const [providerId, items] of providerRegistry.getAllDiscoveredItems()) {
     for (const item of items) {
       const state = stateStore.getState(providerId, item.externalId);
       if (state === undefined || state === 'unseen') {
-        if (!seenItems?.has(`${providerId}::${item.externalId}`)) {
+        const key = `${providerId}::${item.externalId}`;
+        if (!hidden.has(key) && !seenItems?.has(key)) {
           count++;
         }
       }

--- a/packages/core/src/services/inboxBadge.ts
+++ b/packages/core/src/services/inboxBadge.ts
@@ -12,6 +12,18 @@ export function getInboxUnseenCount(
     (pid, eid) => stateStore.getState(pid, eid),
   );
 
+  // Precompute which canonical groups have any member seen in this session
+  const seenCanonicalIds = new Set<string>();
+  if (seenItems && seenItems.size > 0) {
+    for (const [providerId, items] of providerRegistry.getAllDiscoveredItems()) {
+      for (const item of items) {
+        if (item.canonicalId && seenItems.has(`${providerId}::${item.externalId}`)) {
+          seenCanonicalIds.add(item.canonicalId);
+        }
+      }
+    }
+  }
+
   let count = 0;
   for (const [providerId, items] of providerRegistry.getAllDiscoveredItems()) {
     for (const item of items) {
@@ -19,6 +31,10 @@ export function getInboxUnseenCount(
       if (state === undefined || state === 'unseen') {
         const key = `${providerId}::${item.externalId}`;
         if (!hidden.has(key) && !seenItems?.has(key)) {
+          // Also treat as seen if any canonical peer was seen this session
+          if (item.canonicalId && seenCanonicalIds.has(item.canonicalId)) {
+            continue;
+          }
           count++;
         }
       }

--- a/packages/core/src/services/inboxBadge.ts
+++ b/packages/core/src/services/inboxBadge.ts
@@ -1,35 +1,16 @@
 import { ProviderRegistry } from './providerRegistry';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
+import { buildCanonicalHiddenSet } from './canonicalDedup';
 
 export function getInboxUnseenCount(
   providerRegistry: ProviderRegistry,
   stateStore: DiscoveredStateStore,
   seenItems?: ReadonlySet<string>,
 ): number {
-  // Build the canonicalId hidden set for dedup
-  const hidden = new Set<string>();
-  const groups = new Map<string, string[]>();
-  for (const [providerId, items] of providerRegistry.getAllDiscoveredItems()) {
-    for (const item of items) {
-      if (!item.canonicalId) { continue; }
-      const state = stateStore.getState(providerId, item.externalId);
-      if (state !== undefined && state !== 'unseen') { continue; }
-      const key = `${providerId}::${item.externalId}`;
-      let group = groups.get(item.canonicalId);
-      if (!group) {
-        group = [];
-        groups.set(item.canonicalId, group);
-      }
-      group.push(key);
-    }
-  }
-  for (const members of groups.values()) {
-    if (members.length <= 1) { continue; }
-    members.sort();
-    for (let i = 1; i < members.length; i++) {
-      hidden.add(members[i]);
-    }
-  }
+  const hidden = buildCanonicalHiddenSet(
+    providerRegistry.getAllDiscoveredItems(),
+    (pid, eid) => stateStore.getState(pid, eid),
+  );
 
   let count = 0;
   for (const [providerId, items] of providerRegistry.getAllDiscoveredItems()) {

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -85,21 +85,24 @@ function createMockActionRegistry(): { [K in keyof UsedActionRegistryMethods]: M
   };
 }
 
-type UsedStateStoreMethods = Pick<DiscoveredStateStore, 'setState' | 'setStates'>;
+type UsedStateStoreMethods = Pick<DiscoveredStateStore, 'setState' | 'setStates' | 'getState'>;
 
 function createMockStateStore(): { [K in keyof UsedStateStoreMethods]: Mock } {
   return {
     setState: vi.fn(),
     setStates: vi.fn(),
+    getState: vi.fn(),
   };
 }
 
-type UsedProviderRegistryMethods = Pick<ProviderRegistry, 'refreshAll' | 'resolveUrl'>;
+type UsedProviderRegistryMethods = Pick<ProviderRegistry, 'refreshAll' | 'resolveUrl' | 'getAllDiscoveredItems' | 'getDiscoveredItems'>;
 
 function createMockProviderRegistry(): { [K in keyof UsedProviderRegistryMethods]: Mock } {
   return {
     refreshAll: vi.fn().mockResolvedValue(undefined),
     resolveUrl: vi.fn().mockResolvedValue(undefined),
+    getAllDiscoveredItems: vi.fn().mockReturnValue(new Map()),
+    getDiscoveredItems: vi.fn().mockReturnValue([]),
   };
 }
 
@@ -2001,6 +2004,90 @@ describe('registerCommands', () => {
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
         'DevDocket: Failed to update state after accepting item — disk full',
       );
+    });
+  });
+
+  // ── Sources canonical peer propagation ────────────────────────────
+
+  describe('Sources canonical peer propagation', () => {
+    function setupCanonicalPeers() {
+      const items = new Map<string, any[]>();
+      items.set('prs', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      items.set('reviews', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      providerRegistry.getAllDiscoveredItems.mockReturnValue(items);
+      // stateStore.getState returns undefined (unseen) for peers
+      stateStore.getState.mockReturnValue(undefined);
+    }
+
+    it('acceptFromSources propagates accepted state to canonical peers', async () => {
+      setupCanonicalPeers();
+      const sourceItem = makeSourceItem({
+        providerId: 'prs',
+        externalId: 'repo#1',
+        canonicalId: 'github:pull:repo#1',
+      });
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem.mockResolvedValue(createWorkItem());
+
+      await invoke('devdocket.acceptFromSources', sourceItem);
+
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'reviews', externalId: 'repo#1', state: 'accepted' },
+      ]);
+    });
+
+    it('dismissFromSources propagates dismissed state to canonical peers', async () => {
+      setupCanonicalPeers();
+      const sourceItem = makeSourceItem({
+        providerId: 'prs',
+        externalId: 'repo#1',
+        canonicalId: 'github:pull:repo#1',
+      });
+
+      await invoke('devdocket.dismissFromSources', sourceItem);
+
+      expect(stateStore.setState).toHaveBeenCalledWith('prs', 'repo#1', 'dismissed');
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'reviews', externalId: 'repo#1', state: 'dismissed' },
+      ]);
+    });
+
+    it('does not propagate when item has no canonicalId', async () => {
+      providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map());
+      const sourceItem = makeSourceItem({ providerId: 'prs', externalId: 'repo#1' });
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem.mockResolvedValue(createWorkItem());
+
+      await invoke('devdocket.acceptFromSources', sourceItem);
+
+      expect(stateStore.setStates).not.toHaveBeenCalled();
+    });
+
+    it('does not propagate to already-accepted peers', async () => {
+      const items = new Map<string, any[]>();
+      items.set('prs', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      items.set('reviews', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      providerRegistry.getAllDiscoveredItems.mockReturnValue(items);
+      stateStore.getState.mockReturnValue('accepted');
+
+      const sourceItem = makeSourceItem({
+        providerId: 'prs',
+        externalId: 'repo#1',
+        canonicalId: 'github:pull:repo#1',
+      });
+
+      await invoke('devdocket.dismissFromSources', sourceItem);
+
+      // Peer is already accepted, so setStates should not be called for propagation
+      expect(stateStore.setStates).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/test/getInboxUnseenCount.test.ts
+++ b/packages/core/src/test/getInboxUnseenCount.test.ts
@@ -205,4 +205,19 @@ describe('getInboxUnseenCount', () => {
 
     expect(getInboxUnseenCount(registry, stateStore as any)).toBe(2);
   });
+
+  it('treats canonical group as seen when any peer is in seenItems', () => {
+    const p1 = createMockProvider('prs');
+    const p2 = createMockProvider('reviews');
+    registry.register(p1);
+    registry.register(p2);
+    p1.fireItems([{ externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' }]);
+    p2.fireItems([{ externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' }]);
+
+    // Mark one peer as seen — the representative (prs::repo#1) should also count as seen
+    const seen = new Set(['reviews::repo#1']);
+    // Canonical dedup hides the non-representative peer; the representative (prs::repo#1)
+    // is treated as seen because its canonical peer is in seenItems
+    expect(getInboxUnseenCount(registry, stateStore as any, seen)).toBe(0);
+  });
 });

--- a/packages/core/src/test/getInboxUnseenCount.test.ts
+++ b/packages/core/src/test/getInboxUnseenCount.test.ts
@@ -171,4 +171,38 @@ describe('getInboxUnseenCount', () => {
     const seen = new Set(['gh::1', 'gh::2']);
     expect(getInboxUnseenCount(registry, stateStore as any, seen)).toBe(0);
   });
+
+  it('deduplicates items sharing the same canonicalId across providers', () => {
+    const p1 = createMockProvider('prs');
+    const p2 = createMockProvider('reviews');
+    registry.register(p1);
+    registry.register(p2);
+    p1.fireItems([{ externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' }]);
+    p2.fireItems([{ externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' }]);
+
+    // Should count as 1, not 2
+    expect(getInboxUnseenCount(registry, stateStore as any)).toBe(1);
+  });
+
+  it('does not dedup items without canonicalId', () => {
+    const p1 = createMockProvider('prs');
+    const p2 = createMockProvider('reviews');
+    registry.register(p1);
+    registry.register(p2);
+    p1.fireItems([{ externalId: 'repo#1', title: 'PR #1' }]);
+    p2.fireItems([{ externalId: 'repo#1', title: 'PR #1' }]);
+
+    expect(getInboxUnseenCount(registry, stateStore as any)).toBe(2);
+  });
+
+  it('dedup does not affect items with different canonicalIds', () => {
+    const p1 = createMockProvider('prs');
+    registry.register(p1);
+    p1.fireItems([
+      { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      { externalId: 'repo#2', title: 'PR #2', canonicalId: 'github:pull:repo#2' },
+    ]);
+
+    expect(getInboxUnseenCount(registry, stateStore as any)).toBe(2);
+  });
 });

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -1020,5 +1020,37 @@ describe('InboxTreeProvider', () => {
       expect(provider.sessionSeenItems.has('prs::repo#1')).toBe(true);
       expect(provider.sessionSeenItems.has('reviews::repo#1')).toBe(true);
     });
+
+    it('markSeen does not propagate to already-accepted canonical peers', async () => {
+      registry._setItems('prs', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      registry._setItems('reviews', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      stateStore._set('reviews', 'repo#1', 'accepted');
+
+      await provider.markSeen('prs', 'repo#1');
+
+      expect(provider.sessionSeenItems.has('prs::repo#1')).toBe(true);
+      // Peer is already accepted — should not be marked seen
+      expect(provider.sessionSeenItems.has('reviews::repo#1')).toBe(false);
+    });
+
+    it('markSeenBatch does not propagate to already-dismissed canonical peers', async () => {
+      registry._setItems('prs', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      registry._setItems('reviews', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      stateStore._set('reviews', 'repo#1', 'dismissed');
+
+      await provider.markSeenBatch([{ providerId: 'prs', externalId: 'repo#1' }]);
+
+      expect(provider.sessionSeenItems.has('prs::repo#1')).toBe(true);
+      // Peer is already dismissed — should not be marked seen
+      expect(provider.sessionSeenItems.has('reviews::repo#1')).toBe(false);
+    });
   });
 });

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -60,6 +60,16 @@ function createMockReadStateStore() {
       items.add(key);
       return true;
     }),
+    addMany: vi.fn(async (keys: string[]) => {
+      const added: string[] = [];
+      for (const key of keys) {
+        if (!items.has(key)) {
+          items.add(key);
+          added.push(key);
+        }
+      }
+      return added;
+    }),
     deleteMany: vi.fn(async (keys: string[]) => {
       for (const key of keys) { items.delete(key); }
     }),
@@ -851,6 +861,164 @@ describe('InboxTreeProvider', () => {
       const children = provider.getChildren();
       expect(children).toHaveLength(1);
       expect((children[0] as InboxProviderNode).providerId).toBe('gh');
+    });
+  });
+
+  describe('canonicalId dedup', () => {
+    it('shows only one representative when items share canonicalId across providers', () => {
+      registry._setItems('prs', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      registry._setItems('reviews', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+
+      // Flat mode shows all unseen items
+      provider.layout = 'flat';
+      const items = provider.getChildren();
+      expect(items).toHaveLength(1);
+      // Representative is the first by sorted key
+      const item = items[0] as InboxItem;
+      expect(item.kind).toBe('item');
+    });
+
+    it('shows items without canonicalId individually', () => {
+      registry._setItems('prs', [
+        { externalId: 'repo#1', title: 'PR #1' },
+      ]);
+      registry._setItems('reviews', [
+        { externalId: 'repo#1', title: 'Review #1' },
+      ]);
+
+      provider.layout = 'flat';
+      const items = provider.getChildren();
+      expect(items).toHaveLength(2);
+    });
+
+    it('hides duplicates in tree mode provider children', () => {
+      registry._setLabel('prs', 'My PRs');
+      registry._setLabel('reviews', 'PR Reviews');
+      registry._setItems('prs', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      registry._setItems('reviews', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+
+      // Tree mode: only one provider should have unseen items
+      const topLevel = provider.getChildren();
+      // One provider's items are hidden, so only one provider node appears
+      expect(topLevel).toHaveLength(1);
+    });
+
+    it('deterministic representative selection (sorted by key)', () => {
+      // 'alpha' provider key comes before 'beta'
+      registry._setItems('beta', [
+        { externalId: 'x#1', title: 'From beta', canonicalId: 'shared:x#1' },
+      ]);
+      registry._setItems('alpha', [
+        { externalId: 'x#1', title: 'From alpha', canonicalId: 'shared:x#1' },
+      ]);
+
+      provider.layout = 'flat';
+      const items = provider.getChildren();
+      expect(items).toHaveLength(1);
+      const representative = items[0] as InboxItem;
+      // alpha::x#1 < beta::x#1
+      expect(representative.providerId).toBe('alpha');
+    });
+
+    it('does not dedup items with different canonicalIds', () => {
+      registry._setItems('prs', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+        { externalId: 'repo#2', title: 'PR #2', canonicalId: 'github:pull:repo#2' },
+      ]);
+
+      provider.layout = 'flat';
+      const items = provider.getChildren();
+      expect(items).toHaveLength(2);
+    });
+
+    it('dedup respects accepted/dismissed state', () => {
+      registry._setItems('prs', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      registry._setItems('reviews', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      // Accept one of them
+      stateStore._set('prs', 'repo#1', 'accepted');
+
+      provider.layout = 'flat';
+      const items = provider.getChildren();
+      // Only the reviews item remains since the prs one is accepted
+      expect(items).toHaveLength(1);
+      expect((items[0] as InboxItem).providerId).toBe('reviews');
+    });
+
+    it('dedup correctly counts unseen items per provider', () => {
+      registry._setLabel('prs', 'My PRs');
+      registry._setLabel('reviews', 'PR Reviews');
+      registry._setItems('prs', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+        { externalId: 'repo#2', title: 'PR #2' },
+      ]);
+      registry._setItems('reviews', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+
+      // prs provider: repo#1 is representative (prs::repo#1 < reviews::repo#1), repo#2 no canonicalId
+      const prsTreeItem = provider.getTreeItem(providerNode('prs'));
+      expect(prsTreeItem.description).toBe('2');
+
+      // reviews provider: repo#1 is hidden (reviews::repo#1 > prs::repo#1)
+      const reviewsTreeItem = provider.getTreeItem(providerNode('reviews'));
+      expect(reviewsTreeItem.description).toBe('0');
+    });
+
+    it('dedup with groups hides items correctly', () => {
+      registry._setItems('prs', [
+        { externalId: 'repo#1', title: 'PR #1', group: 'myrepo', canonicalId: 'github:pull:repo#1' },
+      ]);
+      registry._setItems('reviews', [
+        { externalId: 'repo#1', title: 'PR #1', group: 'myrepo', canonicalId: 'github:pull:repo#1' },
+      ]);
+
+      const prsChildren = provider.getChildren(providerNode('prs'));
+      // prs is the representative (prs < reviews alphabetically)
+      expect(prsChildren.length).toBeGreaterThan(0);
+
+      const reviewsChildren = provider.getChildren(providerNode('reviews'));
+      expect(reviewsChildren).toHaveLength(0);
+    });
+
+    it('markSeen propagates to canonical peers', async () => {
+      registry._setItems('prs', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      registry._setItems('reviews', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+
+      await provider.markSeen('prs', 'repo#1');
+
+      // Both should now be seen
+      expect(provider.sessionSeenItems.has('prs::repo#1')).toBe(true);
+      expect(provider.sessionSeenItems.has('reviews::repo#1')).toBe(true);
+    });
+
+    it('markSeenBatch propagates to canonical peers', async () => {
+      registry._setItems('prs', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      registry._setItems('reviews', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+
+      await provider.markSeenBatch([{ providerId: 'prs', externalId: 'repo#1' }]);
+
+      expect(provider.sessionSeenItems.has('prs::repo#1')).toBe(true);
+      expect(provider.sessionSeenItems.has('reviews::repo#1')).toBe(true);
     });
   });
 });

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -404,10 +404,10 @@ describe('InboxTreeProvider', () => {
       expect(await provider.markSeen('gh', '1')).toBe(false);
     });
 
-    it('should fire onDidMarkSeen when a new item is marked seen', () => {
+    it('should fire onDidMarkSeen when a new item is marked seen', async () => {
       const listener = vi.fn();
       provider.onDidMarkSeen(listener);
-      provider.markSeen('gh', '1');
+      await provider.markSeen('gh', '1');
       expect(listener).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -75,6 +75,7 @@ function createMockReadStateStore() {
     }),
     keys: vi.fn(() => items.values()),
     load: vi.fn(async () => {}),
+    _add: (key: string) => { items.add(key); },
   };
 }
 
@@ -1051,6 +1052,24 @@ describe('InboxTreeProvider', () => {
       expect(provider.sessionSeenItems.has('prs::repo#1')).toBe(true);
       // Peer is already dismissed — should not be marked seen
       expect(provider.sessionSeenItems.has('reviews::repo#1')).toBe(false);
+    });
+
+    it('tree item isSeen reflects canonical peer read state', async () => {
+      registry._setItems('prs', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+      registry._setItems('reviews', [
+        { externalId: 'repo#1', title: 'PR #1', canonicalId: 'github:pull:repo#1' },
+      ]);
+
+      // Mark one peer as read
+      readStateStore._add('reviews::repo#1');
+
+      // The representative (prs::repo#1) should show as seen because its canonical peer is read
+      const items = provider.getChildren(providerNode('prs')) as InboxItem[];
+      expect(items).toHaveLength(1);
+      const treeItem = provider.getTreeItem(items[0]);
+      expect(treeItem.iconPath).toEqual(expect.objectContaining({ id: 'circle-outline' }));
     });
   });
 });

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -412,17 +412,17 @@ describe('InboxTreeProvider', () => {
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
-    it('should not fire onDidMarkSeen when item is already seen', () => {
-      provider.markSeen('gh', '1');
+    it('should not fire onDidMarkSeen when item is already seen', async () => {
+      await provider.markSeen('gh', '1');
       const listener = vi.fn();
       provider.onDidMarkSeen(listener);
-      provider.markSeen('gh', '1');
+      await provider.markSeen('gh', '1');
       expect(listener).not.toHaveBeenCalled();
     });
 
-    it('should expose seen items via sessionSeenItems', () => {
+    it('should expose seen items via sessionSeenItems', async () => {
       expect(provider.sessionSeenItems.size).toBe(0);
-      provider.markSeen('gh', '1');
+      await provider.markSeen('gh', '1');
       expect(provider.sessionSeenItems.has('gh::1')).toBe(true);
       expect(provider.sessionSeenItems.size).toBe(1);
     });

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -29,6 +29,7 @@ export interface InboxItem {
   url?: string;
   group?: string;
   reason?: string;
+  canonicalId?: string;
 }
 
 export type InboxElement = InboxProviderNode | InboxGroupNode | InboxItem;
@@ -116,16 +117,36 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   async markSeen(providerId: string, externalId: string): Promise<boolean> {
     const key = `${providerId}::${externalId}`;
-    if (!this.seenItems.has(key)) {
-      this.seenItems.add(key);
+    const peerKeys = this.findCanonicalPeerKeys(providerId, externalId);
+    const allKeys = [key, ...peerKeys];
+    let changed = false;
+    for (const k of allKeys) {
+      if (!this.seenItems.has(k)) {
+        this.seenItems.add(k);
+        changed = true;
+      }
+    }
+    if (changed) {
       this._onDidMarkSeen.fire();
+    }
+    if (peerKeys.length > 0) {
+      await this.readStateStore.addMany(allKeys);
+      return true;
     }
     return this.readStateStore.add(key);
   }
 
   /** Marks multiple items as seen in a single write operation. */
   async markSeenBatch(items: Array<{ providerId: string; externalId: string }>): Promise<boolean> {
-    const keys = items.map(i => `${i.providerId}::${i.externalId}`);
+    // Expand with canonical peers
+    const allItems = new Set<string>();
+    for (const item of items) {
+      allItems.add(`${item.providerId}::${item.externalId}`);
+      for (const peerKey of this.findCanonicalPeerKeys(item.providerId, item.externalId)) {
+        allItems.add(peerKey);
+      }
+    }
+    const keys = [...allItems];
     const newKeys = keys.filter(k => !this.seenItems.has(k));
     // Persist first so in-memory state stays consistent on write failure
     const newlyAdded = await this.readStateStore.addMany(keys);
@@ -136,6 +157,22 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       this._onDidMarkSeen.fire();
     }
     return newKeys.length > 0 || newlyAdded.length > 0;
+  }
+
+  /** Finds `providerId::externalId` keys of canonical peers for the given item. */
+  private findCanonicalPeerKeys(providerId: string, externalId: string): string[] {
+    const items = this.providerRegistry.getDiscoveredItems(providerId);
+    const item = items.find(i => i.externalId === externalId);
+    if (!item?.canonicalId) { return []; }
+    const peers: string[] = [];
+    for (const [pid, pItems] of this.providerRegistry.getAllDiscoveredItems()) {
+      for (const pi of pItems) {
+        if (pi.canonicalId !== item.canonicalId) { continue; }
+        if (pid === providerId && pi.externalId === externalId) { continue; }
+        peers.push(`${pid}::${pi.externalId}`);
+      }
+    }
+    return peers;
   }
 
   getTreeItem(element: InboxElement): vscode.TreeItem {
@@ -243,11 +280,13 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   private getAllUnseenItems(): InboxItem[] {
     const result: InboxItem[] = [];
+    const hidden = this.buildCanonicalHiddenSet();
     const allItems = this.providerRegistry.getAllDiscoveredItems();
     for (const [providerId, items] of allItems) {
       for (const item of items) {
         const state = this.stateStore.getState(providerId, item.externalId);
         if (state !== undefined && state !== 'unseen') { continue; }
+        if (hidden.has(`${providerId}::${item.externalId}`)) { continue; }
         result.push(this.toItemNode(providerId, item));
       }
     }
@@ -256,12 +295,14 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   private getProviderChildren(providerId: string): (InboxGroupNode | InboxItem)[] {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
+    const hidden = this.buildCanonicalHiddenSet();
     const groupCounts = new Map<string, number>();
     const ungrouped: typeof items = [];
 
     for (const item of items) {
       const state = this.stateStore.getState(providerId, item.externalId);
       if (state !== undefined && state !== 'unseen') { continue; }
+      if (hidden.has(`${providerId}::${item.externalId}`)) { continue; }
 
       if (item.group?.trim()) {
         const normalizedGroup = item.group.trim();
@@ -290,11 +331,13 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   private getGroupChildren(providerId: string, groupName: string): InboxItem[] {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
+    const hidden = this.buildCanonicalHiddenSet();
     const result: InboxItem[] = [];
     for (const item of items) {
       if (item.group?.trim() !== groupName) { continue; }
       const state = this.stateStore.getState(providerId, item.externalId);
       if (state !== undefined && state !== 'unseen') { continue; }
+      if (hidden.has(`${providerId}::${item.externalId}`)) { continue; }
       result.push(this.toItemNode(providerId, item));
     }
     return result.sort((a, b) => a.title.localeCompare(b.title));
@@ -310,23 +353,64 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       url: item.url,
       group: item.group?.trim() || undefined,
       reason: item.reason,
+      canonicalId: item.canonicalId,
     };
+  }
+
+  /**
+   * Builds a set of `providerId::externalId` keys that should be hidden due to
+   * cross-provider canonicalId dedup. For each group of unseen items sharing the
+   * same canonicalId, the first key alphabetically is the representative;
+   * the rest are hidden.
+   */
+  private buildCanonicalHiddenSet(): Set<string> {
+    const hidden = new Set<string>();
+    // Map canonicalId → list of providerId::externalId keys
+    const groups = new Map<string, string[]>();
+    const allItems = this.providerRegistry.getAllDiscoveredItems();
+    for (const [providerId, items] of allItems) {
+      for (const item of items) {
+        if (!item.canonicalId) { continue; }
+        const state = this.stateStore.getState(providerId, item.externalId);
+        if (state !== undefined && state !== 'unseen') { continue; }
+        const key = `${providerId}::${item.externalId}`;
+        let group = groups.get(item.canonicalId);
+        if (!group) {
+          group = [];
+          groups.set(item.canonicalId, group);
+        }
+        group.push(key);
+      }
+    }
+    for (const members of groups.values()) {
+      if (members.length <= 1) { continue; }
+      members.sort();
+      // First sorted key is the representative; hide the rest
+      for (let i = 1; i < members.length; i++) {
+        hidden.add(members[i]);
+      }
+    }
+    return hidden;
   }
 
   private getGroupUnseenCount(providerId: string, groupName: string): number {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
+    const hidden = this.buildCanonicalHiddenSet();
     return items.filter((item) => {
       if (item.group?.trim() !== groupName) { return false; }
       const state = this.stateStore.getState(providerId, item.externalId);
-      return state === undefined || state === 'unseen';
+      if (state !== undefined && state !== 'unseen') { return false; }
+      return !hidden.has(`${providerId}::${item.externalId}`);
     }).length;
   }
 
   private getUnseenCount(providerId: string): number {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
+    const hidden = this.buildCanonicalHiddenSet();
     return items.filter((item) => {
       const state = this.stateStore.getState(providerId, item.externalId);
-      return state === undefined || state === 'unseen';
+      if (state !== undefined && state !== 'unseen') { return false; }
+      return !hidden.has(`${providerId}::${item.externalId}`);
     }).length;
   }
 

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -193,6 +193,25 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     return peers;
   }
 
+  /** Checks if this item or any canonical peer is marked as read in the persistent store. */
+  private isCanonicalGroupSeen(key: string, canonicalId?: string): boolean {
+    if (this.readStateStore.has(key)) {
+      return true;
+    }
+    if (!canonicalId) { return false; }
+    for (const [pid, pItems] of this.providerRegistry.getAllDiscoveredItems()) {
+      for (const pi of pItems) {
+        if (pi.canonicalId !== canonicalId) { continue; }
+        const peerKey = `${pid}::${pi.externalId}`;
+        if (peerKey === key) { continue; }
+        if (this.readStateStore.has(peerKey)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
   getTreeItem(element: InboxElement): vscode.TreeItem {
     if (element.kind === 'provider') {
       const count = this.getUnseenCount(element.providerId);
@@ -220,7 +239,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     }
 
     const key = `${element.providerId}::${element.externalId}`;
-    const isSeen = this.readStateStore.has(key);
+    const isSeen = this.isCanonicalGroupSeen(key, element.canonicalId);
 
     const treeItem = new vscode.TreeItem(element.title, vscode.TreeItemCollapsibleState.None);
     treeItem.id = `inbox::item::${element.providerId}::${element.externalId}`;

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { DiscoveredItem } from '../api/types';
 import { ProviderRegistry } from '../services/providerRegistry';
+import { buildCanonicalHiddenSet } from '../services/canonicalDedup';
 import { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import { ReadStateStore } from '../storage/readStateStore';
 import { logger } from '../services/logger';
@@ -359,45 +360,12 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     };
   }
 
-  /**
-   * Builds a set of `providerId::externalId` keys that should be hidden due to
-   * cross-provider canonicalId dedup. For each group of unseen items sharing the
-   * same canonicalId, the first key alphabetically is the representative;
-   * the rest are hidden.
-   */
-  private buildCanonicalHiddenSet(): Set<string> {
-    const hidden = new Set<string>();
-    // Map canonicalId → list of providerId::externalId keys
-    const groups = new Map<string, string[]>();
-    const allItems = this.providerRegistry.getAllDiscoveredItems();
-    for (const [providerId, items] of allItems) {
-      for (const item of items) {
-        if (!item.canonicalId) { continue; }
-        const state = this.stateStore.getState(providerId, item.externalId);
-        if (state !== undefined && state !== 'unseen') { continue; }
-        const key = `${providerId}::${item.externalId}`;
-        let group = groups.get(item.canonicalId);
-        if (!group) {
-          group = [];
-          groups.set(item.canonicalId, group);
-        }
-        group.push(key);
-      }
-    }
-    for (const members of groups.values()) {
-      if (members.length <= 1) { continue; }
-      members.sort();
-      // First sorted key is the representative; hide the rest
-      for (let i = 1; i < members.length; i++) {
-        hidden.add(members[i]);
-      }
-    }
-    return hidden;
-  }
-
   private getCanonicalHiddenSet(): Set<string> {
     if (!this.cachedHiddenSet) {
-      this.cachedHiddenSet = this.buildCanonicalHiddenSet();
+      this.cachedHiddenSet = buildCanonicalHiddenSet(
+        this.providerRegistry.getAllDiscoveredItems(),
+        (pid, eid) => this.stateStore.getState(pid, eid),
+      );
     }
     return this.cachedHiddenSet;
   }

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -175,7 +175,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     return newKeys.length > 0 || newlyAdded.length > 0;
   }
 
-  /** Finds `providerId::externalId` keys of canonical peers for the given item. */
+  /** Finds `providerId::externalId` keys of canonical peers for the given item, excluding already accepted/dismissed peers. */
   private findCanonicalPeerKeys(providerId: string, externalId: string): string[] {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
     const item = items.find(i => i.externalId === externalId);
@@ -185,6 +185,8 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       for (const pi of pItems) {
         if (pi.canonicalId !== item.canonicalId) { continue; }
         if (pid === providerId && pi.externalId === externalId) { continue; }
+        const state = this.stateStore.getState(pid, pi.externalId);
+        if (state !== undefined && state !== 'unseen') { continue; }
         peers.push(`${pid}::${pi.externalId}`);
       }
     }

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -44,6 +44,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
   private refreshTimer: ReturnType<typeof setTimeout> | undefined;
   static readonly REFRESH_DEBOUNCE_MS = 50;
   private readonly _layoutState: LayoutState;
+  private cachedHiddenSet: Set<string> | undefined;
 
   get layout(): ViewLayout { return this._layoutState.value; }
   set layout(value: ViewLayout) { this._layoutState.value = value; }
@@ -65,6 +66,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     if (this.refreshTimer !== undefined) {
       clearTimeout(this.refreshTimer);
     }
+    this.cachedHiddenSet = undefined;
     this.refreshTimer = setTimeout(() => {
       this.refreshTimer = undefined;
       this.pruneSeenItems();
@@ -130,8 +132,8 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       this._onDidMarkSeen.fire();
     }
     if (peerKeys.length > 0) {
-      await this.readStateStore.addMany(allKeys);
-      return true;
+      const addedCount = await this.readStateStore.addMany(allKeys);
+      return changed || addedCount > 0;
     }
     return this.readStateStore.add(key);
   }
@@ -280,7 +282,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   private getAllUnseenItems(): InboxItem[] {
     const result: InboxItem[] = [];
-    const hidden = this.buildCanonicalHiddenSet();
+    const hidden = this.getCanonicalHiddenSet();
     const allItems = this.providerRegistry.getAllDiscoveredItems();
     for (const [providerId, items] of allItems) {
       for (const item of items) {
@@ -295,7 +297,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   private getProviderChildren(providerId: string): (InboxGroupNode | InboxItem)[] {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
-    const hidden = this.buildCanonicalHiddenSet();
+    const hidden = this.getCanonicalHiddenSet();
     const groupCounts = new Map<string, number>();
     const ungrouped: typeof items = [];
 
@@ -331,7 +333,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   private getGroupChildren(providerId: string, groupName: string): InboxItem[] {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
-    const hidden = this.buildCanonicalHiddenSet();
+    const hidden = this.getCanonicalHiddenSet();
     const result: InboxItem[] = [];
     for (const item of items) {
       if (item.group?.trim() !== groupName) { continue; }
@@ -393,9 +395,16 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     return hidden;
   }
 
+  private getCanonicalHiddenSet(): Set<string> {
+    if (!this.cachedHiddenSet) {
+      this.cachedHiddenSet = this.buildCanonicalHiddenSet();
+    }
+    return this.cachedHiddenSet;
+  }
+
   private getGroupUnseenCount(providerId: string, groupName: string): number {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
-    const hidden = this.buildCanonicalHiddenSet();
+    const hidden = this.getCanonicalHiddenSet();
     return items.filter((item) => {
       if (item.group?.trim() !== groupName) { return false; }
       const state = this.stateStore.getState(providerId, item.externalId);
@@ -406,7 +415,7 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
 
   private getUnseenCount(providerId: string): number {
     const items = this.providerRegistry.getDiscoveredItems(providerId);
-    const hidden = this.buildCanonicalHiddenSet();
+    const hidden = this.getCanonicalHiddenSet();
     return items.filter((item) => {
       const state = this.stateStore.getState(providerId, item.externalId);
       if (state !== undefined && state !== 'unseen') { return false; }

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -122,21 +122,34 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     const key = `${providerId}::${externalId}`;
     const peerKeys = this.findCanonicalPeerKeys(providerId, externalId);
     const allKeys = [key, ...peerKeys];
-    let changed = false;
+    const addedKeys: string[] = [];
     for (const k of allKeys) {
       if (!this.seenItems.has(k)) {
         this.seenItems.add(k);
-        changed = true;
+        addedKeys.push(k);
       }
     }
-    if (changed) {
-      this._onDidMarkSeen.fire();
+    try {
+      if (peerKeys.length > 0) {
+        const newlyAdded = await this.readStateStore.addMany(allKeys);
+        const changed = addedKeys.length > 0;
+        if (changed) {
+          this._onDidMarkSeen.fire();
+        }
+        return changed || newlyAdded.length > 0;
+      }
+      const persisted = await this.readStateStore.add(key);
+      if (addedKeys.length > 0) {
+        this._onDidMarkSeen.fire();
+      }
+      return persisted;
+    } catch (err) {
+      // Roll back in-memory state on persistence failure
+      for (const k of addedKeys) {
+        this.seenItems.delete(k);
+      }
+      throw err;
     }
-    if (peerKeys.length > 0) {
-      const newlyAdded = await this.readStateStore.addMany(allKeys);
-      return changed || newlyAdded.length > 0;
-    }
-    return this.readStateStore.add(key);
   }
 
   /** Marks multiple items as seen in a single write operation. */

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -132,8 +132,8 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       this._onDidMarkSeen.fire();
     }
     if (peerKeys.length > 0) {
-      const addedCount = await this.readStateStore.addMany(allKeys);
-      return changed || addedCount > 0;
+      const newlyAdded = await this.readStateStore.addMany(allKeys);
+      return changed || newlyAdded.length > 0;
     }
     return this.readStateStore.add(key);
   }

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -27,6 +27,7 @@ export interface SourceItemNode {
   description?: string;
   url?: string;
   group?: string;
+  canonicalId?: string;
 }
 
 export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesElement> {
@@ -232,6 +233,7 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
       description: item.description,
       url: item.url,
       group: item.group?.trim() || undefined,
+      canonicalId: item.canonicalId,
     };
   }
 

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -55,10 +55,18 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
       : { prs: [] as GitHubIssue[], failures: [] as string[] };
 
     if (authoredSettled.status === 'rejected') {
-      logger.error('Failed to fetch authored PRs', authoredSettled.reason);
+      const err = authoredSettled.reason;
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw err;
+      }
+      logger.error('Failed to fetch authored PRs', err);
     }
     if (assignedSettled.status === 'rejected') {
-      logger.error('Failed to fetch assigned PRs', assignedSettled.reason);
+      const err = assignedSettled.reason;
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw err;
+      }
+      logger.error('Failed to fetch assigned PRs', err);
     }
 
     logger.info(`Discovered ${authoredResult.prs.length} authored PRs and ${assignedResult.prs.length} assigned PRs`);

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -41,11 +41,25 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
     logger.info('Fetching authored and assigned PRs...');
     const repos = this.getConfiguredRepos();
 
-    // Fetch authored and assigned PRs in parallel
-    const [authoredResult, assignedResult] = await Promise.all([
+    // Fetch authored and assigned PRs in parallel; proceed with partial results if one fails
+    const [authoredSettled, assignedSettled] = await Promise.allSettled([
       this.fetchAuthoredPrs(accessToken, repos, signal),
       this.fetchAssignedPrs(accessToken, repos, signal),
     ]);
+
+    const authoredResult = authoredSettled.status === 'fulfilled'
+      ? authoredSettled.value
+      : { prs: [] as GitHubIssue[], failures: [] as string[] };
+    const assignedResult = assignedSettled.status === 'fulfilled'
+      ? assignedSettled.value
+      : { prs: [] as GitHubIssue[], failures: [] as string[] };
+
+    if (authoredSettled.status === 'rejected') {
+      logger.error('Failed to fetch authored PRs', authoredSettled.reason);
+    }
+    if (assignedSettled.status === 'rejected') {
+      logger.error('Failed to fetch assigned PRs', assignedSettled.reason);
+    }
 
     logger.info(`Discovered ${authoredResult.prs.length} authored PRs and ${assignedResult.prs.length} assigned PRs`);
 

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -91,7 +91,7 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
 
     this._onDidDiscoverItems.fire(items);
 
-    const failures = [...authoredResult.failures, ...assignedResult.failures];
+    const failures = [...new Set([...authoredResult.failures, ...assignedResult.failures])];
     if (failures.length > 0) {
       const message = failures.length === 1
         ? `Failed to fetch PRs from ${failures[0]}`

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -198,17 +198,24 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
   }
 
   private async fetchAllAuthoredPrs(token: string, signal?: AbortSignal): Promise<{ prs: GitHubIssue[]; failures: string[] }> {
-    const response = await fetch(
-      'https://api.github.com/search/issues?q=type:pr+state:open+author:@me&per_page=100',
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/vnd.github+json',
-          'X-GitHub-Api-Version': '2022-11-28',
+    let response: Response;
+    try {
+      response = await fetch(
+        'https://api.github.com/search/issues?q=type:pr+state:open+author:@me&per_page=100',
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+          signal: combineSignals(signal, 30_000),
         },
-        signal: combineSignals(signal, 30_000),
-      },
-    );
+      );
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === 'AbortError') { throw err; }
+      logger.error('Failed to fetch authored PRs', err);
+      return { prs: [], failures: ['all repositories'] };
+    }
 
     if (!response.ok) {
       logger.error(`Failed to fetch authored PRs: ${response.status}`);
@@ -285,17 +292,24 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
   }
 
   private async fetchAllAssignedPrs(token: string, signal?: AbortSignal): Promise<{ prs: GitHubIssue[]; failures: string[] }> {
-    const response = await fetch(
-      'https://api.github.com/search/issues?q=type:pr+state:open+assignee:@me&per_page=100',
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/vnd.github+json',
-          'X-GitHub-Api-Version': '2022-11-28',
+    let response: Response;
+    try {
+      response = await fetch(
+        'https://api.github.com/search/issues?q=type:pr+state:open+assignee:@me&per_page=100',
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+          signal: combineSignals(signal, 30_000),
         },
-        signal: combineSignals(signal, 30_000),
-      },
-    );
+      );
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === 'AbortError') { throw err; }
+      logger.error('Failed to fetch assigned PRs', err);
+      return { prs: [], failures: ['all repositories'] };
+    }
 
     if (!response.ok) {
       logger.error(`Failed to fetch assigned PRs: ${response.status}`);

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -38,36 +38,64 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
   readonly label = 'My GitHub PRs';
 
   protected async fetchAndPublish(accessToken: string, isUserTriggered: boolean, signal?: AbortSignal): Promise<void> {
-    logger.info('Fetching authored PRs...');
+    logger.info('Fetching authored and assigned PRs...');
     const repos = this.getConfiguredRepos();
-    const { prs, failures } = await this.fetchAuthoredPrs(accessToken, repos, signal);
 
-    logger.info(`Discovered ${prs.length} authored PRs`);
+    // Fetch authored and assigned PRs in parallel
+    const [authoredResult, assignedResult] = await Promise.all([
+      this.fetchAuthoredPrs(accessToken, repos, signal),
+      this.fetchAssignedPrs(accessToken, repos, signal),
+    ]);
 
-    const statusMap = prs.length > 0
-      ? await this.fetchPrStatuses(accessToken, prs, signal)
+    logger.info(`Discovered ${authoredResult.prs.length} authored PRs and ${assignedResult.prs.length} assigned PRs`);
+
+    // Filter out self-authored PRs from assigned results to avoid duplicates
+    const authoredUrls = new Set(authoredResult.prs.map(pr => pr.html_url));
+    const uniqueAssignedPrs = assignedResult.prs.filter(pr => !authoredUrls.has(pr.html_url));
+
+    const allPrs = [...authoredResult.prs, ...uniqueAssignedPrs];
+
+    const statusMap = allPrs.length > 0
+      ? await this.fetchPrStatuses(accessToken, allPrs, signal)
       : new Map<string, string>();
 
-    const items: DiscoveredItem[] = prs.map((pr) => {
+    const items: DiscoveredItem[] = [];
+    for (const pr of authoredResult.prs) {
       const repoName = parseRepoFromUrls(pr.html_url, pr.repository_url);
       const status = statusMap.get(pr.html_url) ?? 'Open';
-      return {
+      items.push({
         externalId: `${repoName}#${pr.number}`,
         title: `#${pr.number}: ${pr.title}`,
         description: pr.body?.slice(0, 200),
         url: pr.html_url,
         group: repoName,
-        reason: 'authored',
+        reason: 'You authored this PR',
         state: status,
-      };
-    });
+        canonicalId: `github:pull:${repoName}#${pr.number}`,
+      });
+    }
+    for (const pr of uniqueAssignedPrs) {
+      const repoName = parseRepoFromUrls(pr.html_url, pr.repository_url);
+      const status = statusMap.get(pr.html_url) ?? 'Open';
+      items.push({
+        externalId: `${repoName}#${pr.number}`,
+        title: `#${pr.number}: ${pr.title}`,
+        description: pr.body?.slice(0, 200),
+        url: pr.html_url,
+        group: repoName,
+        reason: 'You are assigned to this PR',
+        state: status,
+        canonicalId: `github:pull:${repoName}#${pr.number}`,
+      });
+    }
 
     this._onDidDiscoverItems.fire(items);
 
+    const failures = [...authoredResult.failures, ...assignedResult.failures];
     if (failures.length > 0) {
       const message = failures.length === 1
-        ? `Failed to fetch authored PRs from ${failures[0]}`
-        : `Failed to fetch authored PRs from ${failures.length} repositories`;
+        ? `Failed to fetch PRs from ${failures[0]}`
+        : `Failed to fetch PRs from ${failures.length} repositories`;
       if (isUserTriggered) {
         void vscode.window.showWarningMessage(`DevDocket GitHub: ${message}`);
       } else {
@@ -161,6 +189,93 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
 
     if (!response.ok) {
       logger.error(`Failed to fetch authored PRs: ${response.status}`);
+      return { prs: [], failures: ['all repositories'] };
+    }
+
+    const data = (await response.json()) as GitHubSearchResponse;
+    return { prs: data.items, failures: [] };
+  }
+
+  private async fetchAssignedPrs(
+    token: string,
+    repos: string[],
+    signal?: AbortSignal,
+  ): Promise<{ prs: GitHubIssue[]; failures: string[] }> {
+    if (repos.length > 0) {
+      return this.fetchPerRepoAssignedPrs(token, repos, signal);
+    }
+    return this.fetchAllAssignedPrs(token, signal);
+  }
+
+  private async fetchPerRepoAssignedPrs(
+    token: string,
+    repos: string[],
+    signal?: AbortSignal,
+  ): Promise<{ prs: GitHubIssue[]; failures: string[] }> {
+    const results = await runWorkerPoolSettled(repos, async (repo) => {
+      if (signal?.aborted) {
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      }
+      return await this.fetchRepoAssignedPrs(token, repo, signal);
+    }, 3);
+
+    const allPrs: GitHubIssue[] = [];
+    const failures: string[] = [];
+
+    results.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        allPrs.push(...result.value.prs);
+        if (result.value.failed) {
+          failures.push(repos[index]);
+        }
+      } else {
+        failures.push(repos[index]);
+      }
+    });
+
+    return { prs: allPrs, failures };
+  }
+
+  private async fetchRepoAssignedPrs(token: string, repo: string, signal?: AbortSignal): Promise<{ prs: GitHubIssue[]; failed: boolean }> {
+    logger.debug(`Fetching assigned PRs for repo: ${repo}`);
+    const response = await fetch(
+      `https://api.github.com/search/issues?q=type:pr+state:open+assignee:@me+repo:${repo}&per_page=100`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        signal: combineSignals(signal, 30_000),
+      },
+    );
+
+    if (!response.ok) {
+      logger.error(`Failed to fetch assigned PRs for ${repo}: ${response.status}`);
+      return { prs: [], failed: true };
+    }
+
+    const data = (await response.json()) as GitHubSearchResponse;
+    return { prs: data.items, failed: false };
+  }
+
+  private async fetchAllAssignedPrs(token: string, signal?: AbortSignal): Promise<{ prs: GitHubIssue[]; failures: string[] }> {
+    const response = await fetch(
+      'https://api.github.com/search/issues?q=type:pr+state:open+assignee:@me&per_page=100',
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        signal: combineSignals(signal, 30_000),
+      },
+    );
+
+    if (!response.ok) {
+      logger.error(`Failed to fetch assigned PRs: ${response.status}`);
       return { prs: [], failures: ['all repositories'] };
     }
 

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -22,12 +22,13 @@ export interface PrReview {
 }
 
 /**
- * DevDocket provider that discovers GitHub pull requests authored by the
- * current user and surfaces their review/CI status.
+ * DevDocket provider that discovers GitHub pull requests authored by or
+ * assigned to the current user and surfaces their review/CI status.
  *
- * Uses the GitHub Search API (`author:@me`) to find open PRs, then enriches
- * each with review decisions and mergeable state via the PR detail and
- * reviews REST endpoints.
+ * Uses the GitHub Search API (`author:@me` and `assignee:@me`) to find
+ * open PRs, deduplicates self-authored PRs from assigned results, then
+ * enriches each with review decisions and mergeable state via the PR
+ * detail and reviews REST endpoints.
  *
  * Status values: Open (fallback when detailed PR/review status cannot be
  * determined), Draft, Waiting on reviews, Review received,

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -62,6 +62,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
         url: pr.html_url,
         group: repoName,
         reason: 'review_requested',
+        canonicalId: `github:pull:${repoName}#${pr.number}`,
       };
       if (pr.state) { item.state = pr.state; }
       const headSha = headShas.get(pr.html_url);

--- a/packages/github/src/test/githubMyPrsProvider.cancellation.test.ts
+++ b/packages/github/src/test/githubMyPrsProvider.cancellation.test.ts
@@ -86,28 +86,41 @@ describe('GitHubMyPrsProvider — cancellation (AbortSignal wiring)', () => {
   describe('AbortSignal passed to fetch', () => {
     it('passes AbortSignal to search fetch', async () => {
       const { token } = createMockCancellationToken();
-      mockFetch.mockResolvedValueOnce(mockSearchResponse([]));
+      mockFetch.mockResolvedValue(mockSearchResponse([]));
 
       await provider.refresh(token);
 
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-      const fetchOptions = mockFetch.mock.calls[0][1];
-      expect(fetchOptions.signal).toBeInstanceOf(AbortSignal);
+      // 2 calls: author:@me and assignee:@me
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      for (const call of mockFetch.mock.calls) {
+        expect(call[1].signal).toBeInstanceOf(AbortSignal);
+      }
     });
 
     it('passes AbortSignal to PR detail and review fetch calls', async () => {
       const { token } = createMockCancellationToken();
       const pr = createMockPr(1, 'Test PR');
 
-      mockFetch
-        .mockResolvedValueOnce(mockSearchResponse([pr]))
-        .mockResolvedValueOnce(mockPrDetailResponse({ draft: false }))
-        .mockResolvedValueOnce(mockReviewsResponse([]));
+      mockFetch.mockImplementation(async (url: string) => {
+        if (url.includes('search/issues') && url.includes('author:@me')) {
+          return mockSearchResponse([pr]);
+        }
+        if (url.includes('search/issues') && url.includes('assignee:@me')) {
+          return mockSearchResponse([]);
+        }
+        if (url.endsWith('/pulls/1')) {
+          return mockPrDetailResponse({ draft: false });
+        }
+        if (url.endsWith('/pulls/1/reviews')) {
+          return mockReviewsResponse([]);
+        }
+        return { ok: false, status: 404 };
+      });
 
       await provider.refresh(token);
 
-      // 3 calls: search, PR detail, reviews
-      expect(mockFetch).toHaveBeenCalledTimes(3);
+      // 4 calls: 2 search + PR detail + reviews
+      expect(mockFetch).toHaveBeenCalledTimes(4);
       for (const call of mockFetch.mock.calls) {
         expect(call[1].signal).toBeInstanceOf(AbortSignal);
       }
@@ -277,7 +290,7 @@ describe('GitHubMyPrsProvider — cancellation (AbortSignal wiring)', () => {
     it('resets _isRefreshing after abort', async () => {
       const { token, cancel } = createMockCancellationToken();
 
-      mockFetch.mockImplementationOnce(async () => {
+      mockFetch.mockImplementation(async () => {
         cancel();
         const error = new Error('The operation was aborted.');
         error.name = 'AbortError';
@@ -287,7 +300,12 @@ describe('GitHubMyPrsProvider — cancellation (AbortSignal wiring)', () => {
       await provider.refresh(token);
 
       // Next refresh should proceed
-      mockFetch.mockResolvedValueOnce(mockSearchResponse([]));
+      mockFetch.mockImplementation(async (url: string) => {
+        if (url.includes('search/issues')) {
+          return mockSearchResponse([]);
+        }
+        return { ok: false, status: 404 };
+      });
 
       const listener = vi.fn();
       provider.onDidDiscoverItems(listener);

--- a/packages/github/src/test/githubMyPrsProvider.test.ts
+++ b/packages/github/src/test/githubMyPrsProvider.test.ts
@@ -93,8 +93,11 @@ describe('GitHubMyPrsProvider', () => {
 
     // Use URL-based routing because concurrent workers consume mocks in unpredictable order
     mockFetch.mockImplementation(async (url: string) => {
-      if (url.includes('search/issues')) {
+      if (url.includes('search/issues') && url.includes('author:@me')) {
         return mockSearchResponse([pr1, pr2]);
+      }
+      if (url.includes('search/issues') && url.includes('assignee:@me')) {
+        return mockSearchResponse([]);
       }
       if (url.endsWith('/pulls/1')) {
         return mockPrDetailResponse({ draft: false, mergeable_state: 'blocked' });
@@ -123,9 +126,13 @@ describe('GitHubMyPrsProvider', () => {
     expect(items[0].title).toBe('#1: Fix bug');
     expect(items[0].state).toBe('Waiting on reviews');
     expect(items[0].group).toBe('owner/repo');
+    expect(items[0].reason).toBe('You authored this PR');
+    expect(items[0].canonicalId).toBe('github:pull:owner/repo#1');
 
     expect(items[1].externalId).toBe('owner/repo#2');
     expect(items[1].state).toBe('Draft');
+    expect(items[1].reason).toBe('You authored this PR');
+    expect(items[1].canonicalId).toBe('github:pull:owner/repo#2');
   });
 
   it('uses search API with repos when configured', async () => {
@@ -136,29 +143,35 @@ describe('GitHubMyPrsProvider', () => {
       }),
     } as any);
 
-    mockFetch.mockResolvedValueOnce(mockSearchResponse([]));
+    mockFetch.mockResolvedValue(mockSearchResponse([]));
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
     await provider.refresh();
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    const url = mockFetch.mock.calls[0][0];
-    expect(url).toContain('repo:myorg/myrepo');
-    expect(url).toContain('author:@me');
+    // 2 calls: author:@me and assignee:@me
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const authorUrl = mockFetch.mock.calls.find((c: any[]) => c[0].includes('author:@me'))?.[0];
+    expect(authorUrl).toContain('repo:myorg/myrepo');
+    const assigneeUrl = mockFetch.mock.calls.find((c: any[]) => c[0].includes('assignee:@me'))?.[0];
+    expect(assigneeUrl).toContain('repo:myorg/myrepo');
   });
 
   it('uses global search when no repos configured', async () => {
-    mockFetch.mockResolvedValueOnce(mockSearchResponse([]));
+    mockFetch.mockResolvedValue(mockSearchResponse([]));
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
     await provider.refresh();
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
-    const url = mockFetch.mock.calls[0][0];
-    expect(url).toContain('author:@me');
-    expect(url).not.toContain('repo:');
+    // 2 calls: author:@me and assignee:@me
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    const authorUrl = mockFetch.mock.calls.find((c: any[]) => c[0].includes('author:@me'))?.[0];
+    expect(authorUrl).toBeDefined();
+    expect(authorUrl).not.toContain('repo:');
+    const assigneeUrl = mockFetch.mock.calls.find((c: any[]) => c[0].includes('assignee:@me'))?.[0];
+    expect(assigneeUrl).toBeDefined();
+    expect(assigneeUrl).not.toContain('repo:');
   });
 
   it('reports failures for individual repos', async () => {
@@ -169,9 +182,12 @@ describe('GitHubMyPrsProvider', () => {
       }),
     } as any);
 
-    mockFetch
-      .mockResolvedValueOnce(mockSearchResponse([]))
-      .mockResolvedValueOnce(mockFailedResponse());
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('bad/repo')) {
+        return mockFailedResponse();
+      }
+      return mockSearchResponse([]);
+    });
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
@@ -185,8 +201,11 @@ describe('GitHubMyPrsProvider', () => {
     const pr = createMockPr(1, 'My PR');
 
     mockFetch.mockImplementation(async (url: string) => {
-      if (url.includes('search/issues')) {
+      if (url.includes('search/issues') && url.includes('author:@me')) {
         return mockSearchResponse([pr]);
+      }
+      if (url.includes('search/issues') && url.includes('assignee:@me')) {
+        return mockSearchResponse([]);
       }
       // PR detail fails
       return mockFailedResponse(404);
@@ -212,7 +231,15 @@ describe('GitHubMyPrsProvider', () => {
       // No pull_request field
     };
 
-    mockFetch.mockResolvedValueOnce(mockSearchResponse([pr as any]));
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('search/issues') && url.includes('author:@me')) {
+        return mockSearchResponse([pr as any]);
+      }
+      if (url.includes('search/issues') && url.includes('assignee:@me')) {
+        return mockSearchResponse([]);
+      }
+      return mockFailedResponse(404);
+    });
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
@@ -228,8 +255,11 @@ describe('GitHubMyPrsProvider', () => {
     pr.body = 'a'.repeat(500);
 
     mockFetch.mockImplementation(async (url: string) => {
-      if (url.includes('search/issues')) {
+      if (url.includes('search/issues') && url.includes('author:@me')) {
         return mockSearchResponse([pr]);
+      }
+      if (url.includes('search/issues') && url.includes('assignee:@me')) {
+        return mockSearchResponse([]);
       }
       if (url.endsWith('/pulls/1')) {
         return mockPrDetailResponse({ draft: false });
@@ -249,7 +279,7 @@ describe('GitHubMyPrsProvider', () => {
   });
 
   it('reports all-repos failure for global search', async () => {
-    mockFetch.mockResolvedValueOnce(mockFailedResponse());
+    mockFetch.mockResolvedValue(mockFailedResponse());
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
@@ -258,6 +288,187 @@ describe('GitHubMyPrsProvider', () => {
     // Should still fire with empty items
     expect(listener).toHaveBeenCalledTimes(1);
     expect(listener.mock.calls[0][0]).toHaveLength(0);
+  });
+
+  it('discovers assigned PRs alongside authored PRs', async () => {
+    const authoredPr = createMockPr(1, 'My PR');
+    const assignedPr = createMockPr(2, 'Assigned to me', 'other/repo');
+
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('search/issues') && url.includes('author:@me')) {
+        return mockSearchResponse([authoredPr]);
+      }
+      if (url.includes('search/issues') && url.includes('assignee:@me')) {
+        return mockSearchResponse([assignedPr]);
+      }
+      if (url.endsWith('/pulls/1')) {
+        return mockPrDetailResponse({ draft: false });
+      }
+      if (url.endsWith('/pulls/1/reviews')) {
+        return mockReviewsResponse([]);
+      }
+      if (url.endsWith('/pulls/2')) {
+        return mockPrDetailResponse({ draft: false });
+      }
+      if (url.endsWith('/pulls/2/reviews')) {
+        return mockReviewsResponse([]);
+      }
+      return mockFailedResponse(404);
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const items = listener.mock.calls[0][0];
+    expect(items).toHaveLength(2);
+
+    expect(items[0].externalId).toBe('owner/repo#1');
+    expect(items[0].reason).toBe('You authored this PR');
+
+    expect(items[1].externalId).toBe('other/repo#2');
+    expect(items[1].reason).toBe('You are assigned to this PR');
+  });
+
+  it('excludes self-authored PRs from assigned results', async () => {
+    const pr = createMockPr(1, 'Both authored and assigned');
+
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('search/issues') && url.includes('author:@me')) {
+        return mockSearchResponse([pr]);
+      }
+      if (url.includes('search/issues') && url.includes('assignee:@me')) {
+        // Same PR also returned as assigned
+        return mockSearchResponse([pr]);
+      }
+      if (url.endsWith('/pulls/1')) {
+        return mockPrDetailResponse({ draft: false });
+      }
+      if (url.endsWith('/pulls/1/reviews')) {
+        return mockReviewsResponse([]);
+      }
+      return mockFailedResponse(404);
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    // Should only appear once (as authored)
+    expect(items).toHaveLength(1);
+    expect(items[0].reason).toBe('You authored this PR');
+  });
+
+  it('sets canonicalId on all discovered items', async () => {
+    const authoredPr = createMockPr(1, 'Authored');
+    const assignedPr = createMockPr(2, 'Assigned', 'org/other');
+
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('search/issues') && url.includes('author:@me')) {
+        return mockSearchResponse([authoredPr]);
+      }
+      if (url.includes('search/issues') && url.includes('assignee:@me')) {
+        return mockSearchResponse([assignedPr]);
+      }
+      if (url.includes('/pulls/')) {
+        return mockPrDetailResponse({ draft: false });
+      }
+      if (url.includes('/reviews')) {
+        return mockReviewsResponse([]);
+      }
+      return mockFailedResponse(404);
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items[0].canonicalId).toBe('github:pull:owner/repo#1');
+    expect(items[1].canonicalId).toBe('github:pull:org/other#2');
+  });
+
+  it('handles assigned PRs API failure gracefully', async () => {
+    const authoredPr = createMockPr(1, 'Authored');
+
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('search/issues') && url.includes('author:@me')) {
+        return mockSearchResponse([authoredPr]);
+      }
+      if (url.includes('search/issues') && url.includes('assignee:@me')) {
+        return mockFailedResponse();
+      }
+      if (url.endsWith('/pulls/1')) {
+        return mockPrDetailResponse({ draft: false });
+      }
+      if (url.endsWith('/pulls/1/reviews')) {
+        return mockReviewsResponse([]);
+      }
+      return mockFailedResponse(404);
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    // Should still emit authored PRs even if assigned API fails
+    expect(listener).toHaveBeenCalledTimes(1);
+    const items = listener.mock.calls[0][0];
+    expect(items).toHaveLength(1);
+    expect(items[0].reason).toBe('You authored this PR');
+  });
+
+  it('fetches status for assigned PRs', async () => {
+    const assignedPr = createMockPr(1, 'Assigned PR');
+
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('search/issues') && url.includes('author:@me')) {
+        return mockSearchResponse([]);
+      }
+      if (url.includes('search/issues') && url.includes('assignee:@me')) {
+        return mockSearchResponse([assignedPr]);
+      }
+      if (url.endsWith('/pulls/1')) {
+        return mockPrDetailResponse({ draft: false, mergeable_state: 'clean' });
+      }
+      if (url.endsWith('/pulls/1/reviews')) {
+        return mockReviewsResponse([
+          { user: { id: 10 }, state: 'APPROVED', submitted_at: '2025-01-01T00:00:00Z' },
+        ]);
+      }
+      return mockFailedResponse(404);
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items).toHaveLength(1);
+    expect(items[0].reason).toBe('You are assigned to this PR');
+    expect(items[0].state).toBe('Ready to merge');
+  });
+
+  it('fetches assigned PRs per-repo when repos configured', async () => {
+    vi.mocked(workspace.getConfiguration).mockReturnValue({
+      get: vi.fn((key: string, defaultValue?: any) => {
+        if (key === 'repos') { return ['myorg/myrepo']; }
+        return defaultValue;
+      }),
+    } as any);
+
+    mockFetch.mockResolvedValue(mockSearchResponse([]));
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const assigneeCall = mockFetch.mock.calls.find((c: any[]) =>
+      c[0].includes('assignee:@me') && c[0].includes('repo:myorg/myrepo')
+    );
+    expect(assigneeCall).toBeDefined();
   });
 });
 

--- a/packages/github/src/test/githubMyPrsProvider.test.ts
+++ b/packages/github/src/test/githubMyPrsProvider.test.ts
@@ -290,6 +290,18 @@ describe('GitHubMyPrsProvider', () => {
     expect(listener.mock.calls[0][0]).toHaveLength(0);
   });
 
+  it('handles network error in global search without throwing', async () => {
+    mockFetch.mockRejectedValue(new TypeError('fetch failed'));
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    // Should still fire with empty items (no throw)
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0]).toHaveLength(0);
+  });
+
   it('discovers assigned PRs alongside authored PRs', async () => {
     const authoredPr = createMockPr(1, 'My PR');
     const assignedPr = createMockPr(2, 'Assigned to me', 'other/repo');

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -180,6 +180,7 @@ describe('GitHubPrReviewProvider', () => {
       url: 'https://github.com/org/myrepo/pull/42',
       group: 'org/myrepo',
       reason: 'review_requested',
+      canonicalId: 'github:pull:org/myrepo#42',
     });
   });
 

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -43,6 +43,14 @@ export interface DiscoveredItem {
    * commits via `version` and re-requested reviews via `resurfaceVersion`).
    */
   resurfaceVersion?: string;
+  /**
+   * Optional cross-provider deduplication key.
+   * When set, items from different providers that share the same `canonicalId`
+   * are grouped in the Inbox view and only one representative is shown.
+   * Accept/dismiss/read-state actions propagate to all items in the group.
+   * Items without `canonicalId` always show individually (backward compatible).
+   */
+  canonicalId?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Expands the "My GitHub PRs" provider to also surface PRs the user is assigned to (via `assignee:@me`), not just PRs they authored. Implements cross-provider canonical ID dedup at the inbox level to handle overlap with the PR Reviews provider.

Closes #355

## Changes

### GitHub Provider (`packages/github`)
- **Assigned PR fetching**: `GitHubMyPrsProvider` now fetches both `author:@me` and `assignee:@me` PRs in parallel, deduplicating by PR number within each repo
- **`canonicalId`**: Both My PRs and PR Reviews providers set `canonicalId` (e.g. `github:pull:owner/repo#123`) so the inbox can identify cross-provider duplicates
- **Failure dedup**: Deduplicated repo failure lists when the same repo fails for both authored and assigned fetches

### Core Inbox (`packages/core`)
- **Canonical dedup in inbox views**: `InboxTreeProvider` builds a hidden set from `canonicalId` groups — for each group of unseen items sharing the same canonical ID, only the first key alphabetically is shown as the representative; the rest are hidden. Works in both flat and tree layout modes.
- **Cached hidden set**: `getCanonicalHiddenSet()` caches the computed hidden set per render cycle, invalidated on `scheduleRefresh()`
- **`markSeen` propagation**: When an item is marked as seen, all canonical peers are also marked seen in a single write via `readStateStore.addMany()`
- **Accept/dismiss propagation**: Single-item accept and dismiss propagate state to canonical peers. Batch accept uses post-hoc state propagation (no duplicate work items created for peers).
- **Badge count dedup**: `getInboxUnseenCount` applies the same canonical dedup to the badge count

### Shared (`packages/shared`)
- **`canonicalId` on `DiscoveredItem`**: Added optional `canonicalId?: string` property. This is a non-breaking addition to the public API surface.

## Design Decision

Chose **Option 4 from the issue** — deduplicate at the inbox level using `canonicalId`. Both providers emit items independently, and the inbox uses canonical ID grouping to show only one representative. This preserves provider independence and keeps data fresh from both sources.

## Test Coverage

- 3 new tests for `getInboxUnseenCount` canonical dedup
- 10 new tests for `InboxTreeProvider` canonical dedup (flat mode, tree mode, grouped items, deterministic representative, markSeen/markSeenBatch propagation)
- 7 new tests for `GitHubMyPrsProvider` assigned PRs (discovery, self-authored dedup, canonicalId, failure handling, status fetching, per-repo fetching)
- Updated cancellation tests for the additional API call
