### PR TITLE
Publish @devdocket/shared to GitHub Packages npm registry

### DIFF
--- a/.github/workflows/publish-shared.yml
+++ b/.github/workflows/publish-shared.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -48,7 +50,23 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Generate release notes
+        run: |
+          # Find the previous shared-v* tag to scope the changelog
+          PREV_TAG=$(git tag -l 'shared-v*' --sort=-v:refname | grep -v "^${GITHUB_REF_NAME}$" | head -n1)
+          if [ -n "$PREV_TAG" ]; then
+            RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
+          else
+            RANGE="$GITHUB_REF_NAME"
+          fi
+          # Only include commits that touched packages/shared/
+          NOTES=$(git log "$RANGE" --pretty=format:"* %s (%h)" -- packages/shared/)
+          if [ -z "$NOTES" ]; then
+            NOTES="* No changes to packages/shared in this release"
+          fi
+          echo "$NOTES" > release-notes.md
+
       - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
+        run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-shared.yml
+++ b/.github/workflows/publish-shared.yml
@@ -64,7 +64,7 @@ jobs:
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/shared in this release"
           fi
-          echo "$NOTES" > release-notes.md
+          printf '%s\n' "$NOTES" > release-notes.md
 
       - name: Create GitHub Release
         run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md

--- a/.github/workflows/publish-shared.yml
+++ b/.github/workflows/publish-shared.yml
@@ -1,0 +1,53 @@
+name: Publish @devdocket/shared
+
+on:
+  push:
+    tags:
+      - 'shared-v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+          registry-url: 'https://npm.pkg.github.com'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build shared
+        working-directory: packages/shared
+        run: npm run build
+
+      - name: Test shared
+        working-directory: packages/shared
+        run: npm run test
+
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#shared-v}"
+          PKG_VERSION=$(node -p "require('./packages/shared/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Publish to GitHub Packages
+        working-directory: packages/shared
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-shared.yml
+++ b/.github/workflows/publish-shared.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Generate release notes
         run: |
           # Find the previous shared-v* tag to scope the changelog
-          PREV_TAG=$(git tag -l 'shared-v*' --sort=-v:refname | grep -v "^${GITHUB_REF_NAME}$" | head -n1)
+          PREV_TAG=$(git tag -l 'shared-v*' --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
           if [ -n "$PREV_TAG" ]; then
             RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
           else

--- a/.github/workflows/publish-shared.yml
+++ b/.github/workflows/publish-shared.yml
@@ -20,6 +20,7 @@ jobs:
           node-version: 22
           cache: 'npm'
           registry-url: 'https://npm.pkg.github.com'
+          scope: '@devdocket'
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
@@ -43,7 +44,7 @@ jobs:
 
       - name: Publish to GitHub Packages
         working-directory: packages/shared
-        run: npm publish
+        run: npm publish --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/publish-shared.yml
+++ b/.github/workflows/publish-shared.yml
@@ -23,7 +23,7 @@ jobs:
           scope: '@devdocket'
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts
+        run: npm ci
 
       - name: Build shared
         working-directory: packages/shared

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -356,31 +356,7 @@ This example shows a provider that discovers items from a hypothetical task API.
 
 ```ts
 import * as vscode from 'vscode';
-
-interface DiscoveredItem {
-  externalId: string;
-  title: string;
-  description?: string;
-  url?: string;
-  group?: string;
-  canonicalId?: string;
-}
-
-interface Disposable {
-  dispose(): void;
-}
-
-interface Event<T> {
-  (listener: (e: T) => void): Disposable;
-}
-
-interface DevDocketProvider {
-  readonly id: string;
-  readonly label: string;
-  readonly onDidDiscoverItems: Event<DiscoveredItem[]>;
-  refresh(token?: vscode.CancellationToken): Promise<void>;
-  getClosedItems?(externalIds: string[], signal?: AbortSignal): Promise<string[]>;
-}
+import { DiscoveredItem, DevDocketProvider } from '@devdocket/shared';
 
 class MyTaskProvider implements DevDocketProvider {
   readonly id = 'my-tasks';
@@ -445,34 +421,7 @@ This example shows an action that opens a dashboard page for a work item using i
 
 ```ts
 import * as vscode from 'vscode';
-
-enum WorkItemState {
-  New = 'New',
-  InProgress = 'InProgress',
-  Paused = 'Paused',
-  Done = 'Done',
-  Archived = 'Archived',
-}
-
-interface WorkItem {
-  id: string;
-  title: string;
-  notes?: string;
-  state: WorkItemState;
-  providerId?: string;
-  externalId?: string;
-  url?: string;
-  sortOrder?: number;
-  createdAt: number;
-  updatedAt: number;
-}
-
-interface DevDocketAction {
-  readonly id: string;
-  readonly label: string;
-  canRun(item: Readonly<WorkItem>): boolean;
-  run(item: Readonly<WorkItem>): Promise<void>;
-}
+import { WorkItem, WorkItemState, DevDocketAction } from '@devdocket/shared';
 
 class OpenDashboardAction implements DevDocketAction {
   readonly id = 'my-tasks.openDashboard';

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -15,6 +15,30 @@ Your extension must declare a dependency on DevDocket so that VS Code activates 
 }
 ```
 
+### Installing `@devdocket/shared`
+
+The `@devdocket/shared` package provides the TypeScript types and base classes (`DiscoveredItem`, `BaseProvider`, `Event`, `Disposable`, etc.) needed to build providers and actions with full type safety.
+
+The package is published to the GitHub Packages npm registry. Add a `.npmrc` file to your project to configure the `@devdocket` scope:
+
+```ini
+@devdocket:registry=https://npm.pkg.github.com
+```
+
+Then install the package:
+
+```bash
+npm install @devdocket/shared
+```
+
+> **Note:** GitHub Packages requires authentication. See [GitHub's docs on authenticating to GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-to-github-packages) for setup instructions.
+
+You can then import types directly instead of redefining them:
+
+```ts
+import { BaseProvider, DiscoveredItem } from '@devdocket/shared';
+```
+
 ### Acquiring the API
 
 In your extension's `activate()` function, acquire the `DevDocketApi` from the core extension:

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -36,7 +36,7 @@ npm install @devdocket/shared
 You can then import types directly instead of redefining them:
 
 ```ts
-import { BaseProvider, DiscoveredItem } from '@devdocket/shared';
+import { BaseProvider, type DiscoveredItem } from '@devdocket/shared';
 ```
 
 ### Acquiring the API
@@ -356,7 +356,7 @@ This example shows a provider that discovers items from a hypothetical task API.
 
 ```ts
 import * as vscode from 'vscode';
-import { DiscoveredItem, DevDocketProvider } from '@devdocket/shared';
+import type { DiscoveredItem, DevDocketProvider } from '@devdocket/shared';
 
 class MyTaskProvider implements DevDocketProvider {
   readonly id = 'my-tasks';
@@ -421,7 +421,7 @@ This example shows an action that opens a dashboard page for a work item using i
 
 ```ts
 import * as vscode from 'vscode';
-import { WorkItem, WorkItemState, DevDocketAction } from '@devdocket/shared';
+import { WorkItemState, type WorkItem, type DevDocketAction } from '@devdocket/shared';
 
 class OpenDashboardAction implements DevDocketAction {
   readonly id = 'my-tasks.openDashboard';

--- a/packages/shared/LICENSE
+++ b/packages/shared/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Thalman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -16,6 +16,8 @@ Then install:
 npm install @devdocket/shared
 ```
 
+> **Note:** GitHub Packages requires authentication. See [Authenticating to GitHub Packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-to-github-packages) for setup instructions.
+
 ## Usage
 
 ```typescript

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -1,0 +1,29 @@
+# @devdocket/shared
+
+Shared types, base classes, and utilities for building [DevDocket](https://github.com/devdocket/devdocket) extensions.
+
+## Installation
+
+This package is published to the GitHub Packages npm registry. Add the following to your `.npmrc`:
+
+```
+@devdocket:registry=https://npm.pkg.github.com
+```
+
+Then install:
+
+```bash
+npm install @devdocket/shared
+```
+
+## Usage
+
+```typescript
+import { BaseProvider, DiscoveredItem, Event } from '@devdocket/shared';
+```
+
+See the [DevDocket documentation](https://github.com/devdocket/devdocket) for details on building provider and action extensions.
+
+## License
+
+[MIT](LICENSE)

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -21,7 +21,7 @@ npm install @devdocket/shared
 ## Usage
 
 ```typescript
-import { BaseProvider, DiscoveredItem, Event } from '@devdocket/shared';
+import { BaseProvider, type DiscoveredItem, type Event } from '@devdocket/shared';
 ```
 
 See the [DevDocket documentation](https://github.com/devdocket/devdocket) for details on building provider and action extensions.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,9 +1,22 @@
 {
   "name": "@devdocket/shared",
   "version": "0.1.0",
-  "private": true,
+  "description": "Shared types, base classes, and utilities for DevDocket extensions",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/devdocket/devdocket.git",
+    "directory": "packages/shared"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "build:prod": "tsc",


### PR DESCRIPTION
Publish @devdocket/shared to the GitHub Packages npm registry so third-party DevDocket provider/action authors can install it as a real dependency.

## Changes

### `packages/shared/package.json`
- Removed `"private": true` to allow publishing
- Added `publishConfig` targeting `https://npm.pkg.github.com` with `"access": "public"`
- Added `files: ["dist"]` to ship only compiled output
- Added `repository` (monorepo-aware with `directory` field), `license` (MIT), and `description` metadata

### `packages/shared/LICENSE` and `packages/shared/README.md` (new)
- Added package-level LICENSE (MIT, matching root) and README with installation/usage instructions and authentication note
- npm automatically includes these in the published tarball

### `.github/workflows/publish-shared.yml` (new)
- Triggered by `shared-v*` tag pushes
- Full history checkout for tag comparison
- Installs dependencies with `npm ci`, scoped registry for `@devdocket`
- Builds and tests `@devdocket/shared` before publishing
- Verifies the tag version matches `package.json` version
- Publishes to GitHub Packages via `npm publish --ignore-scripts` using `GITHUB_TOKEN`
- Generates path-filtered release notes (only commits touching `packages/shared/`)
- Creates a GitHub Release with the scoped notes

### `docs/extension-api.md`
- Added section on installing `@devdocket/shared` from GitHub Packages
- Replaced inline type redefinitions in examples with `import type` from the package

## Consumer Setup

To install from GitHub Packages, consumers add to `.npmrc`:
```
@devdocket:registry=https://npm.pkg.github.com
```

## Publishing a New Version

1. Bump version in `packages/shared/package.json`
2. Merge to `dev`
3. Tag and push: `git tag shared-v<version> && git push origin shared-v<version>`

Closes #421
