### PR TITLE
Add pruning for stale discovered state records

### DIFF
--- a/packages/core/src/storage/discoveredStateStore.ts
+++ b/packages/core/src/storage/discoveredStateStore.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import type { Memento } from 'vscode';
+import type { DiscoveredItem } from '../api/types';
 import { logger } from '../services/logger';
 import {
   validateObject,
@@ -169,6 +170,49 @@ export class DiscoveredStateStore {
       logger.debug(`Loaded discovered state: ${this.cache.size} entries`);
     }
     this.loaded = true;
+  }
+
+  /**
+   * Removes persisted state records for items that are no longer reported by
+   * their provider. Providers with empty item arrays are skipped to avoid
+   * pruning during transient API failures.
+   *
+   * @returns The number of records removed.
+   */
+  async prune(activeItems: Map<string, DiscoveredItem[]>): Promise<number> {
+    if (!this.loaded) { await this.load(); }
+
+    // Build a set of active composite keys and collect provider IDs that
+    // actually have items. Providers with empty arrays are excluded so their
+    // records survive transient failures.
+    const activeKeys = new Set<string>();
+    const activeProviderIds = new Set<string>();
+    for (const [providerId, items] of activeItems) {
+      if (items.length === 0) { continue; }
+      activeProviderIds.add(providerId);
+      for (const item of items) {
+        activeKeys.add(this.key(providerId, item.externalId));
+      }
+    }
+
+    if (activeProviderIds.size === 0) { return 0; }
+
+    const staleKeys: string[] = [];
+    for (const [k, record] of this.cache) {
+      if (activeProviderIds.has(record.providerId) && !activeKeys.has(k)) {
+        staleKeys.push(k);
+      }
+    }
+
+    if (staleKeys.length === 0) { return 0; }
+
+    for (const k of staleKeys) {
+      this.cache.delete(k);
+    }
+
+    await this.persist();
+    this._onDidChange.fire();
+    return staleKeys.length;
   }
 
   /** Disposes the change event emitter. */

--- a/packages/core/src/test/discoveredStateStore.test.ts
+++ b/packages/core/src/test/discoveredStateStore.test.ts
@@ -553,4 +553,132 @@ describe('DiscoveredStateStore', () => {
       freshStore.dispose();
     });
   });
+
+  // ── prune ──────────────────────────────────────────────────────────
+
+  describe('prune', () => {
+    it('should remove stale records for providers that have active items', async () => {
+      await store.setStates([
+        { providerId: 'gh', externalId: 'issue-1', state: 'accepted' },
+        { providerId: 'gh', externalId: 'issue-2', state: 'accepted' },
+        { providerId: 'gh', externalId: 'issue-3', state: 'dismissed' },
+      ]);
+
+      const activeItems = new Map([
+        ['gh', [
+          { externalId: 'issue-1', title: 'Issue 1' },
+          { externalId: 'issue-2', title: 'Issue 2' },
+        ]],
+      ]);
+
+      const pruned = await store.prune(activeItems);
+
+      expect(pruned).toBe(1);
+      expect(store.getState('gh', 'issue-1')).toBe('accepted');
+      expect(store.getState('gh', 'issue-2')).toBe('accepted');
+      expect(store.getState('gh', 'issue-3')).toBeUndefined();
+    });
+
+    it('should skip providers with empty item arrays', async () => {
+      await store.setStates([
+        { providerId: 'gh', externalId: 'issue-1', state: 'accepted' },
+      ]);
+
+      const activeItems = new Map([
+        ['gh', []],
+      ]);
+
+      const pruned = await store.prune(activeItems);
+
+      expect(pruned).toBe(0);
+      expect(store.getState('gh', 'issue-1')).toBe('accepted');
+    });
+
+    it('should not prune when no active providers have items', async () => {
+      await store.setStates([
+        { providerId: 'gh', externalId: 'issue-1', state: 'unseen' },
+        { providerId: 'jira', externalId: 'task-1', state: 'accepted' },
+      ]);
+
+      const activeItems = new Map([
+        ['gh', []],
+        ['jira', []],
+      ]);
+
+      const pruned = await store.prune(activeItems);
+
+      expect(pruned).toBe(0);
+      expect(store.getState('gh', 'issue-1')).toBe('unseen');
+      expect(store.getState('jira', 'task-1')).toBe('accepted');
+    });
+
+    it('should only prune keys belonging to active providers', async () => {
+      await store.setStates([
+        { providerId: 'gh', externalId: 'issue-1', state: 'accepted' },
+        { providerId: 'gh', externalId: 'issue-2', state: 'accepted' },
+        { providerId: 'jira', externalId: 'task-1', state: 'dismissed' },
+      ]);
+
+      // Only 'gh' is in the active map; 'jira' is absent entirely.
+      const activeItems = new Map([
+        ['gh', [
+          { externalId: 'issue-1', title: 'Issue 1' },
+        ]],
+      ]);
+
+      const pruned = await store.prune(activeItems);
+
+      expect(pruned).toBe(1);
+      expect(store.getState('gh', 'issue-1')).toBe('accepted');
+      expect(store.getState('gh', 'issue-2')).toBeUndefined();
+      // jira records preserved — provider not in active map
+      expect(store.getState('jira', 'task-1')).toBe('dismissed');
+    });
+
+    it('should fire onDidChange when records are pruned', async () => {
+      await store.setState('gh', 'issue-1', 'accepted');
+      await store.setState('gh', 'issue-2', 'accepted');
+
+      const listener = vi.fn();
+      store.onDidChange(listener);
+
+      const activeItems = new Map([
+        ['gh', [{ externalId: 'issue-1', title: 'Issue 1' }]],
+      ]);
+
+      await store.prune(activeItems);
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not fire onDidChange when nothing is pruned', async () => {
+      await store.setState('gh', 'issue-1', 'accepted');
+
+      const listener = vi.fn();
+      store.onDidChange(listener);
+
+      const activeItems = new Map([
+        ['gh', [{ externalId: 'issue-1', title: 'Issue 1' }]],
+      ]);
+
+      await store.prune(activeItems);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('should return the count of pruned records', async () => {
+      await store.setStates([
+        { providerId: 'gh', externalId: 'issue-1', state: 'accepted' },
+        { providerId: 'gh', externalId: 'issue-2', state: 'dismissed' },
+        { providerId: 'gh', externalId: 'issue-3', state: 'unseen' },
+      ]);
+
+      const activeItems = new Map([
+        ['gh', [{ externalId: 'issue-1', title: 'Issue 1' }]],
+      ]);
+
+      const pruned = await store.prune(activeItems);
+      expect(pruned).toBe(2);
+    });
+  });
 });

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -583,6 +583,23 @@ describe('InboxTreeProvider', () => {
       const item: InboxItem = { kind: 'item', providerId: 'gh', externalId: '1', title: 'Bug' };
       expect((provider.getTreeItem(item).iconPath as any).id).toBe('circle-outline');
     });
