### PR TITLE
Add Move to Top and Move to Bottom commands

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -320,6 +320,18 @@
         "icon": "$(arrow-down)"
       },
       {
+        "command": "devdocket.moveToTop",
+        "title": "Move to Top",
+        "category": "DevDocket",
+        "icon": "$(arrow-up)"
+      },
+      {
+        "command": "devdocket.moveToBottom",
+        "title": "Move to Bottom",
+        "category": "DevDocket",
+        "icon": "$(arrow-down)"
+      },
+      {
         "command": "devdocket.focusMoveUp",
         "title": "Move Up",
         "category": "DevDocket",
@@ -328,6 +340,18 @@
       {
         "command": "devdocket.focusMoveDown",
         "title": "Move Down",
+        "category": "DevDocket",
+        "icon": "$(arrow-down)"
+      },
+      {
+        "command": "devdocket.focusMoveToTop",
+        "title": "Move to Top",
+        "category": "DevDocket",
+        "icon": "$(arrow-up)"
+      },
+      {
+        "command": "devdocket.focusMoveToBottom",
+        "title": "Move to Bottom",
         "category": "DevDocket",
         "icon": "$(arrow-down)"
       },
@@ -756,6 +780,11 @@
           "group": "1_actions"
         },
         {
+          "command": "devdocket.moveToTop",
+          "when": "view == devdocket.queue && viewItem =~ /^queueItem/ && !listMultiSelection",
+          "group": "3_reorder@0"
+        },
+        {
           "command": "devdocket.moveUp",
           "when": "view == devdocket.queue && viewItem =~ /^queueItem/ && !listMultiSelection",
           "group": "3_reorder@1"
@@ -766,6 +795,16 @@
           "group": "3_reorder@2"
         },
         {
+          "command": "devdocket.moveToBottom",
+          "when": "view == devdocket.queue && viewItem =~ /^queueItem/ && !listMultiSelection",
+          "group": "3_reorder@3"
+        },
+        {
+          "command": "devdocket.focusMoveToTop",
+          "when": "view == devdocket.focus && viewItem =~ /^(active|paused)/ && !listMultiSelection",
+          "group": "3_reorder@0"
+        },
+        {
           "command": "devdocket.focusMoveUp",
           "when": "view == devdocket.focus && viewItem =~ /^(active|paused)/ && !listMultiSelection",
           "group": "3_reorder@1"
@@ -774,6 +813,11 @@
           "command": "devdocket.focusMoveDown",
           "when": "view == devdocket.focus && viewItem =~ /^(active|paused)/ && !listMultiSelection",
           "group": "3_reorder@2"
+        },
+        {
+          "command": "devdocket.focusMoveToBottom",
+          "when": "view == devdocket.focus && viewItem =~ /^(active|paused)/ && !listMultiSelection",
+          "group": "3_reorder@3"
         },
         {
           "command": "devdocket.openInBrowser",

--- a/packages/core/src/commands/focusCommands.ts
+++ b/packages/core/src/commands/focusCommands.ts
@@ -61,7 +61,7 @@ async function handleFocusMoveToBottom(workGraph: WorkGraph, item?: { id?: strin
     void vscode.window.showInformationMessage('DevDocket: Select an item in Focus to move.');
     return;
   }
-  await workGraph.moveToEnd(item.id);
+  await workGraph.moveToBottom(item.id);
 }
 
 export function registerFocusCommands(

--- a/packages/core/src/commands/focusCommands.ts
+++ b/packages/core/src/commands/focusCommands.ts
@@ -61,7 +61,7 @@ async function handleFocusMoveToBottom(workGraph: WorkGraph, item?: { id?: strin
     void vscode.window.showInformationMessage('DevDocket: Select an item in Focus to move.');
     return;
   }
-  await workGraph.moveToBottom(item.id);
+  await workGraph.moveToEnd(item.id);
 }
 
 export function registerFocusCommands(

--- a/packages/core/src/commands/focusCommands.ts
+++ b/packages/core/src/commands/focusCommands.ts
@@ -48,6 +48,22 @@ async function handleFocusMoveDown(workGraph: WorkGraph, item?: { id?: string })
   await workGraph.moveItem(item.id, 'down');
 }
 
+async function handleFocusMoveToTop(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
+  if (!item?.id) {
+    void vscode.window.showInformationMessage('DevDocket: Select an item in Focus to move.');
+    return;
+  }
+  await workGraph.moveToTop(item.id);
+}
+
+async function handleFocusMoveToBottom(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
+  if (!item?.id) {
+    void vscode.window.showInformationMessage('DevDocket: Select an item in Focus to move.');
+    return;
+  }
+  await workGraph.moveToBottom(item.id);
+}
+
 export function registerFocusCommands(
   context: vscode.ExtensionContext,
   workGraph: WorkGraph,
@@ -66,5 +82,9 @@ export function registerFocusCommands(
       wrapCommand('Failed to move focus item up', (item) => handleFocusMoveUp(workGraph, item))),
     vscode.commands.registerCommand('devdocket.focusMoveDown',
       wrapCommand('Failed to move focus item down', (item) => handleFocusMoveDown(workGraph, item))),
+    vscode.commands.registerCommand('devdocket.focusMoveToTop',
+      wrapCommand('Failed to move focus item to top', (item) => handleFocusMoveToTop(workGraph, item))),
+    vscode.commands.registerCommand('devdocket.focusMoveToBottom',
+      wrapCommand('Failed to move focus item to bottom', (item) => handleFocusMoveToBottom(workGraph, item))),
   );
 }

--- a/packages/core/src/commands/queueCommands.ts
+++ b/packages/core/src/commands/queueCommands.ts
@@ -44,6 +44,22 @@ async function handleMoveDown(workGraph: WorkGraph, item?: { id?: string }): Pro
   await workGraph.moveItem(item.id, 'down');
 }
 
