### PR TITLE
Add per-package publishing workflows

### DIFF
--- a/.github/workflows/publish-ado.yml
+++ b/.github/workflows/publish-ado.yml
@@ -74,6 +74,12 @@ jobs:
           printf '%s\n' "$NOTES" > "$RUNNER_TEMP/release-notes.md"
 
       - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
+            echo "Release already exists, updating..."
+            gh release upload "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
+          fi

--- a/.github/workflows/publish-ado.yml
+++ b/.github/workflows/publish-ado.yml
@@ -66,7 +66,7 @@ jobs:
           if [ -z "$PREV_TAG" ]; then
             NOTES=$(git log --pretty=format:"* %s (%h)" -- packages/ado/)
           else
-            NOTES=$(git log "$PREV_TAG"..HEAD --pretty=format:"* %s (%h)" -- packages/ado/)
+            NOTES=$(git log "$PREV_TAG".."$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/ado/)
           fi
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/ado in this release"

--- a/.github/workflows/publish-ado.yml
+++ b/.github/workflows/publish-ado.yml
@@ -24,6 +24,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#ado-v}"
+          PKG_VERSION=$(node -p "require('./packages/ado/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
       - name: Build shared
         working-directory: packages/shared
         run: npm run build
@@ -35,15 +44,6 @@ jobs:
       - name: Test ado
         working-directory: packages/ado
         run: npm run test
-
-      - name: Verify tag version matches package.json
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#ado-v}"
-          PKG_VERSION=$(node -p "require('./packages/ado/package.json').version")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-            exit 1
-          fi
 
       - name: Package extension
         id: package
@@ -71,9 +71,9 @@ jobs:
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/ado in this release"
           fi
-          printf '%s\n' "$NOTES" > release-notes.md
+          printf '%s\n' "$NOTES" > "$RUNNER_TEMP/release-notes.md"
 
       - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-ado.yml
+++ b/.github/workflows/publish-ado.yml
@@ -50,13 +50,13 @@ jobs:
         working-directory: packages/ado
         run: |
           rm -f ./*.vsix
-          npx @vscode/vsce package
+          npx @vscode/vsce@3 package
           VSIX_FILE=$(ls -1 *.vsix | head -n1)
           echo "vsix_path=packages/ado/$VSIX_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Publish to VS Code Marketplace
         working-directory: packages/ado
-        run: npx @vscode/vsce publish -p "$VSCE_PAT"
+        run: npx @vscode/vsce@3 publish -p "$VSCE_PAT"
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 

--- a/.github/workflows/publish-ado.yml
+++ b/.github/workflows/publish-ado.yml
@@ -1,0 +1,79 @@
+name: Publish DevDocket Azure DevOps
+
+on:
+  push:
+    tags:
+      - 'ado-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared
+        working-directory: packages/shared
+        run: npm run build
+
+      - name: Build ado
+        working-directory: packages/ado
+        run: npm run build
+
+      - name: Test ado
+        working-directory: packages/ado
+        run: npm run test
+
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#ado-v}"
+          PKG_VERSION=$(node -p "require('./packages/ado/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Package extension
+        id: package
+        working-directory: packages/ado
+        run: |
+          rm -f ./*.vsix
+          npx @vscode/vsce package
+          VSIX_FILE=$(ls -1 *.vsix | head -n1)
+          echo "vsix_path=packages/ado/$VSIX_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to VS Code Marketplace
+        working-directory: packages/ado
+        run: npx @vscode/vsce publish -p "$VSCE_PAT"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Generate release notes
+        run: |
+          PREV_TAG=$(git tag -l 'ado-v*' --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
+          if [ -n "$PREV_TAG" ]; then
+            NOTES=$(git log "${PREV_TAG}..${GITHUB_REF_NAME}" --pretty=format:"* %s (%h)" -- packages/ado/)
+          else
+            NOTES=$(git log -1 "$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/ado/)
+          fi
+          if [ -z "$NOTES" ]; then
+            NOTES="* No changes to packages/ado in this release"
+          fi
+          printf '%s\n' "$NOTES" > release-notes.md
+
+      - name: Create GitHub Release
+        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-ado.yml
+++ b/.github/workflows/publish-ado.yml
@@ -63,10 +63,10 @@ jobs:
       - name: Generate release notes
         run: |
           PREV_TAG=$(git tag -l 'ado-v*' --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
-          if [ -n "$PREV_TAG" ]; then
-            NOTES=$(git log "${PREV_TAG}..${GITHUB_REF_NAME}" --pretty=format:"* %s (%h)" -- packages/ado/)
+          if [ -z "$PREV_TAG" ]; then
+            NOTES=$(git log --pretty=format:"* %s (%h)" -- packages/ado/)
           else
-            NOTES=$(git log -1 "$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/ado/)
+            NOTES=$(git log "$PREV_TAG"..HEAD --pretty=format:"* %s (%h)" -- packages/ado/)
           fi
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/ado in this release"

--- a/.github/workflows/publish-ai-reviewer.yml
+++ b/.github/workflows/publish-ai-reviewer.yml
@@ -74,6 +74,12 @@ jobs:
           printf '%s\n' "$NOTES" > "$RUNNER_TEMP/release-notes.md"
 
       - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
+            echo "Release already exists, updating..."
+            gh release upload "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
+          fi

--- a/.github/workflows/publish-ai-reviewer.yml
+++ b/.github/workflows/publish-ai-reviewer.yml
@@ -66,7 +66,7 @@ jobs:
           if [ -z "$PREV_TAG" ]; then
             NOTES=$(git log --pretty=format:"* %s (%h)" -- packages/ai-reviewer/)
           else
-            NOTES=$(git log "$PREV_TAG"..HEAD --pretty=format:"* %s (%h)" -- packages/ai-reviewer/)
+            NOTES=$(git log "$PREV_TAG".."$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/ai-reviewer/)
           fi
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/ai-reviewer in this release"

--- a/.github/workflows/publish-ai-reviewer.yml
+++ b/.github/workflows/publish-ai-reviewer.yml
@@ -24,6 +24,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#ai-reviewer-v}"
+          PKG_VERSION=$(node -p "require('./packages/ai-reviewer/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
       - name: Build shared
         working-directory: packages/shared
         run: npm run build
@@ -35,15 +44,6 @@ jobs:
       - name: Test ai-reviewer
         working-directory: packages/ai-reviewer
         run: npm run test
-
-      - name: Verify tag version matches package.json
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#ai-reviewer-v}"
-          PKG_VERSION=$(node -p "require('./packages/ai-reviewer/package.json').version")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-            exit 1
-          fi
 
       - name: Package extension
         id: package
@@ -71,9 +71,9 @@ jobs:
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/ai-reviewer in this release"
           fi
-          printf '%s\n' "$NOTES" > release-notes.md
+          printf '%s\n' "$NOTES" > "$RUNNER_TEMP/release-notes.md"
 
       - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-ai-reviewer.yml
+++ b/.github/workflows/publish-ai-reviewer.yml
@@ -50,13 +50,13 @@ jobs:
         working-directory: packages/ai-reviewer
         run: |
           rm -f ./*.vsix
-          npx @vscode/vsce package
+          npx @vscode/vsce@3 package
           VSIX_FILE=$(ls -1 *.vsix | head -n1)
           echo "vsix_path=packages/ai-reviewer/$VSIX_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Publish to VS Code Marketplace
         working-directory: packages/ai-reviewer
-        run: npx @vscode/vsce publish -p "$VSCE_PAT"
+        run: npx @vscode/vsce@3 publish -p "$VSCE_PAT"
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 

--- a/.github/workflows/publish-ai-reviewer.yml
+++ b/.github/workflows/publish-ai-reviewer.yml
@@ -1,0 +1,79 @@
+name: Publish DevDocket AI Actions
+
+on:
+  push:
+    tags:
+      - 'ai-reviewer-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared
+        working-directory: packages/shared
+        run: npm run build
+
+      - name: Build ai-reviewer
+        working-directory: packages/ai-reviewer
+        run: npm run build
+
+      - name: Test ai-reviewer
+        working-directory: packages/ai-reviewer
+        run: npm run test
+
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#ai-reviewer-v}"
+          PKG_VERSION=$(node -p "require('./packages/ai-reviewer/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Package extension
+        id: package
+        working-directory: packages/ai-reviewer
+        run: |
+          rm -f ./*.vsix
+          npx @vscode/vsce package
+          VSIX_FILE=$(ls -1 *.vsix | head -n1)
+          echo "vsix_path=packages/ai-reviewer/$VSIX_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to VS Code Marketplace
+        working-directory: packages/ai-reviewer
+        run: npx @vscode/vsce publish -p "$VSCE_PAT"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Generate release notes
+        run: |
+          PREV_TAG=$(git tag -l 'ai-reviewer-v*' --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
+          if [ -n "$PREV_TAG" ]; then
+            NOTES=$(git log "${PREV_TAG}..${GITHUB_REF_NAME}" --pretty=format:"* %s (%h)" -- packages/ai-reviewer/)
+          else
+            NOTES=$(git log -1 "$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/ai-reviewer/)
+          fi
+          if [ -z "$NOTES" ]; then
+            NOTES="* No changes to packages/ai-reviewer in this release"
+          fi
+          printf '%s\n' "$NOTES" > release-notes.md
+
+      - name: Create GitHub Release
+        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-ai-reviewer.yml
+++ b/.github/workflows/publish-ai-reviewer.yml
@@ -63,10 +63,10 @@ jobs:
       - name: Generate release notes
         run: |
           PREV_TAG=$(git tag -l 'ai-reviewer-v*' --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
-          if [ -n "$PREV_TAG" ]; then
-            NOTES=$(git log "${PREV_TAG}..${GITHUB_REF_NAME}" --pretty=format:"* %s (%h)" -- packages/ai-reviewer/)
+          if [ -z "$PREV_TAG" ]; then
+            NOTES=$(git log --pretty=format:"* %s (%h)" -- packages/ai-reviewer/)
           else
-            NOTES=$(git log -1 "$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/ai-reviewer/)
+            NOTES=$(git log "$PREV_TAG"..HEAD --pretty=format:"* %s (%h)" -- packages/ai-reviewer/)
           fi
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/ai-reviewer in this release"

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -63,10 +63,10 @@ jobs:
       - name: Generate release notes
         run: |
           PREV_TAG=$(git tag -l 'core-v*' --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
-          if [ -n "$PREV_TAG" ]; then
-            NOTES=$(git log "${PREV_TAG}..${GITHUB_REF_NAME}" --pretty=format:"* %s (%h)" -- packages/core/)
+          if [ -z "$PREV_TAG" ]; then
+            NOTES=$(git log --pretty=format:"* %s (%h)" -- packages/core/)
           else
-            NOTES=$(git log -1 "$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/core/)
+            NOTES=$(git log "$PREV_TAG"..HEAD --pretty=format:"* %s (%h)" -- packages/core/)
           fi
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/core in this release"

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -74,6 +74,12 @@ jobs:
           printf '%s\n' "$NOTES" > "$RUNNER_TEMP/release-notes.md"
 
       - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
+            echo "Release already exists, updating..."
+            gh release upload "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
+          fi

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -1,0 +1,79 @@
+name: Publish DevDocket Core
+
+on:
+  push:
+    tags:
+      - 'core-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared
+        working-directory: packages/shared
+        run: npm run build
+
+      - name: Build core
+        working-directory: packages/core
+        run: npm run build
+
+      - name: Test core
+        working-directory: packages/core
+        run: npm run test
+
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#core-v}"
+          PKG_VERSION=$(node -p "require('./packages/core/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Package extension
+        id: package
+        working-directory: packages/core
+        run: |
+          rm -f ./*.vsix
+          npx @vscode/vsce package
+          VSIX_FILE=$(ls -1 *.vsix | head -n1)
+          echo "vsix_path=packages/core/$VSIX_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to VS Code Marketplace
+        working-directory: packages/core
+        run: npx @vscode/vsce publish -p "$VSCE_PAT"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Generate release notes
+        run: |
+          PREV_TAG=$(git tag -l 'core-v*' --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
+          if [ -n "$PREV_TAG" ]; then
+            NOTES=$(git log "${PREV_TAG}..${GITHUB_REF_NAME}" --pretty=format:"* %s (%h)" -- packages/core/)
+          else
+            NOTES=$(git log -1 "$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/core/)
+          fi
+          if [ -z "$NOTES" ]; then
+            NOTES="* No changes to packages/core in this release"
+          fi
+          printf '%s\n' "$NOTES" > release-notes.md
+
+      - name: Create GitHub Release
+        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -24,6 +24,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#core-v}"
+          PKG_VERSION=$(node -p "require('./packages/core/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
       - name: Build shared
         working-directory: packages/shared
         run: npm run build
@@ -35,15 +44,6 @@ jobs:
       - name: Test core
         working-directory: packages/core
         run: npm run test
-
-      - name: Verify tag version matches package.json
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#core-v}"
-          PKG_VERSION=$(node -p "require('./packages/core/package.json').version")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-            exit 1
-          fi
 
       - name: Package extension
         id: package
@@ -71,9 +71,9 @@ jobs:
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/core in this release"
           fi
-          printf '%s\n' "$NOTES" > release-notes.md
+          printf '%s\n' "$NOTES" > "$RUNNER_TEMP/release-notes.md"
 
       - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -66,7 +66,7 @@ jobs:
           if [ -z "$PREV_TAG" ]; then
             NOTES=$(git log --pretty=format:"* %s (%h)" -- packages/core/)
           else
-            NOTES=$(git log "$PREV_TAG"..HEAD --pretty=format:"* %s (%h)" -- packages/core/)
+            NOTES=$(git log "$PREV_TAG".."$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/core/)
           fi
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/core in this release"

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -50,13 +50,13 @@ jobs:
         working-directory: packages/core
         run: |
           rm -f ./*.vsix
-          npx @vscode/vsce package
+          npx @vscode/vsce@3 package
           VSIX_FILE=$(ls -1 *.vsix | head -n1)
           echo "vsix_path=packages/core/$VSIX_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Publish to VS Code Marketplace
         working-directory: packages/core
-        run: npx @vscode/vsce publish -p "$VSCE_PAT"
+        run: npx @vscode/vsce@3 publish -p "$VSCE_PAT"
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -74,6 +74,12 @@ jobs:
           printf '%s\n' "$NOTES" > "$RUNNER_TEMP/release-notes.md"
 
       - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
+            echo "Release already exists, updating..."
+            gh release upload "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
+          fi

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -24,6 +24,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#github-v}"
+          PKG_VERSION=$(node -p "require('./packages/github/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
       - name: Build shared
         working-directory: packages/shared
         run: npm run build
@@ -35,15 +44,6 @@ jobs:
       - name: Test github
         working-directory: packages/github
         run: npm run test
-
-      - name: Verify tag version matches package.json
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#github-v}"
-          PKG_VERSION=$(node -p "require('./packages/github/package.json').version")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-            exit 1
-          fi
 
       - name: Package extension
         id: package
@@ -71,9 +71,9 @@ jobs:
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/github in this release"
           fi
-          printf '%s\n' "$NOTES" > release-notes.md
+          printf '%s\n' "$NOTES" > "$RUNNER_TEMP/release-notes.md"
 
       - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,0 +1,79 @@
+name: Publish DevDocket GitHub
+
+on:
+  push:
+    tags:
+      - 'github-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared
+        working-directory: packages/shared
+        run: npm run build
+
+      - name: Build github
+        working-directory: packages/github
+        run: npm run build
+
+      - name: Test github
+        working-directory: packages/github
+        run: npm run test
+
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#github-v}"
+          PKG_VERSION=$(node -p "require('./packages/github/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Package extension
+        id: package
+        working-directory: packages/github
+        run: |
+          rm -f ./*.vsix
+          npx @vscode/vsce package
+          VSIX_FILE=$(ls -1 *.vsix | head -n1)
+          echo "vsix_path=packages/github/$VSIX_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to VS Code Marketplace
+        working-directory: packages/github
+        run: npx @vscode/vsce publish -p "$VSCE_PAT"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Generate release notes
+        run: |
+          PREV_TAG=$(git tag -l 'github-v*' --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
+          if [ -n "$PREV_TAG" ]; then
+            NOTES=$(git log "${PREV_TAG}..${GITHUB_REF_NAME}" --pretty=format:"* %s (%h)" -- packages/github/)
+          else
+            NOTES=$(git log -1 "$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/github/)
+          fi
+          if [ -z "$NOTES" ]; then
+            NOTES="* No changes to packages/github in this release"
+          fi
+          printf '%s\n' "$NOTES" > release-notes.md
+
+      - name: Create GitHub Release
+        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -63,10 +63,10 @@ jobs:
       - name: Generate release notes
         run: |
           PREV_TAG=$(git tag -l 'github-v*' --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
-          if [ -n "$PREV_TAG" ]; then
-            NOTES=$(git log "${PREV_TAG}..${GITHUB_REF_NAME}" --pretty=format:"* %s (%h)" -- packages/github/)
+          if [ -z "$PREV_TAG" ]; then
+            NOTES=$(git log --pretty=format:"* %s (%h)" -- packages/github/)
           else
-            NOTES=$(git log -1 "$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/github/)
+            NOTES=$(git log "$PREV_TAG"..HEAD --pretty=format:"* %s (%h)" -- packages/github/)
           fi
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/github in this release"

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -50,13 +50,13 @@ jobs:
         working-directory: packages/github
         run: |
           rm -f ./*.vsix
-          npx @vscode/vsce package
+          npx @vscode/vsce@3 package
           VSIX_FILE=$(ls -1 *.vsix | head -n1)
           echo "vsix_path=packages/github/$VSIX_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Publish to VS Code Marketplace
         working-directory: packages/github
-        run: npx @vscode/vsce publish -p "$VSCE_PAT"
+        run: npx @vscode/vsce@3 publish -p "$VSCE_PAT"
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -66,7 +66,7 @@ jobs:
           if [ -z "$PREV_TAG" ]; then
             NOTES=$(git log --pretty=format:"* %s (%h)" -- packages/github/)
           else
-            NOTES=$(git log "$PREV_TAG"..HEAD --pretty=format:"* %s (%h)" -- packages/github/)
+            NOTES=$(git log "$PREV_TAG".."$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/github/)
           fi
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/github in this release"

--- a/.github/workflows/publish-start-git-work.yml
+++ b/.github/workflows/publish-start-git-work.yml
@@ -74,6 +74,12 @@ jobs:
           printf '%s\n' "$NOTES" > "$RUNNER_TEMP/release-notes.md"
 
       - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" > /dev/null 2>&1; then
+            echo "Release already exists, updating..."
+            gh release upload "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
+          fi

--- a/.github/workflows/publish-start-git-work.yml
+++ b/.github/workflows/publish-start-git-work.yml
@@ -50,13 +50,13 @@ jobs:
         working-directory: packages/start-git-work
         run: |
           rm -f ./*.vsix
-          npx @vscode/vsce package
+          npx @vscode/vsce@3 package
           VSIX_FILE=$(ls -1 *.vsix | head -n1)
           echo "vsix_path=packages/start-git-work/$VSIX_FILE" >> "$GITHUB_OUTPUT"
 
       - name: Publish to VS Code Marketplace
         working-directory: packages/start-git-work
-        run: npx @vscode/vsce publish -p "$VSCE_PAT"
+        run: npx @vscode/vsce@3 publish -p "$VSCE_PAT"
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 

--- a/.github/workflows/publish-start-git-work.yml
+++ b/.github/workflows/publish-start-git-work.yml
@@ -63,10 +63,10 @@ jobs:
       - name: Generate release notes
         run: |
           PREV_TAG=$(git tag -l 'start-git-work-v*' --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
-          if [ -n "$PREV_TAG" ]; then
-            NOTES=$(git log "${PREV_TAG}..${GITHUB_REF_NAME}" --pretty=format:"* %s (%h)" -- packages/start-git-work/)
+          if [ -z "$PREV_TAG" ]; then
+            NOTES=$(git log --pretty=format:"* %s (%h)" -- packages/start-git-work/)
           else
-            NOTES=$(git log -1 "$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/start-git-work/)
+            NOTES=$(git log "$PREV_TAG"..HEAD --pretty=format:"* %s (%h)" -- packages/start-git-work/)
           fi
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/start-git-work in this release"

--- a/.github/workflows/publish-start-git-work.yml
+++ b/.github/workflows/publish-start-git-work.yml
@@ -66,7 +66,7 @@ jobs:
           if [ -z "$PREV_TAG" ]; then
             NOTES=$(git log --pretty=format:"* %s (%h)" -- packages/start-git-work/)
           else
-            NOTES=$(git log "$PREV_TAG"..HEAD --pretty=format:"* %s (%h)" -- packages/start-git-work/)
+            NOTES=$(git log "$PREV_TAG".."$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/start-git-work/)
           fi
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/start-git-work in this release"

--- a/.github/workflows/publish-start-git-work.yml
+++ b/.github/workflows/publish-start-git-work.yml
@@ -1,0 +1,79 @@
+name: Publish DevDocket Start Git Work
+
+on:
+  push:
+    tags:
+      - 'start-git-work-v*'
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared
+        working-directory: packages/shared
+        run: npm run build
+
+      - name: Build start-git-work
+        working-directory: packages/start-git-work
+        run: npm run build
+
+      - name: Test start-git-work
+        working-directory: packages/start-git-work
+        run: npm run test
+
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#start-git-work-v}"
+          PKG_VERSION=$(node -p "require('./packages/start-git-work/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Package extension
+        id: package
+        working-directory: packages/start-git-work
+        run: |
+          rm -f ./*.vsix
+          npx @vscode/vsce package
+          VSIX_FILE=$(ls -1 *.vsix | head -n1)
+          echo "vsix_path=packages/start-git-work/$VSIX_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Publish to VS Code Marketplace
+        working-directory: packages/start-git-work
+        run: npx @vscode/vsce publish -p "$VSCE_PAT"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Generate release notes
+        run: |
+          PREV_TAG=$(git tag -l 'start-git-work-v*' --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
+          if [ -n "$PREV_TAG" ]; then
+            NOTES=$(git log "${PREV_TAG}..${GITHUB_REF_NAME}" --pretty=format:"* %s (%h)" -- packages/start-git-work/)
+          else
+            NOTES=$(git log -1 "$GITHUB_REF_NAME" --pretty=format:"* %s (%h)" -- packages/start-git-work/)
+          fi
+          if [ -z "$NOTES" ]; then
+            NOTES="* No changes to packages/start-git-work in this release"
+          fi
+          printf '%s\n' "$NOTES" > release-notes.md
+
+      - name: Create GitHub Release
+        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-start-git-work.yml
+++ b/.github/workflows/publish-start-git-work.yml
@@ -24,6 +24,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#start-git-work-v}"
+          PKG_VERSION=$(node -p "require('./packages/start-git-work/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
       - name: Build shared
         working-directory: packages/shared
         run: npm run build
@@ -35,15 +44,6 @@ jobs:
       - name: Test start-git-work
         working-directory: packages/start-git-work
         run: npm run test
-
-      - name: Verify tag version matches package.json
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#start-git-work-v}"
-          PKG_VERSION=$(node -p "require('./packages/start-git-work/package.json').version")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-            exit 1
-          fi
 
       - name: Package extension
         id: package
@@ -71,9 +71,9 @@ jobs:
           if [ -z "$NOTES" ]; then
             NOTES="* No changes to packages/start-git-work in this release"
           fi
-          printf '%s\n' "$NOTES" > release-notes.md
+          printf '%s\n' "$NOTES" > "$RUNNER_TEMP/release-notes.md"
 
       - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+        run: gh release create "$GITHUB_REF_NAME" "${{ steps.package.outputs.vsix_path }}" --title "$GITHUB_REF_NAME" --notes-file "$RUNNER_TEMP/release-notes.md"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Creates independent publishing workflows for each VS Code extension package (core, github, ado, start-git-work, ai-reviewer), triggered by package-specific tags. Each workflow builds, tests, publishes to VS Code Marketplace, and creates a GitHub Release.

Closes #409
