### PR TITLE
Auto-watch authored PRs on provider refresh

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -133,6 +133,11 @@
             "type": "boolean",
             "default": true,
             "description": "Show a notification when an individual job fails while the pipeline run is still in progress"
+          },
+          "devDocket.watches.autoWatchAuthoredPRs": {
+            "type": "boolean",
+            "default": true,
+            "description": "Automatically watch authored pull requests when a provider refresh discovers them"
           }
         }
       }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -394,6 +394,8 @@ function wireEvents(
       logger.error('Error syncing provider descriptions', err);
     }
 
+    const refreshTasks: Promise<void>[] = [];
+
     const watchConfig = vscode.workspace.getConfiguration('devDocket.watches');
     if (watchConfig.get<boolean>('autoWatchAuthoredPRs', true)) {
       const prevAutoWatch = autoWatchControllers.get(providerId);
@@ -402,32 +404,42 @@ function wireEvents(
       }
       const autoWatchController = new AbortController();
       autoWatchControllers.set(providerId, autoWatchController);
-      try {
-        await autoWatchAuthoredPRs(providerId, providerRegistry, prWatcherRegistry, watcherService, autoWatchController.signal);
-      } finally {
-        if (autoWatchControllers.get(providerId) === autoWatchController) {
-          autoWatchControllers.delete(providerId);
+      refreshTasks.push((async () => {
+        try {
+          await autoWatchAuthoredPRs(providerId, providerRegistry, prWatcherRegistry, watcherService, autoWatchController.signal);
+        } finally {
+          if (autoWatchControllers.get(providerId) === autoWatchController) {
+            autoWatchControllers.delete(providerId);
+          }
         }
-      }
+      })());
     }
 
     const config = vscode.workspace.getConfiguration('devDocket');
-    if (!config.get<boolean>('autoCompleteOnClose', true)) {
-      return;
+    if (config.get<boolean>('autoCompleteOnClose', true)) {
+      // Abort any in-flight check for this provider
+      const prev = autoCompleteControllers.get(providerId);
+      if (prev) {
+        prev.abort();
+      }
+      const controller = new AbortController();
+      autoCompleteControllers.set(providerId, controller);
+      refreshTasks.push((async () => {
+        try {
+          const completedTitles = await checkAutoComplete(providerId, workGraph, providerRegistry, controller.signal);
+          showAutoCompleteNotification(completedTitles);
+        } finally {
+          if (autoCompleteControllers.get(providerId) === controller) {
+            autoCompleteControllers.delete(providerId);
+          }
+        }
+      })());
     }
-    // Abort any in-flight check for this provider
-    const prev = autoCompleteControllers.get(providerId);
-    if (prev) {
-      prev.abort();
-    }
-    const controller = new AbortController();
-    autoCompleteControllers.set(providerId, controller);
-    try {
-      const completedTitles = await checkAutoComplete(providerId, workGraph, providerRegistry, controller.signal);
-      showAutoCompleteNotification(completedTitles);
-    } finally {
-      if (autoCompleteControllers.get(providerId) === controller) {
-        autoCompleteControllers.delete(providerId);
+
+    const results = await Promise.allSettled(refreshTasks);
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        logger.error(`Error running provider refresh follow-up for ${providerId}`, result.reason);
       }
     }
   }));

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -156,7 +156,7 @@ export async function autoWatchAuthoredPRs(
       if (signal.aborted) {
         return;
       }
-      logger.warn(`Failed to auto-watch authored PR from provider ${providerId}: ${String(err)}`);
+      logger.warn(`Failed to auto-watch authored PR from provider ${providerId}`, { url: item.url }, err);
     }
   }
 }

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -122,6 +122,45 @@ async function migrateDiscoveredState(workGraph: WorkGraph, stateStore: Discover
   }
 }
 