+async function handleMoveToTop(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
+  if (!item?.id) {
+    void vscode.window.showInformationMessage('DevDocket: Select an item in the Queue to move.');
+    return;
+  }
+  await workGraph.moveToTop(item.id);
+}
+
+async function handleMoveToBottom(workGraph: WorkGraph, item?: { id?: string }): Promise<void> {
+  if (!item?.id) {
+    void vscode.window.showInformationMessage('DevDocket: Select an item in the Queue to move.');
+    return;
+  }
+  await workGraph.moveToBottom(item.id);
+}
+
 async function handleDeleteItem(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[]): Promise<void> {
   const ids = resolveItemIds(item, selectedItems);
   if (ids.length === 0) { return; }
@@ -94,6 +110,10 @@ export function registerQueueCommands(
       wrapCommand('Failed to move item up', (item) => handleMoveUp(workGraph, item))),
     vscode.commands.registerCommand('devdocket.moveDown',
       wrapCommand('Failed to move item down', (item) => handleMoveDown(workGraph, item))),
+    vscode.commands.registerCommand('devdocket.moveToTop',
+      wrapCommand('Failed to move item to top', (item) => handleMoveToTop(workGraph, item))),
+    vscode.commands.registerCommand('devdocket.moveToBottom',
+      wrapCommand('Failed to move item to bottom', (item) => handleMoveToBottom(workGraph, item))),
     vscode.commands.registerCommand('devdocket.deleteItem',
       wrapCommand('Failed to delete item', (item, selectedItems) => handleDeleteItem(workGraph, item, selectedItems))),
   );

--- a/packages/core/src/commands/queueCommands.ts
+++ b/packages/core/src/commands/queueCommands.ts
@@ -57,7 +57,7 @@ async function handleMoveToBottom(workGraph: WorkGraph, item?: { id?: string }):
     void vscode.window.showInformationMessage('DevDocket: Select an item in the Queue to move.');
     return;
   }
-  await workGraph.moveToEnd(item.id);
+  await workGraph.moveToBottom(item.id);
 }
 
 async function handleDeleteItem(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[]): Promise<void> {

--- a/packages/core/src/commands/queueCommands.ts
+++ b/packages/core/src/commands/queueCommands.ts
@@ -57,7 +57,7 @@ async function handleMoveToBottom(workGraph: WorkGraph, item?: { id?: string }):
     void vscode.window.showInformationMessage('DevDocket: Select an item in the Queue to move.');
     return;
   }
-  await workGraph.moveToBottom(item.id);
+  await workGraph.moveToEnd(item.id);
 }
 
 async function handleDeleteItem(workGraph: WorkGraph, item?: { id?: string }, selectedItems?: { id?: string }[]): Promise<void> {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -374,6 +374,11 @@ export class WorkGraph {
     }
   }
 
