### PR TITLE
Scope title and description sync to single provider per refresh

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -342,13 +342,17 @@ function wireEvents(
   // Per-provider guard prevents overlapping auto-complete runs; AbortController cancels in-flight checks.
   const autoCompleteControllers = new Map<string, AbortController>();
   const autoCompleteSub = providerRegistry.onDidRefreshProvider(safeHandler('Error handling provider refresh', async (providerId) => {
-    void syncProviderTitles(providerId, providerRegistry, workGraph).catch(err => {
+    try {
+      await syncProviderTitles(providerId, providerRegistry, workGraph);
+    } catch (err) {
       logger.error('Error syncing provider titles', err);
-    });
+    }
 
-    void syncProviderDescriptions(providerId, providerRegistry, workGraph).catch(err => {
+    try {
+      await syncProviderDescriptions(providerId, providerRegistry, workGraph);
+    } catch (err) {
       logger.error('Error syncing provider descriptions', err);
-    });
+    }
 
     const config = vscode.workspace.getConfiguration('devDocket');
     if (!config.get<boolean>('autoCompleteOnClose', true)) {

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -257,14 +257,6 @@ function wireEvents(
   const discoveredSub = providerRegistry.onDidChangeDiscoveredItems(safeHandler('Error handling discovered items change', () => {
     scheduleUiUpdate();
 
-    void syncProviderTitles(providerRegistry, workGraph).catch(err => {
-      logger.error('Error syncing provider titles', err);
-    });
-
-    void syncProviderDescriptions(providerRegistry, workGraph).catch(err => {
-      logger.error('Error syncing provider descriptions', err);
-    });
-
     // Mark initial load complete when loading transitions from true to false
     if (!initialLoadComplete) {
       if (wasLoading && !providerRegistry.loading) {
@@ -351,6 +343,14 @@ function wireEvents(
   // Per-provider guard prevents overlapping runs; AbortController cancels in-flight checks.
   const autoCompleteControllers = new Map<string, AbortController>();
   const autoCompleteSub = providerRegistry.onDidRefreshProvider(safeHandler('Error handling auto-complete', async (providerId) => {
+    void syncProviderTitles(providerId, providerRegistry, workGraph).catch(err => {
+      logger.error('Error syncing provider titles', err);
+    });
+
+    void syncProviderDescriptions(providerId, providerRegistry, workGraph).catch(err => {
+      logger.error('Error syncing provider descriptions', err);
+    });
+
     const config = vscode.workspace.getConfiguration('devDocket');
     if (!config.get<boolean>('autoCompleteOnClose', true)) {
       return;

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -338,11 +338,10 @@ function wireEvents(
     }
   }));
 
-  // Auto-complete: after each provider refresh, scan all WorkGraph items with
-  // that providerId and check whether their external items are closed/merged.
-  // Per-provider guard prevents overlapping runs; AbortController cancels in-flight checks.
+  // Provider refresh handler: sync titles/descriptions and auto-complete.
+  // Per-provider guard prevents overlapping auto-complete runs; AbortController cancels in-flight checks.
   const autoCompleteControllers = new Map<string, AbortController>();
-  const autoCompleteSub = providerRegistry.onDidRefreshProvider(safeHandler('Error handling auto-complete', async (providerId) => {
+  const autoCompleteSub = providerRegistry.onDidRefreshProvider(safeHandler('Error handling provider refresh', async (providerId) => {
     void syncProviderTitles(providerId, providerRegistry, workGraph).catch(err => {
       logger.error('Error syncing provider titles', err);
     });

--- a/packages/core/src/services/descriptionSync.ts
+++ b/packages/core/src/services/descriptionSync.ts
@@ -12,19 +12,22 @@ import { logger } from './logger';
  * persisted value should reflect that).
  */
 export async function syncProviderDescriptions(
+  providerId: string,
   providerRegistry: ProviderRegistry,
   workGraph: WorkGraph,
 ): Promise<void> {
-  for (const [providerId, discoveredItems] of providerRegistry.getAllDiscoveredItems()) {
-    for (const discovered of discoveredItems) {
-      const workItem = workGraph.findItemByProvenance(providerId, discovered.externalId);
-      if (workItem && 'description' in discovered && workItem.description !== discovered.description) {
-        try {
-          await workGraph.updateItem(workItem.id, { description: discovered.description });
-          logger.debug(`Synced description for ${providerId}/${discovered.externalId}`);
-        } catch (err) {
-          logger.error(`Failed to sync description for ${providerId}/${discovered.externalId}`, err);
-        }
+  const discoveredItems = providerRegistry.getAllDiscoveredItems().get(providerId);
+  if (!discoveredItems) {
+    return;
+  }
+  for (const discovered of discoveredItems) {
+    const workItem = workGraph.findItemByProvenance(providerId, discovered.externalId);
+    if (workItem && 'description' in discovered && workItem.description !== discovered.description) {
+      try {
+        await workGraph.updateItem(workItem.id, { description: discovered.description });
+        logger.debug(`Synced description for ${providerId}/${discovered.externalId}`);
+      } catch (err) {
+        logger.error(`Failed to sync description for ${providerId}/${discovered.externalId}`, err);
       }
     }
   }

--- a/packages/core/src/services/titleSync.ts
+++ b/packages/core/src/services/titleSync.ts
@@ -14,19 +14,22 @@ import { logger } from './logger';
  * that share the same providerId + externalId.
  */
 export async function syncProviderTitles(
+  providerId: string,
   providerRegistry: ProviderRegistry,
   workGraph: WorkGraph,
 ): Promise<void> {
-  for (const [providerId, discoveredItems] of providerRegistry.getAllDiscoveredItems()) {
-    for (const discovered of discoveredItems) {
-      const workItem = workGraph.findItemByProvenance(providerId, discovered.externalId);
-      if (workItem && discovered.title?.trim() && workItem.title !== discovered.title) {
-        try {
-          await workGraph.updateItem(workItem.id, { title: discovered.title });
-          logger.debug(`Synced title for ${providerId}/${discovered.externalId}: "${workItem.title}" → "${discovered.title}"`);
-        } catch (err) {
-          logger.error(`Failed to sync title for ${providerId}/${discovered.externalId}`, err);
-        }
+  const discoveredItems = providerRegistry.getAllDiscoveredItems().get(providerId);
+  if (!discoveredItems) {
+    return;
+  }
+  for (const discovered of discoveredItems) {
+    const workItem = workGraph.findItemByProvenance(providerId, discovered.externalId);
+    if (workItem && discovered.title?.trim() && workItem.title !== discovered.title) {
+      try {
+        await workGraph.updateItem(workItem.id, { title: discovered.title });
+        logger.debug(`Synced title for ${providerId}/${discovered.externalId}: "${workItem.title}" → "${discovered.title}"`);
+      } catch (err) {
+        logger.error(`Failed to sync title for ${providerId}/${discovered.externalId}`, err);
       }
     }
   }

--- a/packages/core/src/test/descriptionSync.test.ts
+++ b/packages/core/src/test/descriptionSync.test.ts
@@ -30,7 +30,7 @@ describe('syncProviderDescriptions', () => {
     ]));
     workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', description: 'Old description' });
 
-    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+    await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.findItemByProvenance).toHaveBeenCalledWith('github', '42');
     expect(workGraph.updateItem).toHaveBeenCalledWith('item-1', { description: 'New description' });
@@ -42,7 +42,7 @@ describe('syncProviderDescriptions', () => {
     ]));
     workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', description: 'Same description' });
 
-    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+    await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.updateItem).not.toHaveBeenCalled();
   });
@@ -53,31 +53,45 @@ describe('syncProviderDescriptions', () => {
     ]));
     workGraph.findItemByProvenance.mockReturnValue(undefined);
 
-    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+    await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.updateItem).not.toHaveBeenCalled();
   });
 
-  it('handles multiple providers and items', async () => {
+  it('only scans the specified provider, not others', async () => {
     providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
       ['github', [
         { externalId: '1', description: 'Updated GH desc' },
-        { externalId: '2', description: 'Same GH desc' },
       ]],
       ['ado', [
         { externalId: '100', description: 'Updated ADO desc' },
       ]],
     ]));
     workGraph.findItemByProvenance
-      .mockReturnValueOnce({ id: 'gh-1', description: 'Old GH desc' })
-      .mockReturnValueOnce({ id: 'gh-2', description: 'Same GH desc' })
-      .mockReturnValueOnce({ id: 'ado-1', description: 'Old ADO desc' });
+      .mockReturnValueOnce({ id: 'gh-1', description: 'Old GH desc' });
 
-    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+    await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
 
-    expect(workGraph.updateItem).toHaveBeenCalledTimes(2);
+    expect(workGraph.updateItem).toHaveBeenCalledTimes(1);
     expect(workGraph.updateItem).toHaveBeenCalledWith('gh-1', { description: 'Updated GH desc' });
-    expect(workGraph.updateItem).toHaveBeenCalledWith('ado-1', { description: 'Updated ADO desc' });
+    expect(workGraph.findItemByProvenance).not.toHaveBeenCalledWith('ado', expect.anything());
+  });
+
+  it('handles multiple items within the specified provider', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [
+        { externalId: '1', description: 'Updated GH desc' },
+        { externalId: '2', description: 'Same GH desc' },
+      ]],
+    ]));
+    workGraph.findItemByProvenance
+      .mockReturnValueOnce({ id: 'gh-1', description: 'Old GH desc' })
+      .mockReturnValueOnce({ id: 'gh-2', description: 'Same GH desc' });
+
+    await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).toHaveBeenCalledTimes(1);
+    expect(workGraph.updateItem).toHaveBeenCalledWith('gh-1', { description: 'Updated GH desc' });
   });
 
   it('continues syncing other items when one update fails', async () => {
@@ -94,16 +108,16 @@ describe('syncProviderDescriptions', () => {
       .mockRejectedValueOnce(new Error('write error'))
       .mockResolvedValueOnce(undefined);
 
-    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+    await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.updateItem).toHaveBeenCalledTimes(2);
     expect(workGraph.updateItem).toHaveBeenCalledWith('item-2', { description: 'Updated' });
   });
 
-  it('does nothing when no providers have items', async () => {
+  it('does nothing when provider has no items', async () => {
     providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map());
 
-    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+    await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.findItemByProvenance).not.toHaveBeenCalled();
     expect(workGraph.updateItem).not.toHaveBeenCalled();
@@ -115,7 +129,7 @@ describe('syncProviderDescriptions', () => {
     ]));
     workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', description: 'Old description' });
 
-    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+    await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.updateItem).toHaveBeenCalledWith('item-1', { description: undefined });
   });
@@ -126,7 +140,7 @@ describe('syncProviderDescriptions', () => {
     ]));
     workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', description: undefined });
 
-    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+    await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.updateItem).not.toHaveBeenCalled();
   });
@@ -137,7 +151,7 @@ describe('syncProviderDescriptions', () => {
     ]));
     workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', description: 'Existing description' });
 
-    await syncProviderDescriptions(providerRegistry as any, workGraph as any);
+    await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.updateItem).not.toHaveBeenCalled();
   });

