### PR TITLE
Fix collapsed view expansion on item move

### DIFF
--- a/packages/core/src/services/viewRevealer.ts
+++ b/packages/core/src/services/viewRevealer.ts
@@ -70,7 +70,7 @@ export class ViewRevealer {
     try {
       await view.reveal(item, { select: true, focus: false });
     } catch (err: unknown) {
-      logger.debug('Auto-reveal failed (view may not be visible)', err);
+      logger.debug('Auto-reveal failed', err);
     }
   }
 }

--- a/packages/core/src/services/viewRevealer.ts
+++ b/packages/core/src/services/viewRevealer.ts
@@ -68,7 +68,7 @@ export class ViewRevealer {
   private async doReveal(view: WorkItemTreeView, item: WorkItem): Promise<void> {
     if (!view.visible) { return; }
     try {
-      await view.reveal(item, { select: true, focus: false, expand: false });
+      await view.reveal(item, { select: true, focus: false });
     } catch (err: unknown) {
       logger.debug('Auto-reveal failed (view may not be visible)', err);
     }

--- a/packages/core/src/services/viewRevealer.ts
+++ b/packages/core/src/services/viewRevealer.ts
@@ -67,7 +67,7 @@ export class ViewRevealer {
 
   private async doReveal(view: WorkItemTreeView, item: WorkItem): Promise<void> {
     try {
-      await view.reveal(item, { select: true, focus: false });
+      await view.reveal(item, { select: true, focus: false, expand: false });
     } catch (err: unknown) {
       logger.debug('Auto-reveal failed (view may not be visible)', err);
     }

--- a/packages/core/src/services/viewRevealer.ts
+++ b/packages/core/src/services/viewRevealer.ts
@@ -66,6 +66,7 @@ export class ViewRevealer {
   }
 
   private async doReveal(view: WorkItemTreeView, item: WorkItem): Promise<void> {
+    if (!view.visible) { return; }
     try {
       await view.reveal(item, { select: true, focus: false, expand: false });
     } catch (err: unknown) {


### PR DESCRIPTION
## Summary

Fixes #366 — Moving an item to a collapsed view no longer expands that view.

## Problem

When moving an item between views (e.g., Queue → Focus), the `ViewRevealer` service called `TreeView.reveal()` without checking if the target view was visible. This caused collapsed view sections to automatically expand, disrupting the user's carefully arranged sidebar layout.

## Solution

Added a `view.visible` guard in `ViewRevealer.doReveal()` before calling `reveal()`. When a view section is collapsed in the sidebar, `view.visible` returns `false`, so the reveal is skipped entirely and the view remains collapsed.

```typescript
private async doReveal(view: WorkItemTreeView, item: WorkItem): Promise<void> {
  if (!view.visible) { return; } // Don't un-collapse a collapsed view
  try {
    await view.reveal(item, { select: true, focus: false });
  } catch (err: unknown) {
    logger.debug('Auto-reveal failed', err);
  }
}
```

## Testing

- ✅ All builds pass
- ✅ All tests pass (0 test changes needed)

## Files Changed

- `packages/core/src/services/viewRevealer.ts` — Added `view.visible` guard and updated log message