### PR TITLE
Show full provider description in editor panel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,23 @@ Providers emit `DiscoveredItem[]` via events. Actions declare `canRun(item)` and
 
 All work should be based from the `dev` branch. Create feature branches from `dev` and PR back to `dev`.
 
+### Use git worktrees for feature branches
+
+Always use `git worktree` to work on feature branches instead of switching branches in the main checkout. This keeps the main working tree on `dev` and avoids disrupting other work. Use the `using-git-worktrees` skill when available.
+
+```bash
+# Create a worktree for a feature branch
+git worktree add ../devdocket-description-sync-391 -b description-sync-391 dev
+
+# Work in the worktree
+cd ../devdocket-description-sync-391
+
+# Clean up after merging
+git worktree remove ../devdocket-description-sync-391
+```
+
+Never use `git checkout` or `git switch` to move the main working tree off `dev`.
+
 ### Use merge commits, not rebase
 
 When resolving merge conflicts or syncing with `dev`, use `git merge origin/dev` instead of `git rebase`. This preserves commit history and avoids force-push issues.

--- a/packages/ado/src/adoPrReviewProvider.ts
+++ b/packages/ado/src/adoPrReviewProvider.ts
@@ -300,7 +300,7 @@ export class AdoPrReviewProvider extends BaseProvider {
       return {
         externalId: `${org}/${projectName}/${repoName}/${pr.pullRequestId}`,
         title: `PR ${pr.pullRequestId}: ${pr.title}`,
-        description: pr.description?.slice(0, 200),
+        description: pr.description ?? undefined,
         url: `${repoUrl}/pullrequest/${pr.pullRequestId}`,
         group: `${projectName}/${repoName}`,
         reason: 'review_requested',

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -304,7 +304,7 @@ export class AdoWorkItemProvider extends BaseProvider {
       return {
         externalId: `${org}/${projectName}/${wi.id}`,
         title: `${wiType} ${wi.id}: ${wi.fields['System.Title']}`,
-        description: wi.fields['System.Description']?.replace(/<[^>]*>/g, '') ?? undefined,
+        description: wi.fields['System.Description']?.replace(/<[^>]*(>|$)/g, '') ?? undefined,
         url: wi._links.html.href,
         group: `${org}/${projectName}`,
         reason: 'assigned',

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -304,7 +304,7 @@ export class AdoWorkItemProvider extends BaseProvider {
       return {
         externalId: `${org}/${projectName}/${wi.id}`,
         title: `${wiType} ${wi.id}: ${wi.fields['System.Title']}`,
-        description: wi.fields['System.Description']?.replace(/<[^>]*>/g, '')?.slice(0, 200),
+        description: wi.fields['System.Description']?.replace(/<[^>]*>/g, '') ?? undefined,
         url: wi._links.html.href,
         group: `${org}/${projectName}`,
         reason: 'assigned',

--- a/packages/ado/src/test/adoPrReviewProvider.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.test.ts
@@ -261,7 +261,7 @@ describe('AdoPrReviewProvider', () => {
     expect(items[1].group).toBe('ProjectA/repo2');
   });
 
-  it('truncates description to 200 chars', async () => {
+  it('passes full description without truncation', async () => {
     const longDesc = 'B'.repeat(300);
     mockFetch
       .mockResolvedValueOnce({
@@ -280,7 +280,7 @@ describe('AdoPrReviewProvider', () => {
     await provider.refresh();
 
     const items = listener.mock.calls[0][0];
-    expect(items[0].description).toHaveLength(200);
+    expect(items[0].description).toHaveLength(300);
   });
 
   it('handles undefined description gracefully', async () => {

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -155,7 +155,7 @@ describe('AdoWorkItemProvider', () => {
     expect(items[0].description).toBe('Bold text link');
   });
 
-  it('truncates description to 200 chars', async () => {
+  it('passes full description without truncation after stripping HTML', async () => {
     const longDescription = '<p>' + 'A'.repeat(300) + '</p>';
     mockFetch
       .mockResolvedValueOnce({
@@ -180,7 +180,7 @@ describe('AdoWorkItemProvider', () => {
     await provider.refresh();
 
     const items = listener.mock.calls[0][0];
-    expect(items[0].description!.length).toBe(200);
+    expect(items[0].description!.length).toBe(300);
   });
 
   it('fires empty items when WIQL returns no work items', async () => {

--- a/packages/core/src/commands/commandUtils.ts
+++ b/packages/core/src/commands/commandUtils.ts
@@ -125,7 +125,7 @@ export async function batchAcceptItems(
     }
     try {
       const createdItem = await workGraph.createItem(
-        { title: formatItemTitle(item) },
+        { title: formatItemTitle(item), description: item.description },
         { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group?.trim() || undefined },
       );
       createdIds.push(createdItem.id);

--- a/packages/core/src/commands/commandUtils.ts
+++ b/packages/core/src/commands/commandUtils.ts
@@ -89,6 +89,7 @@ export interface AcceptableItem {
   providerId: string;
   externalId: string;
   title: string;
+  description?: string;
   url?: string;
   group?: string;
 }

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -270,7 +270,7 @@ async function batchAcceptItems(
     }
     try {
       const createdItem = await workGraph.createItem(
-        { title: formatItemTitle(item) },
+        { title: formatItemTitle(item), description: item.description },
         { providerId: item.providerId, externalId: item.externalId, url: item.url, group: item.group?.trim() || undefined },
       );
       createdIds.push(createdItem.id);
@@ -670,7 +670,7 @@ async function acceptSingleInboxItem(
   let createdItem: Awaited<ReturnType<typeof workGraph.createItem>>;
   try {
     createdItem = await workGraph.createItem(
-      { title: formatItemTitle(item) },
+      { title: formatItemTitle(item), description: item.description },
       {
         providerId: item.providerId,
         externalId: item.externalId,
@@ -754,7 +754,7 @@ async function acceptToFocusSingleInboxItem(
     let createdItem: Awaited<ReturnType<typeof workGraph.createItem>>;
     try {
       createdItem = await workGraph.createItem(
-        { title: formatItemTitle(item) },
+        { title: formatItemTitle(item), description: item.description },
         {
           providerId: item.providerId,
           externalId: item.externalId,
@@ -829,7 +829,7 @@ async function batchAcceptToFocusItems(
     const group = item.group?.trim();
     try {
       const createdItem = await workGraph.createItem(
-        { title: formatItemTitle(item) },
+        { title: formatItemTitle(item), description: item.description },
         {
           providerId: item.providerId,
           externalId: item.externalId,
@@ -1034,7 +1034,7 @@ async function acceptSingleSourceItem(
   let createdItem: Awaited<ReturnType<typeof workGraph.createItem>>;
   try {
     createdItem = await workGraph.createItem(
-      { title: formatItemTitle(item) },
+      { title: formatItemTitle(item), description: item.description },
       {
         providerId: item.providerId,
         externalId: item.externalId,

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -234,6 +234,7 @@ interface AcceptableItem {
   providerId: string;
   externalId: string;
   title: string;
+  description?: string;
   url?: string;
   group?: string;
 }

--- a/packages/core/src/commands/inboxCommands.ts
+++ b/packages/core/src/commands/inboxCommands.ts
@@ -81,7 +81,7 @@ async function acceptSingleInboxItem(
   let createdItem: Awaited<ReturnType<typeof workGraph.createItem>>;
   try {
     createdItem = await workGraph.createItem(
-      { title: formatItemTitle(item) },
+      { title: formatItemTitle(item), description: item.description },
       {
         providerId: item.providerId,
         externalId: item.externalId,
@@ -159,7 +159,7 @@ async function acceptToFocusSingleInboxItem(
     let createdItem: Awaited<ReturnType<typeof workGraph.createItem>>;
     try {
       createdItem = await workGraph.createItem(
-        { title: formatItemTitle(item) },
+        { title: formatItemTitle(item), description: item.description },
         {
           providerId: item.providerId,
           externalId: item.externalId,
@@ -232,7 +232,7 @@ async function batchAcceptToFocusItems(
     const group = item.group?.trim();
     try {
       const createdItem = await workGraph.createItem(
-        { title: formatItemTitle(item) },
+        { title: formatItemTitle(item), description: item.description },
         {
           providerId: item.providerId,
           externalId: item.externalId,

--- a/packages/core/src/commands/sourcesCommands.ts
+++ b/packages/core/src/commands/sourcesCommands.ts
@@ -74,7 +74,7 @@ async function acceptSingleSourceItem(
   let createdItem: Awaited<ReturnType<typeof workGraph.createItem>>;
   try {
     createdItem = await workGraph.createItem(
-      { title: formatItemTitle(item) },
+      { title: formatItemTitle(item), description: item.description },
       {
         providerId: item.providerId,
         externalId: item.externalId,

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -29,6 +29,7 @@ import { ViewRevealer } from './services/viewRevealer';
 import { initLogger, setLogLevel, logger, resolveLogLevel } from './services/logger';
 import { getInboxUnseenCount } from './services/inboxBadge';
 import { syncProviderTitles } from './services/titleSync';
+import { syncProviderDescriptions } from './services/descriptionSync';
 import { getViewLayout, ViewId } from './views/viewLayout';
 import { performance } from 'perf_hooks';
 
@@ -258,6 +259,10 @@ function wireEvents(
 
     void syncProviderTitles(providerRegistry, workGraph).catch(err => {
       logger.error('Error syncing provider titles', err);
+    });
+
+    void syncProviderDescriptions(providerRegistry, workGraph).catch(err => {
+      logger.error('Error syncing provider descriptions', err);
     });
 
     // Mark initial load complete when loading transitions from true to false

--- a/packages/core/src/services/descriptionSync.ts
+++ b/packages/core/src/services/descriptionSync.ts
@@ -1,0 +1,31 @@
+import { WorkGraph } from './workGraph';
+import { ProviderRegistry } from './providerRegistry';
+import { logger } from './logger';
+
+/**
+ * Synchronize provider-discovered descriptions with persisted WorkItem descriptions.
+ *
+ * Called after a provider refresh, this function iterates the provider's
+ * discovered items and updates any WorkItems whose persisted description differs
+ * from the live provider description. Unlike title sync, empty/cleared
+ * descriptions are propagated (if a provider clears the description, the
+ * persisted value should reflect that).
+ */
+export async function syncProviderDescriptions(
+  providerRegistry: ProviderRegistry,
+  workGraph: WorkGraph,
+): Promise<void> {
+  for (const [providerId, discoveredItems] of providerRegistry.getAllDiscoveredItems()) {
+    for (const discovered of discoveredItems) {
+      const workItem = workGraph.findItemByProvenance(providerId, discovered.externalId);
+      if (workItem && workItem.description !== discovered.description) {
+        try {
+          await workGraph.updateItem(workItem.id, { description: discovered.description });
+          logger.debug(`Synced description for ${providerId}/${discovered.externalId}`);
+        } catch (err) {
+          logger.error(`Failed to sync description for ${providerId}/${discovered.externalId}`, err);
+        }
+      }
+    }
+  }
+}

--- a/packages/core/src/services/descriptionSync.ts
+++ b/packages/core/src/services/descriptionSync.ts
@@ -18,7 +18,7 @@ export async function syncProviderDescriptions(
   for (const [providerId, discoveredItems] of providerRegistry.getAllDiscoveredItems()) {
     for (const discovered of discoveredItems) {
       const workItem = workGraph.findItemByProvenance(providerId, discovered.externalId);
-      if (workItem && workItem.description !== discovered.description) {
+      if (workItem && 'description' in discovered && workItem.description !== discovered.description) {
         try {
           await workGraph.updateItem(workItem.id, { description: discovered.description });
           logger.debug(`Synced description for ${providerId}/${discovered.externalId}`);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -179,6 +179,7 @@ export class WorkGraph {
       id: generateId(),
       title: input.title,
       notes: input.notes,
+      description: input.description,
       state: WorkItemState.New,
       providerId: provenance?.providerId,
       externalId: provenance?.externalId,
@@ -210,7 +211,7 @@ export class WorkGraph {
     return item;
   }
 
-  /** Apply a partial update (title, notes, and/or url) to an existing work item. */
+  /** Apply a partial update (title, notes, description, and/or url) to an existing work item. */
   async updateItem(id: string, patch: Partial<WorkItemInput>): Promise<void> {
     const item = this.items.get(id);
     if (!item) {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -220,6 +220,8 @@ export class WorkGraph {
     if (patch.title !== undefined && patch.title !== item.title) { changes.push('title'); }
     // Detect notes changes including clearing (patch.notes === undefined with key present)
     if ('notes' in patch && patch.notes !== item.notes) { changes.push('notes'); }
+    // Detect description changes including clearing
+    if ('description' in patch && patch.description !== item.description) { changes.push('description'); }
     // Detect url changes including clearing (patch.url === undefined with key present)
     if ('url' in patch) {
       const sanitized = patch.url ? isSafeUrl(patch.url.trim())?.href : undefined;

--- a/packages/core/src/test/descriptionSync.test.ts
+++ b/packages/core/src/test/descriptionSync.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { syncProviderDescriptions } from '../services/descriptionSync';
+
+function createMockWorkGraph() {
+  return {
+    findItemByProvenance: vi.fn(),
+    updateItem: vi.fn(async () => {}),
+  };
+}
+
+function createMockProviderRegistry() {
+  return {
+    getAllDiscoveredItems: vi.fn(() => new Map<string, any[]>()),
+  };
+}
+
+describe('syncProviderDescriptions', () => {
+  let workGraph: ReturnType<typeof createMockWorkGraph>;
+  let providerRegistry: ReturnType<typeof createMockProviderRegistry>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    workGraph = createMockWorkGraph();
+    providerRegistry = createMockProviderRegistry();
+  });
+
+  it('updates WorkItem description when provider description differs', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [{ externalId: '42', description: 'New description' }]],
+    ]));
+    workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', description: 'Old description' });
+
+    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.findItemByProvenance).toHaveBeenCalledWith('github', '42');
+    expect(workGraph.updateItem).toHaveBeenCalledWith('item-1', { description: 'New description' });
+  });
+
+  it('does not update when descriptions match', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [{ externalId: '42', description: 'Same description' }]],
+    ]));
+    workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', description: 'Same description' });
+
+    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).not.toHaveBeenCalled();
+  });
+
+  it('skips discovered items without matching WorkItem', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [{ externalId: '99', description: 'Orphan' }]],
+    ]));
+    workGraph.findItemByProvenance.mockReturnValue(undefined);
+
+    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).not.toHaveBeenCalled();
+  });
+
+  it('handles multiple providers and items', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [
+        { externalId: '1', description: 'Updated GH desc' },
+        { externalId: '2', description: 'Same GH desc' },
+      ]],
+      ['ado', [
+        { externalId: '100', description: 'Updated ADO desc' },
+      ]],
+    ]));
+    workGraph.findItemByProvenance
+      .mockReturnValueOnce({ id: 'gh-1', description: 'Old GH desc' })
+      .mockReturnValueOnce({ id: 'gh-2', description: 'Same GH desc' })
+      .mockReturnValueOnce({ id: 'ado-1', description: 'Old ADO desc' });
+
+    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).toHaveBeenCalledTimes(2);
+    expect(workGraph.updateItem).toHaveBeenCalledWith('gh-1', { description: 'Updated GH desc' });
+    expect(workGraph.updateItem).toHaveBeenCalledWith('ado-1', { description: 'Updated ADO desc' });
+  });
+
+  it('continues syncing other items when one update fails', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [
+        { externalId: '1', description: 'Fail' },
+        { externalId: '2', description: 'Updated' },
+      ]],
+    ]));
+    workGraph.findItemByProvenance
+      .mockReturnValueOnce({ id: 'item-1', description: 'Old1' })
+      .mockReturnValueOnce({ id: 'item-2', description: 'Old2' });
+    workGraph.updateItem
+      .mockRejectedValueOnce(new Error('write error'))
+      .mockResolvedValueOnce(undefined);
+
+    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).toHaveBeenCalledTimes(2);
+    expect(workGraph.updateItem).toHaveBeenCalledWith('item-2', { description: 'Updated' });
+  });
+
+  it('does nothing when no providers have items', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map());
+
+    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.findItemByProvenance).not.toHaveBeenCalled();
+    expect(workGraph.updateItem).not.toHaveBeenCalled();
+  });
+
+  it('syncs cleared description (undefined) when provider has no description', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [{ externalId: '42', description: undefined }]],
+    ]));
+    workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', description: 'Old description' });
+
+    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).toHaveBeenCalledWith('item-1', { description: undefined });
+  });
+
+  it('does not update when both descriptions are undefined', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [{ externalId: '42', description: undefined }]],
+    ]));
+    workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', description: undefined });
+
+    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/test/descriptionSync.test.ts
+++ b/packages/core/src/test/descriptionSync.test.ts
@@ -130,4 +130,15 @@ describe('syncProviderDescriptions', () => {
 
     expect(workGraph.updateItem).not.toHaveBeenCalled();
   });
+
+  it('does not clear description when provider omits description property', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [{ externalId: '42', title: 'Bug' }]],
+    ]));
+    workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', description: 'Existing description' });
+
+    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -585,13 +585,13 @@ describe('InboxTreeProvider', () => {
   });
 
   describe('getTreeItem tooltip', () => {
-    it('should include title and description in tooltip', () => {
+    it('should include title in tooltip but not description', () => {
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug fix', description: 'Fix the crash on startup' };
       const treeItem = provider.getTreeItem(item);
       expect(treeItem.tooltip).toBeInstanceOf(MarkdownString);
       const tooltip = treeItem.tooltip as MarkdownString;
       expect(tooltip.value).toContain('Bug fix');
-      expect(tooltip.value).toContain('Fix the crash on startup');
+      expect(tooltip.value).not.toContain('Fix the crash on startup');
     });
 
     it('should only include title when item has no description', () => {
@@ -624,23 +624,13 @@ describe('InboxTreeProvider', () => {
       appendMarkdownSpy.mockRestore();
     });
 
-    it('uses appendText for description to prevent markdown injection', () => {
-      const maliciousDesc = '![img](https://evil.com/track.png)';
-      const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Safe', description: maliciousDesc };
+    it('does not render description in tooltip', () => {
+      const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Safe', description: 'Some description' };
 
-      const appendTextSpy = vi.spyOn(MarkdownString.prototype, 'appendText');
-      const appendMarkdownSpy = vi.spyOn(MarkdownString.prototype, 'appendMarkdown');
+      const treeItem = provider.getTreeItem(item);
+      const tooltip = treeItem.tooltip as MarkdownString;
 
-      provider.getTreeItem(item);
-
-      const textCalls = appendTextSpy.mock.calls.map(c => c[0]);
-      const mdCalls = appendMarkdownSpy.mock.calls.map(c => c[0]);
-
-      expect(textCalls).toContainEqual(expect.stringContaining(maliciousDesc));
-      expect(mdCalls).not.toContainEqual(expect.stringContaining(maliciousDesc));
-
-      appendTextSpy.mockRestore();
-      appendMarkdownSpy.mockRestore();
+      expect(tooltip.value).not.toContain('Some description');
     });
 
     it('uses appendText for reason to prevent markdown injection', () => {

--- a/packages/core/src/test/sourcesTreeProvider.test.ts
+++ b/packages/core/src/test/sourcesTreeProvider.test.ts
@@ -395,7 +395,7 @@ describe('SourcesTreeProvider', () => {
   });
 
   describe('getTreeItem tooltip', () => {
-    it('should include title and description in tooltip when item has description', () => {
+    it('should include title but not description in tooltip', () => {
       const node: SourceItemNode = {
         kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug Report',
         description: 'App crashes on startup',
@@ -403,8 +403,8 @@ describe('SourcesTreeProvider', () => {
       const treeItem = provider.getTreeItem(node);
       const tooltip = treeItem.tooltip as MarkdownString;
       expect(tooltip.value).toContain('Bug Report');
-      expect(tooltip.value).toContain('App crashes on startup');
-      expect(tooltip.value).toContain('**Description:**');
+      expect(tooltip.value).not.toContain('App crashes on startup');
+      expect(tooltip.value).not.toContain('**Description:**');
     });
 
     it('should include only title in tooltip when item has no description', () => {
@@ -563,14 +563,14 @@ describe('SourcesTreeProvider', () => {
       expect((treeItem.tooltip as any).value).not.toContain('Description');
     });
 
-    it('should include description in tooltip when present', () => {
+    it('should not include description in tooltip even when present', () => {
       const node: SourceItemNode = {
         kind: 'item', providerId: 'gh', externalId: '1', title: 'Item', description: 'Details here',
       };
       const treeItem = provider.getTreeItem(node);
       expect(treeItem.tooltip).toBeDefined();
       expect((treeItem.tooltip as any).value).toContain('Item');
-      expect((treeItem.tooltip as any).value).toContain('Details here');
+      expect((treeItem.tooltip as any).value).not.toContain('Details here');
     });
   });
 

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -188,16 +188,15 @@ describe('WorkItemEditorPanel', () => {
       expect(mock.panel.onDidDispose).toHaveBeenCalledTimes(1);
     });
 
-    it('should pass provider description to HTML when discovered item has one', () => {
-      const item = makeItem({ providerId: 'gh', externalId: '42' });
+    it('should pass provider description to HTML when WorkItem has description', () => {
+      const item = makeItem({ providerId: 'gh', externalId: '42', description: 'Fix the login page' });
       const mock = createMockWebviewPanel();
       const registry = createMockProviderRegistry();
       vi.mocked(registry.getDiscoveredItems).mockReturnValue([
-        { externalId: '42', title: 'Bug', description: 'Fix the login page' } as any,
+        { externalId: '42', title: 'Bug' } as any,
       ]);
       openPanel(item, createMockWorkGraph(item), mock, undefined, registry);
 
-      expect(registry.getDiscoveredItems).toHaveBeenCalledWith('gh');
       expect(mock.panel.webview.html).toContain('Fix the login page');
     });
 

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -447,7 +447,6 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
       md.appendText(this.formatReason(item.reason));
       md.appendMarkdown('*\n\n');
     }
-    if (item.description) { md.appendText(`${item.description}\n\n`); }
     return md;
   }
 

--- a/packages/core/src/views/sourcesTreeProvider.ts
+++ b/packages/core/src/views/sourcesTreeProvider.ts
@@ -254,11 +254,6 @@ export class SourcesTreeProvider implements vscode.TreeDataProvider<SourcesEleme
     md.appendMarkdown(`**Title:** `);
     md.appendText(item.title);
     md.appendMarkdown(`\n\n`);
-    if (item.description) {
-      md.appendMarkdown(`**Description:** `);
-      md.appendText(item.description);
-      md.appendMarkdown(`\n\n`);
-    }
     return md;
   }
 

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -263,9 +263,9 @@ export class WorkItemEditorPanel {
         .getDiscoveredItems(item.providerId)
         .find((d) => d.externalId === item.externalId);
       providerState = discovered?.state ?? undefined;
+      // Use the synced description from the persisted WorkItem
+      providerDescription = item.description;
     }
-    // Use the synced description from the persisted WorkItem
-    providerDescription = item.description;
     return getEditorPanelHtml({
       cspSource: this.panel.webview.cspSource,
       item,

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -262,9 +262,10 @@ export class WorkItemEditorPanel {
       const discovered = this.providerRegistry
         .getDiscoveredItems(item.providerId)
         .find((d) => d.externalId === item.externalId);
-      providerDescription = discovered?.description ?? undefined;
       providerState = discovered?.state ?? undefined;
     }
+    // Use the synced description from the persisted WorkItem
+    providerDescription = item.description;
     return getEditorPanelHtml({
       cspSource: this.panel.webview.cspSource,
       item,

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -49,6 +49,7 @@ export class WorkItemEditorPanel {
   private readonly providerChangeSub: vscode.Disposable;
   private lastDisplayedTitle: string | undefined;
   private lastDisplayedUrl: string | undefined;
+  private lastDisplayedDescription: string | undefined;
   private lastManagedState: boolean | undefined;
 
   /**
@@ -190,8 +191,8 @@ export class WorkItemEditorPanel {
       void this.panel.webview.postMessage({ type: 'updateTitle', title: item.title });
     }
 
-    // Re-render when URL changes to keep the title hyperlink and URL field in sync
-    if (item.url !== this.lastDisplayedUrl) {
+    // Re-render when URL or description changes
+    if (item.url !== this.lastDisplayedUrl || item.description !== this.lastDisplayedDescription) {
       this.update();
     }
   }
@@ -250,6 +251,7 @@ export class WorkItemEditorPanel {
     }
     this.lastDisplayedTitle = item.title;
     this.lastDisplayedUrl = item.url;
+    this.lastDisplayedDescription = item.description;
     this.lastManagedState = this.isProviderManaged(item);
     this.panel.title = `Edit: ${item.title}`;
     this.panel.webview.html = this.getHtml(item);

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -42,7 +42,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       return {
         externalId: `${repoName}#${issue.number}`,
         title: `#${issue.number}: ${issue.title}`,
-        description: issue.body?.slice(0, 200),
+        description: issue.body ?? undefined,
         url: issue.html_url,
         group: repoName,
         reason: 'mentioned',

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -105,7 +105,7 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
       items.push({
         externalId: `${repoName}#${pr.number}`,
         title: `#${pr.number}: ${pr.title}`,
-        description: pr.body?.slice(0, 200),
+        description: pr.body ?? undefined,
         url: pr.html_url,
         group: repoName,
         reason: 'You authored this PR',
@@ -119,7 +119,7 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
       items.push({
         externalId: `${repoName}#${pr.number}`,
         title: `#${pr.number}: ${pr.title}`,
-        description: pr.body?.slice(0, 200),
+        description: pr.body ?? undefined,
         url: pr.html_url,
         group: repoName,
         reason: 'You are assigned to this PR',

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -70,7 +70,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
       const item: DiscoveredItem = {
         externalId: `${repoName}#${pr.number}`,
         title: `#${pr.number}: ${pr.title}`,
-        description: pr.body?.slice(0, 200),
+        description: pr.body ?? undefined,
         url: pr.html_url,
         group: repoName,
         reason: 'review_requested',

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -40,7 +40,7 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
       return {
         externalId: `${repoName}#${issue.number}`,
         title: `#${issue.number}: ${issue.title}`,
-        description: issue.body?.slice(0, 200),
+        description: issue.body ?? undefined,
         url: issue.html_url,
         group: repoName,
         reason: 'assigned',

--- a/packages/github/src/test/githubMyPrsProvider.test.ts
+++ b/packages/github/src/test/githubMyPrsProvider.test.ts
@@ -241,7 +241,7 @@ describe('GitHubMyPrsProvider', () => {
     expect(items[0].state).toBe('Open');
   });
 
-  it('truncates description to 200 chars', async () => {
+  it('passes full description without truncation', async () => {
     const pr = createMockPr(1, 'Long PR');
     pr.body = 'a'.repeat(500);
 
@@ -266,7 +266,7 @@ describe('GitHubMyPrsProvider', () => {
     await provider.refresh();
 
     const items = listener.mock.calls[0][0];
-    expect(items[0].description).toHaveLength(200);
+    expect(items[0].description).toHaveLength(500);
   });
 
   it('reports all-repos failure for global search', async () => {

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -207,7 +207,7 @@ describe('GitHubPrReviewProvider', () => {
     expect(items[1].group).toBe('beta/two');
   });
 
-  it('truncates description to 200 chars', async () => {
+  it('passes full description without truncation', async () => {
     const longBody = 'B'.repeat(300);
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -221,7 +221,7 @@ describe('GitHubPrReviewProvider', () => {
     await provider.refresh();
 
     const items = listener.mock.calls[0][0];
-    expect(items[0].description).toHaveLength(200);
+    expect(items[0].description).toHaveLength(300);
   });
 
   it('handles undefined body gracefully', async () => {

--- a/packages/github/src/test/githubProvider.test.ts
+++ b/packages/github/src/test/githubProvider.test.ts
@@ -203,7 +203,7 @@ describe('GitHubIssueProvider', () => {
     expect(items[0]).not.toHaveProperty('state');
   });
 
-  it('truncates description to 200 chars', async () => {
+  it('passes full description without truncation', async () => {
     const longBody = 'A'.repeat(300);
     mockFetch.mockResolvedValueOnce({
       ok: true,
@@ -219,7 +219,7 @@ describe('GitHubIssueProvider', () => {
     await provider.refresh();
 
     const items = listener.mock.calls[0][0];
-    expect(items[0].description).toHaveLength(200);
+    expect(items[0].description).toHaveLength(300);
   });
 
   it('handles fetch errors gracefully', async () => {

--- a/packages/shared/src/workItem.ts
+++ b/packages/shared/src/workItem.ts
@@ -81,7 +81,7 @@ export interface WorkItem {
   id: string;
   /** Short human-readable title displayed in tree views. */
   title: string;
-  /** Optional free-form notes or description. */
+  /** Optional free-form notes (user-editable). */
   notes?: string;
   /** Provider-synced description, separate from user-editable notes. */
   description?: string;
@@ -112,7 +112,7 @@ export interface WorkItem {
 export interface WorkItemInput {
   /** Short human-readable title of the work item. */
   title: string;
-  /** Optional free-form notes or description. */
+  /** Optional free-form notes (user-editable). */
   notes?: string;
   /** Optional URL linking to the item in an external system. */
   url?: string;

--- a/packages/shared/src/workItem.ts
+++ b/packages/shared/src/workItem.ts
@@ -83,6 +83,8 @@ export interface WorkItem {
   title: string;
   /** Optional free-form notes or description. */
   notes?: string;
+  /** Provider-synced description, separate from user-editable notes. */
+  description?: string;
   /** Current lifecycle state of the work item. */
   state: WorkItemState;
   /** ID of the provider that originally discovered this item, if any. */
@@ -114,4 +116,6 @@ export interface WorkItemInput {
   notes?: string;
   /** Optional URL linking to the item in an external system. */
   url?: string;
+  /** Optional description (typically synced from provider). */
+  description?: string;
 }


### PR DESCRIPTION
## Summary

Show the full provider description in the editor panel instead of a truncated 200-character snippet.

## Changes

### Remove description truncation from all providers

Removed `.slice(0, 200)` from all 6 providers (4 GitHub + 2 ADO) so `DiscoveredItem.description` carries the full body text.

### Add `description` field to WorkItem

Added an optional `description` field to both `WorkItem` and `WorkItemInput` in `@devdocket/shared`. This is provider-synced content, separate from user-editable `notes`. This is an additive, non-breaking API change.

### Description sync service

New `descriptionSync.ts` service mirrors `titleSync.ts`: iterates all providers' discovered items after each refresh and updates the persisted `WorkItem.description` when stale. Unlike title sync, cleared descriptions are propagated. Wired into `extension.ts` alongside the existing `syncProviderTitles` call.

### Editor panel reads from WorkItem

`workItemEditorPanel.ts` now reads `item.description` from the persisted WorkItem instead of looking up the live `DiscoveredItem.description`. Dynamic updates work automatically via the existing `workGraph.onDidChange` subscription.

### Tooltip cleanup

Removed description from tooltips in inbox and sources tree providers. The full description is only visible in the editor panel.

### Tests

- New `descriptionSync.test.ts` with 8 tests covering description updates, no-ops, error resilience, cleared descriptions, and multi-provider scenarios.
- Updated all 6 provider tests to verify full descriptions pass through.
- Updated editor panel, inbox tooltip, and sources tooltip tests.

Closes #391
