### PR TITLE
feat(core): render provider description as markdown (#356)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -647,6 +647,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/sanitize-html": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@types/sanitize-html/-/sanitize-html-2.16.1.tgz",
+      "integrity": "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "htmlparser2": "^10.1"
+      }
+    },
     "node_modules/@types/vscode": {
       "version": "1.110.0",
       "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
@@ -1249,6 +1259,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/devdocket": {
       "resolved": "packages/core",
       "link": true
@@ -1305,11 +1324,89 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1811,6 +1908,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -1918,6 +2034,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-stream": {
@@ -2065,6 +2190,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
+      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -2156,7 +2293,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2296,6 +2432,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2357,7 +2499,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -2396,7 +2537,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2604,6 +2744,20 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/sanitize-html": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.3.tgz",
+      "integrity": "sha512-Kn4srCAo2+wZyvCNKCSyB2g8RQ8IkX/gQs2uqoSRNu5t9I2qvUyAVvRDiFUVAiX3N3PNuwStY0eNr+ooBHVWEg==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^10.1.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -2674,7 +2828,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -4419,10 +4572,13 @@
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*",
+        "marked": "^18.0.2",
+        "sanitize-html": "^2.17.3",
         "timeago.js": "^4.0.2"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
+        "@types/sanitize-html": "^2.16.1",
         "@types/vscode": "^1.85.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -909,10 +909,13 @@
   },
   "dependencies": {
     "@devdocket/shared": "*",
+    "marked": "^18.0.2",
+    "sanitize-html": "^2.17.3",
     "timeago.js": "^4.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
+    "@types/sanitize-html": "^2.16.1",
     "@types/vscode": "^1.85.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -519,4 +519,24 @@ describe('renderMarkdown', () => {
     const result = renderMarkdown('<a href="javascript:alert(1)">click</a>');
     expect(result).not.toContain('javascript:');
   });