+  /** Move a work item to the last position among siblings in the same state. Alias for moveToEnd. */
+  async moveToBottom(id: string): Promise<void> {
+    return this.moveToEnd(id);
+  }
+
   /** Insert a work item before or after a target item (drag-and-drop reorder). */
   async reorderItem(draggedId: string, targetId: string): Promise<void> {
     const dragged = this.items.get(draggedId);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -340,6 +340,72 @@ export class WorkGraph {
     this._onDidChange.fire();
   }
 
+  async moveToTop(id: string): Promise<void> {
+    const item = this.items.get(id);
+    if (!item) { return; }
+
+    const siblings = this.getItemsByState(item.state)
+      .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
+
+    if (siblings.length === 0) { return; }
+
+    const firstSibling = siblings[0];
+    if (firstSibling.id === item.id) { return; }
+
+    const withoutItem = siblings.filter(s => s.id !== item.id);
+    withoutItem.unshift(item);
+
+    const itemsToSave: WorkItem[] = [];
+    withoutItem.forEach((sibling, index) => {
+      if (sibling.sortOrder !== index) {
+        const updated = { ...sibling, sortOrder: index, updatedAt: Date.now() };
+        itemsToSave.push(updated);
+      }
+    });
+
+    if (itemsToSave.length > 0) {
+      await this.store.saveAll(itemsToSave);
+      for (const updated of itemsToSave) {
+        this.items.set(updated.id, updated);
+      }
+      this.invalidateStateCache();
+      this._onDidChange.fire();
+    }
+  }
+
+  async moveToBottom(id: string): Promise<void> {
+    const item = this.items.get(id);
+    if (!item) { return; }
+
+    const siblings = this.getItemsByState(item.state)
+      .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
+
+    if (siblings.length === 0) { return; }
+
+    const lastSibling = siblings[siblings.length - 1];
+    if (lastSibling.id === item.id) { return; }
+
+    const withoutItem = siblings.filter(s => s.id !== item.id);
+    withoutItem.push(item);
+
+    const itemsToSave: WorkItem[] = [];
+    withoutItem.forEach((sibling, index) => {
+      if (sibling.sortOrder !== index) {
+        const updated = { ...sibling, sortOrder: index, updatedAt: Date.now() };
+        itemsToSave.push(updated);
+      }
+    });
+
+    if (itemsToSave.length > 0) {
+      await this.store.saveAll(itemsToSave);
+      for (const updated of itemsToSave) {
+        this.items.set(updated.id, updated);
+      }
+      this.invalidateStateCache();
+      this._onDidChange.fire();
+    }
+  }
+
   /** Insert a work item before or after a target item (drag-and-drop reorder). */
   async reorderItem(draggedId: string, targetId: string): Promise<void> {
     const dragged = this.items.get(draggedId);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -340,6 +340,7 @@ export class WorkGraph {
     this._onDidChange.fire();
   }
 
+  /** Move a work item to the first position among siblings in the same state. */
   async moveToTop(id: string): Promise<void> {
     const item = this.items.get(id);
     if (!item) { return; }
@@ -354,39 +355,6 @@ export class WorkGraph {
 
     const withoutItem = siblings.filter(s => s.id !== item.id);
     withoutItem.unshift(item);
-
-    const itemsToSave: WorkItem[] = [];
-    withoutItem.forEach((sibling, index) => {
-      if (sibling.sortOrder !== index) {
-        const updated = { ...sibling, sortOrder: index, updatedAt: Date.now() };
-        itemsToSave.push(updated);
-      }
-    });
-
-    if (itemsToSave.length > 0) {
-      await this.store.saveAll(itemsToSave);
-      for (const updated of itemsToSave) {
-        this.items.set(updated.id, updated);
-      }
-      this.invalidateStateCache();
-      this._onDidChange.fire();
-    }
-  }
-
-  async moveToBottom(id: string): Promise<void> {
-    const item = this.items.get(id);
-    if (!item) { return; }
-
-    const siblings = this.getItemsByState(item.state)
-      .sort((a, b) => (a.sortOrder ?? Number.MAX_SAFE_INTEGER) - (b.sortOrder ?? Number.MAX_SAFE_INTEGER));
-
-    if (siblings.length === 0) { return; }
-
-    const lastSibling = siblings[siblings.length - 1];
-    if (lastSibling.id === item.id) { return; }
-
-    const withoutItem = siblings.filter(s => s.id !== item.id);
-    withoutItem.push(item);
 
     const itemsToSave: WorkItem[] = [];
     withoutItem.forEach((sibling, index) => {


### PR DESCRIPTION
## Summary

Implements Move to Top and Move to Bottom commands for reordering items in Queue and Focus views, complementing the existing Move Up/Down commands.

## Changes

### WorkGraph Service
- Added `moveToTop(id)` method - moves item to first position among siblings in same state
- Added `moveToBottom(id)` method - alias for existing `moveToEnd()` to maintain consistent naming (Top/Up/Down/Bottom pattern)

### Queue Commands
- Added `handleMoveToTop` and `handleMoveToBottom` handlers
- Registered `devdocket.moveToTop` and `devdocket.moveToBottom` commands

### Focus Commands  
- Added `handleFocusMoveToTop` and `handleFocusMoveToBottom` handlers
- Registered `devdocket.focusMoveToTop` and `devdocket.focusMoveToBottom` commands

### Package.json
- Added 4 command contributions with appropriate titles and icons
- Added 4 menu items in `3_reorder` group with correct sort order:
  - `@0` - Move to Top (before Move Up)
  - `@1` - Move Up
  - `@2` - Move Down  
  - `@3` - Move to Bottom (after Move Down)

## Testing
- All existing tests pass
- Build successful across all packages

Closes #365
