### PR TITLE
Enforce strict import boundaries between packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "npm run build --workspaces",
     "build:prod": "npm run build:prod --workspaces",
     "test": "npm run test --workspaces",
-    "lint": "npm run lint --workspaces"
+    "check-boundaries": "node scripts/check-import-boundaries.mjs",
+    "lint": "npm run check-boundaries && npm run lint --workspaces"
   }
 }

--- a/scripts/check-import-boundaries.mjs
+++ b/scripts/check-import-boundaries.mjs
@@ -3,7 +3,7 @@
 // npm packages, and relative paths within the same package.
 
 import { readFileSync, readdirSync } from 'fs';
-import { resolve, relative, dirname } from 'path';
+import { resolve, relative, dirname, isAbsolute } from 'path';
 import { fileURLToPath } from 'url';
 
 // Exempt packages that are not providers/actions
@@ -98,8 +98,9 @@ function isRelativeEscape(specifier, filePath, pkgDir) {
 
 function isAllowedImport(specifier) {
   if (specifier.startsWith('.')) return true;
-  // Block absolute paths and repo-relative paths
-  if (specifier.startsWith('/') || specifier.startsWith('packages/')) return false;
+  // Block absolute paths (Unix, Windows, UNC), file:// URLs, and repo-relative paths
+  const normalized = specifier.replace(/\\/g, '/');
+  if (isAbsolute(normalized) || normalized.startsWith('file:') || normalized.startsWith('packages/')) return false;
   if (specifier === '@devdocket/shared' || specifier.startsWith('@devdocket/shared/')) return true;
   if (specifier === 'vscode') return true;
   if (isNodeBuiltin(specifier)) return true;

--- a/scripts/check-import-boundaries.mjs
+++ b/scripts/check-import-boundaries.mjs
@@ -4,11 +4,13 @@
 
 import { readFileSync, readdirSync } from 'fs';
 import { resolve, relative, dirname } from 'path';
+import { fileURLToPath } from 'url';
 
 // Exempt packages that are not providers/actions
 const EXEMPT_PACKAGES = new Set(['core', 'shared']);
 
-const repoRoot = resolve(import.meta.dirname, '..');
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
 
 function discoverConsumerPackages() {
   const pkgsDir = resolve(repoRoot, 'packages');

--- a/scripts/check-import-boundaries.mjs
+++ b/scripts/check-import-boundaries.mjs
@@ -5,12 +5,17 @@
 import { readFileSync, readdirSync } from 'fs';
 import { resolve, relative, dirname } from 'path';
 
-const CONSUMER_PACKAGES = [
-  'packages/github',
-  'packages/ado',
-  'packages/start-git-work',
-  'packages/ai-reviewer',
-];
+// Exempt packages that are not providers/actions
+const EXEMPT_PACKAGES = new Set(['core', 'shared']);
+
+const repoRoot = resolve(import.meta.dirname, '..');
+
+function discoverConsumerPackages() {
+  const pkgsDir = resolve(repoRoot, 'packages');
+  return readdirSync(pkgsDir, { withFileTypes: true })
+    .filter(e => e.isDirectory() && !EXEMPT_PACKAGES.has(e.name))
+    .map(e => `packages/${e.name}`);
+}
 
 const NODE_BUILTINS = new Set([
   'assert', 'async_hooks', 'buffer', 'child_process', 'cluster', 'console',
@@ -22,10 +27,11 @@ const NODE_BUILTINS = new Set([
   'worker_threads', 'zlib',
 ]);
 
-const IMPORT_RE = /(?:import|export)\s+(?:[\s\S]*?\s+from\s+)?['"]([^'"]+)['"]/g;
+const IMPORT_RE = /(?:import|export)\s+(?:.*?\s+from\s+)?['"]([^'"]+)['"]/g;
 const REQUIRE_RE = /require\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+const DYNAMIC_IMPORT_RE = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
 
-const repoRoot = resolve(import.meta.dirname, '..');
+const SKIP_DIRS = new Set(['test', '__tests__', '__mocks__', 'node_modules']);
 
 function collectTsFiles(dir, results) {
   let entries;
@@ -38,7 +44,7 @@ function collectTsFiles(dir, results) {
   for (const entry of entries) {
     const fullPath = resolve(dir, entry.name);
     if (entry.isDirectory()) {
-      if (entry.name === 'test' || entry.name === '__tests__' || entry.name === '__mocks__') {
+      if (SKIP_DIRS.has(entry.name)) {
         continue;
       }
       collectTsFiles(fullPath, results);
@@ -53,12 +59,12 @@ function collectTsFiles(dir, results) {
   }
 }
 
-function extractSpecifiers(content) {
+function extractSpecifiersFromLine(line) {
   const specifiers = [];
-  for (const re of [IMPORT_RE, REQUIRE_RE]) {
+  for (const re of [IMPORT_RE, REQUIRE_RE, DYNAMIC_IMPORT_RE]) {
     re.lastIndex = 0;
     let match;
-    while ((match = re.exec(content)) !== null) {
+    while ((match = re.exec(line)) !== null) {
       specifiers.push(match[1]);
     }
   }
@@ -79,41 +85,36 @@ function isRelativeEscape(specifier, filePath, pkgDir) {
   return relative(pkgRoot, resolved).startsWith('..');
 }
 
-function isForbiddenBareImport(specifier) {
-  // Any @devdocket/* import other than @devdocket/shared is forbidden
-  if (specifier.startsWith('@devdocket/') && !specifier.startsWith('@devdocket/shared')) {
-    return true;
-  }
-  return false;
-}
-
 function isAllowedImport(specifier) {
   if (specifier.startsWith('.')) return true;
   if (specifier === '@devdocket/shared' || specifier.startsWith('@devdocket/shared/')) return true;
   if (specifier === 'vscode') return true;
   if (isNodeBuiltin(specifier)) return true;
-  if (isForbiddenBareImport(specifier)) return false;
+  // Any other @devdocket/* import is forbidden
+  if (specifier.startsWith('@devdocket/')) return false;
   // Other bare specifiers are npm packages
   return true;
 }
 
+const consumerPackages = discoverConsumerPackages();
 const violations = [];
 
-for (const pkgDir of CONSUMER_PACKAGES) {
+for (const pkgDir of consumerPackages) {
   const srcDir = resolve(repoRoot, pkgDir, 'src');
   const files = [];
   collectTsFiles(srcDir, files);
 
   for (const filePath of files) {
     const content = readFileSync(filePath, 'utf-8');
-    const specifiers = extractSpecifiers(content);
+    const lines = content.split('\n');
     const relFile = relative(repoRoot, filePath).replaceAll('\\', '/');
 
-    for (const specifier of specifiers) {
-      if (!isAllowedImport(specifier)) {
-        violations.push({ file: relFile, specifier });
-      } else if (isRelativeEscape(specifier, filePath, pkgDir)) {
-        violations.push({ file: relFile, specifier });
+    for (let i = 0; i < lines.length; i++) {
+      const specifiers = extractSpecifiersFromLine(lines[i]);
+      for (const specifier of specifiers) {
+        if (!isAllowedImport(specifier) || isRelativeEscape(specifier, filePath, pkgDir)) {
+          violations.push({ file: relFile, line: i + 1, specifier });
+        }
       }
     }
   }
@@ -121,8 +122,8 @@ for (const pkgDir of CONSUMER_PACKAGES) {
 
 if (violations.length > 0) {
   console.error('Import boundary violations found:\n');
-  for (const { file, specifier } of violations) {
-    console.error(`  ${file}`);
+  for (const { file, line, specifier } of violations) {
+    console.error(`  ${file}:${line}`);
     console.error(`    Forbidden import: ${specifier}\n`);
   }
   console.error(

--- a/scripts/check-import-boundaries.mjs
+++ b/scripts/check-import-boundaries.mjs
@@ -59,13 +59,16 @@ function collectTsFiles(dir, results) {
   }
 }
 
-function stripSingleLineComments(content) {
-  return content.replace(/\/\/.*$/gm, '');
+function stripFullLineComments(content) {
+  return content.split('\n').map(line => {
+    const trimmed = line.trimStart();
+    return trimmed.startsWith('//') ? '' : line;
+  }).join('\n');
 }
 
 function extractSpecifiers(content) {
   const results = [];
-  const stripped = stripSingleLineComments(content);
+  const stripped = stripFullLineComments(content);
   for (const re of [IMPORT_RE, REQUIRE_RE, DYNAMIC_IMPORT_RE]) {
     re.lastIndex = 0;
     let match;

--- a/scripts/check-import-boundaries.mjs
+++ b/scripts/check-import-boundaries.mjs
@@ -96,6 +96,8 @@ function isRelativeEscape(specifier, filePath, pkgDir) {
 
 function isAllowedImport(specifier) {
   if (specifier.startsWith('.')) return true;
+  // Block absolute paths and repo-relative paths
+  if (specifier.startsWith('/') || specifier.startsWith('packages/')) return false;
   if (specifier === '@devdocket/shared' || specifier.startsWith('@devdocket/shared/')) return true;
   if (specifier === 'vscode') return true;
   if (isNodeBuiltin(specifier)) return true;

--- a/scripts/check-import-boundaries.mjs
+++ b/scripts/check-import-boundaries.mjs
@@ -1,0 +1,135 @@
+// Enforces import boundaries for provider/action packages.
+// These packages may only import from: @devdocket/shared, vscode, node builtins,
+// npm packages, and relative paths within the same package.
+
+import { readFileSync, readdirSync } from 'fs';
+import { resolve, relative, dirname } from 'path';
+
+const CONSUMER_PACKAGES = [
+  'packages/github',
+  'packages/ado',
+  'packages/start-git-work',
+  'packages/ai-reviewer',
+];
+
+const NODE_BUILTINS = new Set([
+  'assert', 'async_hooks', 'buffer', 'child_process', 'cluster', 'console',
+  'constants', 'crypto', 'dgram', 'diagnostics_channel', 'dns', 'domain',
+  'events', 'fs', 'http', 'http2', 'https', 'inspector', 'module', 'net',
+  'os', 'path', 'perf_hooks', 'process', 'punycode', 'querystring',
+  'readline', 'repl', 'stream', 'string_decoder', 'timers', 'tls',
+  'trace_events', 'tty', 'url', 'util', 'v8', 'vm', 'wasi',
+  'worker_threads', 'zlib',
+]);
+
+const IMPORT_RE = /(?:import|export)\s+(?:[\s\S]*?\s+from\s+)?['"]([^'"]+)['"]/g;
+const REQUIRE_RE = /require\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
+
+const repoRoot = resolve(import.meta.dirname, '..');
+
+function collectTsFiles(dir, results) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    const fullPath = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'test' || entry.name === '__tests__' || entry.name === '__mocks__') {
+        continue;
+      }
+      collectTsFiles(fullPath, results);
+    } else if (
+      entry.name.endsWith('.ts') &&
+      !entry.name.endsWith('.test.ts') &&
+      !entry.name.endsWith('.spec.ts') &&
+      !entry.name.endsWith('.d.ts')
+    ) {
+      results.push(fullPath);
+    }
+  }
+}
+
+function extractSpecifiers(content) {
+  const specifiers = [];
+  for (const re of [IMPORT_RE, REQUIRE_RE]) {
+    re.lastIndex = 0;
+    let match;
+    while ((match = re.exec(content)) !== null) {
+      specifiers.push(match[1]);
+    }
+  }
+  return specifiers;
+}
+
+function isNodeBuiltin(specifier) {
+  const bare = specifier.startsWith('node:') ? specifier.slice(5) : specifier;
+  return NODE_BUILTINS.has(bare.split('/')[0]);
+}
+
+function isRelativeEscape(specifier, filePath, pkgDir) {
+  if (!specifier.startsWith('.')) {
+    return false;
+  }
+  const resolved = resolve(dirname(filePath), specifier);
+  const pkgRoot = resolve(repoRoot, pkgDir);
+  return relative(pkgRoot, resolved).startsWith('..');
+}
+
+function isForbiddenBareImport(specifier) {
+  // Any @devdocket/* import other than @devdocket/shared is forbidden
+  if (specifier.startsWith('@devdocket/') && !specifier.startsWith('@devdocket/shared')) {
+    return true;
+  }
+  return false;
+}
+
+function isAllowedImport(specifier) {
+  if (specifier.startsWith('.')) return true;
+  if (specifier === '@devdocket/shared' || specifier.startsWith('@devdocket/shared/')) return true;
+  if (specifier === 'vscode') return true;
+  if (isNodeBuiltin(specifier)) return true;
+  if (isForbiddenBareImport(specifier)) return false;
+  // Other bare specifiers are npm packages
+  return true;
+}
+
+const violations = [];
+
+for (const pkgDir of CONSUMER_PACKAGES) {
+  const srcDir = resolve(repoRoot, pkgDir, 'src');
+  const files = [];
+  collectTsFiles(srcDir, files);
+
+  for (const filePath of files) {
+    const content = readFileSync(filePath, 'utf-8');
+    const specifiers = extractSpecifiers(content);
+    const relFile = relative(repoRoot, filePath).replaceAll('\\', '/');
+
+    for (const specifier of specifiers) {
+      if (!isAllowedImport(specifier)) {
+        violations.push({ file: relFile, specifier });
+      } else if (isRelativeEscape(specifier, filePath, pkgDir)) {
+        violations.push({ file: relFile, specifier });
+      }
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('Import boundary violations found:\n');
+  for (const { file, specifier } of violations) {
+    console.error(`  ${file}`);
+    console.error(`    Forbidden import: ${specifier}\n`);
+  }
+  console.error(
+    `${violations.length} violation(s) found. Provider/action packages may only import from ` +
+    `@devdocket/shared, vscode, node builtins, and npm packages.`
+  );
+  process.exit(1);
+} else {
+  console.log('No import boundary violations found.');
+}

--- a/scripts/check-import-boundaries.mjs
+++ b/scripts/check-import-boundaries.mjs
@@ -27,7 +27,7 @@ const NODE_BUILTINS = new Set([
   'worker_threads', 'zlib',
 ]);
 
-const IMPORT_RE = /(?:import|export)\s+(?:.*?\s+from\s+)?['"]([^'"]+)['"]/g;
+const IMPORT_RE = /(?:import|export)\s+(?:[\s\S]*?\s+from\s+)?['"]([^'"]+)['"]/g;
 const REQUIRE_RE = /require\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
 const DYNAMIC_IMPORT_RE = /\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g;
 
@@ -59,16 +59,22 @@ function collectTsFiles(dir, results) {
   }
 }
 
-function extractSpecifiersFromLine(line) {
-  const specifiers = [];
+function stripSingleLineComments(content) {
+  return content.replace(/\/\/.*$/gm, '');
+}
+
+function extractSpecifiers(content) {
+  const results = [];
+  const stripped = stripSingleLineComments(content);
   for (const re of [IMPORT_RE, REQUIRE_RE, DYNAMIC_IMPORT_RE]) {
     re.lastIndex = 0;
     let match;
-    while ((match = re.exec(line)) !== null) {
-      specifiers.push(match[1]);
+    while ((match = re.exec(stripped)) !== null) {
+      const line = stripped.slice(0, match.index).split('\n').length;
+      results.push({ specifier: match[1], line });
     }
   }
-  return specifiers;
+  return results;
 }
 
 function isNodeBuiltin(specifier) {
@@ -106,15 +112,12 @@ for (const pkgDir of consumerPackages) {
 
   for (const filePath of files) {
     const content = readFileSync(filePath, 'utf-8');
-    const lines = content.split('\n');
     const relFile = relative(repoRoot, filePath).replaceAll('\\', '/');
+    const specifiers = extractSpecifiers(content);
 
-    for (let i = 0; i < lines.length; i++) {
-      const specifiers = extractSpecifiersFromLine(lines[i]);
-      for (const specifier of specifiers) {
-        if (!isAllowedImport(specifier) || isRelativeEscape(specifier, filePath, pkgDir)) {
-          violations.push({ file: relFile, line: i + 1, specifier });
-        }
+    for (const { specifier, line } of specifiers) {
+      if (!isAllowedImport(specifier) || isRelativeEscape(specifier, filePath, pkgDir)) {
+        violations.push({ file: relFile, line, specifier });
       }
     }
   }


### PR DESCRIPTION
Enforce that provider and action packages only import from `@devdocket/shared` and never from `packages/core/src/...` or each other's internals.

## Changes

- Added `scripts/check-import-boundaries.mjs` that scans all `.ts` source files in consumer packages and validates import paths
- Added `check-boundaries` script to root `package.json` and wired it into the `lint` target

### Rules enforced

- **Allowed**: `@devdocket/shared`, `vscode`, node builtins, npm packages, same-package relative imports
- **Forbidden**: `@devdocket/*` (except shared), relative imports escaping the package boundary

No existing violations were found in the codebase.

Closes #410