+function isAutoWatchCandidate(item: { authored?: boolean; url?: string }): item is { authored: true; url: string } {
+  return item.authored === true && typeof item.url === 'string';
+}
+
+export async function autoWatchAuthoredPRs(
+  providerId: string,
+  providerRegistry: ProviderRegistry,
+  prWatcherRegistry: PRWatcherRegistry,
+  watcherService: WatcherService,
+  signal: AbortSignal,
+): Promise<void> {
+  const items = providerRegistry.getDiscoveredItems(providerId).filter(isAutoWatchCandidate);
+
+  for (const item of items) {
+    if (signal.aborted) {
+      return;
+    }
+
+    try {
+      const prWatcher = prWatcherRegistry.findWatcherForUrl(item.url);
+      if (!prWatcher) {
+        continue;
+      }
+
+      const identifier = prWatcher.parsePRUrl(item.url);
+      if (watcherService.isPRWatched(identifier)) {
+        continue;
+      }
+
+      await watcherService.startPRWatch(identifier);
+    } catch (err) {
+      if (signal.aborted) {
+        return;
+      }
+      logger.warn(`Failed to auto-watch authored PR from provider ${providerId}: ${String(err)}`);
+    }
+  }
+}
+
 function createTreeViews(
   providerRegistry: ProviderRegistry,
   stateStore: DiscoveredStateStore,
@@ -338,8 +377,9 @@ function wireEvents(
     }
   }));
 
