### PR TITLE
Migrate view layout storage from configuration to globalState

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -404,7 +404,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const initStart = performance.now();
   const storagePath = context.globalStorageUri.fsPath;
   await migrateToGlobalState(context.globalState, storagePath);
-  initViewLayoutStore(context.globalState);
+  await initViewLayoutStore(context.globalState);
   const { workGraph: wg, stateStore: ss, readStateStore, labelCache } = await loadStores(context.globalState);
   await migrateDiscoveredState(wg, ss);
 

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -30,7 +30,7 @@ import { initLogger, setLogLevel, logger, resolveLogLevel } from './services/log
 import { getInboxUnseenCount } from './services/inboxBadge';
 import { syncProviderTitles } from './services/titleSync';
 import { syncProviderDescriptions } from './services/descriptionSync';
-import { getViewLayout, ViewId } from './views/viewLayout';
+import { getViewLayout, initViewLayoutStore, onDidChangeLayout, ViewId } from './views/viewLayout';
 import { performance } from 'perf_hooks';
 
 export type { DevDocketApi, DevDocketProvider, DevDocketAction, DiscoveredItem, Disposable, ActivityLogEntry, ActivityType, StateTransitionEvent, DevDocketPRWatcher } from './api/types';
@@ -404,6 +404,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const initStart = performance.now();
   const storagePath = context.globalStorageUri.fsPath;
   await migrateToGlobalState(context.globalState, storagePath);
+  initViewLayoutStore(context.globalState);
   const { workGraph: wg, stateStore: ss, readStateStore, labelCache } = await loadStores(context.globalState);
   await migrateDiscoveredState(wg, ss);
 
@@ -491,15 +492,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     void vscode.commands.executeCommand('setContext', `devdocket.${id}Layout`, getViewLayout(id));
   }
   context.subscriptions.push(
-    vscode.workspace.onDidChangeConfiguration(safeHandler('Error handling viewLayout configuration change', (e) => {
-      if (e.affectsConfiguration('devDocket.viewLayout')) {
-        for (const id of viewIds) {
-          const layout = getViewLayout(id);
-          providerMap[id].layout = layout;
-          void vscode.commands.executeCommand('setContext', `devdocket.${id}Layout`, layout);
-        }
-      }
-    })),
+    onDidChangeLayout((viewId, layout) => {
+      providerMap[viewId].layout = layout;
+      void vscode.commands.executeCommand('setContext', `devdocket.${viewId}Layout`, layout);
+    }),
   );
 
   logger.info(`DevDocket activated in ${Math.round(performance.now() - activationStart)}ms`);

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import * as vscode from 'vscode';
 import { MockMemento } from 'vscode';
 import { activate, deactivate, logger } from '../extension';
