### PR TITLE
feat(github): add GitHub Mentions provider

### DIFF
--- a/packages/github/src/extension.ts
+++ b/packages/github/src/extension.ts
@@ -4,17 +4,20 @@ import { GitHubPrReviewProvider } from './githubPrReviewProvider';
 import { GitHubActionsWatcher } from './githubActionsWatcher';
 import { GitHubPRWatcher } from './githubPRWatcher';
 import { GitHubMyPrsProvider } from './githubMyPrsProvider';
+import { GitHubMentionsProvider } from './githubMentionsProvider';
 import { validateRefreshInterval } from '@devdocket/shared';
 import { initLogger, setLogLevel, logger, resolveLogLevel } from './logger';
 
 let issueProvider: GitHubIssueProvider | undefined;
 let prReviewProvider: GitHubPrReviewProvider | undefined;
 let myPrsProvider: GitHubMyPrsProvider | undefined;
+let mentionsProvider: GitHubMentionsProvider | undefined;
 let providerRegistration: vscode.Disposable | undefined;
 let prReviewRegistration: vscode.Disposable | undefined;
 let watcherRegistration: vscode.Disposable | undefined;
 let prWatcherRegistration: vscode.Disposable | undefined;
 let myPrsRegistration: vscode.Disposable | undefined;