+
+  it('strips data: scheme from image src', () => {
+    const result = renderMarkdown('<img src="data:image/png;base64,abc" alt="test">');
+    expect(result).not.toContain('data:');
+  });
+
+  it('renders ordered lists', () => {
+    const result = renderMarkdown('1. first\n2. second');
+    expect(result).toContain('<ol>');
+    expect(result).toContain('<li>first</li>');
+    expect(result).toContain('<li>second</li>');
+  });
+
+  it('renders details/summary elements', () => {
+    const result = renderMarkdown('<details><summary>Click me</summary>Hidden content</details>');
+    expect(result).toContain('<details>');
+    expect(result).toContain('<summary>');
+    expect(result).toContain('Click me');
+    expect(result).toContain('Hidden content');
+  });
 });

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getEditorPanelHtml } from '../views/editorPanelHtml';
+import { getEditorPanelHtml, renderMarkdown } from '../views/editorPanelHtml';
 import { WorkItem, WorkItemState } from '../models/workItem';
 
 function makeItem(overrides: Partial<WorkItem> = {}): WorkItem {
@@ -248,33 +248,31 @@ describe('getEditorPanelHtml', () => {
       expect(html).not.toMatch(descLabelPattern);
     });
 
-    it('HTML-escapes the description to prevent XSS', () => {
+    it('strips dangerous attributes from HTML in description', () => {
       const xss = '<img src=x onerror="alert(1)"> & "quotes"';
       const html = getEditorPanelHtml({
         cspSource,
         item: makeItem({ providerId: 'github' }),
         providerDescription: xss,
       });
-      expect(html).not.toContain('<img src=x');
-      expect(html).toContain('&lt;img src=x');
-      expect(html).toContain('&amp;');
+      // onerror handler must be stripped
+      expect(html).not.toContain('onerror');
+      expect(html).not.toContain('alert(1)');
     });
 
-    it('renders the description as a non-editable div, not an input or textarea', () => {
+    it('renders the description as markdown inside a non-editable div', () => {
       const html = getEditorPanelHtml({
         cspSource,
         item: makeItem({ providerId: 'github' }),
         providerDescription: 'Some provider description',
       });
-      // The description should be in a div (inherently read-only), not an input/textarea
-      const descIndex = html.indexOf('Some provider description');
-      expect(descIndex).toBeGreaterThan(-1);
-
-      const before = html.substring(0, descIndex);
-      const lastTagOpen = before.lastIndexOf('<');
-      const containingTag = html.substring(lastTagOpen, descIndex);
-      expect(containingTag).toMatch(/^<div\b/);
-      expect(containingTag).not.toMatch(/^<(input|textarea)\b/);
+      // The description should be rendered as markdown (wrapped in <p>) inside a div
+      expect(html).toContain('<p>Some provider description</p>');
+      expect(html).toContain('class="provider-description"');
+      // Not editable
+      const descDiv = html.match(/<div class="provider-description"[^>]*>([\s\S]*?)<\/div>/);
+      expect(descDiv).not.toBeNull();
+      expect(descDiv![0]).not.toMatch(/<(input|textarea)\b/);
     });
   });
 
@@ -447,5 +445,78 @@ describe('getEditorPanelHtml', () => {
       const html = getEditorPanelHtml({ cspSource, item });
       expect(html).toContain('custom-type');
     });
+  });
+});
+
+describe('renderMarkdown', () => {
+  it('renders bold text', () => {
+    expect(renderMarkdown('**bold**')).toContain('<strong>bold</strong>');
+  });
+
+  it('renders italic text', () => {
+    expect(renderMarkdown('*italic*')).toContain('<em>italic</em>');
+  });
+
+  it('wraps plain text in a paragraph', () => {
+    expect(renderMarkdown('hello world')).toContain('<p>hello world</p>');
+  });
+
+  it('renders links with href preserved', () => {
+    const result = renderMarkdown('[link](https://example.com)');
+    expect(result).toContain('<a href="https://example.com">link</a>');
+  });
+
+  it('renders images with src and alt', () => {
+    const result = renderMarkdown('![alt text](https://example.com/img.png)');
+    expect(result).toContain('<img src="https://example.com/img.png"');
+    expect(result).toContain('alt="alt text"');
+  });
+
+  it('strips script tags', () => {
+    const result = renderMarkdown('<script>alert("xss")</script>');
+    expect(result).not.toContain('<script');
+    expect(result).not.toContain('alert');
+  });
+
+  it('strips event handler attributes', () => {
+    const result = renderMarkdown('<div onclick="alert(\'xss\')">content</div>');
+    expect(result).not.toContain('onclick');
+    expect(result).toContain('content');
+  });
+
+  it('strips style tags', () => {
+    expect(renderMarkdown('<style>body{color:red}</style>')).not.toContain('<style');
+  });
+
+  it('strips iframe tags', () => {
+    expect(renderMarkdown('<iframe src="https://evil.com"></iframe>')).not.toContain('<iframe');
+  });
+
+  it('renders code blocks', () => {
+    const result = renderMarkdown('```\nconst x = 1;\n```');
+    expect(result).toContain('<pre>');
+    expect(result).toContain('<code>');
+  });
+
+  it('renders inline code', () => {
+    expect(renderMarkdown('use `npm install`')).toContain('<code>npm install</code>');
+  });
+
+  it('renders unordered lists', () => {
+    const result = renderMarkdown('- item 1\n- item 2');
+    expect(result).toContain('<ul>');
+    expect(result).toContain('<li>item 1</li>');
+  });
+
+  it('renders tables', () => {
+    const result = renderMarkdown('| A | B |\n|---|---|\n| 1 | 2 |');
+    expect(result).toContain('<table>');
+    expect(result).toContain('<th>A</th>');
+    expect(result).toContain('<td>1</td>');
+  });
+
+  it('strips javascript: scheme from links', () => {
+    const result = renderMarkdown('<a href="javascript:alert(1)">click</a>');
+    expect(result).not.toContain('javascript:');
   });
 });

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -370,9 +370,11 @@ ${renderActivityLog(item.activityLog)}
       descEl.addEventListener('click', (e) => {
         if (!(e.target instanceof Element)) return;
         const anchor = e.target.closest('a');
-        const href = anchor && anchor.getAttribute('href');
+        if (!anchor) return;
+        // Always prevent default to avoid unintended webview navigation
+        e.preventDefault();
+        const href = anchor.getAttribute('href');
         if (href && isExternalUrl(href)) {
-          e.preventDefault();
           vscode.postMessage({ type: 'openUrl', url: href });
         }
       });

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -31,7 +31,7 @@ export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDes
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'nonce-${nonce}'; script-src 'nonce-${nonce}'; img-src https:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'nonce-${nonce}'; script-src 'nonce-${nonce}'; img-src https: http:;">
   <style nonce="${nonce}">
     :root {
       --input-bg: var(--vscode-input-background);

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -358,6 +358,7 @@ ${renderActivityLog(item.activityLog)}
     const descEl = document.querySelector('.provider-description');
     if (descEl) {
       descEl.addEventListener('click', (e) => {
+        if (!(e.target instanceof Element)) return;
         const anchor = e.target.closest('a');
         if (anchor && anchor.href) {
           e.preventDefault();

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -1,4 +1,6 @@
 import * as crypto from 'crypto';
+import { marked } from 'marked';
+import sanitizeHtml from 'sanitize-html';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import type { ActivityLogEntry } from '../models/activityLog';
 import { isSafeUrl } from '../utils/url';
@@ -8,7 +10,7 @@ export interface EditorHtmlOptions {
   item: WorkItem;
   /** Display label for the provider, shown only when item.providerId is set. */
   providerLabel?: string;
-  /** Read-only description from the provider. Will be HTML-escaped before rendering. */
+  /** Read-only description from the provider. Rendered as markdown. */
   providerDescription?: string;
   /** Upstream state from the provider (e.g. "open", "closed", "Active"). Will be HTML-escaped. */
   providerState?: string;
@@ -21,7 +23,7 @@ export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDes
   const descriptionSection = providerDescription
     ? `    <div class="field">
       <label id="provider-desc-label">Provider Description</label>
-      <div class="provider-description" role="note" aria-labelledby="provider-desc-label">${escapeHtml(providerDescription)}</div>
+      <div class="provider-description" role="note" aria-labelledby="provider-desc-label">${renderMarkdown(providerDescription)}</div>
     </div>`
     : '';
   return /*html*/ `<!DOCTYPE html>
@@ -158,9 +160,86 @@ export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDes
       padding: 8px 10px;
       border-left: 3px solid var(--vscode-textBlockQuote-border, var(--vscode-focusBorder));
       background: var(--vscode-textBlockQuote-background, var(--vscode-editor-inactiveSelectionBackground, rgba(128,128,128,0.08)));
-      font-style: italic;
-      white-space: pre-wrap;
       margin-top: 2px;
+      line-height: 1.5;
+    }
+    .provider-description h1,
+    .provider-description h2,
+    .provider-description h3,
+    .provider-description h4,
+    .provider-description h5,
+    .provider-description h6 {
+      margin-top: 12px;
+      margin-bottom: 6px;
+      font-weight: 600;
+    }
+    .provider-description h1 { font-size: 1.3em; }
+    .provider-description h2 { font-size: 1.15em; }
+    .provider-description h3 { font-size: 1.05em; }
+    .provider-description p {
+      margin: 6px 0;
+    }
+    .provider-description ul,
+    .provider-description ol {
+      padding-left: 24px;
+      margin: 6px 0;
+    }
+    .provider-description li {
+      margin: 2px 0;
+    }
+    .provider-description pre {
+      background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.15));
+      padding: 8px 10px;
+      border-radius: 3px;
+      overflow-x: auto;
+      margin: 6px 0;
+    }
+    .provider-description code {
+      background: var(--vscode-textCodeBlock-background, rgba(128,128,128,0.15));
+      padding: 1px 4px;
+      border-radius: 3px;
+      font-size: 0.9em;
+    }
+    .provider-description pre code {
+      background: none;
+      padding: 0;
+    }
+    .provider-description a {
+      color: var(--vscode-textLink-foreground);
+      text-decoration: none;
+    }
+    .provider-description a:hover {
+      color: var(--vscode-textLink-activeForeground);
+      text-decoration: underline;
+    }
+    .provider-description blockquote {
+      border-left: 3px solid var(--vscode-textBlockQuote-border, var(--vscode-focusBorder));
+      padding: 4px 12px;
+      margin: 6px 0;
+      opacity: 0.85;
+    }
+    .provider-description img {
+      max-width: 100%;
+      height: auto;
+    }
+    .provider-description table {
+      border-collapse: collapse;
+      margin: 6px 0;
+      width: 100%;
+    }
+    .provider-description th,
+    .provider-description td {
+      border: 1px solid var(--vscode-widget-border, rgba(128,128,128,0.35));
+      padding: 4px 8px;
+      text-align: left;
+    }
+    .provider-description th {
+      font-weight: 600;
+    }
+    .provider-description hr {
+      border: none;
+      border-top: 1px solid var(--vscode-widget-border, rgba(128,128,128,0.35));
+      margin: 10px 0;
     }
     .title-link {
       color: var(--vscode-textLink-foreground);
@@ -276,6 +355,17 @@ ${renderActivityLog(item.activityLog)}
       });
     }
 
+    const descEl = document.querySelector('.provider-description');
+    if (descEl) {
+      descEl.addEventListener('click', (e) => {
+        const anchor = e.target.closest('a');
+        if (anchor && anchor.href) {
+          e.preventDefault();
+          vscode.postMessage({ type: 'openUrl', url: anchor.getAttribute('href') });
+        }
+      });
+    }
+
     window.addEventListener('message', event => {
       const msg = event.data;
       if (msg && msg.type === 'updateTitle' && typeof msg.title === 'string') {
@@ -297,6 +387,29 @@ ${renderActivityLog(item.activityLog)}
   </script>
 </body>
 </html>`;
+}
+
+const sanitizeAllowList: sanitizeHtml.IOptions = {
+  allowedTags: [
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'p', 'br', 'hr',
+    'ul', 'ol', 'li',
+    'blockquote', 'pre', 'code',
+    'em', 'strong', 'a', 'img',
+    'table', 'thead', 'tbody', 'tr', 'th', 'td',
+    'del', 's', 'sup', 'sub',
+    'details', 'summary',
+  ],
+  allowedAttributes: {
+    a: ['href'],
+    img: ['src', 'alt'],
+  },
+  allowedSchemes: ['http', 'https', 'mailto'],
+};
+
+export function renderMarkdown(markdown: string): string {
+  const rawHtml = marked.parse(markdown, { async: false }) as string;
+  return sanitizeHtml(rawHtml, sanitizeAllowList);
 }
 
 function getNonce(): string {

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -416,7 +416,7 @@ const sanitizeAllowList: sanitizeHtml.IOptions = {
     a: ['href'],
     img: ['src', 'alt'],
   },
-  allowedSchemes: ['http', 'https', 'mailto'],
+  allowedSchemes: ['http', 'https'],
 };
 
 export function renderMarkdown(markdown: string): string {

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -31,7 +31,7 @@ export function getEditorPanelHtml({ cspSource, item, providerLabel, providerDes
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'nonce-${nonce}'; script-src 'nonce-${nonce}';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${cspSource} 'nonce-${nonce}'; script-src 'nonce-${nonce}'; img-src https:;">
   <style nonce="${nonce}">
     :root {
       --input-bg: var(--vscode-input-background);

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -355,14 +355,25 @@ ${renderActivityLog(item.activityLog)}
       });
     }
 
+    function isExternalUrl(href) {
+      if (!href) return false;
+      try {
+        const url = new URL(href, window.location.href);
+        return url.protocol === 'http:' || url.protocol === 'https:';
+      } catch {
+        return false;
+      }
+    }
+
     const descEl = document.querySelector('.provider-description');
     if (descEl) {
       descEl.addEventListener('click', (e) => {
         if (!(e.target instanceof Element)) return;
         const anchor = e.target.closest('a');
-        if (anchor && anchor.href) {
+        const href = anchor && anchor.getAttribute('href');
+        if (href && isExternalUrl(href)) {
           e.preventDefault();
-          vscode.postMessage({ type: 'openUrl', url: anchor.getAttribute('href') });
+          vscode.postMessage({ type: 'openUrl', url: href });
         }
       });
     }


### PR DESCRIPTION
## Summary

Renders provider descriptions as markdown in the editor panel using a `marked` + `sanitize-html` pipeline. Closes #356.

## Changes

- **Markdown rendering**: Added `renderMarkdown()` function using `marked` to parse markdown and `sanitize-html` to sanitize the output with a strict allowlist
- **Sanitization**: Allowlist permits only safe structural tags (`h1`-`h6`, `p`, `ul`, `ol`, `li`, `pre`, `code`, `table`, `blockquote`, `details`, `summary`, etc.) with minimal attributes (`href` on links, `src`/`alt` on images). Only `http` and `https` schemes are allowed.
- **Scoped CSS**: Added `.provider-description` styles for markdown elements (headings, lists, code blocks, tables, blockquotes, images, horizontal rules) using VS Code theme variables
- **Link interception**: Click handler on `.provider-description` intercepts all link clicks, routing only `http`/`https` URLs through VS Code's `openUrl` message. Non-external links are blocked to prevent unintended webview navigation.
- **CSP**: Added `img-src https: http:;` to Content Security Policy to allow remote images in rendered markdown
- **Tests**: 65 tests covering markdown rendering, XSS prevention (`<script>`, event handlers, `javascript:` URIs, `data:` URIs, `<iframe>`, `<style>`), element rendering (bold, italic, links, images, code blocks, lists, tables, `details`/`summary`), and integration with `getEditorPanelHtml`

## Dependencies

- `marked` ^18.0.2 — Markdown parser
- `sanitize-html` ^2.17.3 — HTML sanitizer
- `@types/sanitize-html` ^2.16.1 (dev)
