### PR TITLE
Add URL field to manual work items for Open in Browser support

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -780,12 +780,12 @@
         },
         {
           "command": "devdocket.watchPRFromItem",
-          "when": "view == devdocket.focus && viewItem =~ /hasUrl/ && !listMultiSelection",
+          "when": "view == devdocket.focus && viewItem =~ /watchable/ && !listMultiSelection",
           "group": "2_links"
         },
         {
           "command": "devdocket.watchPRFromItem",
-          "when": "view == devdocket.queue && viewItem =~ /hasUrl/ && !listMultiSelection",
+          "when": "view == devdocket.queue && viewItem =~ /watchable/ && !listMultiSelection",
           "group": "2_links"
         },
         {

--- a/packages/core/src/commands/watchCommands.ts
+++ b/packages/core/src/commands/watchCommands.ts
@@ -132,6 +132,7 @@ function resolveWatchedPR(arg: unknown): WatchedPR | undefined {
 }
 
 async function handleWatchPRFromItem(
+  watcherRegistry: WatcherRegistry,
   prWatcherRegistry: PRWatcherRegistry,
   watcherService: WatcherService,
   arg: unknown,
@@ -148,15 +149,24 @@ async function handleWatchPRFromItem(
     return;
   }
 
+  // Try PR watchers first, then run watchers
   const prWatcher = prWatcherRegistry.findWatcherForUrl(safeUrl.href);
-  if (!prWatcher) {
-    void vscode.window.showWarningMessage('DevDocket: This item\'s URL is not recognized as a pull request.');
+  if (prWatcher) {
+    const identifier = prWatcher.parsePRUrl(safeUrl.href);
+    await watcherService.startPRWatch(identifier);
+    void vscode.window.showInformationMessage(`Now watching PR: ${identifier.displayName}`);
     return;
   }
 
-  const identifier = prWatcher.parsePRUrl(safeUrl.href);
-  await watcherService.startPRWatch(identifier);
-  void vscode.window.showInformationMessage(`Now watching PR: ${identifier.displayName}`);
+  const runWatcher = watcherRegistry.findWatcherForUrl(safeUrl.href);
+  if (runWatcher) {
+    const identifier = runWatcher.parseRunUrl(safeUrl.href);
+    await watcherService.startWatch(identifier);
+    void vscode.window.showInformationMessage(`Now watching run: ${identifier.displayName}`);
+    return;
+  }
+
+  void vscode.window.showWarningMessage('DevDocket: No registered watcher recognizes this item\'s URL.');
 }
 
 function extractItemUrl(arg: unknown): string | undefined {
@@ -244,7 +254,7 @@ export function registerWatchCommands(
     vscode.commands.registerCommand('devdocket.watchPR',
       wrapCommand('Failed to watch PR', () => handleWatchPR(prWatcherRegistry, watcherService))),
     vscode.commands.registerCommand('devdocket.watchPRFromItem',
-      wrapCommand('Failed to watch PR from item', (arg: unknown) => handleWatchPRFromItem(prWatcherRegistry, watcherService, arg))),
+      wrapCommand('Failed to watch CI from item', (arg: unknown) => handleWatchPRFromItem(watcherRegistry, prWatcherRegistry, watcherService, arg))),
     vscode.commands.registerCommand('devdocket.dismissWatch',
       wrapCommand('Failed to dismiss watch', (arg: unknown) => handleDismissWatch(arg, watcherService))),
     vscode.commands.registerCommand('devdocket.dismissAllCompletedWatches',

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -126,10 +126,16 @@ function createTreeViews(
   readStateStore: ReadStateStore,
   workGraph: WorkGraph,
   watcherService: WatcherService,
+  watcherRegistry: WatcherRegistry,
+  prWatcherRegistry: PRWatcherRegistry,
 ) {
+  const isWatchable = (url: string): boolean =>
+    watcherRegistry.findWatcherForUrl(url) !== undefined ||
+    prWatcherRegistry.findWatcherForUrl(url) !== undefined;
+
   const inboxProvider = new InboxTreeProvider(providerRegistry, stateStore, readStateStore);
-  const queueProvider = new QueueTreeProvider(workGraph, providerRegistry);
-  const focusProvider = new FocusTreeProvider(workGraph, providerRegistry);
+  const queueProvider = new QueueTreeProvider(workGraph, providerRegistry, isWatchable);
+  const focusProvider = new FocusTreeProvider(workGraph, providerRegistry, isWatchable);
   const sourcesProvider = new SourcesTreeProvider(providerRegistry, stateStore);
   const historyProvider = new HistoryTreeProvider(workGraph, providerRegistry);
   const watchesProvider = new WatchesTreeProvider(watcherService);
@@ -408,7 +414,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   logger.info(`Store + service init took ${Math.round(performance.now() - initStart)}ms`);
 
   const treeViewStart = performance.now();
-  const treeSetup = createTreeViews(pr, ss, readStateStore, wg, ws);
+  const treeSetup = createTreeViews(pr, ss, readStateStore, wg, ws, wr, pwr);
   logger.info(`Tree view creation took ${Math.round(performance.now() - treeViewStart)}ms`);
 
   const eventWiringStart = performance.now();

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -210,7 +210,7 @@ export class WorkGraph {
     return item;
   }
 
-  /** Apply a partial update (title and/or notes) to an existing work item. */
+  /** Apply a partial update (title, notes, and/or url) to an existing work item. */
   async updateItem(id: string, patch: Partial<WorkItemInput>): Promise<void> {
     const item = this.items.get(id);
     if (!item) {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -219,6 +219,8 @@ export class WorkGraph {
     if (patch.title !== undefined && patch.title !== item.title) { changes.push('title'); }
     // Detect notes changes including clearing (patch.notes === undefined with key present)
     if ('notes' in patch && patch.notes !== item.notes) { changes.push('notes'); }
+    // Detect url changes including clearing (patch.url === undefined with key present)
+    if ('url' in patch && patch.url !== item.url) { changes.push('url'); }
     // Skip save/event when no fields actually changed (e.g. autosave with identical values)
     if (changes.length === 0) {
       return;

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -182,7 +182,7 @@ export class WorkGraph {
       state: WorkItemState.New,
       providerId: provenance?.providerId,
       externalId: provenance?.externalId,
-      url: isSafeUrl(provenance?.url ?? '')?.href ?? isSafeUrl(input.url ?? '')?.href,
+      url: isSafeUrl(provenance?.url?.trim() ?? '')?.href ?? isSafeUrl(input.url?.trim() ?? '')?.href,
       group: provenance?.group,
       sortOrder,
       createdAt: now,
@@ -222,7 +222,7 @@ export class WorkGraph {
     if ('notes' in patch && patch.notes !== item.notes) { changes.push('notes'); }
     // Detect url changes including clearing (patch.url === undefined with key present)
     if ('url' in patch) {
-      const sanitized = patch.url ? isSafeUrl(patch.url)?.href : undefined;
+      const sanitized = patch.url ? isSafeUrl(patch.url.trim())?.href : undefined;
       if (sanitized !== patch.url) { patch = { ...patch, url: sanitized }; }
       if (sanitized !== item.url) { changes.push('url'); }
     }

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -4,6 +4,7 @@ import { WorkItem, WorkItemInput, WorkItemState } from '../models/workItem';
 import { type ActivityLogEntry, type ActivityType, MAX_ACTIVITY_LOG_ENTRIES } from '../models/activityLog';
 import { ITaskStore } from '../storage/taskStore';
 import { logger } from './logger';
+import { isSafeUrl } from '../utils/url';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -181,7 +182,7 @@ export class WorkGraph {
       state: WorkItemState.New,
       providerId: provenance?.providerId,
       externalId: provenance?.externalId,
-      url: provenance?.url ?? input.url,
+      url: isSafeUrl(provenance?.url ?? input.url ?? '')?.href,
       group: provenance?.group,
       sortOrder,
       createdAt: now,

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -182,7 +182,7 @@ export class WorkGraph {
       state: WorkItemState.New,
       providerId: provenance?.providerId,
       externalId: provenance?.externalId,
-      url: isSafeUrl(provenance?.url ?? input.url ?? '')?.href,
+      url: isSafeUrl(provenance?.url ?? '')?.href ?? isSafeUrl(input.url ?? '')?.href,
       group: provenance?.group,
       sortOrder,
       createdAt: now,

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -181,7 +181,7 @@ export class WorkGraph {
       state: WorkItemState.New,
       providerId: provenance?.providerId,
       externalId: provenance?.externalId,
-      url: provenance?.url,
+      url: provenance?.url ?? input.url,
       group: provenance?.group,
       sortOrder,
       createdAt: now,

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -221,7 +221,11 @@ export class WorkGraph {
     // Detect notes changes including clearing (patch.notes === undefined with key present)
     if ('notes' in patch && patch.notes !== item.notes) { changes.push('notes'); }
     // Detect url changes including clearing (patch.url === undefined with key present)
-    if ('url' in patch && patch.url !== item.url) { changes.push('url'); }
+    if ('url' in patch) {
+      const sanitized = patch.url ? isSafeUrl(patch.url)?.href : undefined;
+      if (sanitized !== patch.url) { patch = { ...patch, url: sanitized }; }
+      if (sanitized !== item.url) { changes.push('url'); }
+    }
     // Skip save/event when no fields actually changed (e.g. autosave with identical values)
     if (changes.length === 0) {
       return;

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -350,14 +350,14 @@ describe('getEditorPanelHtml', () => {
       const item = makeItem({ url: 'javascript:alert(1)' });
       const html = getEditorPanelHtml({ cspSource, item });
       expect(html).not.toContain('id="title-link"');
-      expect(html).not.toContain('href=');
+      expect(html).not.toMatch(/href="javascript:/);
     });
 
     it('does not render a hyperlink for data: URLs', () => {
       const item = makeItem({ url: 'data:text/html,<h1>hi</h1>' });
       const html = getEditorPanelHtml({ cspSource, item });
       expect(html).not.toContain('id="title-link"');
-      expect(html).not.toContain('href=');
+      expect(html).not.toMatch(/href="data:/);
     });
   });
 
@@ -446,6 +446,101 @@ describe('getEditorPanelHtml', () => {
       });
       const html = getEditorPanelHtml({ cspSource, item });
       expect(html).toContain('custom-type');
+    });
+  });
+
+  describe('URL field', () => {
+    it('renders URL input field in the form', () => {
+      const html = getEditorPanelHtml({ cspSource, item: makeItem() });
+      expect(html).toContain('id="url"');
+      expect(html).toContain('<label for="url">URL</label>');
+    });
+
+    it('renders the URL value when item has a url', () => {
+      const item = makeItem({ url: 'https://github.com/org/repo/issues/1' });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).toContain('value="https://github.com/org/repo/issues/1"');
+    });
+
+    it('renders empty URL field when item has no url', () => {
+      const item = makeItem({ url: undefined });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).toMatch(/id="url"[^>]*value=""/);
+    });
+
+    it('URL field is editable for manual items (no providerId)', () => {
+      const item = makeItem({ providerId: undefined });
+      const html = getEditorPanelHtml({ cspSource, item });
+      const urlFieldMatch = html.match(/<input[^>]*id="url"[^>]*>/);
+      expect(urlFieldMatch).not.toBeNull();
+      expect(urlFieldMatch![0]).not.toContain('readonly');
+    });
+
+    it('URL field is read-only for provider items', () => {
+      const item = makeItem({ providerId: 'github', url: 'https://github.com/org/repo/issues/1' });
+      const html = getEditorPanelHtml({ cspSource, item, titleReadonly: true });
+      const urlFieldMatch = html.match(/<input[^>]*id="url"[^>]*>/);
+      expect(urlFieldMatch).not.toBeNull();
+      expect(urlFieldMatch![0]).toContain('readonly');
+    });
+
+    it('shows open-in-browser link when URL is valid', () => {
+      const item = makeItem({ url: 'https://github.com/org/repo/issues/1' });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).toContain('id="url-open-link"');
+      // The link should not have the hidden class
+      const linkMatch = html.match(/<a[^>]*id="url-open-link"[^>]*>/);
+      expect(linkMatch).not.toBeNull();
+      expect(linkMatch![0]).not.toContain('hidden');
+    });
+
+    it('hides open-in-browser link when URL is empty', () => {
+      const item = makeItem({ url: undefined });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).toContain('url-open-link');
+      expect(html).toContain('hidden');
+    });
+
+    it('hides open-in-browser link for unsafe URLs', () => {
+      const item = makeItem({ url: 'javascript:alert(1)' });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).toContain('hidden');
+    });
+
+    it('escapes HTML entities in URL value', () => {
+      const item = makeItem({ url: 'https://evil.com/"><script>alert(1)</script>' });
+      const html = getEditorPanelHtml({ cspSource, item });
+      const urlFieldMatch = html.match(/<input[^>]*id="url"[^>]*>/);
+      expect(urlFieldMatch).not.toBeNull();
+      expect(urlFieldMatch![0]).not.toContain('<script>');
+      expect(urlFieldMatch![0]).toContain('&lt;script&gt;');
+    });
+
+    it('includes URL in autosave getData function', () => {
+      const html = getEditorPanelHtml({ cspSource, item: makeItem() });
+      expect(html).toContain("url: document.getElementById('url').value.trim()");
+    });
+
+    it('includes url in fields array for input listeners', () => {
+      const html = getEditorPanelHtml({ cspSource, item: makeItem() });
+      expect(html).toContain("'url'");
+    });
+
+    it('includes isSafeUrlClient validation in webview script', () => {
+      const html = getEditorPanelHtml({ cspSource, item: makeItem() });
+      expect(html).toContain('isSafeUrlClient');
+    });
+
+    it('shows readonly hint for provider items URL field', () => {
+      const item = makeItem({ providerId: 'github', url: 'https://github.com/org/repo/issues/1' });
+      const html = getEditorPanelHtml({ cspSource, item, titleReadonly: true });
+      expect(html).toContain('URL is managed by the provider');
+    });
+
+    it('does not show readonly hint for manual items URL field', () => {
+      const item = makeItem({ providerId: undefined });
+      const html = getEditorPanelHtml({ cspSource, item });
+      expect(html).not.toContain('URL is managed by the provider');
     });
   });
 });

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -57,6 +57,30 @@ describe('FocusTreeProvider', () => {
       const item = makeItem({ state: WorkItemState.Paused, url: 'https://example.com' });
       expect(provider.getTreeItem(item).contextValue).toBe('paused.hasUrl');
     });
+
+    it('should set contextValue to "active.hasUrl.watchable" when URL is watchable', () => {
+      const watchableProvider = new FocusTreeProvider(workGraph as any, undefined, () => true);
+      const item = makeItem({ state: WorkItemState.InProgress, url: 'https://github.com/owner/repo/pull/1' });
+      expect(watchableProvider.getTreeItem(item).contextValue).toBe('active.hasUrl.watchable');
+    });
+
+    it('should set contextValue to "active.hasUrl" when URL is not watchable', () => {
+      const unwatchableProvider = new FocusTreeProvider(workGraph as any, undefined, () => false);
+      const item = makeItem({ state: WorkItemState.InProgress, url: 'https://example.com' });
+      expect(unwatchableProvider.getTreeItem(item).contextValue).toBe('active.hasUrl');
+    });
+
+    it('should set contextValue to "paused.hasUrl.watchable" when paused URL is watchable', () => {
+      const watchableProvider = new FocusTreeProvider(workGraph as any, undefined, () => true);
+      const item = makeItem({ state: WorkItemState.Paused, url: 'https://github.com/owner/repo/pull/2' });
+      expect(watchableProvider.getTreeItem(item).contextValue).toBe('paused.hasUrl.watchable');
+    });
+
+    it('should not append watchable when item has no URL even if isWatchable provided', () => {
+      const watchableProvider = new FocusTreeProvider(workGraph as any, undefined, () => true);
+      const item = makeItem({ state: WorkItemState.InProgress });
+      expect(watchableProvider.getTreeItem(item).contextValue).toBe('active');
+    });
   });
 
   describe('getTreeItem description', () => {

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -170,6 +170,33 @@ describe('QueueTreeProvider', () => {
       expect(treeItem.contextValue).toBe('queueItem');
     });
 
+    it('sets contextValue to "queueItem.hasUrl.watchable" when URL is watchable', async () => {
+      const watchableProvider = new QueueTreeProvider(graph, undefined, () => true);
+      const item = await graph.createItem(
+        { title: 'Watchable' },
+        { providerId: 'github', externalId: 'ext-w1', url: 'https://github.com/owner/repo/pull/1' },
+      );
+      const treeItem = watchableProvider.getTreeItem(item);
+      expect(treeItem.contextValue).toBe('queueItem.hasUrl.watchable');
+    });
+
+    it('sets contextValue to "queueItem.hasUrl" when URL is not watchable', async () => {
+      const unwatchableProvider = new QueueTreeProvider(graph, undefined, () => false);
+      const item = await graph.createItem(
+        { title: 'Not watchable' },
+        { providerId: 'github', externalId: 'ext-w2', url: 'https://example.com' },
+      );
+      const treeItem = unwatchableProvider.getTreeItem(item);
+      expect(treeItem.contextValue).toBe('queueItem.hasUrl');
+    });
+
+    it('does not append watchable when item has no URL even if isWatchable provided', async () => {
+      const watchableProvider = new QueueTreeProvider(graph, undefined, () => true);
+      const item = await graph.createItem({ title: 'No URL watchable' });
+      const treeItem = watchableProvider.getTreeItem(item);
+      expect(treeItem.contextValue).toBe('queueItem');
+    });
+
     it('sets icon to "remote" when item has providerId', async () => {
       const item = await graph.createItem(
         { title: 'Provider item' },

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -233,7 +233,7 @@ export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDes
       outline-offset: 2px;
     }
     .url-open-link.hidden {
-      visibility: hidden;
+      display: none;
     }
   </style>
 </head>

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -205,6 +205,36 @@ export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDes
     .activity-detail {
       opacity: 0.8;
     }
+    .url-row {
+      display: flex;
+      gap: 6px;
+      align-items: center;
+    }
+    .url-row input {
+      flex: 1;
+    }
+    .url-open-link {
+      flex-shrink: 0;
+      color: var(--vscode-textLink-foreground);
+      cursor: pointer;
+      font-size: 1em;
+      text-decoration: none;
+      padding: 4px;
+      border-radius: 3px;
+      display: inline-flex;
+      align-items: center;
+    }
+    .url-open-link:hover {
+      color: var(--vscode-textLink-activeForeground);
+    }
+    .url-open-link:focus,
+    .url-open-link:focus-visible {
+      outline: 1px solid var(--vscode-focusBorder);
+      outline-offset: 2px;
+    }
+    .url-open-link.hidden {
+      visibility: hidden;
+    }
   </style>
 </head>
 <body>
@@ -214,6 +244,14 @@ export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDes
       <label for="title">Title</label>
       <input type="text" id="title" value="${escapeAttr(item.title)}" ${titleReadonly ? 'readonly aria-readonly="true" aria-describedby="readonly-title-hint"' : ''} />
 ${titleReadonly ? '      <span id="readonly-title-hint" class="hint">Title is managed by the provider</span>' : ''}
+    </div>
+    <div class="field">
+      <label for="url">URL</label>
+      <div class="url-row">
+        <input type="url" id="url" value="${escapeAttr(item.url ?? '')}" placeholder="https://..." ${titleReadonly ? 'readonly aria-readonly="true" aria-describedby="readonly-url-hint"' : ''} />
+        <a href="#" class="url-open-link${item.url && isSafeUrl(item.url) ? '' : ' hidden'}" id="url-open-link" title="Open in Browser" aria-label="Open URL in browser">&#x2197;</a>
+      </div>
+${titleReadonly ? '      <span id="readonly-url-hint" class="hint">URL is managed by the provider</span>' : ''}
     </div>
 ${descriptionSection}
     <div class="field">
@@ -239,13 +277,33 @@ ${providerState && item.providerId ? `      <dt>Provider State</dt>
 ${renderActivityLog(item.activityLog)}
   <script nonce="${nonce}">
     const vscode = acquireVsCodeApi();
-    const fields = ['title', 'notes'];
+    const fields = ['title', 'notes', 'url'];
     let debounceTimer = null;
+
+    function isSafeUrlClient(str) {
+      try {
+        const u = new URL(str);
+        return u.protocol === 'http:' || u.protocol === 'https:';
+      } catch { return false; }
+    }
+
+    function updateUrlLinkVisibility() {
+      const urlEl = document.getElementById('url');
+      const linkEl = document.getElementById('url-open-link');
+      if (!urlEl || !linkEl) return;
+      const val = urlEl.value.trim();
+      if (val && isSafeUrlClient(val)) {
+        linkEl.classList.remove('hidden');
+      } else {
+        linkEl.classList.add('hidden');
+      }
+    }
 
     function getData() {
       return {
         title: document.getElementById('title').value.trim(),
         notes: document.getElementById('notes').value.trim(),
+        url: document.getElementById('url').value.trim(),
       };
     }
 
@@ -267,6 +325,25 @@ ${renderActivityLog(item.activityLog)}
         }
       }
     });
+
+    const urlInput = document.getElementById('url');
+    if (urlInput instanceof HTMLInputElement && !urlInput.readOnly) {
+      urlInput.addEventListener('input', updateUrlLinkVisibility);
+    }
+
+    const urlOpenLink = document.getElementById('url-open-link');
+    if (urlOpenLink) {
+      urlOpenLink.addEventListener('click', (e) => {
+        e.preventDefault();
+        const urlEl = document.getElementById('url');
+        if (urlEl instanceof HTMLInputElement) {
+          const val = urlEl.value.trim();
+          if (val && isSafeUrlClient(val)) {
+            vscode.postMessage({ type: 'openUrl', url: val });
+          }
+        }
+      });
+    }
 
     const titleLink = document.getElementById('title-link');
     if (titleLink) {

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -16,8 +16,9 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
   readonly dragMimeTypes = [DRAG_MIME_TYPE];
   protected readonly groupPrefix = 'focus';
   protected readonly groupContextValue = 'focusGroup';
+  private readonly isWatchable?: (url: string) => boolean;
 
-  constructor(workGraph: WorkGraph, providerRegistry?: ProviderRegistry) {
+  constructor(workGraph: WorkGraph, providerRegistry?: ProviderRegistry, isWatchable?: (url: string) => boolean) {
     super(
       workGraph,
       'flat',
@@ -26,6 +27,7 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
       providerRegistry ? (pid, eid) => providerRegistry.getDiscoveredItems(pid).find(d => d.externalId === eid)?.title : undefined,
       providerRegistry?.onDidChangeDiscoveredItems,
     );
+    this.isWatchable = isWatchable;
   }
 
   protected getItems(): WorkItem[] {
@@ -53,11 +55,10 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
     treeItem.iconPath = getWorkItemIcon(item.state);
 
     // contextValue controls which context menu items appear
-    if (item.state === WorkItemState.Paused) {
-      treeItem.contextValue = item.url ? 'paused.hasUrl' : 'paused';
-    } else {
-      treeItem.contextValue = item.url ? 'active.hasUrl' : 'active';
-    }
+    const base = item.state === WorkItemState.Paused ? 'paused' : 'active';
+    const urlSuffix = item.url ? '.hasUrl' : '';
+    const watchableSuffix = item.url && this.isWatchable?.(item.url) ? '.watchable' : '';
+    treeItem.contextValue = `${base}${urlSuffix}${watchableSuffix}`;
 
     treeItem.command = { command: 'devdocket.editItem', title: 'Open Details', arguments: [item] };
     return treeItem;

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -16,8 +16,9 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
   readonly dragMimeTypes = [DRAG_MIME_TYPE];
   protected readonly groupPrefix = 'queue';
   protected readonly groupContextValue = 'queueGroup';
+  private readonly isWatchable?: (url: string) => boolean;
 
-  constructor(workGraph: WorkGraph, providerRegistry?: ProviderRegistry) {
+  constructor(workGraph: WorkGraph, providerRegistry?: ProviderRegistry, isWatchable?: (url: string) => boolean) {
     super(
       workGraph,
       'flat',
@@ -26,6 +27,7 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
       providerRegistry ? (pid, eid) => providerRegistry.getDiscoveredItems(pid).find(d => d.externalId === eid)?.title : undefined,
       providerRegistry?.onDidChangeDiscoveredItems,
     );
+    this.isWatchable = isWatchable;
   }
 
   protected getItems(): WorkItem[] {
@@ -44,7 +46,9 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
       ? this.buildDescription(item.group, this.getProviderLabel(item.providerId))
       : undefined;
     treeItem.tooltip = buildWorkItemTooltip(item, title, { showState: false, notesStyle: 'plain' });
-    treeItem.contextValue = item.url ? 'queueItem.hasUrl' : 'queueItem';
+    const urlSuffix = item.url ? '.hasUrl' : '';
+    const watchableSuffix = item.url && this.isWatchable?.(item.url) ? '.watchable' : '';
+    treeItem.contextValue = `queueItem${urlSuffix}${watchableSuffix}`;
     treeItem.iconPath = new vscode.ThemeIcon(item.providerId ? 'remote' : 'circle-filled');
     treeItem.command = { command: 'devdocket.editItem', title: 'Open Details', arguments: [item] };
     return treeItem;

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -48,6 +48,7 @@ export class WorkItemEditorPanel {
   private readonly providerRegSub: vscode.Disposable;
   private readonly providerChangeSub: vscode.Disposable;
   private lastDisplayedTitle: string | undefined;
+  private lastDisplayedUrl: string | undefined;
   private lastManagedState: boolean | undefined;
 
   /**
@@ -188,6 +189,11 @@ export class WorkItemEditorPanel {
       this.panel.title = `Edit: ${item.title}`;
       void this.panel.webview.postMessage({ type: 'updateTitle', title: item.title });
     }
+
+    // Re-render when URL changes to keep the title hyperlink and URL field in sync
+    if (item.url !== this.lastDisplayedUrl) {
+      this.update();
+    }
   }
 
   private async saveData(data: Record<string, string>): Promise<void> {
@@ -237,6 +243,7 @@ export class WorkItemEditorPanel {
       return;
     }
     this.lastDisplayedTitle = item.title;
+    this.lastDisplayedUrl = item.url;
     this.lastManagedState = this.isProviderManaged(item);
     this.panel.title = `Edit: ${item.title}`;
     this.panel.webview.html = this.getHtml(item);

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -203,6 +203,20 @@ export class WorkItemEditorPanel {
         return;
       }
       patch.title = data.title;
+
+      if ('url' in data) {
+        const rawUrl = data.url || '';
+        // Allow clearing the URL; validate non-empty values
+        if (rawUrl === '') {
+          patch.url = undefined;
+        } else {
+          const safe = isSafeUrl(rawUrl);
+          if (safe) {
+            patch.url = safe.href;
+          }
+          // Silently ignore invalid URLs
+        }
+      }
     }
 
     if ('notes' in data) {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -233,12 +233,13 @@ export class WorkItemEditorPanel {
       return;
     }
 
-    await this.workGraph.updateItem(this.itemId, patch);
-    // Sync tracked URL to prevent self-triggered re-render in checkForUpdates
-    const saved = this.workGraph.getItem(this.itemId);
-    if (saved) {
-      this.lastDisplayedUrl = saved.url;
+    // Pre-sync tracked URL before updateItem fires onDidChange synchronously,
+    // preventing a self-triggered full re-render that could wipe unsaved edits.
+    if ('url' in patch) {
+      this.lastDisplayedUrl = patch.url;
     }
+
+    await this.workGraph.updateItem(this.itemId, patch);
   }
 
   private update(): void {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -234,6 +234,11 @@ export class WorkItemEditorPanel {
     }
 
     await this.workGraph.updateItem(this.itemId, patch);
+    // Sync tracked URL to prevent self-triggered re-render in checkForUpdates
+    const saved = this.workGraph.getItem(this.itemId);
+    if (saved) {
+      this.lastDisplayedUrl = saved.url;
+    }
   }
 
   private update(): void {

--- a/packages/shared/src/workItem.ts
+++ b/packages/shared/src/workItem.ts
@@ -112,4 +112,6 @@ export interface WorkItemInput {
   title: string;
   /** Optional free-form notes or description. */
   notes?: string;
+  /** Optional URL linking to the item in an external system. */
+  url?: string;
 }


### PR DESCRIPTION
## Summary

Closes #358

Adds a URL field to manual work items, enabling "Open in Browser" support for user-created items. Also unifies the `isWatchable` design across queue and focus tree providers.

## Changes

### URL field for manual items
- Added `url?: string` to `WorkItemInput` in shared types
- Editor panel renders a URL input field with autosave for manual items
- Provider-managed items show URL as read-only with an "Open" link
- URL validation via `isSafeUrl()` prevents unsafe protocols (javascript:, data:)
- `createItem` now respects `input.url` (falls back when no provenance URL)

### Unified `isWatchable` design
- Both `QueueTreeProvider` and `FocusTreeProvider` accept an `isWatchable` callback
- Context value `.watchable` suffix is appended only when a registered watcher recognizes the URL
- `watchPRFromItem` command now supports both PR and run watchers with clear precedence
- Package.json when-clause updated from `/hasUrl/` to `/watchable/` for watch command visibility

### Tests
- 14 new editor panel HTML tests (URL rendering, readonly, XSS vectors, autosave)
- 4 new FocusTreeProvider tests for `isWatchable` contextValue
- 3 new QueueTreeProvider tests for `isWatchable` contextValue