+let mentionsRegistration: vscode.Disposable | undefined;
 
 export async function activate(_context: vscode.ExtensionContext): Promise<void> {
   const outputChannel = vscode.window.createOutputChannel('DevDocket GitHub');
@@ -84,6 +87,11 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
   myPrsProvider.startPeriodicRefresh(intervalSeconds);
   myPrsRegistration = api.registerProvider(myPrsProvider);
 
+  // Register the GitHub Mentions provider (@mentioned issues and PRs)
+  mentionsProvider = new GitHubMentionsProvider(_context);
+  mentionsProvider.startPeriodicRefresh(intervalSeconds);
+  mentionsRegistration = api.registerProvider(mentionsProvider);
+
   // Register the GitHub Actions watcher
   if (typeof api.registerRunWatcher === 'function') {
     watcherRegistration = api.registerRunWatcher(new GitHubActionsWatcher());
@@ -94,7 +102,7 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
     prWatcherRegistration = api.registerPRWatcher(new GitHubPRWatcher());
   }
 
-  const parts = ['3 providers'];
+  const parts = ['4 providers'];
   if (watcherRegistration) { parts.push('1 watcher'); }
   if (prWatcherRegistration) { parts.push('1 PR watcher'); }
   logger.info(`DevDocket GitHub activated, registered ${parts.join(' + ')}`);
@@ -107,8 +115,10 @@ export function deactivate(): void {
   watcherRegistration?.dispose();
   prWatcherRegistration?.dispose();
   myPrsRegistration?.dispose();
+  mentionsRegistration?.dispose();
   issueProvider?.dispose();
   prReviewProvider?.dispose();
   myPrsProvider?.dispose();
+  mentionsProvider?.dispose();
   logger.info('DevDocket GitHub deactivated');
 }

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -1,0 +1,269 @@
+import * as vscode from 'vscode';
+import { DiscoveredItem, combineSignals, isValidGitHubRepo, runWorkerPoolSettled, safeDecodeComponent, type ResolvedItem } from '@devdocket/shared';
+import { BaseGitHubProvider } from './baseGithubProvider';
+import { logger } from './logger';
+import { parseRepoFromUrls } from './parseRepo';
+import { getHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, type GitHubIssue } from './githubApiHelpers';
+
+interface GitHubSearchResponse {
+  items: GitHubIssue[];
+}
+
+const MENTIONS_ACTIVATED_KEY = 'mentionsActivatedAt';
+
+/**
+ * DevDocket provider that discovers GitHub issues and pull requests
+ * where the current user is @mentioned.
+ *
+ * Uses the GitHub Search API with `mentions:@me` to find items.
+ * On first activation, records a timestamp to avoid flooding the
+ * inbox with historical mentions.
+ */
+export class GitHubMentionsProvider extends BaseGitHubProvider {
+  readonly id = 'github-mentions';
+  readonly label = 'GitHub Mentions';
+
+  private readonly _context: vscode.ExtensionContext;
+
+  constructor(context: vscode.ExtensionContext) {
+    super();
+    this._context = context;
+  }
+
+  protected async fetchAndPublish(accessToken: string, isUserTriggered: boolean, signal?: AbortSignal): Promise<void> {
+    logger.info('Fetching mentioned issues and PRs...');
+    const activatedAt = await this.getOrSetActivatedAt();
+    const repos = this.getConfiguredRepos();
+    const { results, failures } = await this.fetchMentionedItems(accessToken, repos, activatedAt, signal);
+
+    const items: DiscoveredItem[] = results.map((issue) => {
+      const repoName = parseRepoFromUrls(issue.html_url, issue.repository_url);
+      const isPr = !!issue.pull_request;
+      return {
+        externalId: `${repoName}#${issue.number}`,
+        title: `#${issue.number}: ${issue.title}`,
+        description: issue.body?.slice(0, 200),
+        url: issue.html_url,
+        group: repoName,
+        reason: 'mentioned',
+        canonicalId: `github:${isPr ? 'pull' : 'issue'}:${repoName}#${issue.number}`,
+        ...(issue.state ? { state: issue.state } : {}),
+      };
+    });
+
+    logger.info(`Discovered ${items.length} mentioned items`);
+    this._onDidDiscoverItems.fire(items);
+
+    if (failures.length > 0) {
+      const message = failures.length === 1
+        ? `Failed to fetch mentions from ${failures[0]}`
+        : `Failed to fetch mentions from ${failures.length} repositories`;
+      if (isUserTriggered) {
+        void vscode.window.showWarningMessage(`DevDocket GitHub: ${message}`);
+      } else {
+        logger.warn(message);
+      }
+    }
+  }
+
+  private static readonly GITHUB_ISSUE_PATTERN = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)\b/i;
+  private static readonly GITHUB_PR_PATTERN = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)\b/i;
+
+  async resolveUrl(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined> {
+    const trimmed = url.trim();
+    const issueMatch = trimmed.match(GitHubMentionsProvider.GITHUB_ISSUE_PATTERN);
+    const prMatch = trimmed.match(GitHubMentionsProvider.GITHUB_PR_PATTERN);
+    const match = issueMatch ?? prMatch;
+    if (!match) { return undefined; }
+
+    const [, rawOwner, rawRepo, numStr] = match;
+    const owner = safeDecodeComponent(rawOwner);
+    const repo = safeDecodeComponent(rawRepo);
+    const number = parseInt(numStr, 10);
+    const isPr = !!prMatch;
+
+    const apiPath = isPr ? 'pulls' : 'issues';
+    const apiUrl = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${apiPath}/${number}`;
+    const headers = await getHeaders();
+    const wasAuthenticated = 'Authorization' in headers;
+
+    let response = await fetch(apiUrl, { headers, signal });
+
+    if (response.status === 404 && !wasAuthenticated && !signal?.aborted) {
+      const retryResponse = await retryWithAuth(apiUrl, signal);
+      if (retryResponse) { response = retryResponse; }
+    }
+
+    if (!response.ok) {
+      const label = isPr ? 'GitHub PR' : 'GitHub issue';
+      throwApiError(response, `${label} ${owner}/${repo}#${number}`);
+    }
+
+    const data = await response.json() as { title: string; body: string | null; html_url: string };
+    const canonicalRepo = parseCanonicalRepo(data.html_url, owner, repo);
+    return {
+      title: `#${number}: ${data.title}`,
+      notes: data.body ?? '',
+      url: data.html_url,
+      externalId: `${canonicalRepo}#${number}`,
+      group: canonicalRepo,
+      providerId: this.id,
+    };
+  }
+
+  /**
+   * Check which of the given external IDs correspond to closed items.
+   * Items are split by canonicalId prefix to call the correct API endpoint.
+   */
+  async getClosedItems(externalIds: string[], signal?: AbortSignal): Promise<string[]> {
+    if (externalIds.length === 0) { return []; }
+
+    // Determine which IDs are PRs vs issues by looking at the last-known canonicalId.
+    // Since we emit canonicalId on every item, the core extension stores it.
+    // However, getClosedItems receives plain externalIds. We check both endpoints.
+    const [closedIssues, closedPrs] = await Promise.all([
+      fetchClosedGitHubItems(externalIds, 'issues', signal),
+      fetchClosedGitHubItems(externalIds, 'pulls', signal),
+    ]);
+
+    // Deduplicate — an ID that appears in both results should only appear once
+    return [...new Set([...closedIssues, ...closedPrs])];
+  }
+
+  private getConfiguredRepos(): string[] {
+    const config = vscode.workspace.getConfiguration('devDocketGithub');
+    return config.get<string[]>('repos', []);
+  }
+
+  /**
+   * Returns the activation timestamp, setting it on first call.
+   * This prevents flooding the inbox with old mentions when the
+   * provider is first enabled.
+   */
+  private async getOrSetActivatedAt(): Promise<string> {
+    const existing = this._context.globalState.get<string>(MENTIONS_ACTIVATED_KEY);
+    if (existing) {
+      return existing;
+    }
+    const now = new Date().toISOString();
+    await this._context.globalState.update(MENTIONS_ACTIVATED_KEY, now);
+    return now;
+  }
+
+  private async fetchMentionedItems(
+    token: string,
+    repos: string[],
+    activatedAt: string,
+    signal?: AbortSignal,
+  ): Promise<{ results: GitHubIssue[]; failures: string[] }> {
+    if (repos.length > 0) {
+      return this.fetchPerRepoMentions(token, repos, activatedAt, signal);
+    }
+    return this.fetchAllMentions(token, activatedAt, signal);
+  }
+
+  private async fetchPerRepoMentions(
+    token: string,
+    repos: string[],
+    activatedAt: string,
+    signal?: AbortSignal,
+  ): Promise<{ results: GitHubIssue[]; failures: string[] }> {
+    const validRepos: string[] = [];
+    for (const repo of repos) {
+      if (isValidGitHubRepo(repo)) {
+        validRepos.push(repo);
+      } else {
+        logger.warn('Skipping invalid repo identifier', repo);
+      }
+    }
+
+    const settled = await runWorkerPoolSettled(validRepos, async (repo) => {
+      if (signal?.aborted) {
+        const error = new Error('The operation was aborted.');
+        error.name = 'AbortError';
+        throw error;
+      }
+      return await this.fetchRepoMentions(token, repo, activatedAt, signal);
+    }, 3);
+
+    const allItems: GitHubIssue[] = [];
+    const failures: string[] = [];
+
+    settled.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        const { items, failed } = result.value;
+        allItems.push(...items);
+        if (failed) {
+          failures.push(validRepos[index]);
+        }
+      } else {
+        failures.push(validRepos[index]);
+      }
+    });
+
+    return { results: allItems, failures };
+  }
+
+  private async fetchRepoMentions(
+    token: string,
+    repo: string,
+    activatedAt: string,
+    signal?: AbortSignal,
+  ): Promise<{ items: GitHubIssue[]; failed: boolean }> {
+    logger.debug(`Fetching mentions for repo: ${repo}`);
+    const q = `mentions:@me+created:>${activatedAt}+repo:${repo}`;
+    const response = await fetch(
+      `https://api.github.com/search/issues?q=${q}&per_page=100`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        signal: combineSignals(signal, 30_000),
+      },
+    );
+
+    if (!response.ok) {
+      logger.error(`Failed to fetch mentions for ${repo}: ${response.status}`);
+      return { items: [], failed: true };
+    }
+
+    const data = (await response.json()) as GitHubSearchResponse;
+    return { items: data.items, failed: false };
+  }
+
+  private async fetchAllMentions(
+    token: string,
+    activatedAt: string,
+    signal?: AbortSignal,
+  ): Promise<{ results: GitHubIssue[]; failures: string[] }> {
+    const q = `mentions:@me+created:>${activatedAt}`;
+    let response: Response;
+    try {
+      response = await fetch(
+        `https://api.github.com/search/issues?q=${q}&per_page=100`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+          signal: combineSignals(signal, 30_000),
+        },
+      );
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === 'AbortError') { throw err; }
+      logger.error('Failed to fetch mentions', err);
+      return { results: [], failures: ['all repositories'] };
+    }
+
+    if (!response.ok) {
+      logger.error(`Failed to fetch mentions: ${response.status}`);
+      return { results: [], failures: ['all repositories'] };
+    }
+
+    const data = (await response.json()) as GitHubSearchResponse;
+    return { results: data.items, failures: [] };
+  }
+}

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -217,25 +217,37 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
   ): Promise<{ items: GitHubIssue[]; failed: boolean }> {
     logger.debug(`Fetching mentions for repo: ${repo}`);
     const q = `mentions:@me+updated:>${activatedAt}+repo:${repo}`;
-    const response = await fetch(
-      `https://api.github.com/search/issues?q=${q}&per_page=100`,
-      {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: 'application/vnd.github+json',
-          'X-GitHub-Api-Version': '2022-11-28',
-        },
-        signal: combineSignals(signal, 30_000),
-      },
-    );
 
