### PR TITLE
Auto-open editor after creating manual work item

### DIFF
--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -334,7 +334,7 @@ async function handleCreateItem(
   logger.info(`Creating new work item: ${title.trim()}`);
   const createdItem = await workGraph.createItem({ title: title.trim() });
   const providerLabel = createdItem.providerId ? labelCache.get(createdItem.providerId) : undefined;
-  WorkItemEditorPanel.open(context, workGraph, providerRegistry, createdItem, providerLabel);
+  void WorkItemEditorPanel.open(context, workGraph, providerRegistry, createdItem, providerLabel);
   void vscode.window.showInformationMessage(`DevDocket: Created "${title.trim()}"`);
   void revealer?.revealInQueue(createdItem.id);
 }

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -315,7 +315,13 @@ async function batchAcceptItems(
   }
 }
 
-async function handleCreateItem(workGraph: WorkGraph, revealer?: ViewRevealer): Promise<void> {
+async function handleCreateItem(
+  context: vscode.ExtensionContext,
+  workGraph: WorkGraph,
+  providerRegistry: ProviderRegistry,
+  labelCache: ProviderLabelCache,
+  revealer?: ViewRevealer,
+): Promise<void> {
   const title = await vscode.window.showInputBox({
     prompt: 'Work item title',
     placeHolder: 'e.g. Fix login redirect bug',
@@ -327,6 +333,8 @@ async function handleCreateItem(workGraph: WorkGraph, revealer?: ViewRevealer): 
 
   logger.info(`Creating new work item: ${title.trim()}`);
   const createdItem = await workGraph.createItem({ title: title.trim() });
+  const providerLabel = createdItem.providerId ? labelCache.get(createdItem.providerId) : undefined;
+  WorkItemEditorPanel.open(context, workGraph, providerRegistry, createdItem, providerLabel);
   void vscode.window.showInformationMessage(`DevDocket: Created "${title.trim()}"`);
   void revealer?.revealInQueue(createdItem.id);
 }
@@ -1116,7 +1124,7 @@ export function registerCommands(
     vscode.commands.registerCommand('devdocket.refresh',
       wrapCommand('Failed to refresh', () => handleRefresh(providerRegistry))),
     vscode.commands.registerCommand('devdocket.createItem',
-      wrapCommand('Failed to create item', () => handleCreateItem(workGraph, revealer))),
+      wrapCommand('Failed to create item', () => handleCreateItem(context, workGraph, providerRegistry, labelCache, revealer))),
     vscode.commands.registerCommand('devdocket.createItemFromUrl',
       wrapCommand('Failed to create item from URL', () => handleCreateItemFromUrl(context, workGraph, providerRegistry, labelCache, revealer))),
     vscode.commands.registerCommand('devdocket.acceptToFocus',

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -245,6 +245,8 @@ describe('registerCommands', () => {
 
     it('trims whitespace from the title', async () => {
       (vscode.window.showInputBox as Mock).mockResolvedValue('  Padded  ');
+      workGraph.createItem.mockResolvedValue(createWorkItem({ id: 'wc-trimmed', title: 'Padded' }));
+
       await invoke('devdocket.createItem');
 
       expect(workGraph.createItem).toHaveBeenCalledWith({ title: 'Padded' });

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -223,11 +223,21 @@ describe('registerCommands', () => {
   // ── createItem ───────────────────────────────────────────────────
 
   describe('devdocket.createItem', () => {
-    it('creates item when user provides a title', async () => {
+    it('creates item when user provides a title and opens the editor', async () => {
       (vscode.window.showInputBox as Mock).mockResolvedValue('My Task');
+      const createdItem = createWorkItem({ id: 'wc-created', title: 'My Task' });
+      workGraph.createItem.mockResolvedValue(createdItem);
+
       await invoke('devdocket.createItem');
 
       expect(workGraph.createItem).toHaveBeenCalledWith({ title: 'My Task' });
+      expect(WorkItemEditorPanel.open).toHaveBeenCalledWith(
+        ctx,
+        workGraph,
+        providerRegistry,
+        createdItem,
+        undefined,
+      );
       expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
         'DevDocket: Created "My Task"',
       );


### PR DESCRIPTION
After creating a manual work item via the Create Work Item command, the editor panel now opens automatically so users can immediately add notes, URL, or context.

Closes #430