+import { _resetViewLayoutStore } from '../views/viewLayout';
 
 // Stub fs so migration never touches disk
 vi.mock('fs/promises', () => ({
@@ -38,6 +39,7 @@ describe('activate()', () => {
   });
 
   afterEach(() => {
+    _resetViewLayoutStore();
     // Dispose everything activate pushed into subscriptions.
     // Surface disposal errors so cleanup bugs are caught.
     const errors: unknown[] = [];
@@ -486,52 +488,28 @@ describe('activate()', () => {
   });
 
   // ------------------------------------------------------------------
-  // 19. Layout config change updates provider layouts and context keys
+  // 19. Layout change updates provider layouts and context keys
   // ------------------------------------------------------------------
-  it('updates provider layouts and context keys on configuration change', async () => {
+  it('updates provider layouts and context keys on layout toggle', async () => {
     await activate(context);
     await flushMicrotasks();
 
     const executeCommand = vscode.commands.executeCommand as ReturnType<typeof vi.fn>;
     executeCommand.mockClear();
 
-    // Simulate a configuration change for devdocket.viewLayout
-    const onDidChangeCfg = vscode.workspace.onDidChangeConfiguration as ReturnType<typeof vi.fn>;
-    // Find the viewLayout config listener (the last registered one)
-    const listeners = onDidChangeCfg.mock.calls.map((c: any[]) => c[0]);
-    expect(listeners.length).toBeGreaterThan(0);
+    // Import the functions to trigger a layout change
+    const { toggleViewLayout } = await import('../views/viewLayout');
 
-    // Mock getConfiguration to return a specific layout
-    (vscode.workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
-      get: vi.fn((_key: string) => {
-        if (_key === 'viewLayout') { return { focus: 'tree', queue: 'tree' }; }
-        return undefined;
-      }),
-      update: vi.fn().mockResolvedValue(undefined),
-      inspect: vi.fn(() => undefined),
-    });
-
-    // Fire configuration change event on all listeners
-    for (const listener of listeners) {
-      listener({ affectsConfiguration: (section: string) => section === 'devDocket.viewLayout' });
-    }
+    // Toggle focus from default 'flat' → 'tree'
+    await toggleViewLayout('focus');
     await flushMicrotasks();
 
-    // setContext should have been called for all five views
+    // setContext should have been called for the toggled view
     const setContextCalls = executeCommand.mock.calls.filter(
       (c: any[]) => c[0] === 'setContext' && typeof c[1] === 'string' && c[1].endsWith('Layout'),
     );
-    const contextKeys = setContextCalls.map((c: any[]) => c[1]);
-    expect(contextKeys).toContain('devdocket.focusLayout');
-    expect(contextKeys).toContain('devdocket.queueLayout');
-
-    // Verify context key values reflect the updated layout
     const contextMap = Object.fromEntries(setContextCalls.map((c: any[]) => [c[1], c[2]]));
     expect(contextMap['devdocket.focusLayout']).toBe('tree');
-    expect(contextMap['devdocket.queueLayout']).toBe('tree');
-    // Views not in the override should still have their defaults
-    expect(contextMap['devdocket.inboxLayout']).toBe('tree');
-    expect(contextMap['devdocket.historyLayout']).toBe('flat');
   });
 });
 

--- a/packages/core/src/test/viewLayout.test.ts
+++ b/packages/core/src/test/viewLayout.test.ts
@@ -1,151 +1,88 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { workspace, ConfigurationTarget, window } from 'vscode';
-import { getViewLayout, toggleViewLayout, isProviderGroupNode, ProviderGroupNode, LayoutState } from '../views/viewLayout';
+import { MockMemento } from 'vscode';
+import { getViewLayout, toggleViewLayout, isProviderGroupNode, ProviderGroupNode, LayoutState, initViewLayoutStore, onDidChangeLayout, _resetViewLayoutStore } from '../views/viewLayout';
 
 describe('viewLayout', () => {
+  let memento: InstanceType<typeof MockMemento>;
+
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetViewLayoutStore();
+    memento = new MockMemento();
+    initViewLayoutStore(memento);
   });
 
   describe('getViewLayout', () => {
-    it('returns default "tree" for inbox when no config set', () => {
+    it('returns default "tree" for inbox when no state set', () => {
       expect(getViewLayout('inbox')).toBe('tree');
     });
 
-    it('returns default "flat" for queue when no config set', () => {
+    it('returns default "flat" for queue when no state set', () => {
       expect(getViewLayout('queue')).toBe('flat');
     });
 
-    it('returns default "flat" for focus when no config set', () => {
+    it('returns default "flat" for focus when no state set', () => {
       expect(getViewLayout('focus')).toBe('flat');
     });
 
-    it('returns default "flat" for history when no config set', () => {
+    it('returns default "flat" for history when no state set', () => {
       expect(getViewLayout('history')).toBe('flat');
     });
 
-    it('returns default "tree" for sources when no config set', () => {
+    it('returns default "tree" for sources when no state set', () => {
       expect(getViewLayout('sources')).toBe('tree');
     });
 
-    it('returns configured value when set', () => {
-      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
-        get: vi.fn((_key: string, defaultValue?: any) => {
-          if (_key === 'viewLayout') { return { inbox: 'flat' }; }
-          return defaultValue;
-        }),
-      });
+    it('returns stored value when set', async () => {
+      await memento.update('devdocket.viewLayout', { inbox: 'flat' });
       expect(getViewLayout('inbox')).toBe('flat');
     });
 
-    it('falls back to default for invalid values', () => {
-      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
-        get: vi.fn((_key: string, defaultValue?: any) => {
-          if (_key === 'viewLayout') { return { inbox: 'invalid' }; }
-          return defaultValue;
-        }),
-      });
+    it('falls back to default for invalid values', async () => {
+      await memento.update('devdocket.viewLayout', { inbox: 'invalid' });
       expect(getViewLayout('inbox')).toBe('tree');
     });
   });
 
   describe('toggleViewLayout', () => {
     it('toggles from tree to flat', async () => {
-      const mockUpdate = vi.fn().mockResolvedValue(undefined);
-      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
-        get: vi.fn((_key: string, defaultValue?: any) => {
-          if (_key === 'viewLayout') { return { inbox: 'tree' }; }
-          return defaultValue;
-        }),
-        update: mockUpdate,
-        inspect: vi.fn(() => undefined),
-      });
+      await memento.update('devdocket.viewLayout', { inbox: 'tree' });
 
       await toggleViewLayout('inbox');
-      expect(mockUpdate).toHaveBeenCalledWith(
-        'viewLayout',
-        expect.objectContaining({ inbox: 'flat' }),
-        ConfigurationTarget.Global,
-      );
+      const stored = memento.get<Record<string, string>>('devdocket.viewLayout');
+      expect(stored?.inbox).toBe('flat');
     });
 
     it('toggles from flat to tree', async () => {
-      const mockUpdate = vi.fn().mockResolvedValue(undefined);
-      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
-        get: vi.fn((_key: string, defaultValue?: any) => {
-          if (_key === 'viewLayout') { return { queue: 'flat' }; }
-          return defaultValue;
-        }),
-        update: mockUpdate,
-        inspect: vi.fn(() => undefined),
-      });
+      await memento.update('devdocket.viewLayout', { queue: 'flat' });
 
       await toggleViewLayout('queue');
-      expect(mockUpdate).toHaveBeenCalledWith(
-        'viewLayout',
-        expect.objectContaining({ queue: 'tree' }),
-        ConfigurationTarget.Global,
-      );
+      const stored = memento.get<Record<string, string>>('devdocket.viewLayout');
+      expect(stored?.queue).toBe('tree');
     });
 
-    it('uses default when no config exists yet', async () => {
-      const mockUpdate = vi.fn().mockResolvedValue(undefined);
-      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
-        get: vi.fn((_key: string, defaultValue?: any) => defaultValue),
-        update: mockUpdate,
-        inspect: vi.fn(() => undefined),
-      });
-
+    it('uses default when no state exists yet', async () => {
       // sources defaults to 'tree', so toggle should set to 'flat'
       await toggleViewLayout('sources');
-      expect(mockUpdate).toHaveBeenCalledWith(
-        'viewLayout',
-        expect.objectContaining({ sources: 'flat' }),
-        ConfigurationTarget.Global,
-      );
+      const stored = memento.get<Record<string, string>>('devdocket.viewLayout');
+      expect(stored?.sources).toBe('flat');
     });
 
-    it('updates workspace scope when workspaceValue exists', async () => {
-      const mockUpdate = vi.fn().mockResolvedValue(undefined);
-      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
-        get: vi.fn((_key: string) => {
-          if (_key === 'viewLayout') { return { focus: 'flat' }; }
-          return undefined;
-        }),
-        update: mockUpdate,
-        inspect: vi.fn(() => ({
-          workspaceValue: { focus: 'flat' },
-        })),
-      });
-
-      await toggleViewLayout('focus');
-      expect(mockUpdate).toHaveBeenCalledWith(
-        'viewLayout',
-        expect.objectContaining({ focus: 'tree' }),
-        ConfigurationTarget.Workspace,
-      );
-    });
-
-    it('prefers workspace scope even when workspaceFolder value exists', async () => {
-      const mockUpdate = vi.fn().mockResolvedValue(undefined);
-      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
-        get: vi.fn((_key: string) => {
-          if (_key === 'viewLayout') { return { inbox: 'flat' }; }
-          return undefined;
-        }),
-        update: mockUpdate,
-        inspect: vi.fn(() => ({
-          workspaceValue: { inbox: 'flat' },
-          workspaceFolderValue: { inbox: 'flat' },
-        })),
-      });
+    it('fires onDidChangeLayout listener', async () => {
+      const listener = vi.fn();
+      onDidChangeLayout(listener);
 
       await toggleViewLayout('inbox');
-      expect(mockUpdate).toHaveBeenCalledWith(
-        'viewLayout',
-        expect.objectContaining({ inbox: 'tree' }),
-        ConfigurationTarget.Workspace,
-      );
+      expect(listener).toHaveBeenCalledWith('inbox', 'flat');
+    });
+
+    it('stops firing after dispose', async () => {
+      const listener = vi.fn();
+      const sub = onDidChangeLayout(listener);
+      sub.dispose();
+
+      await toggleViewLayout('inbox');
+      expect(listener).not.toHaveBeenCalled();
     });
   });
 
@@ -179,82 +116,39 @@ describe('viewLayout', () => {
 
   describe('toggleViewLayout — edge cases', () => {
     it('preserves sibling view layouts when toggling one view', async () => {
-      const mockUpdate = vi.fn().mockResolvedValue(undefined);
-      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
-        get: vi.fn((_key: string) => {
-          if (_key === 'viewLayout') { return { inbox: 'tree', queue: 'tree', focus: 'tree' }; }
-          return undefined;
-        }),
-        update: mockUpdate,
-        inspect: vi.fn(() => ({
-          globalValue: { inbox: 'tree', queue: 'tree', focus: 'tree' },
-        })),
-      });
+      await memento.update('devdocket.viewLayout', { inbox: 'tree', queue: 'tree', focus: 'tree' });
 
       await toggleViewLayout('inbox');
-      const persisted = mockUpdate.mock.calls[0][1];
-      expect(persisted.inbox).toBe('flat');
-      expect(persisted.queue).toBe('tree');
-      expect(persisted.focus).toBe('tree');
+      const stored = memento.get<Record<string, string>>('devdocket.viewLayout')!;
+      expect(stored.inbox).toBe('flat');
+      expect(stored.queue).toBe('tree');
+      expect(stored.focus).toBe('tree');
     });
 
-    it('strips invalid view IDs from stored config during toggle', async () => {
-      const mockUpdate = vi.fn().mockResolvedValue(undefined);
-      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
-        get: vi.fn((_key: string) => {
-          if (_key === 'viewLayout') { return { inbox: 'tree', bogusView: 'flat' }; }
-          return undefined;
-        }),
-        update: mockUpdate,
-        inspect: vi.fn(() => ({
-          globalValue: { inbox: 'tree', bogusView: 'flat' },
-        })),
-      });
+    it('strips invalid view IDs from stored state during toggle', async () => {
+      await memento.update('devdocket.viewLayout', { inbox: 'tree', bogusView: 'flat' });
 
       await toggleViewLayout('inbox');
-      const persisted = mockUpdate.mock.calls[0][1];
-      expect(persisted.inbox).toBe('flat');
-      expect(persisted).not.toHaveProperty('bogusView');
+      const stored = memento.get<Record<string, string>>('devdocket.viewLayout')!;
+      expect(stored.inbox).toBe('flat');
+      expect(stored).not.toHaveProperty('bogusView');
     });
 
-    it('strips invalid layout values from stored config during toggle', async () => {
-      const mockUpdate = vi.fn().mockResolvedValue(undefined);
-      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
-        get: vi.fn((_key: string) => {
-          if (_key === 'viewLayout') { return { inbox: 'tree', focus: 'invalid' }; }
-          return undefined;
-        }),
-        update: mockUpdate,
-        inspect: vi.fn(() => ({
-          globalValue: { inbox: 'tree', focus: 'invalid' },
-        })),
-      });
+    it('strips invalid layout values from stored state during toggle', async () => {
+      await memento.update('devdocket.viewLayout', { inbox: 'tree', focus: 'invalid' });
 
       await toggleViewLayout('inbox');
-      const persisted = mockUpdate.mock.calls[0][1];
-      expect(persisted.inbox).toBe('flat');
-      expect(persisted).not.toHaveProperty('focus');
+      const stored = memento.get<Record<string, string>>('devdocket.viewLayout')!;
+      expect(stored.inbox).toBe('flat');
+      expect(stored).not.toHaveProperty('focus');
     });
 
-    it('reads from globalValue scope when no workspaceValue exists', async () => {
-      const mockUpdate = vi.fn().mockResolvedValue(undefined);
-      (workspace.getConfiguration as ReturnType<typeof vi.fn>).mockReturnValue({
-        get: vi.fn((_key: string) => {
-          if (_key === 'viewLayout') { return { history: 'tree' }; }
-          return undefined;
-        }),
-        update: mockUpdate,
-        inspect: vi.fn(() => ({
-          globalValue: { history: 'tree' },
-        })),
-      });
+    it('persists to globalState', async () => {
+      await memento.update('devdocket.viewLayout', { history: 'tree' });
 
       await toggleViewLayout('history');
-      expect(mockUpdate).toHaveBeenCalledWith(
-        'viewLayout',
-        expect.objectContaining({ history: 'flat' }),
-        ConfigurationTarget.Global,
-      );
+      const stored = memento.get<Record<string, string>>('devdocket.viewLayout')!;
+      expect(stored.history).toBe('flat');
     });
   });
 

--- a/packages/core/src/test/viewLayout.test.ts
+++ b/packages/core/src/test/viewLayout.test.ts
@@ -5,11 +5,11 @@ import { getViewLayout, toggleViewLayout, isProviderGroupNode, ProviderGroupNode
 describe('viewLayout', () => {
   let memento: InstanceType<typeof MockMemento>;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
     _resetViewLayoutStore();
     memento = new MockMemento();
-    initViewLayoutStore(memento);
+    await initViewLayoutStore(memento);
   });
 
   describe('getViewLayout', () => {

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -15,17 +15,47 @@ const VIEW_DEFAULTS: Record<ViewId, ViewLayout> = {
   watches: 'flat',
 };
 
+const STORAGE_KEY = 'devdocket.viewLayout';
+
+const VALID_VIEW_IDS: ReadonlySet<string> = new Set<ViewId>(['inbox', 'queue', 'focus', 'history', 'sources', 'watches']);
+
+let globalState: vscode.Memento | undefined;
+const changeListeners: Array<(viewId: ViewId, layout: ViewLayout) => void> = [];
+
 /**
- * Read the persisted layout for a given view, falling back to its default.
- * 
- * Note: Layout state is stored in VS Code configuration (devDocket.viewLayout)
- * but is not exposed in the settings UI. Users control layout via the UI toggle
- * in each view's title bar. This could be migrated to globalState in the future
- * (see team decision #304).
+ * Initialize the view-layout store with a Memento backend.
+ * Must be called once during activation before any read/write.
+ *
+ * Performs a one-time migration from the legacy configuration-based
+ * storage (`devDocket.viewLayout` in VS Code settings) if globalState
+ * has no layouts yet.
  */
+export function initViewLayoutStore(memento: vscode.Memento): void {
+  globalState = memento;
+
+  // One-time migration from legacy config-based storage
+  if (globalState.get(STORAGE_KEY) === undefined) {
+    const config = vscode.workspace.getConfiguration('devDocket');
+    const legacy: unknown = config.get('viewLayout');
+    const migrated = sanitizeLayouts(legacy);
+    if (Object.keys(migrated).length > 0) {
+      void globalState.update(STORAGE_KEY, migrated);
+    }
+  }
+}
+
+/** Subscribe to layout changes. Returns a disposable that removes the listener. */
+export function onDidChangeLayout(listener: (viewId: ViewId, layout: ViewLayout) => void): vscode.Disposable {
+  changeListeners.push(listener);
+  return { dispose: () => { const i = changeListeners.indexOf(listener); if (i >= 0) { changeListeners.splice(i, 1); } } };
+}
+
+/** Read the persisted layout for a given view, falling back to its default. */
 export function getViewLayout(viewId: ViewId): ViewLayout {
-  const config = vscode.workspace.getConfiguration('devDocket');
-  const layoutsRaw: unknown = config.get('viewLayout');
+  if (!globalState) {
+    return VIEW_DEFAULTS[viewId];
+  }
+  const layoutsRaw: unknown = globalState.get(STORAGE_KEY);
   const layouts = (layoutsRaw && typeof layoutsRaw === 'object' && !Array.isArray(layoutsRaw))
     ? layoutsRaw as Record<string, unknown>
     : {};
@@ -35,8 +65,6 @@ export function getViewLayout(viewId: ViewId): ViewLayout {
   }
   return VIEW_DEFAULTS[viewId];
 }
-
-const VALID_VIEW_IDS: ReadonlySet<string> = new Set<ViewId>(['inbox', 'queue', 'focus', 'history', 'sources', 'watches']);
 
 /** Extract only valid ViewId keys with valid ViewLayout values from an unknown object. */
 function sanitizeLayouts(raw: unknown): Record<string, string> {
@@ -68,19 +96,21 @@ export async function setViewLayout(viewId: ViewId, layout: ViewLayout): Promise
 }
 
 async function applyViewLayout(viewId: ViewId, layout: ViewLayout): Promise<void> {
-  const config = vscode.workspace.getConfiguration('devDocket');
+  if (!globalState) {
+    throw new Error('View layout store not initialized — call initViewLayoutStore() first');
+  }
+  const existing = sanitizeLayouts(globalState.get(STORAGE_KEY));
+  existing[viewId] = layout;
+  await globalState.update(STORAGE_KEY, existing);
+  for (const listener of changeListeners) {
+    listener(viewId, layout);
+  }
+}
 
-  const inspection = config.inspect('viewLayout');
-  const hasWorkspaceValue = inspection?.workspaceValue !== undefined;
-  const scopeValue = hasWorkspaceValue ? inspection.workspaceValue : inspection?.globalValue;
-  const target = hasWorkspaceValue
-    ? vscode.ConfigurationTarget.Workspace
-    : vscode.ConfigurationTarget.Global;
-
-  const layouts = sanitizeLayouts(scopeValue);
-  layouts[viewId] = layout;
-
-  await config.update('viewLayout', layouts, target);
+/** @internal — reset module state between tests. */
+export function _resetViewLayoutStore(): void {
+  globalState = undefined;
+  changeListeners.length = 0;
 }
 
 /**

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -30,7 +30,7 @@ const changeListeners: Array<(viewId: ViewId, layout: ViewLayout) => void> = [];
  * storage (`devDocket.viewLayout` in VS Code settings) if globalState
  * has no layouts yet.
  */
-export function initViewLayoutStore(memento: vscode.Memento): void {
+export async function initViewLayoutStore(memento: vscode.Memento): Promise<void> {
   globalState = memento;
 
   // One-time migration from legacy config-based storage
@@ -39,7 +39,7 @@ export function initViewLayoutStore(memento: vscode.Memento): void {
     const legacy: unknown = config.get('viewLayout');
     const migrated = sanitizeLayouts(legacy);
     if (Object.keys(migrated).length > 0) {
-      void globalState.update(STORAGE_KEY, migrated);
+      await globalState.update(STORAGE_KEY, migrated);
     }
   }
 }
@@ -102,8 +102,12 @@ async function applyViewLayout(viewId: ViewId, layout: ViewLayout): Promise<void
   const existing = sanitizeLayouts(globalState.get(STORAGE_KEY));
   existing[viewId] = layout;
   await globalState.update(STORAGE_KEY, existing);
-  for (const listener of changeListeners) {
-    listener(viewId, layout);
+  for (const listener of [...changeListeners]) {
+    try {
+      listener(viewId, layout);
+    } catch {
+      // Isolate listener errors so remaining listeners still fire
+    }
   }
 }
 

--- a/packages/core/src/views/viewLayout.ts
+++ b/packages/core/src/views/viewLayout.ts
@@ -24,7 +24,8 @@ const changeListeners: Array<(viewId: ViewId, layout: ViewLayout) => void> = [];
 
 /**
  * Initialize the view-layout store with a Memento backend.
- * Must be called once during activation before any read/write.
+ * Must be called once during activation before any persist operation.
+ * Reads (getViewLayout) return defaults if called before init.
  *
  * Performs a one-time migration from the legacy configuration-based
  * storage (`devDocket.viewLayout` in VS Code settings) if globalState


### PR DESCRIPTION
Migrate view layout storage from VS Code configuration to globalState

## Summary

The `devDocket.viewLayout` configuration key was intentionally removed from `package.json`, causing VS Code to reject writes when toggling view layouts (`Unable to write to User Settings because devDocket.viewLayout is not a registered configuration`).

This PR migrates layout persistence to `globalState` (Memento), consistent with all other stores in the extension.

## Changes

- **`viewLayout.ts`** — Replace `vscode.workspace.getConfiguration` reads/writes with `globalState`. Add `initViewLayoutStore()` for activation-time initialization with a one-time migration from legacy config. Add `onDidChangeLayout` event emitter for change notifications. Isolate listener errors with try/catch.
- **`extension.ts`** — Call `await initViewLayoutStore(context.globalState)` during activation. Replace `onDidChangeConfiguration` listener with `onDidChangeLayout` subscription.
- **Tests** — Updated to use `MockMemento` instead of mocking `workspace.getConfiguration`.

## Notes

- Workspace-scoped layout overrides (previously supported via `ConfigurationTarget.Workspace`) are dropped — `globalState` is global-only. This was an unused capability.
- Existing users' layouts are preserved via a one-time migration that reads from the legacy config on first activation.

Closes #413
