### PR TITLE
Fix AI walkthrough responses for GPT models

### DIFF
--- a/packages/ai-reviewer/src/test/walkthroughParticipant.test.ts
+++ b/packages/ai-reviewer/src/test/walkthroughParticipant.test.ts
@@ -280,6 +280,33 @@ describe('WalkthroughParticipant', () => {
       expect((result as { metadata?: Record<string, unknown> }).metadata?.phase).toBe('summary');
     });
 
+    it('stops retrying after repeated phase-only responses without walkthrough text', async () => {
+      const mockModel = {
+        sendRequest: vi.fn().mockImplementation(() => ({
+          stream: (async function* () {
+            yield new LanguageModelTextPart('\n');
+            yield new LanguageModelToolCallPart('phase-1', 'devdocket-signalPhase', { phase: 'summary' });
+          })(),
+        })),
+      };
+
+      participant.register();
+      const handler = vi.mocked(chat.createChatParticipant).mock.calls[0][1];
+
+      const request = createMockRequest('Walk me through https://github.com/owner/repo/pull/42', mockModel);
+      const context = createMockContext();
+      const response = createMockResponse();
+      const token = { isCancellationRequested: false };
+
+      await handler(request, context, response, token);
+
+      expect(lm.invokeTool).not.toHaveBeenCalled();
+      expect(mockModel.sendRequest).toHaveBeenCalledTimes(2);
+      expect(response.markdown).toHaveBeenCalledWith(
+        '⚠️ The model did not produce walkthrough text. Please try again.',
+      );
+    });
+
     it('warns when the model finishes without visible walkthrough text', async () => {
       const mockModel = {
         sendRequest: vi.fn().mockResolvedValue({

--- a/packages/ai-reviewer/src/test/walkthroughParticipant.test.ts
+++ b/packages/ai-reviewer/src/test/walkthroughParticipant.test.ts
@@ -248,6 +248,38 @@ describe('WalkthroughParticipant', () => {
       expect(response.markdown).toHaveBeenCalledWith('File contents analyzed.');
     });
 
+    it('continues when a model emits only signalPhase before walkthrough text', async () => {
+      const mockModel = {
+        sendRequest: vi.fn()
+          .mockResolvedValueOnce({
+            stream: (async function* () {
+              yield new LanguageModelTextPart('\n');
+              yield new LanguageModelToolCallPart('phase-1', 'devdocket-signalPhase', { phase: 'summary' });
+            })(),
+          })
+          .mockResolvedValueOnce({
+            stream: (async function* () {
+              yield new LanguageModelTextPart('Summary after phase acknowledgement.');
+            })(),
+          }),
+      };
+
+      participant.register();
+      const handler = vi.mocked(chat.createChatParticipant).mock.calls[0][1];
+
+      const request = createMockRequest('Walk me through https://github.com/owner/repo/pull/42', mockModel);
+      const context = createMockContext();
+      const response = createMockResponse();
+      const token = { isCancellationRequested: false };
+
+      const result = await handler(request, context, response, token);
+
+      expect(lm.invokeTool).not.toHaveBeenCalled();
+      expect(mockModel.sendRequest).toHaveBeenCalledTimes(2);
+      expect(response.markdown).toHaveBeenCalledWith('Summary after phase acknowledgement.');
+      expect((result as { metadata?: Record<string, unknown> }).metadata?.phase).toBe('summary');
+    });
+
     it('signalPhase with lastFile updates ChatResult metadata', async () => {
       const mockModel = {
         sendRequest: vi.fn().mockResolvedValue({

--- a/packages/ai-reviewer/src/test/walkthroughParticipant.test.ts
+++ b/packages/ai-reviewer/src/test/walkthroughParticipant.test.ts
@@ -280,6 +280,32 @@ describe('WalkthroughParticipant', () => {
       expect((result as { metadata?: Record<string, unknown> }).metadata?.phase).toBe('summary');
     });
 
+    it('warns when the model finishes without visible walkthrough text', async () => {
+      const mockModel = {
+        sendRequest: vi.fn().mockResolvedValue({
+          stream: (async function* () {
+            yield new LanguageModelTextPart('\n  \t');
+          })(),
+        }),
+      };
+
+      participant.register();
+      const handler = vi.mocked(chat.createChatParticipant).mock.calls[0][1];
+
+      const request = createMockRequest('Walk me through https://github.com/owner/repo/pull/42', mockModel);
+      const context = createMockContext();
+      const response = createMockResponse();
+      const token = { isCancellationRequested: false };
+
+      await handler(request, context, response, token);
+
+      expect(mockModel.sendRequest).toHaveBeenCalledTimes(1);
+      expect(response.markdown).toHaveBeenCalledWith('\n  \t');
+      expect(response.markdown).toHaveBeenCalledWith(
+        '⚠️ The model did not produce walkthrough text. Please try again.',
+      );
+    });
+
     it('signalPhase with lastFile updates ChatResult metadata', async () => {
       const mockModel = {
         sendRequest: vi.fn().mockResolvedValue({

--- a/packages/ai-reviewer/src/walkthroughParticipant.ts
+++ b/packages/ai-reviewer/src/walkthroughParticipant.ts
@@ -186,9 +186,11 @@ export class WalkthroughParticipant {
     // Tool-use loop
     const loopMessages = [...messages];
     const maxIterations = 20;
+    const maxPhaseOnlyRetries = 1;
     let iterations = 0;
     let phase = context.history.length === 0 ? 'summary' : 'walkthrough';
     let streamedAnyText = false;
+    let phaseOnlyNoTextIterations = 0;
     this.log.info(`Starting tool-use loop — initial phase: ${phase}, maxIterations: ${maxIterations}`);
 
     while (!token.isCancellationRequested && iterations < maxIterations) {
@@ -278,8 +280,15 @@ export class WalkthroughParticipant {
         }
       }
 
-      const hasOnlyPhaseSignal = !hasToolCalls && toolResults.length > 0;
-      if (!hasToolCalls && !(hasOnlyPhaseSignal && !streamedTextThisIteration)) {
+      const phaseSignalWithoutText = !hasToolCalls && toolResults.length > 0 && !streamedTextThisIteration;
+      if (phaseSignalWithoutText) {
+        phaseOnlyNoTextIterations++;
+      } else {
+        phaseOnlyNoTextIterations = 0;
+      }
+      const shouldRetryForPhaseSignal = phaseSignalWithoutText && phaseOnlyNoTextIterations <= maxPhaseOnlyRetries;
+
+      if (!hasToolCalls && !shouldRetryForPhaseSignal) {
         this.log.info(`No tool calls requiring another model request in iteration ${iterations} — exiting loop`);
         break;
       }

--- a/packages/ai-reviewer/src/walkthroughParticipant.ts
+++ b/packages/ai-reviewer/src/walkthroughParticipant.ts
@@ -188,6 +188,7 @@ export class WalkthroughParticipant {
     const maxIterations = 20;
     let iterations = 0;
     let phase = context.history.length === 0 ? 'summary' : 'walkthrough';
+    let streamedAnyText = false;
     this.log.info(`Starting tool-use loop — initial phase: ${phase}, maxIterations: ${maxIterations}`);
 
     while (!token.isCancellationRequested && iterations < maxIterations) {
@@ -205,17 +206,22 @@ export class WalkthroughParticipant {
       }
 
       let hasToolCalls = false;
+      let streamedTextThisIteration = false;
       const assistantParts: (vscode.LanguageModelTextPart | vscode.LanguageModelToolCallPart)[] = [];
       const toolResults: Array<{ callId: string; content: (vscode.LanguageModelTextPart | vscode.LanguageModelToolResultPart)[] }> = [];
 
       for await (const part of chatResponse.stream) {
         if (part instanceof vscode.LanguageModelTextPart) {
           response.markdown(part.value);
+          if (part.value.trim().length > 0) {
+            streamedTextThisIteration = true;
+            streamedAnyText = true;
+          }
           assistantParts.push(part);
         } else if (part instanceof vscode.LanguageModelToolCallPart) {
           assistantParts.push(part);
 
-          // Handle phase signal locally — not a real tool call, don't trigger another loop
+          // Handle phase signals locally; only loop again for them if no text was streamed.
           if (part.name === 'devdocket-signalPhase') {
             const input = part.input as { phase?: string };
             this.log.debug(`Phase signal: ${input.phase}`);
@@ -272,8 +278,9 @@ export class WalkthroughParticipant {
         }
       }
 
-      if (!hasToolCalls) {
-        this.log.info(`No tool calls in iteration ${iterations} — exiting loop`);
+      const hasOnlyPhaseSignal = !hasToolCalls && toolResults.length > 0;
+      if (!hasToolCalls && !(hasOnlyPhaseSignal && !streamedTextThisIteration)) {
+        this.log.info(`No tool calls requiring another model request in iteration ${iterations} — exiting loop`);
         break;
       }
     }
@@ -283,6 +290,9 @@ export class WalkthroughParticipant {
     }
     if (iterations >= maxIterations) {
       this.log.warn(`Reached max iterations (${maxIterations})`);
+    }
+    if (!streamedAnyText && !token.isCancellationRequested) {
+      response.markdown('⚠️ The model completed tool calls but did not produce walkthrough text. Please try again.');
     }
     this.log.info(`handleRequest complete — final phase: ${phase}, total iterations: ${iterations}`);
     return { metadata: { phase } };

--- a/packages/ai-reviewer/src/walkthroughParticipant.ts
+++ b/packages/ai-reviewer/src/walkthroughParticipant.ts
@@ -292,7 +292,7 @@ export class WalkthroughParticipant {
       this.log.warn(`Reached max iterations (${maxIterations})`);
     }
     if (!streamedAnyText && !token.isCancellationRequested) {
-      response.markdown('⚠️ The model completed tool calls but did not produce walkthrough text. Please try again.');
+      response.markdown('⚠️ The model did not produce walkthrough text. Please try again.');
     }
     this.log.info(`handleRequest complete — final phase: ${phase}, total iterations: ${iterations}`);
     return { metadata: { phase } };


### PR DESCRIPTION
## Summary

- Continue the walkthrough tool loop when a model emits only the synthetic phase-signal tool call before visible text
- Treat whitespace-only chunks as no visible walkthrough text and show a fallback if the model remains silent
- Add regression coverage for GPT-style phase-only streaming behavior

## Validation

- npm run build
- npm run test
- superpowers:code-reviewer clean

Closes #436
