### PR TITLE
Add Copy URL context menu command

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -786,12 +786,12 @@
         {
           "command": "devdocket.openInBrowser",
           "when": "viewItem =~ /hasUrl/ && !listMultiSelection",
-          "group": "2_links"
+          "group": "2_links@0"
         },
         {
           "command": "devdocket.copyUrl",
           "when": "viewItem =~ /hasUrl/ && !listMultiSelection",
-          "group": "2_links"
+          "group": "2_links@1"
         },
         {
           "command": "devdocket.watchPRFromItem",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -256,6 +256,12 @@
         "icon": "$(link-external)"
       },
       {
+        "command": "devdocket.copyUrl",
+        "title": "Copy URL",
+        "category": "DevDocket",
+        "icon": "$(clippy)"
+      },
+      {
         "command": "devdocket.runAction",
         "title": "Run Action…",
         "category": "DevDocket",
@@ -690,6 +696,10 @@
         {
           "command": "devdocket.watchPRFromItem",
           "when": "false"
+        },
+        {
+          "command": "devdocket.copyUrl",
+          "when": "false"
         }
       ],
       "view/item/context": [
@@ -775,6 +785,11 @@
         },
         {
           "command": "devdocket.openInBrowser",
+          "when": "viewItem =~ /hasUrl/ && !listMultiSelection",
+          "group": "2_links"
+        },
+        {
+          "command": "devdocket.copyUrl",
           "when": "viewItem =~ /hasUrl/ && !listMultiSelection",
           "group": "2_links"
         },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -259,7 +259,7 @@
         "command": "devdocket.copyUrl",
         "title": "Copy URL",
         "category": "DevDocket",
