### PR TITLE
Hide Run Action menu when no actions available

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -790,7 +790,7 @@
         },
         {
           "command": "devdocket.runAction",
-          "when": "((view == devdocket.queue && viewItem =~ /^queueItem/) || (view == devdocket.focus && viewItem =~ /^(active|paused)/)) && !listMultiSelection",
+          "when": "((view == devdocket.queue && viewItem =~ /^queueItem/) || (view == devdocket.focus && viewItem =~ /^(active|paused)/)) && viewItem =~ /\\.hasActions/ && !listMultiSelection",
           "group": "0_actions"
         },
         {

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -124,6 +124,7 @@ async function migrateDiscoveredState(workGraph: WorkGraph, stateStore: Discover
 
 function createTreeViews(
   providerRegistry: ProviderRegistry,
+  actionRegistry: ActionRegistry,
   stateStore: DiscoveredStateStore,
   readStateStore: ReadStateStore,
   workGraph: WorkGraph,
@@ -136,8 +137,8 @@ function createTreeViews(
     prWatcherRegistry.findWatcherForUrl(url) !== undefined;
 
   const inboxProvider = new InboxTreeProvider(providerRegistry, stateStore, readStateStore);
-  const queueProvider = new QueueTreeProvider(workGraph, providerRegistry, isWatchable);
-  const focusProvider = new FocusTreeProvider(workGraph, providerRegistry, isWatchable);
+  const queueProvider = new QueueTreeProvider(workGraph, providerRegistry, actionRegistry, isWatchable);
+  const focusProvider = new FocusTreeProvider(workGraph, providerRegistry, actionRegistry, isWatchable);
   const sourcesProvider = new SourcesTreeProvider(providerRegistry, stateStore);
   const historyProvider = new HistoryTreeProvider(workGraph, providerRegistry);
   const watchesProvider = new WatchesTreeProvider(watcherService);
@@ -425,7 +426,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   logger.info(`Store + service init took ${Math.round(performance.now() - initStart)}ms`);
 
   const treeViewStart = performance.now();
-  const treeSetup = createTreeViews(pr, ss, readStateStore, wg, ws, wr, pwr);
+  const treeSetup = createTreeViews(pr, ar, ss, readStateStore, wg, ws, wr, pwr);
   logger.info(`Tree view creation took ${Math.round(performance.now() - treeViewStart)}ms`);
 
   const eventWiringStart = performance.now();

--- a/packages/core/src/services/actionRegistry.ts
+++ b/packages/core/src/services/actionRegistry.ts
@@ -52,7 +52,13 @@ export class ActionRegistry {
    * @returns An array of actions that can be run on the item.
    */
   getActionsFor(item: WorkItem): DevDocketAction[] {
-    const matching = this.registry.getAll().filter((a) => a.canRun(item));
+    const matching = this.registry.getAll().filter((action) => {
+      try {
+        return action.canRun(item);
+      } catch {
+        return false;
+      }
+    });
     logger.debug(`Found ${matching.length} actions for item ${item.id}`);
     return matching;
   }

--- a/packages/core/src/services/actionRegistry.ts
+++ b/packages/core/src/services/actionRegistry.ts
@@ -13,6 +13,8 @@ import { Registry } from './registry';
  */
 export class ActionRegistry {
   private readonly registry = new Registry<DevDocketAction>('Action');
+  private readonly _onDidChange = new vscode.EventEmitter<void>();
+  readonly onDidChangeRegistrations: vscode.Event<void> = this._onDidChange.event;
 
   /**
    * Register an action and make it available in work-item context menus.
@@ -22,7 +24,22 @@ export class ActionRegistry {
    * @throws If an action with the same {@link DevDocketAction.id} is already registered.
    */
   register(action: DevDocketAction): vscode.Disposable {
-    return this.registry.register(action);
+    const registration = this.registry.register(action);
+    this._onDidChange.fire();
+
+    let disposed = false;
+    return new vscode.Disposable(() => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+
+      const wasRegistered = this.registry.get(action.id) === action;
+      registration.dispose();
+      if (wasRegistered) {
+        this._onDidChange.fire();
+      }
+    });
   }
 
   /**
@@ -52,6 +69,11 @@ export class ActionRegistry {
 
   /** Release all registered actions. */
   dispose(): void {
+    const hadActions = this.registry.size > 0;
     this.registry.clear();
+    if (hadActions) {
+      this._onDidChange.fire();
+    }
+    this._onDidChange.dispose();
   }
 }

--- a/packages/core/src/services/actionRegistry.ts
+++ b/packages/core/src/services/actionRegistry.ts
@@ -58,6 +58,29 @@ export class ActionRegistry {
   }
 
   /**
+   * Determine whether any registered action can run for a given work item.
+   *
+   * This is intended for rendering paths that only need a yes/no answer and
+   * must not allow third-party action predicates to break the UI.
+   *
+   * @param item - The work item to match actions against.
+   * @returns `true` when at least one action can run for the item.
+   */
+  hasActionsFor(item: WorkItem): boolean {
+    try {
+      return this.registry.getAll().some((action) => {
+        try {
+          return action.canRun(item);
+        } catch {
+          return false;
+        }
+      });
+    } catch {
+      return false;
+    }
+  }
+
+  /**
    * Look up a registered action by its unique identifier.
    *
    * @param id - The action identifier to search for.

--- a/packages/core/src/test/actionRegistry.test.ts
+++ b/packages/core/src/test/actionRegistry.test.ts
@@ -107,6 +107,33 @@ describe('ActionRegistry', () => {
     expect(actions).toHaveLength(0);
   });
 
+  it('returns true from hasActionsFor when an action can run', () => {
+    const item = createWorkItem({ providerId: 'github' });
+    registry.register(createMockAction('github-only', (i) => i.providerId === 'github'));
+
+    expect(registry.hasActionsFor(item)).toBe(true);
+  });
+
+  it('short-circuits hasActionsFor after the first matching action', () => {
+    const item = createWorkItem();
+    const skippedCanRun = vi.fn(() => false);
+
+    registry.register(createMockAction('first-match', () => true));
+    registry.register(createMockAction('skipped', skippedCanRun));
+
+    expect(registry.hasActionsFor(item)).toBe(true);
+    expect(skippedCanRun).not.toHaveBeenCalled();
+  });
+
+  it('returns false from hasActionsFor when canRun throws', () => {
+    const item = createWorkItem();
+    registry.register(createMockAction('throwing', () => {
+      throw new Error('boom');
+    }));
+
+    expect(registry.hasActionsFor(item)).toBe(false);
+  });
+
   it('clears all actions on dispose', () => {
     registry.register(createMockAction('a1'));
     registry.register(createMockAction('a2'));

--- a/packages/core/src/test/actionRegistry.test.ts
+++ b/packages/core/src/test/actionRegistry.test.ts
@@ -107,6 +107,17 @@ describe('ActionRegistry', () => {
     expect(actions).toHaveLength(0);
   });
 
+  it('skips actions from getActionsFor when canRun throws', () => {
+    const item = createWorkItem();
+    const safeAction = createMockAction('safe');
+    registry.register(createMockAction('throwing', () => {
+      throw new Error('boom');
+    }));
+    registry.register(safeAction);
+
+    expect(registry.getActionsFor(item)).toEqual([safeAction]);
+  });
+
   it('returns true from hasActionsFor when an action can run', () => {
     const item = createWorkItem({ providerId: 'github' });
     registry.register(createMockAction('github-only', (i) => i.providerId === 'github'));

--- a/packages/core/src/test/actionRegistry.test.ts
+++ b/packages/core/src/test/actionRegistry.test.ts
@@ -56,6 +56,17 @@ describe('ActionRegistry', () => {
     expect(registry.getAction('removable')).toBeUndefined();
   });
 
+  it('fires onDidChangeRegistrations when actions are registered and unregistered', () => {
+    const listener = vi.fn();
+    registry.onDidChangeRegistrations(listener);
+
+    const disposable = registry.register(createMockAction('eventful'));
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    disposable.dispose();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
   it('returns registered action from getAction', () => {
     const action = createMockAction('findme');
     registry.register(action);
@@ -104,6 +115,18 @@ describe('ActionRegistry', () => {
 
     expect(registry.getAction('a1')).toBeUndefined();
     expect(registry.getAction('a2')).toBeUndefined();
+  });
+
+  it('fires onDidChangeRegistrations when dispose clears registrations', () => {
+    const listener = vi.fn();
+    registry.onDidChangeRegistrations(listener);
+
+    registry.register(createMockAction('a1'));
+    listener.mockClear();
+
+    registry.dispose();
+
+    expect(listener).toHaveBeenCalledTimes(1);
   });
 
   it('getActionsFor returns empty array when registry is empty', () => {

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -110,6 +110,17 @@ describe('FocusTreeProvider', () => {
       expect(actionableProvider.getTreeItem(item).contextValue).toBe('paused.hasUrl.watchable.hasActions');
     });
 
+    it('should not append hasActions when canRun throws', () => {
+      const actionRegistry = new ActionRegistry();
+      actionRegistry.register(createMockAction('throwing', () => {
+        throw new Error('boom');
+      }));
+      const actionableProvider = new FocusTreeProvider(workGraph as any, undefined, actionRegistry);
+      const item = makeItem({ state: WorkItemState.InProgress });
+
+      expect(actionableProvider.getTreeItem(item).contextValue).toBe('active');
+    });
+
     it('should not append hasActions when no registered action can run', () => {
       const actionRegistry = new ActionRegistry();
       actionRegistry.register(createMockAction('paused-only', (item) => item.state === WorkItemState.Paused));

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventEmitter, DataTransfer, DataTransferItem, window } from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
+import { ActionRegistry } from '../services/actionRegistry';
 import { FocusTreeProvider } from '../views/focusTreeProvider';
 
 const DRAG_MIME_TYPE = 'application/vnd.code.tree.devdocket.focus';
@@ -25,6 +26,15 @@ function makeItem(overrides: Partial<WorkItem> = {}): WorkItem {
     createdAt: 1700000000000,
     updatedAt: 1700000000000,
     ...overrides,
+  };
+}
+
+function createMockAction(id: string, canRun: (item: WorkItem) => boolean = () => true) {
+  return {
+    id,
+    label: `Action ${id}`,
+    canRun: vi.fn(canRun),
+    run: vi.fn(async () => {}),
   };
 }
 
@@ -80,6 +90,33 @@ describe('FocusTreeProvider', () => {
       const watchableProvider = new FocusTreeProvider(workGraph as any, undefined, () => true);
       const item = makeItem({ state: WorkItemState.InProgress });
       expect(watchableProvider.getTreeItem(item).contextValue).toBe('active');
+    });
+
+    it('should set contextValue to "active.hasActions" when actions are available', () => {
+      const actionRegistry = new ActionRegistry();
+      actionRegistry.register(createMockAction('focus-action'));
+      const actionableProvider = new FocusTreeProvider(workGraph as any, undefined, actionRegistry);
+      const item = makeItem({ state: WorkItemState.InProgress });
+
+      expect(actionableProvider.getTreeItem(item).contextValue).toBe('active.hasActions');
+    });
+
+    it('should append hasActions after watchable for paused items with actions', () => {
+      const actionRegistry = new ActionRegistry();
+      actionRegistry.register(createMockAction('paused-action'));
+      const actionableProvider = new FocusTreeProvider(workGraph as any, undefined, actionRegistry, () => true);
+      const item = makeItem({ state: WorkItemState.Paused, url: 'https://github.com/owner/repo/pull/2' });
+
+      expect(actionableProvider.getTreeItem(item).contextValue).toBe('paused.hasUrl.watchable.hasActions');
+    });
+
+    it('should not append hasActions when no registered action can run', () => {
+      const actionRegistry = new ActionRegistry();
+      actionRegistry.register(createMockAction('paused-only', (item) => item.state === WorkItemState.Paused));
+      const actionableProvider = new FocusTreeProvider(workGraph as any, undefined, actionRegistry);
+      const item = makeItem({ state: WorkItemState.InProgress });
+
+      expect(actionableProvider.getTreeItem(item).contextValue).toBe('active');
     });
   });
 
@@ -478,6 +515,19 @@ describe('FocusTreeProvider', () => {
       provider.onDidChangeTreeData(listener);
       workGraph._fire();
       expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('should refresh when action registrations change', () => {
+      const actionRegistry = new ActionRegistry();
+      const actionableProvider = new FocusTreeProvider(workGraph as any, undefined, actionRegistry);
+      const listener = vi.fn();
+      actionableProvider.onDidChangeTreeData(listener);
+
+      const registration = actionRegistry.register(createMockAction('focus-refresh'));
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      registration.dispose();
+      expect(listener).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/packages/core/src/test/focusTreeProvider.test.ts
+++ b/packages/core/src/test/focusTreeProvider.test.ts
@@ -69,25 +69,25 @@ describe('FocusTreeProvider', () => {
     });
 
     it('should set contextValue to "active.hasUrl.watchable" when URL is watchable', () => {
-      const watchableProvider = new FocusTreeProvider(workGraph as any, undefined, () => true);
+      const watchableProvider = new FocusTreeProvider(workGraph as any, undefined, undefined, () => true);
       const item = makeItem({ state: WorkItemState.InProgress, url: 'https://github.com/owner/repo/pull/1' });
       expect(watchableProvider.getTreeItem(item).contextValue).toBe('active.hasUrl.watchable');
     });
 
     it('should set contextValue to "active.hasUrl" when URL is not watchable', () => {
-      const unwatchableProvider = new FocusTreeProvider(workGraph as any, undefined, () => false);
+      const unwatchableProvider = new FocusTreeProvider(workGraph as any, undefined, undefined, () => false);
       const item = makeItem({ state: WorkItemState.InProgress, url: 'https://example.com' });
       expect(unwatchableProvider.getTreeItem(item).contextValue).toBe('active.hasUrl');
     });
 
     it('should set contextValue to "paused.hasUrl.watchable" when paused URL is watchable', () => {
-      const watchableProvider = new FocusTreeProvider(workGraph as any, undefined, () => true);
+      const watchableProvider = new FocusTreeProvider(workGraph as any, undefined, undefined, () => true);
       const item = makeItem({ state: WorkItemState.Paused, url: 'https://github.com/owner/repo/pull/2' });
       expect(watchableProvider.getTreeItem(item).contextValue).toBe('paused.hasUrl.watchable');
     });
 
     it('should not append watchable when item has no URL even if isWatchable provided', () => {
-      const watchableProvider = new FocusTreeProvider(workGraph as any, undefined, () => true);
+      const watchableProvider = new FocusTreeProvider(workGraph as any, undefined, undefined, () => true);
       const item = makeItem({ state: WorkItemState.InProgress });
       expect(watchableProvider.getTreeItem(item).contextValue).toBe('active');
     });

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -181,7 +181,7 @@ describe('QueueTreeProvider', () => {
     });
 
     it('sets contextValue to "queueItem.hasUrl.watchable" when URL is watchable', async () => {
-      const watchableProvider = new QueueTreeProvider(graph, undefined, () => true);
+      const watchableProvider = new QueueTreeProvider(graph, undefined, undefined, () => true);
       const item = await graph.createItem(
         { title: 'Watchable' },
         { providerId: 'github', externalId: 'ext-w1', url: 'https://github.com/owner/repo/pull/1' },
@@ -191,7 +191,7 @@ describe('QueueTreeProvider', () => {
     });
 
     it('sets contextValue to "queueItem.hasUrl" when URL is not watchable', async () => {
-      const unwatchableProvider = new QueueTreeProvider(graph, undefined, () => false);
+      const unwatchableProvider = new QueueTreeProvider(graph, undefined, undefined, () => false);
       const item = await graph.createItem(
         { title: 'Not watchable' },
         { providerId: 'github', externalId: 'ext-w2', url: 'https://example.com' },
@@ -201,7 +201,7 @@ describe('QueueTreeProvider', () => {
     });
 
     it('does not append watchable when item has no URL even if isWatchable provided', async () => {
-      const watchableProvider = new QueueTreeProvider(graph, undefined, () => true);
+      const watchableProvider = new QueueTreeProvider(graph, undefined, undefined, () => true);
       const item = await graph.createItem({ title: 'No URL watchable' });
       const treeItem = watchableProvider.getTreeItem(item);
       expect(treeItem.contextValue).toBe('queueItem');

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { DataTransfer, DataTransferItem, EventEmitter, MarkdownString, TreeItemCollapsibleState } from 'vscode';
 import { WorkGraph } from '../services/workGraph';
-import { WorkItemState } from '../models/workItem';
+import { WorkItem, WorkItemState } from '../models/workItem';
 import { ITaskStore } from '../storage/taskStore';
 import { QueueTreeProvider } from '../views/queueTreeProvider';
 import { ProviderRegistry } from '../services/providerRegistry';
+import { ActionRegistry } from '../services/actionRegistry';
 
 function createMockStore(): ITaskStore {
   const items: Map<string, any> = new Map();
@@ -27,6 +28,15 @@ function createMockProviderRegistry(): ProviderRegistry {
     getDiscoveredItems: vi.fn(() => []),
     onDidRegisterProvider: emitter.event,
   } as any;
+}
+
+function createMockAction(id: string, canRun: (item: WorkItem) => boolean = () => true) {
+  return {
+    id,
+    label: `Action ${id}`,
+    canRun: vi.fn(canRun),
+    run: vi.fn(async () => {}),
+  };
 }
 
 const DRAG_MIME_TYPE = 'application/vnd.code.tree.devdocket.queue';
@@ -195,6 +205,27 @@ describe('QueueTreeProvider', () => {
       const item = await graph.createItem({ title: 'No URL watchable' });
       const treeItem = watchableProvider.getTreeItem(item);
       expect(treeItem.contextValue).toBe('queueItem');
+    });
+
+    it('sets contextValue to "queueItem.hasActions" when actions are available', async () => {
+      const actionRegistry = new ActionRegistry();
+      actionRegistry.register(createMockAction('queue-action'));
+      const actionableProvider = new QueueTreeProvider(graph, undefined, actionRegistry);
+      const item = await graph.createItem({ title: 'Actionable' });
+
+      expect(actionableProvider.getTreeItem(item).contextValue).toBe('queueItem.hasActions');
+    });
+
+    it('appends hasActions after watchable when actions are available', async () => {
+      const actionRegistry = new ActionRegistry();
+      actionRegistry.register(createMockAction('queue-watchable'));
+      const actionableProvider = new QueueTreeProvider(graph, undefined, actionRegistry, () => true);
+      const item = await graph.createItem(
+        { title: 'Actionable Watchable' },
+        { providerId: 'github', externalId: 'ext-action', url: 'https://github.com/owner/repo/pull/1' },
+      );
+
+      expect(actionableProvider.getTreeItem(item).contextValue).toBe('queueItem.hasUrl.watchable.hasActions');
     });
 
     it('sets icon to "remote" when item has providerId', async () => {
@@ -460,6 +491,19 @@ describe('QueueTreeProvider', () => {
 
       provider.refresh();
       expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('fires onDidChangeTreeData when action registrations change', () => {
+      const actionRegistry = new ActionRegistry();
+      const actionableProvider = new QueueTreeProvider(graph, undefined, actionRegistry);
+      const listener = vi.fn();
+      actionableProvider.onDidChangeTreeData(listener);
+
+      const registration = actionRegistry.register(createMockAction('queue-refresh'));
+      expect(listener).toHaveBeenCalledTimes(1);
+
+      registration.dispose();
+      expect(listener).toHaveBeenCalledTimes(2);
     });
 
     it('fires event for each workGraph change', async () => {

--- a/packages/core/src/test/queueTreeProvider.test.ts
+++ b/packages/core/src/test/queueTreeProvider.test.ts
@@ -228,6 +228,17 @@ describe('QueueTreeProvider', () => {
       expect(actionableProvider.getTreeItem(item).contextValue).toBe('queueItem.hasUrl.watchable.hasActions');
     });
 
+    it('does not append hasActions when canRun throws', async () => {
+      const actionRegistry = new ActionRegistry();
+      actionRegistry.register(createMockAction('throwing', () => {
+        throw new Error('boom');
+      }));
+      const actionableProvider = new QueueTreeProvider(graph, undefined, actionRegistry);
+      const item = await graph.createItem({ title: 'Throwing action' });
+
+      expect(actionableProvider.getTreeItem(item).contextValue).toBe('queueItem');
+    });
+
     it('sets icon to "remote" when item has providerId', async () => {
       const item = await graph.createItem(
         { title: 'Provider item' },

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import { ProviderRegistry } from '../services/providerRegistry';
+import { ActionRegistry } from '../services/actionRegistry';
 import {
   WorkItemElement, WorkItemViewProvider, isProviderGroupNode, isSubGroupNode,
 } from './viewLayout';
@@ -16,12 +17,28 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
   readonly dragMimeTypes = [DRAG_MIME_TYPE];
   protected readonly groupPrefix = 'focus';
   protected readonly groupContextValue = 'focusGroup';
+  private readonly actionRegistry?: ActionRegistry;
   private readonly isWatchable?: (url: string) => boolean;
 
-  constructor(workGraph: WorkGraph, providerRegistry?: ProviderRegistry, isWatchable?: (url: string) => boolean) {
+  constructor(
+    workGraph: WorkGraph,
+    providerRegistry?: ProviderRegistry,
+    actionRegistryOrIsWatchable?: ActionRegistry | ((url: string) => boolean),
+    isWatchable?: (url: string) => boolean,
+  ) {
     const [lr, pce, tr, dice] = FocusTreeProvider.buildProviderArgs(providerRegistry);
     super(workGraph, 'flat', lr, pce, tr, dice);
+
+    if (typeof actionRegistryOrIsWatchable === 'function') {
+      this.isWatchable = actionRegistryOrIsWatchable;
+      return;
+    }
+
+    this.actionRegistry = actionRegistryOrIsWatchable;
     this.isWatchable = isWatchable;
+    if (this.actionRegistry) {
+      this.disposables.push(this.actionRegistry.onDidChangeRegistrations(() => this.refresh()));
+    }
   }
 
   protected getItems(): WorkItem[] {
@@ -52,7 +69,8 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
     const base = item.state === WorkItemState.Paused ? 'paused' : 'active';
     const urlSuffix = item.url ? '.hasUrl' : '';
     const watchableSuffix = item.url && this.isWatchable?.(item.url) ? '.watchable' : '';
-    treeItem.contextValue = `${base}${urlSuffix}${watchableSuffix}`;
+    const hasActionsSuffix = this.actionRegistry?.getActionsFor(item).length ? '.hasActions' : '';
+    treeItem.contextValue = `${base}${urlSuffix}${watchableSuffix}${hasActionsSuffix}`;
 
     treeItem.command = { command: 'devdocket.editItem', title: 'Open Details', arguments: [item] };
     return treeItem;

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -23,18 +23,13 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
   constructor(
     workGraph: WorkGraph,
     providerRegistry?: ProviderRegistry,
-    actionRegistryOrIsWatchable?: ActionRegistry | ((url: string) => boolean),
+    actionRegistry?: ActionRegistry,
     isWatchable?: (url: string) => boolean,
   ) {
     const [lr, pce, tr, dice] = FocusTreeProvider.buildProviderArgs(providerRegistry);
     super(workGraph, 'flat', lr, pce, tr, dice);
 
-    if (typeof actionRegistryOrIsWatchable === 'function') {
-      this.isWatchable = actionRegistryOrIsWatchable;
-      return;
-    }
-
-    this.actionRegistry = actionRegistryOrIsWatchable;
+    this.actionRegistry = actionRegistry;
     this.isWatchable = isWatchable;
     if (this.actionRegistry) {
       this.disposables.push(this.actionRegistry.onDidChangeRegistrations(() => this.refresh()));

--- a/packages/core/src/views/focusTreeProvider.ts
+++ b/packages/core/src/views/focusTreeProvider.ts
@@ -64,7 +64,7 @@ export class FocusTreeProvider extends WorkItemViewProvider implements vscode.Tr
     const base = item.state === WorkItemState.Paused ? 'paused' : 'active';
     const urlSuffix = item.url ? '.hasUrl' : '';
     const watchableSuffix = item.url && this.isWatchable?.(item.url) ? '.watchable' : '';
-    const hasActionsSuffix = this.actionRegistry?.getActionsFor(item).length ? '.hasActions' : '';
+    const hasActionsSuffix = this.actionRegistry?.hasActionsFor(item) ? '.hasActions' : '';
     treeItem.contextValue = `${base}${urlSuffix}${watchableSuffix}${hasActionsSuffix}`;
 
     treeItem.command = { command: 'devdocket.editItem', title: 'Open Details', arguments: [item] };

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -23,18 +23,13 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
   constructor(
     workGraph: WorkGraph,
     providerRegistry?: ProviderRegistry,
-    actionRegistryOrIsWatchable?: ActionRegistry | ((url: string) => boolean),
+    actionRegistry?: ActionRegistry,
     isWatchable?: (url: string) => boolean,
   ) {
     const [lr, pce, tr, dice] = QueueTreeProvider.buildProviderArgs(providerRegistry);
     super(workGraph, 'flat', lr, pce, tr, dice);
 
-    if (typeof actionRegistryOrIsWatchable === 'function') {
-      this.isWatchable = actionRegistryOrIsWatchable;
-      return;
-    }
-
-    this.actionRegistry = actionRegistryOrIsWatchable;
+    this.actionRegistry = actionRegistry;
     this.isWatchable = isWatchable;
     if (this.actionRegistry) {
       this.disposables.push(this.actionRegistry.onDidChangeRegistrations(() => this.refresh()));

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { WorkGraph } from '../services/workGraph';
 import { ProviderRegistry } from '../services/providerRegistry';
+import { ActionRegistry } from '../services/actionRegistry';
 import {
   WorkItemElement, WorkItemViewProvider, isProviderGroupNode, isSubGroupNode,
 } from './viewLayout';
@@ -16,12 +17,28 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
   readonly dragMimeTypes = [DRAG_MIME_TYPE];
   protected readonly groupPrefix = 'queue';
   protected readonly groupContextValue = 'queueGroup';
+  private readonly actionRegistry?: ActionRegistry;
   private readonly isWatchable?: (url: string) => boolean;
 
-  constructor(workGraph: WorkGraph, providerRegistry?: ProviderRegistry, isWatchable?: (url: string) => boolean) {
+  constructor(
+    workGraph: WorkGraph,
+    providerRegistry?: ProviderRegistry,
+    actionRegistryOrIsWatchable?: ActionRegistry | ((url: string) => boolean),
+    isWatchable?: (url: string) => boolean,
+  ) {
     const [lr, pce, tr, dice] = QueueTreeProvider.buildProviderArgs(providerRegistry);
     super(workGraph, 'flat', lr, pce, tr, dice);
+
+    if (typeof actionRegistryOrIsWatchable === 'function') {
+      this.isWatchable = actionRegistryOrIsWatchable;
+      return;
+    }
+
+    this.actionRegistry = actionRegistryOrIsWatchable;
     this.isWatchable = isWatchable;
+    if (this.actionRegistry) {
+      this.disposables.push(this.actionRegistry.onDidChangeRegistrations(() => this.refresh()));
+    }
   }
 
   protected getItems(): WorkItem[] {
@@ -42,7 +59,8 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
     treeItem.tooltip = buildWorkItemTooltip(item, title, { showState: false, notesStyle: 'plain' });
     const urlSuffix = item.url ? '.hasUrl' : '';
     const watchableSuffix = item.url && this.isWatchable?.(item.url) ? '.watchable' : '';
-    treeItem.contextValue = `queueItem${urlSuffix}${watchableSuffix}`;
+    const hasActionsSuffix = this.actionRegistry?.getActionsFor(item).length ? '.hasActions' : '';
+    treeItem.contextValue = `queueItem${urlSuffix}${watchableSuffix}${hasActionsSuffix}`;
     treeItem.iconPath = new vscode.ThemeIcon(item.providerId ? 'remote' : 'circle-filled');
     treeItem.command = { command: 'devdocket.editItem', title: 'Open Details', arguments: [item] };
     return treeItem;

--- a/packages/core/src/views/queueTreeProvider.ts
+++ b/packages/core/src/views/queueTreeProvider.ts
@@ -54,7 +54,7 @@ export class QueueTreeProvider extends WorkItemViewProvider implements vscode.Tr
     treeItem.tooltip = buildWorkItemTooltip(item, title, { showState: false, notesStyle: 'plain' });
     const urlSuffix = item.url ? '.hasUrl' : '';
     const watchableSuffix = item.url && this.isWatchable?.(item.url) ? '.watchable' : '';
-    const hasActionsSuffix = this.actionRegistry?.getActionsFor(item).length ? '.hasActions' : '';
+    const hasActionsSuffix = this.actionRegistry?.hasActionsFor(item) ? '.hasActions' : '';
     treeItem.contextValue = `queueItem${urlSuffix}${watchableSuffix}${hasActionsSuffix}`;
     treeItem.iconPath = new vscode.ThemeIcon(item.providerId ? 'remote' : 'circle-filled');
     treeItem.command = { command: 'devdocket.editItem', title: 'Open Details', arguments: [item] };


### PR DESCRIPTION
The Run Action context menu item now only appears when at least one registered action can run for the selected item. Adds an onDidChangeRegistrations event to ActionRegistry and .hasActions contextValue suffix.

Closes #431
