### PR TITLE
React to polling interval configuration changes at runtime

### DIFF
--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -47,6 +47,7 @@ export class WatcherService implements vscode.Disposable {
   private pollTimer: NodeJS.Timeout | undefined;
   private isPollInFlight = false;
   private consecutiveFailures = new Map<string, number>();
+  private configSubscription: vscode.Disposable | undefined;
   
   private readonly _onDidChangeWatchedRuns = new vscode.EventEmitter<WatchedRun[]>();
   readonly onDidChangeWatchedRuns = this._onDidChangeWatchedRuns.event;
@@ -68,7 +69,14 @@ export class WatcherService implements vscode.Disposable {
     private prWatcherRegistry: PRWatcherRegistry,
     private watchStore: WatchStore,
     private logger: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void }
-  ) {}
+  ) {
+    this.configSubscription = vscode.workspace.onDidChangeConfiguration(e => {
+      if (e.affectsConfiguration('devDocket.watches.pollingIntervalSeconds') && this.pollTimer) {
+        this.stopPolling();
+        this.ensurePollingActive();
+      }
+    });
+  }
 
   /**
    * Load persisted watches from disk and resume polling for active ones.
@@ -736,6 +744,7 @@ export class WatcherService implements vscode.Disposable {
   }
 
   dispose(): void {
+    this.configSubscription?.dispose();
     this.stopPolling();
     this._onDidChangeWatchedRuns.dispose();
     this._onDidDetectJobFailure.dispose();

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -179,13 +179,16 @@ class MockMemento {
   }
 }
 
+const _onDidChangeConfigurationEmitter = new MockEventEmitter();
+
 const workspace = {
   getConfiguration: vi.fn().mockReturnValue({
     get: vi.fn((key: string, defaultValue?: any) => defaultValue),
     update: vi.fn().mockResolvedValue(undefined),
     inspect: vi.fn(() => undefined),
   }),
-  onDidChangeConfiguration: vi.fn(() => ({ dispose: vi.fn() })),
+  onDidChangeConfiguration: vi.fn((listener: Function) => _onDidChangeConfigurationEmitter.event(listener)),
+  _onDidChangeConfigurationEmitter,
 };
 
 class MockThemeColor {

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -527,4 +527,79 @@ describe('WatcherService', () => {
       expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to add child run'));
     });
   });
+
+  describe('configuration change handling', () => {
+    it('restarts polling with new interval when config changes while polling is active', async () => {
+      const watcher = createMockWatcher('test');
+      registry.register(watcher);
+
+      const identifier = createIdentifier();
+      await service.startWatch(identifier);
+      // startWatch calls getRunStatus once for initial fetch
+      expect(watcher.getRunStatus).toHaveBeenCalledTimes(1);
+
+      // Advance to trigger one poll tick
+      await vi.advanceTimersByTimeAsync(60000);
+      expect(watcher.getRunStatus).toHaveBeenCalledTimes(2);
+
+      // Change the config to a 30s interval
+      const { workspace } = await import('../test/__mocks__/vscode');
+      workspace.getConfiguration.mockReturnValue({
+        get: vi.fn((key: string, defaultValue?: any) => {
+          if (key === 'pollingIntervalSeconds') { return 30; }
+          return defaultValue;
+        }),
+        update: vi.fn().mockResolvedValue(undefined),
+        inspect: vi.fn(() => undefined),
+      });
+
+      // Fire configuration change event
+      workspace._onDidChangeConfigurationEmitter.fire({
+        affectsConfiguration: (section: string) => section === 'devDocket.watches.pollingIntervalSeconds',
+      });
+
+      // Reset call count to measure new interval
+      (watcher.getRunStatus as ReturnType<typeof vi.fn>).mockClear();
+
+      // Advance 30s — should trigger poll with new interval
+      await vi.advanceTimersByTimeAsync(30000);
+      expect(watcher.getRunStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing when config changes but polling is not active', async () => {
+      // No watches added, so polling is not active
+      const { workspace } = await import('../test/__mocks__/vscode');
+
+      // Fire configuration change — should not throw or start polling
+      workspace._onDidChangeConfigurationEmitter.fire({
+        affectsConfiguration: (section: string) => section === 'devDocket.watches.pollingIntervalSeconds',
+      });
+
+      // Advance time — no polling should have started
+      await vi.advanceTimersByTimeAsync(60000);
+      expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('Started polling'));
+    });
+
+    it('disposes config subscription when service is disposed', async () => {
+      const { workspace } = await import('../test/__mocks__/vscode');
+
+      // Add a watch so polling is active
+      const watcher = createMockWatcher('test');
+      registry.register(watcher);
+      await service.startWatch(createIdentifier());
+
+      // Dispose the service
+      service.dispose();
+
+      // Fire configuration change — should not restart polling
+      workspace._onDidChangeConfigurationEmitter.fire({
+        affectsConfiguration: (section: string) => section === 'devDocket.watches.pollingIntervalSeconds',
+      });
+
+      await vi.advanceTimersByTimeAsync(60000);
+      // getRunStatus was called once during the initial startWatch poll cycle;
+      // after dispose, no more polls should occur
+      expect(watcher.getRunStatus).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -583,23 +583,16 @@ describe('WatcherService', () => {
     it('disposes config subscription when service is disposed', async () => {
       const { workspace } = await import('../test/__mocks__/vscode');
 
-      // Add a watch so polling is active
-      const watcher = createMockWatcher('test');
-      registry.register(watcher);
-      await service.startWatch(createIdentifier());
+      // Verify the config listener is registered
+      const emitter = workspace._onDidChangeConfigurationEmitter;
+      const listenersBefore = (emitter as any).listeners.length;
+      expect(listenersBefore).toBeGreaterThan(0);
 
-      // Dispose the service
+      // Dispose the service — should remove the config listener
       service.dispose();
 
-      // Fire configuration change — should not restart polling
-      workspace._onDidChangeConfigurationEmitter.fire({
-        affectsConfiguration: (section: string) => section === 'devDocket.watches.pollingIntervalSeconds',
-      });
-
-      await vi.advanceTimersByTimeAsync(60000);
-      // getRunStatus was called once during the initial startWatch poll cycle;
-      // after dispose, no more polls should occur
-      expect(watcher.getRunStatus).toHaveBeenCalledTimes(1);
+      const listenersAfter = (emitter as any).listeners.length;
+      expect(listenersAfter).toBe(listenersBefore - 1);
     });
   });
 });


### PR DESCRIPTION
## Summary

WatcherService now subscribes to `vscode.workspace.onDidChangeConfiguration` and restarts the polling timer when the `devDocket.watches.pollingIntervalSeconds` setting changes at runtime. Previously, changes to this setting were only picked up on the next extension activation or when a new watch was started.

## Changes

- **`packages/core/src/services/watcherService.ts`** — Added a `configSubscription` that listens for configuration changes in the constructor. When `devDocket.watches.pollingIntervalSeconds` changes and polling is currently active (`pollTimer` exists), the service stops and restarts polling so the new interval takes effect immediately. The subscription is properly disposed in `dispose()`.
- **`packages/core/src/test/__mocks__/vscode.ts`** — Updated the `workspace.onDidChangeConfiguration` mock to use a real `MockEventEmitter` so tests can fire configuration change events.
- **`packages/core/src/test/watcherService.test.ts`** — Added three tests covering: restart with new interval while active, no-op when polling is inactive, and proper cleanup on dispose.

Closes #402
