### PR TITLE
Reorder Watches view to appear after Focus

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -207,16 +207,16 @@
           "name": "Focus"
         },
         {
+          "id": "devdocket.watches",
+          "name": "Watches"
+        },
+        {
           "id": "devdocket.history",
           "name": "History"
         },
         {
           "id": "devdocket.sources",
           "name": "Sources"
-        },
-        {
-          "id": "devdocket.watches",
-          "name": "Watches"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Fixes #364

Reordered the Watches view to appear immediately after the Focus view in the sidebar, as specified in the issue requirements.

## Changes

- Updated `packages/core/package.json` to reorder view entries in `contributes.views.devdocket`
- Watches now appears in position 4 (after Focus, before History)

## Final View Order

1. Inbox
2. Queue
3. Focus
4. **Watches** (moved from position 6)
5. History
6. Sources

## Testing

- ✅ Build: `npm run build` passes
- ✅ Tests: `npm run test` passes (all packages)