--- a/packages/core/src/test/titleSync.test.ts
+++ b/packages/core/src/test/titleSync.test.ts
@@ -30,7 +30,7 @@ describe('syncProviderTitles', () => {
     ]));
     workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', title: 'Old Title' });
 
-    await syncProviderTitles(providerRegistry as any, workGraph as any);
+    await syncProviderTitles('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.findItemByProvenance).toHaveBeenCalledWith('github', '42');
     expect(workGraph.updateItem).toHaveBeenCalledWith('item-1', { title: 'New Title' });
@@ -42,7 +42,7 @@ describe('syncProviderTitles', () => {
     ]));
     workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', title: 'Same Title' });
 
-    await syncProviderTitles(providerRegistry as any, workGraph as any);
+    await syncProviderTitles('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.updateItem).not.toHaveBeenCalled();
   });
@@ -53,31 +53,45 @@ describe('syncProviderTitles', () => {
     ]));
     workGraph.findItemByProvenance.mockReturnValue(undefined);
 
-    await syncProviderTitles(providerRegistry as any, workGraph as any);
+    await syncProviderTitles('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.updateItem).not.toHaveBeenCalled();
   });
 
-  it('handles multiple providers and items', async () => {
+  it('only scans the specified provider, not others', async () => {
     providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
       ['github', [
         { externalId: '1', title: 'Updated GH' },
-        { externalId: '2', title: 'Same GH' },
       ]],
       ['ado', [
         { externalId: '100', title: 'Updated ADO' },
       ]],
     ]));
     workGraph.findItemByProvenance
-      .mockReturnValueOnce({ id: 'gh-1', title: 'Old GH' })
-      .mockReturnValueOnce({ id: 'gh-2', title: 'Same GH' })
-      .mockReturnValueOnce({ id: 'ado-1', title: 'Old ADO' });
+      .mockReturnValueOnce({ id: 'gh-1', title: 'Old GH' });
 
-    await syncProviderTitles(providerRegistry as any, workGraph as any);
+    await syncProviderTitles('github', providerRegistry as any, workGraph as any);
 
-    expect(workGraph.updateItem).toHaveBeenCalledTimes(2);
+    expect(workGraph.updateItem).toHaveBeenCalledTimes(1);
     expect(workGraph.updateItem).toHaveBeenCalledWith('gh-1', { title: 'Updated GH' });
-    expect(workGraph.updateItem).toHaveBeenCalledWith('ado-1', { title: 'Updated ADO' });
+    expect(workGraph.findItemByProvenance).not.toHaveBeenCalledWith('ado', expect.anything());
+  });
+
+  it('handles multiple items within the specified provider', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [
+        { externalId: '1', title: 'Updated GH' },
+        { externalId: '2', title: 'Same GH' },
+      ]],
+    ]));
+    workGraph.findItemByProvenance
+      .mockReturnValueOnce({ id: 'gh-1', title: 'Old GH' })
+      .mockReturnValueOnce({ id: 'gh-2', title: 'Same GH' });
+
+    await syncProviderTitles('github', providerRegistry as any, workGraph as any);
+
+    expect(workGraph.updateItem).toHaveBeenCalledTimes(1);
+    expect(workGraph.updateItem).toHaveBeenCalledWith('gh-1', { title: 'Updated GH' });
   });
 
   it('continues syncing other items when one update fails', async () => {
@@ -94,16 +108,16 @@ describe('syncProviderTitles', () => {
       .mockRejectedValueOnce(new Error('write error'))
       .mockResolvedValueOnce(undefined);
 
-    await syncProviderTitles(providerRegistry as any, workGraph as any);
+    await syncProviderTitles('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.updateItem).toHaveBeenCalledTimes(2);
     expect(workGraph.updateItem).toHaveBeenCalledWith('item-2', { title: 'Updated' });
   });
 
-  it('does nothing when no providers have items', async () => {
+  it('does nothing when provider has no items', async () => {
     providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map());
 
-    await syncProviderTitles(providerRegistry as any, workGraph as any);
+    await syncProviderTitles('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.findItemByProvenance).not.toHaveBeenCalled();
     expect(workGraph.updateItem).not.toHaveBeenCalled();
@@ -115,7 +129,7 @@ describe('syncProviderTitles', () => {
     ]));
     workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', title: 'Good Title' });
 
-    await syncProviderTitles(providerRegistry as any, workGraph as any);
+    await syncProviderTitles('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.updateItem).not.toHaveBeenCalled();
   });
@@ -126,7 +140,7 @@ describe('syncProviderTitles', () => {
     ]));
     workGraph.findItemByProvenance.mockReturnValue({ id: 'item-1', title: 'Good Title' });
 
-    await syncProviderTitles(providerRegistry as any, workGraph as any);
+    await syncProviderTitles('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.updateItem).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

Scopes `syncProviderTitles` and `syncProviderDescriptions` to operate on a single provider's items instead of scanning all providers on every change event.

Previously, both functions were wired to `onDidChangeDiscoveredItems`, which fires for any provider change. Each invocation iterated over every discovered item across all providers, resulting in O(all_providers × all_items) work per refresh.

Now, both functions accept a `providerId` parameter and are wired to `onDidRefreshProvider`, which supplies the specific provider that changed. Each invocation only processes items from that single provider, reducing work to O(single_provider_items) per refresh.

## Changes

- **`titleSync.ts` / `descriptionSync.ts`**: Added `providerId` parameter; filter discovered items to the single provider via `getAllDiscoveredItems().get(providerId)` with early return when the provider has no items.
- **`extension.ts`**: Moved sync calls from `onDidChangeDiscoveredItems` handler to `onDidRefreshProvider` handler, passing the provider ID.
- **Tests**: Updated to pass `providerId`, added test cases verifying only the specified provider's items are scanned.

Closes #403
