### PR TITLE
Add path-filtered CI for per-package builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,42 +31,36 @@ jobs:
               - 'packages/shared/**'
               - 'package.json'
               - 'package-lock.json'
-              - 'tsconfig.json'
               - '.github/workflows/**'
             core:
               - 'packages/core/**'
               - 'packages/shared/**'
               - 'package.json'
               - 'package-lock.json'
-              - 'tsconfig.json'
               - '.github/workflows/**'
             github:
               - 'packages/github/**'
               - 'packages/shared/**'
               - 'package.json'
               - 'package-lock.json'
-              - 'tsconfig.json'
               - '.github/workflows/**'
             ado:
               - 'packages/ado/**'
               - 'packages/shared/**'
               - 'package.json'
               - 'package-lock.json'
-              - 'tsconfig.json'
               - '.github/workflows/**'
             start-git-work:
               - 'packages/start-git-work/**'
               - 'packages/shared/**'
               - 'package.json'
               - 'package-lock.json'
-              - 'tsconfig.json'
               - '.github/workflows/**'
             ai-reviewer:
               - 'packages/ai-reviewer/**'
               - 'packages/shared/**'
               - 'package.json'
               - 'package-lock.json'
-              - 'tsconfig.json'
               - '.github/workflows/**'
 
   build-shared:
@@ -79,6 +73,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -99,6 +94,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -122,6 +118,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -145,6 +142,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -168,6 +166,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -191,6 +190,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -203,3 +203,15 @@ jobs:
 
       - name: Test ai-reviewer
         run: cd packages/ai-reviewer && npm run test
+
+  ci-gate:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [build-shared, build-core, build-github, build-ado, build-start-git-work, build-ai-reviewer]
+    steps:
+      - name: Check results
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more jobs failed"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
     steps:
       - name: Check results
         run: |
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
-            echo "One or more jobs failed"
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more jobs failed or were cancelled"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,67 @@ permissions:
   contents: read
 
 jobs:
-  build-and-test:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      shared: ${{ steps.filter.outputs.shared }}
+      core: ${{ steps.filter.outputs.core }}
+      github: ${{ steps.filter.outputs.github }}
+      ado: ${{ steps.filter.outputs.ado }}
+      start-git-work: ${{ steps.filter.outputs.start-git-work }}
+      ai-reviewer: ${{ steps.filter.outputs.ai-reviewer }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            shared:
+              - 'packages/shared/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.json'
+              - '.github/workflows/**'
+            core:
+              - 'packages/core/**'
+              - 'packages/shared/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.json'
+              - '.github/workflows/**'
+            github:
+              - 'packages/github/**'
+              - 'packages/shared/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.json'
+              - '.github/workflows/**'
+            ado:
+              - 'packages/ado/**'
+              - 'packages/shared/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.json'
+              - '.github/workflows/**'
+            start-git-work:
+              - 'packages/start-git-work/**'
+              - 'packages/shared/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.json'
+              - '.github/workflows/**'
+            ai-reviewer:
+              - 'packages/ai-reviewer/**'
+              - 'packages/shared/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.json'
+              - '.github/workflows/**'
+
+  build-shared:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.shared == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,8 +83,123 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build
-        run: npm run build
+      - name: Build shared
+        run: cd packages/shared && npm run build
 
-      - name: Test
-        run: npm run test
+      - name: Test shared
+        run: cd packages/shared && npm run test
+
+  build-core:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.core == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared
+        run: cd packages/shared && npm run build
+
+      - name: Build core
+        run: cd packages/core && npm run build
+
+      - name: Test core
+        run: cd packages/core && npm run test
+
+  build-github:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.github == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared
+        run: cd packages/shared && npm run build
+
+      - name: Build github
+        run: cd packages/github && npm run build
+
+      - name: Test github
+        run: cd packages/github && npm run test
+
+  build-ado:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.ado == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared
+        run: cd packages/shared && npm run build
+
+      - name: Build ado
+        run: cd packages/ado && npm run build
+
+      - name: Test ado
+        run: cd packages/ado && npm run test
+
+  build-start-git-work:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.start-git-work == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared
+        run: cd packages/shared && npm run build
+
+      - name: Build start-git-work
+        run: cd packages/start-git-work && npm run build
+
+      - name: Test start-git-work
+        run: cd packages/start-git-work && npm run test
+
+  build-ai-reviewer:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.ai-reviewer == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared
+        run: cd packages/shared && npm run build
+
+      - name: Build ai-reviewer
+        run: cd packages/ai-reviewer && npm run build
+
+      - name: Test ai-reviewer
+        run: cd packages/ai-reviewer && npm run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       core: ${{ steps.filter.outputs.core }}
       github: ${{ steps.filter.outputs.github }}
       ado: ${{ steps.filter.outputs.ado }}
-      start-git-work: ${{ steps.filter.outputs.start-git-work }}
-      ai-reviewer: ${{ steps.filter.outputs.ai-reviewer }}
+      start_git_work: ${{ steps.filter.outputs.start_git_work }}
+      ai_reviewer: ${{ steps.filter.outputs.ai_reviewer }}
     steps:
       - uses: actions/checkout@v4
 
@@ -50,13 +50,13 @@ jobs:
               - 'package.json'
               - 'package-lock.json'
               - '.github/workflows/**'
-            start-git-work:
+            start_git_work:
               - 'packages/start-git-work/**'
               - 'packages/shared/**'
               - 'package.json'
               - 'package-lock.json'
               - '.github/workflows/**'
-            ai-reviewer:
+            ai_reviewer:
               - 'packages/ai-reviewer/**'
               - 'packages/shared/**'
               - 'package.json'
@@ -158,7 +158,7 @@ jobs:
 
   build-start-git-work:
     needs: detect-changes
-    if: needs.detect-changes.outputs.start-git-work == 'true'
+    if: needs.detect-changes.outputs.start_git_work == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -182,7 +182,7 @@ jobs:
 
   build-ai-reviewer:
     needs: detect-changes
-    if: needs.detect-changes.outputs.ai-reviewer == 'true'
+    if: needs.detect-changes.outputs.ai_reviewer == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,10 +207,14 @@ jobs:
   ci-gate:
     runs-on: ubuntu-latest
     if: always()
-    needs: [build-shared, build-core, build-github, build-ado, build-start-git-work, build-ai-reviewer]
+    needs: [detect-changes, build-shared, build-core, build-github, build-ado, build-start-git-work, build-ai-reviewer]
     steps:
       - name: Check results
         run: |
+          if [[ "${{ needs.detect-changes.result == 'failure' || needs.detect-changes.result == 'cancelled' }}" == "true" ]]; then
+            echo "detect-changes failed or was cancelled"
+            exit 1
+          fi
           if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
             echo "One or more jobs failed or were cancelled"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   detect-changes:


### PR DESCRIPTION
Add path-based filtering to CI so that changes scoped to a single package only build and test that package.

## Changes

Replaced the single `build-and-test` job with:
- A `detect-changes` job using `dorny/paths-filter@v3` to determine which packages changed
- 6 per-package jobs (`build-shared`, `build-core`, `build-github`, `build-ado`, `build-start-git-work`, `build-ai-reviewer`) that conditionally run based on filter outputs
- Changes to `packages/shared/**`, root config files, or workflow files trigger all package builds
- Package-scoped changes only trigger that specific package's build/test

Closes #411