+
+    it('should call stateStore.prune during debounced refresh', async () => {
+      registry._setItems('gh', [{ externalId: '1', title: 'Bug' }]);
+      registry._fire();
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+
+      expect(stateStore.prune).toHaveBeenCalledWith(registry.getAllDiscoveredItems());
+    });
+
+    it('should skip stateStore.prune while providers are loading', async () => {
+      registry._setItems('gh', [{ externalId: '1', title: 'Bug' }]);
+      registry._setLoading(true);
+      registry._fire();
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+
+      expect(stateStore.prune).not.toHaveBeenCalled();
+    });
   });
 
   describe('getTreeItem tooltip', () => {

--- a/packages/core/src/test/inboxTreeProvider.test.ts
+++ b/packages/core/src/test/inboxTreeProvider.test.ts
@@ -17,6 +17,7 @@ function createMockStateStore() {
     }),
     load: vi.fn(async () => {}),
     loadAll: vi.fn(async () => []),
+    prune: vi.fn(async () => 0),
     onDidChange: emitter.event,
     dispose: vi.fn(),
     _set: (providerId: string, externalId: string, state: string) => {

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -71,6 +71,9 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     this.refreshTimer = setTimeout(() => {
       this.refreshTimer = undefined;
       this.pruneSeenItems();
+      void this.stateStore.prune(this.providerRegistry.getAllDiscoveredItems()).catch(err =>
+        logger.error('Failed to prune discovered state', err)
+      );
       this._onDidChangeTreeData.fire();
     }, InboxTreeProvider.REFRESH_DEBOUNCE_MS);
   }

--- a/packages/core/src/views/inboxTreeProvider.ts
+++ b/packages/core/src/views/inboxTreeProvider.ts
@@ -71,9 +71,15 @@ export class InboxTreeProvider implements vscode.TreeDataProvider<InboxElement> 
     this.refreshTimer = setTimeout(() => {
       this.refreshTimer = undefined;
       this.pruneSeenItems();
-      void this.stateStore.prune(this.providerRegistry.getAllDiscoveredItems()).catch(err =>
-        logger.error('Failed to prune discovered state', err)
-      );
+      // Skip pruning while providers are still loading to avoid removing
+      // records for items that haven't been fetched yet.
+      // Note: prune() fires stateStore.onDidChange which re-triggers
+      // scheduleRefresh; the second pass finds nothing to prune and exits.
+      if (!this.providerRegistry.loading) {
+        void this.stateStore.prune(this.providerRegistry.getAllDiscoveredItems()).catch(err =>
+          logger.error('Failed to prune discovered state', err)
+        );
+      }
       this._onDidChangeTreeData.fire();
     }, InboxTreeProvider.REFRESH_DEBOUNCE_MS);
   }


### PR DESCRIPTION
## Summary

Add a `prune()` method to `DiscoveredStateStore` that removes persisted state records for items no longer present in any registered provider's discovered-items list. This prevents the discovered-state store from growing unbounded as issues are closed or PRs are merged upstream.

## Changes

- **`DiscoveredStateStore.prune(activeItems)`** — Iterates the in-memory cache and deletes records whose `providerId` belongs to an active provider but whose composite key is absent from the provider's current items. Providers with empty item arrays are skipped to survive transient API failures.
- **`InboxTreeProvider.scheduleRefresh()`** — Calls `stateStore.prune()` alongside the existing `pruneSeenItems()`, with the same `providerRegistry.loading` guard to avoid removing records during provider re-registration.
- **Tests** — 7 unit tests for the store method (stale removal, empty-provider skip, cross-provider isolation, event firing/non-firing, count) and 2 integration tests verifying the refresh-time call and loading guard.

## Design Notes

- Follows the existing store mutation pattern: lazy-load guard, cache mutation, `persist()`, `_onDidChange.fire()`.
- `prune()` firing `onDidChange` triggers one harmless re-entry through `scheduleRefresh` (the second pass finds nothing to prune). A comment documents this.
- Provider items are references, not copies — only the thin inbox-state enum is pruned.

Closes #401