-    if (!response.ok) {
-      logger.error(`Failed to fetch mentions for ${repo}: ${response.status}`);
+    try {
+      const response = await fetch(
+        `https://api.github.com/search/issues?q=${q}&per_page=100`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+          signal: combineSignals(signal, 30_000),
+        },
+      );
+
+      if (!response.ok) {
+        logger.error(`Failed to fetch mentions for ${repo}: ${response.status}`);
+        return { items: [], failed: true };
+      }
+
+      const data = (await response.json()) as GitHubSearchResponse;
+      return { items: data.items, failed: false };
+    } catch (error) {
+      // Only rethrow for explicit outer cancellation
+      if (signal?.aborted) {
+        const abortError = new Error('The operation was aborted.');
+        abortError.name = 'AbortError';
+        throw abortError;
+      }
+      logger.warn(`Failed to fetch mentions for ${repo}`, error);
       return { items: [], failed: true };
     }
-
-    const data = (await response.json()) as GitHubSearchResponse;
-    return { items: data.items, failed: false };
   }
 
   private async fetchAllMentions(

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -32,7 +32,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
 
   protected async fetchAndPublish(accessToken: string, isUserTriggered: boolean, signal?: AbortSignal): Promise<void> {
     logger.info('Fetching mentioned issues and PRs...');
-    const activatedAt = await this.getOrSetActivatedAt();
+    const activatedAt = await this.getOrSetActivatedAt(signal);
     const repos = this.getConfiguredRepos();
     const { results, failures } = await this.fetchMentionedItems(accessToken, repos, activatedAt, signal);
 
@@ -129,13 +129,20 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
    * Returns the activation timestamp, setting it on first call.
    * This prevents flooding the inbox with old mentions when the
    * provider is first enabled.
+   *
+   * If the current refresh has already been cancelled, do not persist
+   * a new activation timestamp to avoid advancing the watermark
+   * for a refresh that never completed.
    */
-  private async getOrSetActivatedAt(): Promise<string> {
+  private async getOrSetActivatedAt(signal?: AbortSignal): Promise<string> {
     const existing = this._context.globalState.get<string>(MENTIONS_ACTIVATED_KEY);
     if (existing) {
       return existing;
     }
     const now = new Date().toISOString();
+    if (signal?.aborted) {
+      return now;
+    }
     await this._context.globalState.update(MENTIONS_ACTIVATED_KEY, now);
     return now;
   }

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -113,21 +113,11 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
 
   /**
    * Check which of the given external IDs correspond to closed items.
-   * Items are split by canonicalId prefix to call the correct API endpoint.
+   * GitHub's /issues/{N} endpoint returns data for both issues and PRs,
+   * so a single call covers both types.
    */
   async getClosedItems(externalIds: string[], signal?: AbortSignal): Promise<string[]> {
-    if (externalIds.length === 0) { return []; }
-
-    // Determine which IDs are PRs vs issues by looking at the last-known canonicalId.
-    // Since we emit canonicalId on every item, the core extension stores it.
-    // However, getClosedItems receives plain externalIds. We check both endpoints.
-    const [closedIssues, closedPrs] = await Promise.all([
-      fetchClosedGitHubItems(externalIds, 'issues', signal),
-      fetchClosedGitHubItems(externalIds, 'pulls', signal),
-    ]);
-
-    // Deduplicate — an ID that appears in both results should only appear once
-    return [...new Set([...closedIssues, ...closedPrs])];
+    return fetchClosedGitHubItems(externalIds, 'issues', signal);
   }
 
   private getConfiguredRepos(): string[] {
@@ -200,6 +190,17 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
         failures.push(validRepos[index]);
       }
     });
+
+    // Propagate cancellation so the refresh stops without publishing partial results
+    const abortedResult = settled.find(
+      (r): r is PromiseRejectedResult =>
+        r.status === 'rejected' && r.reason instanceof Error && r.reason.name === 'AbortError',
+    );
+    if (signal?.aborted || abortedResult) {
+      const error = abortedResult?.reason ?? new Error('The operation was aborted.');
+      if (error.name !== 'AbortError') { error.name = 'AbortError'; }
+      throw error;
+    }
 
     return { results: allItems, failures };
   }

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -251,7 +251,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
         },
       );
     } catch (err: unknown) {
-      if (err instanceof Error && err.name === 'AbortError') { throw err; }
+      if (err instanceof Error && err.name === 'AbortError' && signal?.aborted) { throw err; }
       logger.error('Failed to fetch mentions', err);
       return { results: [], failures: ['all repositories'] };
     }

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -236,7 +236,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     activatedAt: string,
     signal?: AbortSignal,
   ): Promise<{ results: GitHubIssue[]; failures: string[] }> {
-    const q = `mentions:@me+created:>${activatedAt}`;
+    const q = `mentions:@me+updated:>${activatedAt}`;
     let response: Response;
     try {
       response = await fetch(

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -209,7 +209,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     signal?: AbortSignal,
   ): Promise<{ items: GitHubIssue[]; failed: boolean }> {
     logger.debug(`Fetching mentions for repo: ${repo}`);
-    const q = `mentions:@me+created:>${activatedAt}+repo:${repo}`;
+    const q = `mentions:@me+updated:>${activatedAt}+repo:${repo}`;
     const response = await fetch(
       `https://api.github.com/search/issues?q=${q}&per_page=100`,
       {

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -191,14 +191,11 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       }
     });
 
-    // Propagate cancellation so the refresh stops without publishing partial results
-    const abortedResult = settled.find(
-      (r): r is PromiseRejectedResult =>
-        r.status === 'rejected' && r.reason instanceof Error && r.reason.name === 'AbortError',
-    );
-    if (signal?.aborted || abortedResult) {
-      const error = abortedResult?.reason ?? new Error('The operation was aborted.');
-      if (error.name !== 'AbortError') { error.name = 'AbortError'; }
+    // Only propagate explicit outer cancellation; per-repo aborts/timeouts are
+    // treated as individual repo failures so partial results can still be published.
+    if (signal?.aborted) {
+      const error = new Error('The operation was aborted.');
+      error.name = 'AbortError';
       throw error;
     }
 

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -33,6 +33,7 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
         url: issue.html_url,
         group: repoName,
         reason: 'assigned',
+        canonicalId: `github:issue:${repoName}#${issue.number}`,
         ...(issue.state ? { state: issue.state } : {}),
       };
     });

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -197,7 +197,7 @@ describe('GitHubMentionsProvider', () => {
     await provider.refresh();
 
     const calledUrl = mockFetch.mock.calls[0][0] as string;
-    expect(calledUrl).toContain(`created:>${timestamp}`);
+    expect(calledUrl).toContain(`updated:>${timestamp}`);
     expect(calledUrl).toContain('mentions:@me');
   });
 

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -44,7 +44,7 @@ describe('GitHubMentionsProvider', () => {
   let mockChannel: { appendLine: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     vi.stubGlobal('fetch', mockFetch);
     mockContext = createMockContext();
     provider = new GitHubMentionsProvider(mockContext);

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { authentication, workspace } from 'vscode';
+import { GitHubMentionsProvider } from '../githubMentionsProvider';
+import { initLogger, LogLevel } from '../logger';
+
+const mockFetch = vi.fn();
+
+function createMockIssue(number: number, title: string, repo = 'owner/repo') {
+  return {
+    number,
+    title,
+    body: `Body for issue ${number}`,
+    state: 'open',
+    html_url: `https://github.com/${repo}/issues/${number}`,
+    repository_url: `https://api.github.com/repos/${repo}`,
+  };
+}
+
+function createMockPr(number: number, title: string, repo = 'owner/repo') {
+  return {
+    number,
+    title,
+    body: `Body for PR ${number}`,
+    state: 'open',
+    html_url: `https://github.com/${repo}/pull/${number}`,
+    repository_url: `https://api.github.com/repos/${repo}`,
+    pull_request: { url: `https://api.github.com/repos/${repo}/pulls/${number}` },
+  };
+}
+
+function createMockContext(globalStateData: Record<string, unknown> = {}): any {
+  const store = new Map<string, unknown>(Object.entries(globalStateData));
+  return {
+    globalState: {
+      get: vi.fn((key: string) => store.get(key)),
+      update: vi.fn(async (key: string, value: unknown) => { store.set(key, value); }),
+    },
+  };
+}
+
+describe('GitHubMentionsProvider', () => {
+  let provider: GitHubMentionsProvider;
+  let mockContext: ReturnType<typeof createMockContext>;
+  let mockChannel: { appendLine: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+    mockContext = createMockContext();
+    provider = new GitHubMentionsProvider(mockContext);
+
+    mockChannel = { appendLine: vi.fn() };
+    initLogger(mockChannel as any, LogLevel.Debug);
+
+    // Default: workspace config returns defaults (no repos configured)
+    vi.mocked(workspace.getConfiguration).mockReturnValue({
+      get: vi.fn((key: string, defaultValue?: any) => defaultValue),
+    } as any);
+
+    vi.mocked(authentication.getSession).mockResolvedValue({
+      accessToken: 'test-token',
+      id: 'session-1',
+      scopes: ['repo'],
+      account: { id: '1', label: 'testuser' },
+    } as any);
+  });
+
+  afterEach(() => {
+    provider.dispose();
+    vi.unstubAllGlobals();
+  });
+
+  it('has correct id and label', () => {
+    expect(provider.id).toBe('github-mentions');
+    expect(provider.label).toBe('GitHub Mentions');
+  });
+
+  it('discovers mentioned issues and PRs', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [
+          createMockIssue(10, 'Bug report', 'org/repo'),
+          createMockPr(20, 'Fix it', 'org/repo'),
+        ],
+      }),
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    const items = listener.mock.calls[0][0];
+    expect(items).toHaveLength(2);
+
+    expect(items[0]).toEqual(expect.objectContaining({
+      externalId: 'org/repo#10',
+      title: '#10: Bug report',
+      description: 'Body for issue 10',
+      url: 'https://github.com/org/repo/issues/10',
+      group: 'org/repo',
+      reason: 'mentioned',
+    }));
+    expect(items[1]).toEqual(expect.objectContaining({
+      externalId: 'org/repo#20',
+      title: '#20: Fix it',
+      url: 'https://github.com/org/repo/pull/20',
+      reason: 'mentioned',
+    }));
+  });
+
+  it('sets canonicalId with github:issue prefix for issues', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [createMockIssue(5, 'An issue', 'acme/lib')] }),
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items[0].canonicalId).toBe('github:issue:acme/lib#5');
+  });
+
+  it('sets canonicalId with github:pull prefix for PRs', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [createMockPr(8, 'A PR', 'acme/lib')] }),
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items[0].canonicalId).toBe('github:pull:acme/lib#8');
+  });
+
+  it('detects isPullRequest via pull_request field', async () => {
+    const issue = createMockIssue(1, 'Issue');
+    const pr = createMockPr(2, 'PR');
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [issue, pr] }),
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    // Issue should have issue prefix, PR should have pull prefix
+    expect(items[0].canonicalId).toMatch(/^github:issue:/);
+    expect(items[1].canonicalId).toMatch(/^github:pull:/);
+  });
+
+  it('stores activatedAt on first call and reuses it', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [] }),
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+
+    await provider.refresh();
+    expect(mockContext.globalState.update).toHaveBeenCalledWith(
+      'mentionsActivatedAt',
+      expect.any(String),
+    );
+
+    // Extract the stored timestamp
+    const storedTimestamp = mockContext.globalState.update.mock.calls[0][1];
+    expect(new Date(storedTimestamp).getTime()).not.toBeNaN();
+
+    // Second refresh should reuse, not update
+    mockContext.globalState.update.mockClear();
+    await provider.refresh();
+    expect(mockContext.globalState.update).not.toHaveBeenCalled();
+  });
+
+  it('includes activatedAt in search query', async () => {
+    const timestamp = '2024-01-15T00:00:00.000Z';
+    mockContext = createMockContext({ mentionsActivatedAt: timestamp });
+    provider = new GitHubMentionsProvider(mockContext);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [] }),
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain(`created:>${timestamp}`);
+    expect(calledUrl).toContain('mentions:@me');
+  });
+
+  it('uses per-repo query when repos are configured', async () => {
+    vi.mocked(workspace.getConfiguration).mockReturnValue({
+      get: vi.fn((key: string, defaultValue?: any) => {
+        if (key === 'repos') { return ['org/repo1']; }
+        return defaultValue;
+      }),
+    } as any);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [createMockIssue(1, 'Mentioned', 'org/repo1')] }),
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('repo:org/repo1');
+  });
+
+  it('uses all-repos query when no repos are configured', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [] }),
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const calledUrl = mockFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('mentions:@me');
+    expect(calledUrl).not.toContain('repo:');
+  });
+
+  it('does nothing when no auth session exists', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValue(undefined as any);
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('handles auth failure gracefully', async () => {
+    vi.mocked(authentication.getSession).mockRejectedValueOnce(
+      new Error('Auth service unavailable'),
+    );
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('fires empty array when API returns no items', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [] }),
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).toHaveBeenCalledWith([]);
+  });
+
+  describe('getClosedItems', () => {
+    it('returns empty array for empty input', async () => {
+      const result = await provider.getClosedItems([]);
+      expect(result).toEqual([]);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('checks both issues and pulls endpoints', async () => {
+      // Mock authentication for getClosedItems (uses silent session)
+      vi.mocked(authentication.getSession).mockResolvedValue({
+        accessToken: 'test-token',
+        id: 'session-1',
+        scopes: ['repo'],
+        account: { id: '1', label: 'testuser' },
+      } as any);
+
+      // issues endpoint returns closed
+      mockFetch.mockImplementation(async (url: string) => {
+        if (url.includes('/issues/42')) {
+          return { ok: true, json: async () => ({ state: 'closed' }) };
+        }
+        if (url.includes('/pulls/42')) {
+          return { ok: true, json: async () => ({ state: 'open' }) };
+        }
+        return { ok: false, status: 404 };
+      });
+
+      const result = await provider.getClosedItems(['owner/repo#42']);
+      expect(result).toContain('owner/repo#42');
+    });
+  });
+
+  describe('resolveUrl', () => {
+    it('resolves issue URLs', async () => {
+      // getHeaders uses silent auth
+      vi.mocked(authentication.getSession).mockResolvedValue({
+        accessToken: 'test-token',
+        id: 'session-1',
+        scopes: ['repo'],
+        account: { id: '1', label: 'testuser' },
+      } as any);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          title: 'Bug report',
+          body: 'Some description',
+          html_url: 'https://github.com/owner/repo/issues/5',
+        }),
+      });
+
+      const result = await provider.resolveUrl('https://github.com/owner/repo/issues/5');
+      expect(result).toEqual({
+        title: '#5: Bug report',
+        notes: 'Some description',
+        url: 'https://github.com/owner/repo/issues/5',
+        externalId: 'owner/repo#5',
+        group: 'owner/repo',
+        providerId: 'github-mentions',
+      });
+    });
+
+    it('resolves PR URLs', async () => {
+      vi.mocked(authentication.getSession).mockResolvedValue({
+        accessToken: 'test-token',
+        id: 'session-1',
+        scopes: ['repo'],
+        account: { id: '1', label: 'testuser' },
+      } as any);
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          title: 'Feature PR',
+          body: 'PR description',
+          html_url: 'https://github.com/owner/repo/pull/10',
+        }),
+      });
+
+      const result = await provider.resolveUrl('https://github.com/owner/repo/pull/10');
+      expect(result).toEqual({
+        title: '#10: Feature PR',
+        notes: 'PR description',
+        url: 'https://github.com/owner/repo/pull/10',
+        externalId: 'owner/repo#10',
+        group: 'owner/repo',
+        providerId: 'github-mentions',
+      });
+    });
+
+    it('returns undefined for non-GitHub URLs', async () => {
+      const result = await provider.resolveUrl('https://example.com/issue/5');
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -281,7 +281,7 @@ describe('GitHubMentionsProvider', () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it('checks both issues and pulls endpoints', async () => {
+    it('checks the issues endpoint for closed items', async () => {
       // Mock authentication for getClosedItems (uses silent session)
       vi.mocked(authentication.getSession).mockResolvedValue({
         accessToken: 'test-token',
@@ -290,19 +290,19 @@ describe('GitHubMentionsProvider', () => {
         account: { id: '1', label: 'testuser' },
       } as any);
 
-      // issues endpoint returns closed
+      // GitHub /issues/{N} returns data for both issues and PRs
       mockFetch.mockImplementation(async (url: string) => {
         if (url.includes('/issues/42')) {
           return { ok: true, json: async () => ({ state: 'closed' }) };
-        }
-        if (url.includes('/pulls/42')) {
-          return { ok: true, json: async () => ({ state: 'open' }) };
         }
         return { ok: false, status: 404 };
       });
 
       const result = await provider.getClosedItems(['owner/repo#42']);
       expect(result).toContain('owner/repo#42');
+      // Only the issues endpoint should be called, not pulls
+      const fetchCalls = mockFetch.mock.calls.map(c => c[0] as string);
+      expect(fetchCalls.some((u: string) => u.includes('/pulls/'))).toBe(false);
     });
   });
 

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -185,20 +185,24 @@ describe('GitHubMentionsProvider', () => {
   it('includes activatedAt in search query', async () => {
     const timestamp = '2024-01-15T00:00:00.000Z';
     mockContext = createMockContext({ mentionsActivatedAt: timestamp });
-    provider = new GitHubMentionsProvider(mockContext);
+    const localProvider = new GitHubMentionsProvider(mockContext);
 
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ items: [] }),
-    });
+    try {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [] }),
+      });
 
-    const listener = vi.fn();
-    provider.onDidDiscoverItems(listener);
-    await provider.refresh();
+      const listener = vi.fn();
+      localProvider.onDidDiscoverItems(listener);
+      await localProvider.refresh();
 
-    const calledUrl = mockFetch.mock.calls[0][0] as string;
-    expect(calledUrl).toContain(`updated:>${timestamp}`);
-    expect(calledUrl).toContain('mentions:@me');
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toContain(`updated:>${timestamp}`);
+      expect(calledUrl).toContain('mentions:@me');
+    } finally {
+      localProvider.dispose();
+    }
   });
 
   it('uses per-repo query when repos are configured', async () => {

--- a/packages/github/src/test/githubProvider.test.ts
+++ b/packages/github/src/test/githubProvider.test.ts
@@ -146,6 +146,7 @@ describe('GitHubIssueProvider', () => {
       url: 'https://github.com/owner/repo/issues/10',
       group: 'owner/repo',
       reason: 'assigned',
+      canonicalId: 'github:issue:owner/repo#10',
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a new `GitHubMentionsProvider` that discovers GitHub issues and pull requests where the current user is @mentioned. Also adds `canonicalId` to `GitHubIssueProvider` output for cross-provider deduplication.

Closes #383

## Changes

### New: `GitHubMentionsProvider`
- Uses GitHub Search API with `mentions:@me` to find items where the user is mentioned
- Supports both per-repo and all-repo query modes based on `devDocketGithub.repos` config
- Records an `activatedAt` timestamp on first activation to avoid flooding the inbox with historical mentions
- Emits `canonicalId` in the format `github:issue:owner/repo#N` or `github:pull:owner/repo#N` for deduplication
- Implements `resolveUrl` for both issue and PR GitHub URLs
- Implements `getClosedItems` using the GitHub issues endpoint (covers both issues and PRs)
- Properly propagates abort signals during per-repo fetching to prevent publishing partial results

### Updated: `GitHubIssueProvider`
- Added `canonicalId` field to discovered items (format: `github:issue:owner/repo#N`)

### Extension wiring
- Registers `GitHubMentionsProvider` in `extension.ts` with proper lifecycle management

## Testing

17 new tests covering:
- Basic discovery of issues and PRs with correct `canonicalId`
- `activatedAt` persistence and reuse across refreshes
- Per-repo vs all-repo query modes
- Authentication failure and no-auth scenarios
- Empty results handling
- `getClosedItems` using the issues endpoint
- `resolveUrl` for issue URLs, PR URLs, and non-GitHub URLs