-  // Provider refresh handler: sync titles/descriptions and auto-complete.
-  // Per-provider guard prevents overlapping auto-complete runs; AbortController cancels in-flight checks.
+  // Provider refresh handler: sync titles/descriptions, auto-watch authored PRs, and auto-complete.
+  // Per-provider guards prevent overlapping runs; AbortController cancels in-flight checks.
+  const autoWatchControllers = new Map<string, AbortController>();
   const autoCompleteControllers = new Map<string, AbortController>();
   const autoCompleteSub = providerRegistry.onDidRefreshProvider(safeHandler('Error handling provider refresh', async (providerId) => {
     try {
@@ -352,6 +392,23 @@ function wireEvents(
       await syncProviderDescriptions(providerId, providerRegistry, workGraph);
     } catch (err) {
       logger.error('Error syncing provider descriptions', err);
+    }
+
+    const watchConfig = vscode.workspace.getConfiguration('devDocket.watches');
+    if (watchConfig.get<boolean>('autoWatchAuthoredPRs', true)) {
+      const prevAutoWatch = autoWatchControllers.get(providerId);
+      if (prevAutoWatch) {
+        prevAutoWatch.abort();
+      }
+      const autoWatchController = new AbortController();
+      autoWatchControllers.set(providerId, autoWatchController);
+      try {
+        await autoWatchAuthoredPRs(providerId, providerRegistry, prWatcherRegistry, watcherService, autoWatchController.signal);
+      } finally {
+        if (autoWatchControllers.get(providerId) === autoWatchController) {
+          autoWatchControllers.delete(providerId);
+        }
+      }
     }
 
     const config = vscode.workspace.getConfiguration('devDocket');
@@ -375,7 +432,13 @@ function wireEvents(
     }
   }));
 
-  // Abort all in-flight auto-complete checks on disposal
+  // Abort all in-flight auto-watch and auto-complete checks on disposal
+  const autoWatchCleanup = { dispose: () => {
+    for (const controller of autoWatchControllers.values()) {
+      controller.abort();
+    }
+    autoWatchControllers.clear();
+  }};
   const autoCompleteCleanup = { dispose: () => {
     for (const controller of autoCompleteControllers.values()) {
       controller.abort();
@@ -383,7 +446,19 @@ function wireEvents(
     autoCompleteControllers.clear();
   }};
 
-  return [discoveredSub, newItemsSub, providerRegSub, stateStoreSub, markSeenSub, workGraphSub, jobFailureSub, runCompleteSub, autoCompleteSub, autoCompleteCleanup];
+  return [
+    discoveredSub,
+    newItemsSub,
+    providerRegSub,
+    stateStoreSub,
+    markSeenSub,
+    workGraphSub,
+    jobFailureSub,
+    runCompleteSub,
+    autoCompleteSub,
+    autoWatchCleanup,
+    autoCompleteCleanup,
+  ];
 }
 
 /**

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -224,6 +224,7 @@ function wireEvents(
   stateStore: DiscoveredStateStore,
   workGraph: WorkGraph,
   watcherService: WatcherService,
+  prWatcherRegistry: PRWatcherRegistry,
   { providers, views }: ReturnType<typeof createTreeViews>,
 ): vscode.Disposable[] {
   const { inboxProvider, queueProvider, focusProvider, historyProvider } = providers;
@@ -516,7 +517,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   logger.info(`Tree view creation took ${Math.round(performance.now() - treeViewStart)}ms`);
 
   const eventWiringStart = performance.now();
-  const eventDisposables = wireEvents(pr, ss, wg, ws, treeSetup);
+  const eventDisposables = wireEvents(pr, ss, wg, ws, pwr, treeSetup);
   logger.info(`Event wiring took ${Math.round(performance.now() - eventWiringStart)}ms`);
 
   const { providers, views, disposables: viewDisposables } = treeSetup;

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -147,7 +147,7 @@ export async function autoWatchAuthoredPRs(
       }
 
       const identifier = prWatcher.parsePRUrl(item.url);
-      if (watcherService.isPRWatched(identifier)) {
+      if (await watcherService.isPRWatched(identifier)) {
         continue;
       }
 

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -47,6 +47,7 @@ export class WatcherService implements vscode.Disposable {
   private pollTimer: NodeJS.Timeout | undefined;
   private isPollInFlight = false;
   private consecutiveFailures = new Map<string, number>();
+  private persistedPRWatchKeys: Set<string> | undefined;
   private configSubscription: vscode.Disposable | undefined;
   
   private readonly _onDidChangeWatchedRuns = new vscode.EventEmitter<WatchedRun[]>();
@@ -83,6 +84,8 @@ export class WatcherService implements vscode.Disposable {
    */
   async loadPersistedWatches(): Promise<void> {
     const { runs: watches, prs } = await this.watchStore.loadAll();
+    this.persistedPRWatchKeys = new Set(prs.map(pr => this.getPRWatchKey(pr.identifier)));
+
     // Restore non-dismissed run watches
     const restored = watches.filter(w => !w.dismissed);
     for (const watch of restored) {
@@ -221,6 +224,7 @@ export class WatcherService implements vscode.Disposable {
     };
 
     this.prWatches.set(key, watchedPR);
+    this.persistedPRWatchKeys?.add(key);
     this.consecutiveFailures.delete(key);
     this.logger.info(`Started watching PR: ${identifier.displayName} (${identifier.providerId})`);
 
@@ -339,7 +343,7 @@ export class WatcherService implements vscode.Disposable {
       return true;
     }
 
-    return this.watchStore.hasPRWatch(identifier);
+    return (await this.getPersistedPRWatchKeys()).has(key);
   }
 
   /**
@@ -749,6 +753,15 @@ export class WatcherService implements vscode.Disposable {
     return identifier;
   }
 
+  private async getPersistedPRWatchKeys(): Promise<Set<string>> {
+    if (!this.persistedPRWatchKeys) {
+      const { prs } = await this.watchStore.loadAll();
+      this.persistedPRWatchKeys = new Set(prs.map(pr => this.getPRWatchKey(pr.identifier)));
+    }
+
+    return this.persistedPRWatchKeys;
+  }
+
   private persistWatches(): void {
     this.watchStore.saveAll(this.getAllWatches(), this.getAllPRWatches()).catch(err => {
       this.logger.error(`Failed to persist watches: ${err}`);
@@ -766,5 +779,6 @@ export class WatcherService implements vscode.Disposable {
     this.watches.clear();
     this.prWatches.clear();
     this.consecutiveFailures.clear();
+    this.persistedPRWatchKeys = undefined;
   }
 }

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -331,6 +331,13 @@ export class WatcherService implements vscode.Disposable {
   }
 
   /**
+   * Check whether a PR has ever been watched in this session, including dismissed watches.
+   */
+  isPRWatched(identifier: PRIdentifier): boolean {
+    return this.prWatches.has(this.getPRWatchKey(identifier));
+  }
+
+  /**
    * Get active standalone watches (not dismissed, no parent PR).
    */
   getActiveStandaloneWatches(): WatchedRun[] {

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -335,7 +335,7 @@ export class WatcherService implements vscode.Disposable {
   }
 
   /**
-   * Check whether a PR has ever been watched, including dismissed watches restored from persistence.
+   * Check whether a PR has ever been watched, including dismissed entries loaded from persisted state on demand.
    */
   async isPRWatched(identifier: PRIdentifier): Promise<boolean> {
     const key = this.getPRWatchKey(identifier);

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -331,10 +331,15 @@ export class WatcherService implements vscode.Disposable {
   }
 
   /**
-   * Check whether a PR has ever been watched in this session, including dismissed watches.
+   * Check whether a PR has ever been watched, including dismissed watches restored from persistence.
    */
-  isPRWatched(identifier: PRIdentifier): boolean {
-    return this.prWatches.has(this.getPRWatchKey(identifier));
+  async isPRWatched(identifier: PRIdentifier): Promise<boolean> {
+    const key = this.getPRWatchKey(identifier);
+    if (this.prWatches.has(key)) {
+      return true;
+    }
+
+    return this.watchStore.hasPRWatch(identifier);
   }
 
   /**

--- a/packages/core/src/storage/watchStore.ts
+++ b/packages/core/src/storage/watchStore.ts
@@ -1,4 +1,5 @@
 import type { Memento } from 'vscode';
+import type { PRIdentifier } from '@devdocket/shared';
 import { logger } from '../services/logger';
 import type { WatchedRun, WatchedPR } from '../services/watcherService';
 
@@ -70,6 +71,18 @@ export class WatchStore {
       : [];
 
     return { runs, prs };
+  }
+
+  /**
+   * Check whether a PR watch exists in persisted state, including dismissed entries.
+   */
+  async hasPRWatch(identifier: PRIdentifier): Promise<boolean> {
+    const { prs } = await this.loadAll();
+    return prs.some(pr =>
+      pr.identifier.providerId === identifier.providerId
+      && pr.identifier.repo === identifier.repo
+      && pr.identifier.prId === identifier.prId,
+    );
   }
 
   /**

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -377,6 +377,51 @@ describe('activate()', () => {
     expect(watcherService.startPRWatch).not.toHaveBeenCalled();
   });
 
+  it('logs auto-watch failures with URL context and error details', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const providerRegistry = {
+      getDiscoveredItems: vi.fn().mockReturnValue([
+        {
+          externalId: 'owner/repo#42',
+          title: '#42: Authored PR',
+          url: 'https://github.com/owner/repo/pull/42',
+          authored: true,
+        },
+      ]),
+    } as any;
+    const identifier = {
+      providerId: 'github-prs',
+      prId: '42',
+      displayName: 'PR #42',
+      url: 'https://github.com/owner/repo/pull/42',
+      repo: 'owner/repo',
+    };
+    const prWatcherRegistry = {
+      findWatcherForUrl: vi.fn().mockReturnValue({
+        parsePRUrl: vi.fn().mockReturnValue(identifier),
+      }),
+    } as any;
+    const error = new Error('boom');
+    const watcherService = {
+      isPRWatched: vi.fn().mockReturnValue(false),
+      startPRWatch: vi.fn().mockRejectedValue(error),
+    } as any;
+
+    await autoWatchAuthoredPRs(
+      'github-my-prs',
+      providerRegistry,
+      prWatcherRegistry,
+      watcherService,
+      new AbortController().signal,
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      'Failed to auto-watch authored PR from provider github-my-prs',
+      { url: 'https://github.com/owner/repo/pull/42' },
+      error,
+    );
+  });
+
   // ------------------------------------------------------------------
   // 11. State migration: provider-backed items without inbox state get accepted
   // ------------------------------------------------------------------

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import * as vscode from 'vscode';
 import { MockMemento } from 'vscode';
-import { activate, deactivate, logger } from '../extension';
+import { activate, autoWatchAuthoredPRs, deactivate, logger } from '../extension';
 import { _resetViewLayoutStore } from '../views/viewLayout';
 
 // Stub fs so migration never touches disk
@@ -221,7 +221,99 @@ describe('activate()', () => {
   });
 
   // ------------------------------------------------------------------
-  // 10. State migration: provider-backed items without inbox state get accepted
+  // 10. Auto-watch: authored PRs are watched on provider refresh
+  // ------------------------------------------------------------------
+  it('auto-watches authored PRs discovered on provider refresh', async () => {
+    const providerRegistry = {
+      getDiscoveredItems: vi.fn().mockReturnValue([
+        {
+          externalId: 'owner/repo#42',
+          title: '#42: Authored PR',
+          url: 'https://github.com/owner/repo/pull/42',
+          authored: true,
+        },
+        {
+          externalId: 'owner/repo#99',
+          title: '#99: Assigned PR',
+          url: 'https://github.com/owner/repo/pull/99',
+        },
+      ]),
+    } as any;
+    const identifier = {
+      providerId: 'github-prs',
+      prId: '42',
+      displayName: 'PR #42',
+      url: 'https://github.com/owner/repo/pull/42',
+      repo: 'owner/repo',
+    };
+    const prWatcher = {
+      parsePRUrl: vi.fn().mockReturnValue(identifier),
+    };
+    const prWatcherRegistry = {
+      findWatcherForUrl: vi.fn((url: string) => url.includes('/pull/42') ? prWatcher : undefined),
+    } as any;
+    const watcherService = {
+      isPRWatched: vi.fn().mockReturnValue(false),
+      startPRWatch: vi.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await autoWatchAuthoredPRs(
+      'github-my-prs',
+      providerRegistry,
+      prWatcherRegistry,
+      watcherService,
+      new AbortController().signal,
+    );
+
+    expect(prWatcherRegistry.findWatcherForUrl).toHaveBeenCalledWith('https://github.com/owner/repo/pull/42');
+    expect(prWatcher.parsePRUrl).toHaveBeenCalledWith('https://github.com/owner/repo/pull/42');
+    expect(watcherService.isPRWatched).toHaveBeenCalledWith(identifier);
+    expect(watcherService.startPRWatch).toHaveBeenCalledWith(identifier);
+  });
+
+  it('does not recreate auto-watched PRs on later refreshes', async () => {
+    const providerRegistry = {
+      getDiscoveredItems: vi.fn().mockReturnValue([
+        {
+          externalId: 'owner/repo#42',
+          title: '#42: Authored PR',
+          url: 'https://github.com/owner/repo/pull/42',
+          authored: true,
+        },
+      ]),
+    } as any;
+    const identifier = {
+      providerId: 'github-prs',
+      prId: '42',
+      displayName: 'PR #42',
+      url: 'https://github.com/owner/repo/pull/42',
+      repo: 'owner/repo',
+    };
+    const prWatcher = {
+      parsePRUrl: vi.fn().mockReturnValue(identifier),
+    };
+    const prWatcherRegistry = {
+      findWatcherForUrl: vi.fn().mockReturnValue(prWatcher),
+    } as any;
+    const watcherService = {
+      isPRWatched: vi.fn().mockReturnValue(true),
+      startPRWatch: vi.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await autoWatchAuthoredPRs(
+      'github-my-prs',
+      providerRegistry,
+      prWatcherRegistry,
+      watcherService,
+      new AbortController().signal,
+    );
+
+    expect(prWatcher.parsePRUrl).toHaveBeenCalledTimes(1);
+    expect(watcherService.startPRWatch).not.toHaveBeenCalled();
+  });
+
+  // ------------------------------------------------------------------
+  // 11. State migration: provider-backed items without inbox state get accepted
   // ------------------------------------------------------------------
   it('migrates provider-backed work items to accepted state', async () => {
     // Seed the store with a work item that has provider info via globalState

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -271,6 +271,71 @@ describe('activate()', () => {
     expect(watcherService.startPRWatch).toHaveBeenCalledWith(identifier);
   });
 
+  it('runs auto-watch and auto-complete in parallel after provider refresh', async () => {
+    const globalState = context.globalState as InstanceType<typeof MockMemento>;
+    const now = Date.now();
+    await globalState.update('devdocket.workitems', [
+      {
+        id: 'auto-complete-item',
+        title: 'Closed PR',
+        state: 'New',
+        providerId: 'github-my-prs',
+        externalId: 'owner/repo#42',
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]);
+    await globalState.update('devdocket.migrated', true);
+
+    const api = await activate(context);
+
+    let resolveSnapshot: ((value: { prState: 'open'; runs: []; displayName?: string }) => void) | undefined;
+    const snapshotPromise = new Promise<{ prState: 'open'; runs: []; displayName?: string }>((resolve) => {
+      resolveSnapshot = resolve;
+    });
+
+    api.registerPRWatcher({
+      id: 'github-prs',
+      label: 'GitHub PRs',
+      canWatch: (url: string) => url.includes('/pull/'),
+      parsePRUrl: (url: string) => ({
+        providerId: 'github-prs',
+        prId: '42',
+        displayName: 'PR #42',
+        url,
+        repo: 'owner/repo',
+      }),
+      getPRRunsSnapshot: vi.fn(() => snapshotPromise),
+    } as any);
+
+    const itemEmitter = new (vscode.EventEmitter as any)();
+    const provider = {
+      id: 'github-my-prs',
+      label: 'My PRs',
+      onDidDiscoverItems: itemEmitter.event,
+      refresh: vi.fn(async () => {
+        itemEmitter.fire([
+          {
+            externalId: 'owner/repo#42',
+            title: 'Closed PR',
+            url: 'https://github.com/owner/repo/pull/42',
+            authored: true,
+          },
+        ]);
+      }),
+      getClosedItems: vi.fn(async (externalIds: string[]) => externalIds.filter(id => id === 'owner/repo#42')),
+    };
+
+    api.registerProvider(provider as any);
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(provider.getClosedItems).toHaveBeenCalledWith(['owner/repo#42'], expect.any(AbortSignal));
+
+    resolveSnapshot?.({ prState: 'open', runs: [] });
+    await flushMicrotasks();
+  });
+
   it('does not recreate auto-watched PRs on later refreshes', async () => {
     const providerRegistry = {
       getDiscoveredItems: vi.fn().mockReturnValue([

--- a/packages/core/src/test/watchStore.test.ts
+++ b/packages/core/src/test/watchStore.test.ts
@@ -96,6 +96,21 @@ describe('WatchStore', () => {
     });
   });
 
+  describe('hasPRWatch', () => {
+    it('returns true for persisted dismissed PR watches', async () => {
+      const prWatch = createTestPRWatch({ dismissed: true });
+      await memento.update('devdocket.watches', { runs: [], prs: [prWatch] });
+
+      await expect(store.hasPRWatch(prWatch.identifier)).resolves.toBe(true);
+    });
+
+    it('returns false when the PR watch is not persisted', async () => {
+      await memento.update('devdocket.watches', { runs: [], prs: [] });
+
+      await expect(store.hasPRWatch(createTestPRWatch().identifier)).resolves.toBe(false);
+    });
+  });
+
   describe('saveAll', () => {
     it('saves watches to globalState in envelope format', async () => {
       const watch = createTestWatch();

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -315,10 +315,40 @@ describe('WatcherService', () => {
 
     it('reports dismissed PR watches persisted from a previous session', async () => {
       const identifier = createPRIdentifier();
-      (watchStore.hasPRWatch as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+      (watchStore.loadAll as ReturnType<typeof vi.fn>).mockResolvedValue({
+        runs: [],
+        prs: [{
+          identifier,
+          prState: 'closed',
+          childRunKeys: [],
+          watchedAt: new Date().toISOString(),
+          lastPolledAt: new Date().toISOString(),
+          dismissed: true,
+        }],
+      });
 
       await expect(service.isPRWatched(identifier)).resolves.toBe(true);
-      expect(watchStore.hasPRWatch).toHaveBeenCalledWith(identifier);
+      expect(watchStore.loadAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('caches persisted PR watch lookups across repeated checks', async () => {
+      const identifier = createPRIdentifier();
+      (watchStore.loadAll as ReturnType<typeof vi.fn>).mockResolvedValue({
+        runs: [],
+        prs: [{
+          identifier,
+          prState: 'closed',
+          childRunKeys: [],
+          watchedAt: new Date().toISOString(),
+          lastPolledAt: new Date().toISOString(),
+          dismissed: true,
+        }],
+      });
+
+      await expect(service.isPRWatched(identifier)).resolves.toBe(true);
+      await expect(service.isPRWatched(identifier)).resolves.toBe(true);
+
+      expect(watchStore.loadAll).toHaveBeenCalledTimes(1);
     });
 
     it('starts a PR watch and fires change events', async () => {

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -44,6 +44,7 @@ function createIdentifier(providerId: string = 'test'): RunIdentifier {
 function createMockWatchStore(): WatchStore {
   return {
     loadAll: vi.fn().mockResolvedValue({ runs: [], prs: [] }),
+    hasPRWatch: vi.fn().mockResolvedValue(false),
     saveAll: vi.fn().mockResolvedValue(undefined),
   } as unknown as WatchStore;
 }
@@ -303,13 +304,21 @@ describe('WatcherService', () => {
       prRegistry.register(prWatcher);
       const identifier = createPRIdentifier();
 
-      expect(service.isPRWatched(identifier)).toBe(false);
+      await expect(service.isPRWatched(identifier)).resolves.toBe(false);
 
       await service.startPRWatch(identifier);
-      expect(service.isPRWatched(identifier)).toBe(true);
+      await expect(service.isPRWatched(identifier)).resolves.toBe(true);
 
       service.dismissPRWatch(identifier);
-      expect(service.isPRWatched(identifier)).toBe(true);
+      await expect(service.isPRWatched(identifier)).resolves.toBe(true);
+    });
+
+    it('reports dismissed PR watches persisted from a previous session', async () => {
+      const identifier = createPRIdentifier();
+      (watchStore.hasPRWatch as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+      await expect(service.isPRWatched(identifier)).resolves.toBe(true);
+      expect(watchStore.hasPRWatch).toHaveBeenCalledWith(identifier);
     });
 
     it('starts a PR watch and fires change events', async () => {

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -298,6 +298,20 @@ describe('WatcherService', () => {
       };
     }
 
+    it('reports watched PRs even after they are dismissed', async () => {
+      const prWatcher = createMockPRWatcher();
+      prRegistry.register(prWatcher);
+      const identifier = createPRIdentifier();
+
+      expect(service.isPRWatched(identifier)).toBe(false);
+
+      await service.startPRWatch(identifier);
+      expect(service.isPRWatched(identifier)).toBe(true);
+
+      service.dismissPRWatch(identifier);
+      expect(service.isPRWatched(identifier)).toBe(true);
+    });
+
     it('starts a PR watch and fires change events', async () => {
       const prWatcher = createMockPRWatcher();
       prRegistry.register(prWatcher);

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -103,6 +103,7 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
         title: `#${pr.number}: ${pr.title}`,
         description: pr.body ?? undefined,
         url: pr.html_url,
+        authored: true,
         group: repoName,
         reason: 'You authored this PR',
         state: status,

--- a/packages/github/src/test/githubMyPrsProvider.test.ts
+++ b/packages/github/src/test/githubMyPrsProvider.test.ts
@@ -127,11 +127,13 @@ describe('GitHubMyPrsProvider', () => {
     expect(items[0].state).toBe('Waiting on reviews');
     expect(items[0].group).toBe('owner/repo');
     expect(items[0].reason).toBe('You authored this PR');
+    expect(items[0].authored).toBe(true);
     expect(items[0].canonicalId).toBe('github:pull:owner/repo#1');
 
     expect(items[1].externalId).toBe('owner/repo#2');
     expect(items[1].state).toBe('Draft');
     expect(items[1].reason).toBe('You authored this PR');
+    expect(items[1].authored).toBe(true);
     expect(items[1].canonicalId).toBe('github:pull:owner/repo#2');
   });
 
@@ -329,9 +331,11 @@ describe('GitHubMyPrsProvider', () => {
 
     expect(items[0].externalId).toBe('owner/repo#1');
     expect(items[0].reason).toBe('You authored this PR');
+    expect(items[0].authored).toBe(true);
 
     expect(items[1].externalId).toBe('other/repo#2');
     expect(items[1].reason).toBe('You are assigned to this PR');
+    expect(items[1].authored).toBeUndefined();
   });
 
   it('excludes self-authored PRs from assigned results', async () => {

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -23,6 +23,8 @@ export interface DiscoveredItem {
   description?: string;
   /** Optional URL linking back to the item in its source system. */
   url?: string;
+  /** Optional flag indicating the current user authored the item. */
+  authored?: boolean;
   /** Optional grouping key used to organize items in the UI (for example, in the Inbox and Sources views). */
   group?: string;
   /** Optional notification reason explaining why this item was surfaced (e.g. `"assigned"`, `"review_requested"`). */


### PR DESCRIPTION
Adds auto-watching of authored PRs on provider refresh. Introduces an authored flag on DiscoveredItem, a config setting devDocket.watches.autoWatchAuthoredPRs, and isPRWatched method on WatcherService.

Closes #423
