### PR TITLE
Add independent per-package publishing workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,12 +36,25 @@ jobs:
               ;;
           esac
 
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::Version '$VERSION' is not valid semver"
+            exit 1
+          fi
+
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "package_dir=$PACKAGE_DIR" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
+
+      - name: Verify version matches tag
+        run: |
+          PKG_VERSION=$(node -p "require('./${{ steps.parse.outputs.package_dir }}/package.json').version")
+          if [ "$PKG_VERSION" != "${{ steps.parse.outputs.version }}" ]; then
+            echo "::error::Tag version (${{ steps.parse.outputs.version }}) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
 
       - uses: actions/setup-node@v4
         with:
@@ -54,7 +67,9 @@ jobs:
         run: cd packages/shared && npm run build
 
       - name: Build target package
-        run: cd ${{ steps.parse.outputs.package_dir }} && npm run build:prod
+        run: |
+          cd ${{ steps.parse.outputs.package_dir }}
+          npm run build:prod --if-present || npm run build
 
       - name: Package extension
         run: cd ${{ steps.parse.outputs.package_dir }} && npx vsce package
@@ -66,8 +81,13 @@ jobs:
 
       - name: Create GitHub Release
         run: |
+          VSIX_FILE=$(ls ${{ steps.parse.outputs.package_dir }}/*.vsix)
+          if [ -z "$VSIX_FILE" ]; then
+            echo "::error::No .vsix file found"
+            exit 1
+          fi
           gh release create "${{ steps.parse.outputs.tag }}" \
-            ${{ steps.parse.outputs.package_dir }}/*.vsix \
+            "$VSIX_FILE" \
             --title "${{ steps.parse.outputs.tag }}" \
             --generate-notes
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -123,7 +123,7 @@ jobs:
 
       - name: Generate release notes
         run: |
-          PREV_TAG=$(git tag -l '${{ steps.parse.outputs.package_name }}-v*' --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
+          PREV_TAG=$(git tag -l '${{ steps.parse.outputs.package_name }}-v*' --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1 || true)
           if [ -n "$PREV_TAG" ]; then
             RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
           else

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,74 @@
+name: Publish Extension
+
+on:
+  push:
+    tags:
+      - 'core-v*'
+      - 'github-v*'
+      - 'ado-v*'
+      - 'start-git-work-v*'
+      - 'ai-reviewer-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse tag
+        id: parse
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          # Extract package prefix (everything before the last -vX.Y.Z)
+          PACKAGE_NAME="${TAG%-v*}"
+          VERSION="${TAG#*-v}"
+
+          case "$PACKAGE_NAME" in
+            core)           PACKAGE_DIR="packages/core" ;;
+            github)         PACKAGE_DIR="packages/github" ;;
+            ado)            PACKAGE_DIR="packages/ado" ;;
+            start-git-work) PACKAGE_DIR="packages/start-git-work" ;;
+            ai-reviewer)    PACKAGE_DIR="packages/ai-reviewer" ;;
+            *)
+              echo "::error::Unknown package prefix: $PACKAGE_NAME"
+              exit 1
+              ;;
+          esac
+
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "package_name=$PACKAGE_NAME" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "package_dir=$PACKAGE_DIR" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared
+        run: cd packages/shared && npm run build
+
+      - name: Build target package
+        run: cd ${{ steps.parse.outputs.package_dir }} && npm run build:prod
+
+      - name: Package extension
+        run: cd ${{ steps.parse.outputs.package_dir }} && npx vsce package
+
+      - name: Publish extension
+        run: cd ${{ steps.parse.outputs.package_dir }} && npx vsce publish
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Create GitHub Release
+        run: |
+          gh release create "${{ steps.parse.outputs.tag }}" \
+            ${{ steps.parse.outputs.package_dir }}/*.vsix \
+            --title "${{ steps.parse.outputs.tag }}" \
+            --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -121,6 +121,20 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
+      - name: Generate release notes
+        run: |
+          PREV_TAG=$(git tag -l '${{ steps.parse.outputs.package_name }}-v*' --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
+          if [ -n "$PREV_TAG" ]; then
+            RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
+          else
+            RANGE="$GITHUB_REF_NAME"
+          fi
+          NOTES=$(git log "$RANGE" --pretty=format:"* %s (%h)" -- "${{ steps.parse.outputs.package_dir }}/")
+          if [ -z "$NOTES" ]; then
+            NOTES="* No notable changes in this release"
+          fi
+          printf '%s\n' "$NOTES" > release-notes.md
+
       - name: Create GitHub Release
         run: |
           shopt -s nullglob
@@ -133,6 +147,6 @@ jobs:
           gh release create "${{ steps.parse.outputs.tag }}" \
             "$VSIX_FILE" \
             --title "${{ steps.parse.outputs.tag }}" \
-            --generate-notes
+            --notes-file release-notes.md
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  packages: read
 
 jobs:
   publish:
@@ -63,8 +64,24 @@ jobs:
             exit 1
           fi
 
-      - name: Build shared
-        run: cd packages/shared && npm run build
+      - name: Install @devdocket/shared from registry
+        run: |
+          # Replace workspace-linked @devdocket/shared with the published package
+          # from GitHub Packages. Extensions use esbuild --bundle which inlines
+          # shared code, so this ensures prod builds bundle the same artifact
+          # that third-party consumers install.
+          # (See publish-shared.yml for how @devdocket/shared is published.)
+          rm -rf node_modules/@devdocket/shared
+          TMPDIR=$(mktemp -d)
+          cd "$TMPDIR"
+          echo '@devdocket:registry=https://npm.pkg.github.com' > .npmrc
+          echo '//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}' >> .npmrc
+          echo '{"dependencies":{"@devdocket/shared":"*"}}' > package.json
+          npm install
+          cp -r node_modules/@devdocket/shared "$GITHUB_WORKSPACE/node_modules/@devdocket/shared"
+          rm -rf "$TMPDIR"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build target package
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           # Extract package prefix (everything before the last -vX.Y.Z)
           PACKAGE_NAME="${TAG%-v*}"
-          VERSION="${TAG#*-v}"
+          VERSION="${TAG##*-v}"
 
           case "$PACKAGE_NAME" in
             core)           PACKAGE_DIR="packages/core" ;;

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,10 +48,13 @@ jobs:
           echo "package_dir=$PACKAGE_DIR" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -71,12 +74,15 @@ jobs:
           # shared code, so this ensures prod builds bundle the same artifact
           # that third-party consumers install.
           # (See publish-shared.yml for how @devdocket/shared is published.)
+          SHARED_VERSION=$(node -p "require('./packages/shared/package.json').version")
           rm -rf node_modules/@devdocket/shared
           TMPDIR=$(mktemp -d)
           cd "$TMPDIR"
           echo '@devdocket:registry=https://npm.pkg.github.com' > .npmrc
+          # npm expands ${NODE_AUTH_TOKEN} at runtime from the environment;
+          # single quotes are intentional to avoid premature shell expansion.
           echo '//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}' >> .npmrc
-          echo '{"dependencies":{"@devdocket/shared":"*"}}' > package.json
+          echo "{\"dependencies\":{\"@devdocket/shared\":\"$SHARED_VERSION\"}}" > package.json
           npm install
           cp -r node_modules/@devdocket/shared "$GITHUB_WORKSPACE/node_modules/@devdocket/shared"
           rm -rf "$TMPDIR"
@@ -85,7 +91,7 @@ jobs:
 
       - name: Build target package
         run: |
-          cd ${{ steps.parse.outputs.package_dir }}
+          cd "${{ steps.parse.outputs.package_dir }}"
           if node -e "process.exit(require('./package.json').scripts && require('./package.json').scripts['build:prod'] ? 0 : 1)"; then
             npm run build:prod
           else
@@ -93,17 +99,17 @@ jobs:
           fi
 
       - name: Package extension
-        run: cd ${{ steps.parse.outputs.package_dir }} && npx @vscode/vsce package
+        run: cd "${{ steps.parse.outputs.package_dir }}" && npx @vscode/vsce package
 
       - name: Publish extension
-        run: cd ${{ steps.parse.outputs.package_dir }} && npx @vscode/vsce publish
+        run: cd "${{ steps.parse.outputs.package_dir }}" && npx @vscode/vsce publish
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       - name: Create GitHub Release
         run: |
           shopt -s nullglob
-          VSIX_FILES=( ${{ steps.parse.outputs.package_dir }}/*.vsix )
+          VSIX_FILES=( "${{ steps.parse.outputs.package_dir }}"/*.vsix )
           if [ ${#VSIX_FILES[@]} -ne 1 ]; then
             echo "::error::Expected exactly 1 .vsix file, found ${#VSIX_FILES[@]}"
             exit 1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,23 @@ jobs:
         id: parse
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
-          # Extract package prefix (everything before the last -vX.Y.Z)
-          PACKAGE_NAME="${TAG%-v*}"
-          VERSION="${TAG##*-v}"
+
+          # Match against known package prefixes to extract name and version.
+          # This avoids ambiguity when semver pre-release metadata contains "-v".
+          PACKAGE_NAME=""
+          VERSION=""
+          for PREFIX in core github ado start-git-work ai-reviewer; do
+            if [[ "$TAG" == "$PREFIX-v"* ]]; then
+              PACKAGE_NAME="$PREFIX"
+              VERSION="${TAG#"$PREFIX-v"}"
+              break
+            fi
+          done
+
+          if [ -z "$PACKAGE_NAME" ]; then
+            echo "::error::Tag '$TAG' does not match any known package prefix"
+            exit 1
+          fi
 
           case "$PACKAGE_NAME" in
             core)           PACKAGE_DIR="packages/core" ;;

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
               ;;
           esac
 
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
+          if ! echo "$VERSION" | grep -qE '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
             echo "::error::Version '$VERSION' is not valid semver"
             exit 1
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,11 +22,21 @@ jobs:
         run: |
           TAG="${GITHUB_REF#refs/tags/}"
 
+          # Single mapping of package prefix → directory.
+          # Keep in sync with the tag triggers in on.push.tags above.
+          declare -A PACKAGE_DIRS=(
+            [core]="packages/core"
+            [github]="packages/github"
+            [ado]="packages/ado"
+            [start-git-work]="packages/start-git-work"
+            [ai-reviewer]="packages/ai-reviewer"
+          )
+
           # Match against known package prefixes to extract name and version.
           # This avoids ambiguity when semver pre-release metadata contains "-v".
           PACKAGE_NAME=""
           VERSION=""
-          for PREFIX in core github ado start-git-work ai-reviewer; do
+          for PREFIX in "${!PACKAGE_DIRS[@]}"; do
             if [[ "$TAG" == "$PREFIX-v"* ]]; then
               PACKAGE_NAME="$PREFIX"
               VERSION="${TAG#"$PREFIX-v"}"
@@ -39,17 +49,7 @@ jobs:
             exit 1
           fi
 
-          case "$PACKAGE_NAME" in
-            core)           PACKAGE_DIR="packages/core" ;;
-            github)         PACKAGE_DIR="packages/github" ;;
-            ado)            PACKAGE_DIR="packages/ado" ;;
-            start-git-work) PACKAGE_DIR="packages/start-git-work" ;;
-            ai-reviewer)    PACKAGE_DIR="packages/ai-reviewer" ;;
-            *)
-              echo "::error::Unknown package prefix: $PACKAGE_NAME"
-              exit 1
-              ;;
-          esac
+          PACKAGE_DIR="${PACKAGE_DIRS[$PACKAGE_NAME]}"
 
           if ! echo "$VERSION" | grep -qE '^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
             echo "::error::Version '$VERSION' is not valid semver"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,10 +72,10 @@ jobs:
           npm run build:prod --if-present || npm run build
 
       - name: Package extension
-        run: cd ${{ steps.parse.outputs.package_dir }} && npx vsce package
+        run: cd ${{ steps.parse.outputs.package_dir }} && npx @vscode/vsce package
 
       - name: Publish extension
-        run: cd ${{ steps.parse.outputs.package_dir }} && npx vsce publish
+        run: cd ${{ steps.parse.outputs.package_dir }} && npx @vscode/vsce publish
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,11 @@ jobs:
       - name: Build target package
         run: |
           cd ${{ steps.parse.outputs.package_dir }}
-          npm run build:prod --if-present || npm run build
+          if node -e "process.exit(require('./package.json').scripts && require('./package.json').scripts['build:prod'] ? 0 : 1)"; then
+            npm run build:prod
+          else
+            npm run build
+          fi
 
       - name: Package extension
         run: cd ${{ steps.parse.outputs.package_dir }} && npx @vscode/vsce package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,6 +85,7 @@ jobs:
           echo "{\"dependencies\":{\"@devdocket/shared\":\"$SHARED_VERSION\"}}" > package.json
           npm install
           cp -r node_modules/@devdocket/shared "$GITHUB_WORKSPACE/node_modules/@devdocket/shared"
+          cd "$GITHUB_WORKSPACE"
           rm -rf "$TMPDIR"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,6 +48,13 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
       - name: Verify version matches tag
         run: |
           PKG_VERSION=$(node -p "require('./${{ steps.parse.outputs.package_dir }}/package.json').version")
@@ -55,13 +62,6 @@ jobs:
             echo "::error::Tag version (${{ steps.parse.outputs.version }}) does not match package.json version ($PKG_VERSION)"
             exit 1
           fi
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
-      - name: Install dependencies
-        run: npm ci
 
       - name: Build shared
         run: cd packages/shared && npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -113,6 +113,9 @@ jobs:
             npm run build
           fi
 
+      - name: Test target package
+        run: cd "${{ steps.parse.outputs.package_dir }}" && npm run test
+
       - name: Package extension
         run: cd "${{ steps.parse.outputs.package_dir }}" && npx @vscode/vsce package
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
               ;;
           esac
 
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'; then
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?(\+[a-zA-Z0-9.-]+)?$'; then
             echo "::error::Version '$VERSION' is not valid semver"
             exit 1
           fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,7 @@ jobs:
               ;;
           esac
 
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$'; then
             echo "::error::Version '$VERSION' is not valid semver"
             exit 1
           fi
@@ -81,11 +81,13 @@ jobs:
 
       - name: Create GitHub Release
         run: |
-          VSIX_FILE=$(ls ${{ steps.parse.outputs.package_dir }}/*.vsix)
-          if [ -z "$VSIX_FILE" ]; then
-            echo "::error::No .vsix file found"
+          shopt -s nullglob
+          VSIX_FILES=( ${{ steps.parse.outputs.package_dir }}/*.vsix )
+          if [ ${#VSIX_FILES[@]} -ne 1 ]; then
+            echo "::error::Expected exactly 1 .vsix file, found ${#VSIX_FILES[@]}"
             exit 1
           fi
+          VSIX_FILE="${VSIX_FILES[0]}"
           gh release create "${{ steps.parse.outputs.tag }}" \
             "$VSIX_FILE" \
             --title "${{ steps.parse.outputs.tag }}" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,7 +97,7 @@ jobs:
           # single quotes are intentional to avoid premature shell expansion.
           echo '//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}' >> .npmrc
           echo "{\"dependencies\":{\"@devdocket/shared\":\"$SHARED_VERSION\"}}" > package.json
-          npm install
+          npm install --ignore-scripts --no-audit --no-fund
           cp -r node_modules/@devdocket/shared "$GITHUB_WORKSPACE/node_modules/@devdocket/shared"
           cd "$GITHUB_WORKSPACE"
           rm -rf "$TMPDIR"


### PR DESCRIPTION
Add per-package VS Code Marketplace publishing workflows triggered by package-specific tags.

## Changes

Created `.github/workflows/publish.yml` with:
- **Tag convention**: `<package-name>-v<semver>` (e.g., `core-v1.0.0`, `github-v1.2.0`)
- **Tag parsing**: Matches known package prefixes to extract package name and version
- **Build pipeline**: `npm ci` → install `@devdocket/shared` from GitHub Packages → build target package (`build:prod`)
- **Publish**: `vsce package` → `vsce publish` (using `VSCE_PAT` secret)
- **Release**: Creates a GitHub Release with the `.vsix` artifact and package-scoped release notes

### `@devdocket/shared` from registry

Instead of building `packages/shared` from source, the publish workflow installs the published `@devdocket/shared` package from GitHub Packages. This ensures extension builds bundle the same artifact that third-party consumers install. All extensions use `esbuild --bundle` which inlines shared code at build time. The installed version is pinned to the version in `packages/shared/package.json` at the tagged commit.

### Usage

To publish a package, push a tag:
```bash
git tag core-v1.0.0
git push origin core-v1.0.0
```

**Note**: The `VSCE_PAT` repository secret must be configured with a VS Code Marketplace Personal Access Token before publishing will work.

Closes #409
