### PR TITLE
Build @devdocket/shared as a compiled package with declarations

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "npm run build --workspaces",
-    "build:prod": "npm run build:prod --workspaces",
+    "build": "npm run build -w @devdocket/shared && npm run build --workspaces",
+    "build:prod": "npm run build:prod -w @devdocket/shared && npm run build:prod --workspaces",
     "test": "npm run test --workspaces",
     "lint": "npm run lint --workspaces"
   }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
-    "build:prod": "tsc",
+    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
+    "build:prod": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
     "test": "vitest run",
     "lint": "echo No lint needed"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "build:prod": "tsc",
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
-    "prepare": "tsc",
+    "prepare": "npm run build",
     "test": "vitest run",
     "lint": "echo No lint needed"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,6 +8,7 @@
     "build": "tsc",
     "build:prod": "tsc",
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
+    "prepare": "tsc",
     "test": "vitest run",
     "lint": "echo No lint needed"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,8 +5,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
-    "build:prod": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\" && tsc",
+    "build": "tsc",
+    "build:prod": "tsc",
+    "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "test": "vitest run",
     "lint": "echo No lint needed"
   },

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,11 +2,11 @@
   "name": "@devdocket/shared",
   "version": "0.1.0",
   "private": true,
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
-    "build": "echo No build needed",
-    "build:prod": "echo No build needed",
+    "build": "tsc",
+    "build:prod": "tsc",
     "test": "vitest run",
     "lint": "echo No lint needed"
   },

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "sourceMap": true,
+    "declaration": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "src/test"]
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -11,7 +11,8 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist", "src/test"]


### PR DESCRIPTION
Add a build step to `packages/shared` that compiles TypeScript to JavaScript with type declarations (`dist/`), and have consumer packages reference the built output.

## Changes

- Created `packages/shared/tsconfig.json` with `declaration: true` and `outDir: "dist/"` matching other packages' conventions
- Updated `packages/shared/package.json`: `main` → `dist/index.js`, `types` → `dist/index.d.ts`, build scripts → `tsc`
- Updated root `package.json` build scripts to ensure shared builds first before consumers

This validates that `@devdocket/shared` works as a proper compiled package contract — catching issues like missing exports, incorrect declaration files, or broken type references before they'd affect external consumers.

Closes #412