-        "icon": "$(clippy)"
+        "icon": "$(copy)"
       },
       {
         "command": "devdocket.runAction",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -796,12 +796,12 @@
         {
           "command": "devdocket.watchPRFromItem",
           "when": "view == devdocket.focus && viewItem =~ /watchable/ && !listMultiSelection",
-          "group": "2_links"
+          "group": "2_links@2"
         },
         {
           "command": "devdocket.watchPRFromItem",
           "when": "view == devdocket.queue && viewItem =~ /watchable/ && !listMultiSelection",
-          "group": "2_links"
+          "group": "2_links@2"
         },
         {
           "command": "devdocket.runAction",

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -472,6 +472,22 @@ async function handleOpenInBrowser(workGraph: WorkGraph, item?: { id?: string; u
   }
 }
 
+async function handleCopyUrl(workGraph: WorkGraph, item?: { id?: string; url?: string }): Promise<void> {
+  if (!item || (!item.id && !item.url)) {
+    void vscode.window.showWarningMessage('DevDocket: Select an item to copy its URL.');
+    return;
+  }
+  const workItem = item.id ? workGraph.getItem(item.id) : undefined;
+  const url = workItem?.url ?? item.url;
+  if (!url) {
+    void vscode.window.showWarningMessage('This item has no URL to copy.');
+    return;
+  }
+
+  await vscode.env.clipboard.writeText(url);
+  vscode.window.setStatusBarMessage('DevDocket: URL copied to clipboard', 3000);
+}
+
 async function handleRunAction(
   workGraph: WorkGraph,
   actionRegistry: ActionRegistry,
@@ -1137,6 +1153,8 @@ export function registerCommands(
       wrapCommand('Failed to open editor', (item) => handleEditItem(context, workGraph, providerRegistry, labelCache, item))),
     vscode.commands.registerCommand('devdocket.openInBrowser',
       wrapCommand('Failed to open in browser', (item) => handleOpenInBrowser(workGraph, item))),
+    vscode.commands.registerCommand('devdocket.copyUrl',
+      wrapCommand('Failed to copy URL', (item) => handleCopyUrl(workGraph, item))),
     vscode.commands.registerCommand('devdocket.runAction',
       wrapCommand('Failed to run action', (item) => handleRunAction(workGraph, actionRegistry, item))),
     vscode.commands.registerCommand('devdocket.moveUp',

--- a/packages/core/src/commands/generalCommands.ts
+++ b/packages/core/src/commands/generalCommands.ts
@@ -110,23 +110,6 @@ async function handleOpenInBrowser(workGraph: WorkGraph, item?: { id?: string; u
   }
 }
 
-async function handleCopyUrl(workGraph: WorkGraph, item?: { id?: string; url?: string }): Promise<void> {
-  if (!item || (!item.id && !item.url)) {
-    void vscode.window.showWarningMessage('DevDocket: Select an item to copy its URL.');
-    return;
-  }
-  const workItem = item.id ? workGraph.getItem(item.id) : undefined;
-  const url = workItem?.url ?? item.url;
-  if (!url) {
-    void vscode.window.showWarningMessage('This item has no URL to copy.');
-    return;
-  }
-
-  // Copy intentionally preserves non-http URLs because clipboard transfer is not a navigation action.
-  await vscode.env.clipboard.writeText(url);
-  vscode.window.setStatusBarMessage('DevDocket: URL copied to clipboard', 3000);
-}
-
 async function handleRunAction(
   workGraph: WorkGraph,
   actionRegistry: ActionRegistry,
@@ -190,8 +173,6 @@ export function registerGeneralCommands(
       wrapCommand('Failed to open editor', (item) => handleEditItem(context, workGraph, providerRegistry, labelCache, item))),
     vscode.commands.registerCommand('devdocket.openInBrowser',
       wrapCommand('Failed to open in browser', (item) => handleOpenInBrowser(workGraph, item))),
-    vscode.commands.registerCommand('devdocket.copyUrl',
-      wrapCommand('Failed to copy URL', (item) => handleCopyUrl(workGraph, item))),
     vscode.commands.registerCommand('devdocket.runAction',
       wrapCommand('Failed to run action', (item) => handleRunAction(workGraph, actionRegistry, item))),
     vscode.commands.registerCommand('devdocket.showProviderHealthQuickPick',

--- a/packages/core/src/commands/generalCommands.ts
+++ b/packages/core/src/commands/generalCommands.ts
@@ -122,6 +122,7 @@ async function handleCopyUrl(workGraph: WorkGraph, item?: { id?: string; url?: s
     return;
   }
 
+  // Copy intentionally preserves non-http URLs because clipboard transfer is not a navigation action.
   await vscode.env.clipboard.writeText(url);
   vscode.window.setStatusBarMessage('DevDocket: URL copied to clipboard', 3000);
 }

--- a/packages/core/src/commands/generalCommands.ts
+++ b/packages/core/src/commands/generalCommands.ts
@@ -110,6 +110,22 @@ async function handleOpenInBrowser(workGraph: WorkGraph, item?: { id?: string; u
   }
 }
 
+async function handleCopyUrl(workGraph: WorkGraph, item?: { id?: string; url?: string }): Promise<void> {
+  if (!item || (!item.id && !item.url)) {
+    void vscode.window.showWarningMessage('DevDocket: Select an item to copy its URL.');
+    return;
+  }
+  const workItem = item.id ? workGraph.getItem(item.id) : undefined;
+  const url = workItem?.url ?? item.url;
+  if (!url) {
+    void vscode.window.showWarningMessage('This item has no URL to copy.');
+    return;
+  }
+
+  await vscode.env.clipboard.writeText(url);
+  vscode.window.setStatusBarMessage('DevDocket: URL copied to clipboard', 3000);
+}
+
 async function handleRunAction(
   workGraph: WorkGraph,
   actionRegistry: ActionRegistry,
@@ -173,6 +189,8 @@ export function registerGeneralCommands(
       wrapCommand('Failed to open editor', (item) => handleEditItem(context, workGraph, providerRegistry, labelCache, item))),
     vscode.commands.registerCommand('devdocket.openInBrowser',
       wrapCommand('Failed to open in browser', (item) => handleOpenInBrowser(workGraph, item))),
+    vscode.commands.registerCommand('devdocket.copyUrl',
+      wrapCommand('Failed to copy URL', (item) => handleCopyUrl(workGraph, item))),
     vscode.commands.registerCommand('devdocket.runAction',
       wrapCommand('Failed to run action', (item) => handleRunAction(workGraph, actionRegistry, item))),
     vscode.commands.registerCommand('devdocket.showProviderHealthQuickPick',

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -65,6 +65,7 @@ const window = {
   showWarningMessage: vi.fn(),
   showErrorMessage: vi.fn(),
   showQuickPick: vi.fn(),
+  setStatusBarMessage: vi.fn(() => ({ dispose: vi.fn() })),
   withProgress: vi.fn((_options: any, task: (progress: any, token: any) => Promise<any>) => {
     const cancellationEmitter = new MockEventEmitter();
     return task(
@@ -108,6 +109,9 @@ const commands = {
 
 const env = {
   openExternal: vi.fn(),
+  clipboard: {
+    writeText: vi.fn().mockResolvedValue(undefined),
+  },
 };
 
 const Uri = {

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -182,6 +182,7 @@ describe('registerCommands', () => {
       'devdocket.deleteItem',
       'devdocket.editItem',
       'devdocket.openInBrowser',
+      'devdocket.copyUrl',
       'devdocket.runAction',
       'devdocket.moveUp',
       'devdocket.moveDown',
@@ -501,6 +502,66 @@ describe('registerCommands', () => {
         'DevDocket: Select an item to open in the browser.',
       );
       expect(vscode.env.openExternal).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── copyUrl ──────────────────────────────────────────────────────
+
+  describe('devdocket.copyUrl', () => {
+    it('copies workItem url when found', async () => {
+      const item = createWorkItem({ url: 'https://example.com' });
+      workGraph.getItem.mockReturnValue(item);
+
+      await invoke('devdocket.copyUrl', { id: item.id });
+
+      expect(vscode.env.clipboard.writeText).toHaveBeenCalledWith('https://example.com');
+      expect(vscode.window.setStatusBarMessage).toHaveBeenCalledWith('DevDocket: URL copied to clipboard', 3000);
+    });
+
+    it('falls back to item.url when workItem has no url', async () => {
+      workGraph.getItem.mockReturnValue(createWorkItem({ url: undefined }));
+
+      await invoke('devdocket.copyUrl', { id: 'wc-1', url: 'https://fallback.com' });
+
+      expect(vscode.env.clipboard.writeText).toHaveBeenCalledWith('https://fallback.com');
+    });
+
+    it('falls back to tree node url when workItem is not found', async () => {
+      workGraph.getItem.mockReturnValue(undefined);
+
+      await invoke('devdocket.copyUrl', { id: 'wc-gone', url: 'https://tree-fallback.com' });
+
+      expect(vscode.env.clipboard.writeText).toHaveBeenCalledWith('https://tree-fallback.com');
+    });
+
+    it('copies url from item without id (Inbox/Sources items)', async () => {
+      await invoke('devdocket.copyUrl', { url: 'https://provider-item.com' });
+
+      expect(workGraph.getItem).not.toHaveBeenCalled();
+      expect(vscode.env.clipboard.writeText).toHaveBeenCalledWith('https://provider-item.com');
+    });
+
+    it('copies unsafe url-only item without validation', async () => {
+      await invoke('devdocket.copyUrl', { url: 'javascript:alert(1)' });
+
+      expect(vscode.env.clipboard.writeText).toHaveBeenCalledWith('javascript:alert(1)');
+      expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
+    });
+
+    it('shows warning when neither source has a url', async () => {
+      workGraph.getItem.mockReturnValue(createWorkItem({ url: undefined }));
+
+      await invoke('devdocket.copyUrl', { id: 'wc-1' });
+
+      expect(vscode.env.clipboard.writeText).not.toHaveBeenCalled();
+      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith('This item has no URL to copy.');
+    });
+
+    it('shows warning when item has neither id nor url', async () => {
+      await invoke('devdocket.copyUrl', {});
+
+      expect(vscode.env.clipboard.writeText).not.toHaveBeenCalled();
+      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith('DevDocket: Select an item to copy its URL.');
     });
   });
 

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -541,7 +541,7 @@ describe('registerCommands', () => {
       expect(vscode.env.clipboard.writeText).toHaveBeenCalledWith('https://provider-item.com');
     });
 
-    it('copies unsafe url-only item without validation', async () => {
+    it('copies non-http URLs without filtering (copy is not navigation)', async () => {
       await invoke('devdocket.copyUrl', { url: 'javascript:alert(1)' });
 
       expect(vscode.env.clipboard.writeText).toHaveBeenCalledWith('javascript:alert(1)');


### PR DESCRIPTION
Add a 'Copy URL' context menu command for work items with URLs. Copies the item URL to the clipboard with a status bar confirmation.

Closes #424
