### PR TITLE
Fix dismissed mention resurfacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ For detailed view behavior, keyboard shortcuts, and configuration options, see t
 
 ## Installation
 
+DevDocket's core, provider, and git-worktree extensions require VS Code 1.92.0 or later. The AI reviewer extension requires VS Code 1.96.0 or later.
+
 DevDocket is not yet available on the VS Code Marketplace. To run it, build from source:
 
 1. **Clone the repository:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -3713,7 +3713,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
-        "@types/vscode": "^1.85.0",
+        "@types/vscode": "^1.92.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "esbuild": "^0.25.0",
@@ -3722,7 +3722,7 @@
         "vitest": "^1.2.0"
       },
       "engines": {
-        "vscode": "^1.85.0"
+        "vscode": "^1.92.0"
       }
     },
     "packages/ado/node_modules/@esbuild/aix-ppc64": {
@@ -4590,7 +4590,7 @@
       "devDependencies": {
         "@types/node": "^20.11.0",
         "@types/sanitize-html": "^2.16.1",
-        "@types/vscode": "^1.85.0",
+        "@types/vscode": "^1.92.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "esbuild": "^0.25.0",
@@ -4599,7 +4599,7 @@
         "vitest": "^1.2.0"
       },
       "engines": {
-        "vscode": "^1.85.0"
+        "vscode": "^1.92.0"
       }
     },
     "packages/core/node_modules/@esbuild/aix-ppc64": {
@@ -5472,7 +5472,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
-        "@types/vscode": "^1.85.0",
+        "@types/vscode": "^1.92.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "esbuild": "^0.25.0",
@@ -5481,7 +5481,7 @@
         "vitest": "^1.2.0"
       },
       "engines": {
-        "vscode": "^1.85.0"
+        "vscode": "^1.92.0"
       }
     },
     "packages/start-git-work/node_modules/@esbuild/aix-ppc64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5027,7 +5027,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
-        "@types/vscode": "^1.85.0",
+        "@types/vscode": "^1.92.0",
         "@typescript-eslint/eslint-plugin": "^7.0.0",
         "@typescript-eslint/parser": "^7.0.0",
         "esbuild": "^0.25.0",
@@ -5036,7 +5036,7 @@
         "vitest": "^1.2.0"
       },
       "engines": {
-        "vscode": "^1.85.0"
+        "vscode": "^1.92.0"
       }
     },
     "packages/github/node_modules/@esbuild/aix-ppc64": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5022,7 +5022,8 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@devdocket/shared": "*"
+        "@devdocket/shared": "*",
+        "marked": "^18.0.2"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5023,7 +5023,7 @@
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*",
-        "marked": "^18.0.2"
+        "marked": "^14.1.4"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -5452,6 +5452,18 @@
         "@esbuild/win32-arm64": "0.25.0",
         "@esbuild/win32-ia32": "0.25.0",
         "@esbuild/win32-x64": "0.25.0"
+      }
+    },
+    "packages/github/node_modules/marked": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.4.tgz",
+      "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "packages/shared": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5023,7 +5023,7 @@
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*",
-        "marked": "^14.1.4"
+        "marked": "^18.0.2"
       },
       "devDependencies": {
         "@types/node": "^20.11.0",
@@ -5452,18 +5452,6 @@
         "@esbuild/win32-arm64": "0.25.0",
         "@esbuild/win32-ia32": "0.25.0",
         "@esbuild/win32-x64": "0.25.0"
-      }
-    },
-    "packages/github/node_modules/marked": {
-      "version": "14.1.4",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.4.tgz",
-      "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "packages/shared": {

--- a/packages/ado/package.json
+++ b/packages/ado/package.json
@@ -6,7 +6,7 @@
   "publisher": "mthalman",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.85.0"
+    "vscode": "^1.92.0"
   },
   "categories": [
     "Other"
@@ -58,7 +58,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
-    "@types/vscode": "^1.85.0",
+    "@types/vscode": "^1.92.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "esbuild": "^0.25.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,7 +6,7 @@
   "publisher": "mthalman",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.85.0"
+    "vscode": "^1.92.0"
   },
   "categories": [
     "Other"
@@ -501,7 +501,7 @@
   "devDependencies": {
     "@types/node": "^20.11.0",
     "@types/sanitize-html": "^2.16.1",
-    "@types/vscode": "^1.85.0",
+    "@types/vscode": "^1.92.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "esbuild": "^0.25.0",

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -417,17 +417,18 @@ export class ProviderRegistry {
         if (item.version !== undefined) { update.version = item.version; }
         if (item.resurfaceVersion !== undefined) { update.resurfaceVersion = item.resurfaceVersion; }
         newUnseenUpdates.push(update);
-      } else if (existing === 'accepted') {
+      } else if (existing === 'accepted' || existing === 'dismissed') {
         let versionTriggered = false;
         let resurfaceVersionTriggered = false;
-        let needsBackfill = false;
+        let needsAcceptedBackfill = false;
+        let needsDismissedResurfaceVersionBackfill = false;
 
-        if (item.version !== undefined) {
+        if (existing === 'accepted' && item.version !== undefined) {
           const storedVersion = this.stateStore.getVersion(providerId, item.externalId);
           if (storedVersion !== undefined && storedVersion !== item.version) {
             versionTriggered = true;
           } else if (storedVersion === undefined) {
-            needsBackfill = true;
+            needsAcceptedBackfill = true;
           }
         }
 
@@ -436,14 +437,18 @@ export class ProviderRegistry {
           if (storedRV !== undefined && storedRV !== item.resurfaceVersion) {
             resurfaceVersionTriggered = true;
           } else if (storedRV === undefined) {
-            needsBackfill = true;
+            if (existing === 'accepted') {
+              needsAcceptedBackfill = true;
+            } else {
+              needsDismissedResurfaceVersionBackfill = true;
+            }
           }
         }
 
         // resurfaceVersion always resurfaces (hard); version checks work item state (soft)
         let shouldResurface = resurfaceVersionTriggered;
         let suppressedVersionChange = false;
-        if (versionTriggered && !shouldResurface) {
+        if (existing === 'accepted' && versionTriggered && !shouldResurface) {
           const wiState = this.getWorkItemState?.(providerId, item.externalId);
           if (wiState === WorkItemState.New || wiState === WorkItemState.InProgress || wiState === WorkItemState.Paused) {
             // Suppress: backfill version instead of resurfacing
@@ -458,7 +463,7 @@ export class ProviderRegistry {
           if (item.version !== undefined) { update.version = item.version; }
           if (item.resurfaceVersion !== undefined) { update.resurfaceVersion = item.resurfaceVersion; }
           newUnseenUpdates.push(update);
-        } else if (suppressedVersionChange || needsBackfill) {
+        } else if (existing === 'accepted' && (suppressedVersionChange || needsAcceptedBackfill)) {
           const update: typeof versionBackfills[number] = { providerId, externalId: item.externalId, state: 'accepted' };
           if (item.version !== undefined) { update.version = item.version; }
           if (item.resurfaceVersion !== undefined) { update.resurfaceVersion = item.resurfaceVersion; }
@@ -466,6 +471,13 @@ export class ProviderRegistry {
           if (suppressedVersionChange) {
             activityEntries.push({ providerId, externalId: item.externalId });
           }
+        } else if (needsDismissedResurfaceVersionBackfill) {
+          versionBackfills.push({
+            providerId,
+            externalId: item.externalId,
+            state: 'dismissed',
+            resurfaceVersion: item.resurfaceVersion,
+          });
         }
       } else if (existing === 'unseen') {
         if (item.version !== undefined || item.resurfaceVersion !== undefined) {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -1193,25 +1193,40 @@ describe('ProviderRegistry', () => {
       await vi.waitFor(() => expect(listener).toHaveBeenCalledWith(1));
     });
 
-    it('does not resurface when resurfaceVersion is unchanged', async () => {
-      const provider = createMockProvider('gh');
-      registry.register(provider);
+    it.each([
+      { inboxState: 'accepted' as const, commentKind: 'mention' as const, resurfaceVersion: 'rr-new', shouldResurface: true },
+      { inboxState: 'accepted' as const, commentKind: 'non-mention' as const, resurfaceVersion: 'rr-old', shouldResurface: false },
+      { inboxState: 'dismissed' as const, commentKind: 'mention' as const, resurfaceVersion: 'rr-new', shouldResurface: true },
+      { inboxState: 'dismissed' as const, commentKind: 'non-mention' as const, resurfaceVersion: 'rr-old', shouldResurface: false },
+    ])(
+      '$inboxState item handles $commentKind comment resurfacing',
+      async ({ inboxState, resurfaceVersion, shouldResurface }) => {
+        const provider = createMockProvider('gh');
+        registry.register(provider);
 
-      stateStore._set('gh', 'pr-1', 'accepted');
-      stateStore._setVersion('gh', 'pr-1', 'sha-same');
-      stateStore._setResurfaceVersion('gh', 'pr-1', 'rr-same');
+        stateStore._set('gh', 'pr-1', inboxState);
+        stateStore._setVersion('gh', 'pr-1', 'sha-same');
+        stateStore._setResurfaceVersion('gh', 'pr-1', 'rr-old');
 
-      stateStore.setStates.mockClear();
+        stateStore.setStates.mockClear();
 
-      provider.fireItems([
-        { externalId: 'pr-1', title: 'PR 1', version: 'sha-same', resurfaceVersion: 'rr-same' },
-      ]);
+        provider.fireItems([
+          { externalId: 'pr-1', title: 'PR 1', version: 'sha-same', resurfaceVersion },
+        ]);
 
-      await vi.waitFor(() =>
-        expect(registry.getDiscoveredItems('gh')).toHaveLength(1),
-      );
-      expect(stateStore.setStates).not.toHaveBeenCalled();
-    });
+        if (shouldResurface) {
+          await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+          expect(stateStore.setStates).toHaveBeenCalledWith([
+            { providerId: 'gh', externalId: 'pr-1', state: 'unseen', version: 'sha-same', resurfaceVersion },
+          ]);
+        } else {
+          await vi.waitFor(() =>
+            expect(registry.getDiscoveredItems('gh')).toHaveLength(1),
+          );
+          expect(stateStore.setStates).not.toHaveBeenCalled();
+        }
+      },
+    );
 
     it('backfills resurfaceVersion for accepted item without stored resurfaceVersion', async () => {
       const provider = createMockProvider('gh');
@@ -1230,23 +1245,22 @@ describe('ProviderRegistry', () => {
       ]);
     });
 
-    it('does not resurface dismissed item even when resurfaceVersion changes', async () => {
+    it('backfills resurfaceVersion for dismissed item without stored resurfaceVersion', async () => {
       const provider = createMockProvider('gh');
       registry.register(provider);
 
       stateStore._set('gh', 'pr-1', 'dismissed');
-      stateStore._setResurfaceVersion('gh', 'pr-1', 'rr-old');
 
       stateStore.setStates.mockClear();
 
       provider.fireItems([
-        { externalId: 'pr-1', title: 'PR 1', resurfaceVersion: 'rr-new' },
+        { externalId: 'pr-1', title: 'PR 1', resurfaceVersion: 'rr-first' },
       ]);
 
-      await vi.waitFor(() =>
-        expect(registry.getDiscoveredItems('gh')).toHaveLength(1),
-      );
-      expect(stateStore.setStates).not.toHaveBeenCalled();
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'dismissed', resurfaceVersion: 'rr-first' },
+      ]);
     });
 
     it('resurfaces when version is unchanged but resurfaceVersion changes', async () => {

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -57,7 +57,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@devdocket/shared": "*"
+    "@devdocket/shared": "*",
+    "marked": "^18.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -23,28 +23,28 @@
       {
         "title": "DevDocket GitHub",
         "properties": {
-        "devDocketGithub.filteredRepos": {
-          "type": "string",
-          "default": "",
-          "editPresentation": "multilineText",
-          "description": "Filter out repositories from DevDocket results. Uses gitignore-style patterns, one per line. Matching repositories are excluded; unmatched repositories are shown.\n\nExamples:\nmyorg/old-*        # filter out repos starting with old-\nmyorg/*            # filter out all repos in myorg\n!myorg/important   # except keep this one\n\nSupports wildcards (*), negation (!), and comments (#).\nLeave empty to show all repositories."
-        },
-        "devDocketGithub.refreshIntervalSeconds": {
-          "type": "number",
-          "default": 300,
-          "description": "How often to refresh GitHub issues (in seconds). Minimum 60 seconds. Values below 60 are clamped."
-        },
-        "devDocketGithub.resurfaceOnNewVersion": {
-          "type": "boolean",
-          "default": true,
-          "description": "Resurface PR reviews when new commits are pushed."
-        },
-        "devDocketGithub.resurfaceOnReRequestedReview": {
-          "type": "boolean",
-          "default": true,
-          "description": "Resurface PR reviews when review is explicitly re-requested."
+          "devDocketGithub.filteredRepos": {
+            "type": "string",
+            "default": "",
+            "editPresentation": "multilineText",
+            "description": "Filter out repositories from DevDocket results. Uses gitignore-style patterns, one per line. Matching repositories are excluded; unmatched repositories are shown.\n\nExamples:\nmyorg/old-*        # filter out repos starting with old-\nmyorg/*            # filter out all repos in myorg\n!myorg/important   # except keep this one\n\nSupports wildcards (*), negation (!), and comments (#).\nLeave empty to show all repositories."
+          },
+          "devDocketGithub.refreshIntervalSeconds": {
+            "type": "number",
+            "default": 300,
+            "description": "How often to refresh GitHub issues (in seconds). Minimum 60 seconds. Values below 60 are clamped."
+          },
+          "devDocketGithub.resurfaceOnNewVersion": {
+            "type": "boolean",
+            "default": true,
+            "description": "Resurface PR reviews when new commits are pushed."
+          },
+          "devDocketGithub.resurfaceOnReRequestedReview": {
+            "type": "boolean",
+            "default": true,
+            "description": "Resurface PR reviews when review is explicitly re-requested."
+          }
         }
-      }
       }
     ]
   },
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@devdocket/shared": "*",
-    "marked": "^18.0.2"
+    "marked": "^14.1.4"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -6,7 +6,7 @@
   "publisher": "mthalman",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.85.0"
+    "vscode": "^1.92.0"
   },
   "categories": [
     "Other"
@@ -62,7 +62,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
-    "@types/vscode": "^1.85.0",
+    "@types/vscode": "^1.92.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "esbuild": "^0.25.0",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -58,7 +58,7 @@
   },
   "dependencies": {
     "@devdocket/shared": "*",
-    "marked": "^14.1.4"
+    "marked": "^18.0.2"
   },
   "devDependencies": {
     "@types/node": "^20.11.0",

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -21,6 +21,10 @@ export abstract class BaseGitHubProvider extends BaseProvider {
     };
   }
 
+  protected getAuthenticationScopes(): string[] {
+    return ['repo'];
+  }
+
   async refresh(token?: vscode.CancellationToken): Promise<void> {
     if (this._isRefreshing) {
       return;
@@ -36,13 +40,13 @@ export abstract class BaseGitHubProvider extends BaseProvider {
 
       let session: vscode.AuthenticationSession | undefined;
       try {
-        session = await vscode.authentication.getSession('github', ['repo'], {
+        session = await vscode.authentication.getSession('github', this.getAuthenticationScopes(), {
           createIfNone: true,
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         logger.error('GitHub authentication failed', err);
-        vscode.window.showWarningMessage(`DevDocket GitHub: Authentication failed — ${message}`);
+        void vscode.window.showWarningMessage(`DevDocket GitHub: Authentication failed — ${message}`);
         return;
       }
 
@@ -69,7 +73,7 @@ export abstract class BaseGitHubProvider extends BaseProvider {
   protected async doBackgroundRefresh(): Promise<void> {
     let session: vscode.AuthenticationSession | undefined;
     try {
-      session = await vscode.authentication.getSession('github', ['repo'], {
+      session = await vscode.authentication.getSession('github', this.getAuthenticationScopes(), {
         createIfNone: false,
       });
     } catch (err) {

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -10,6 +10,7 @@ export interface GitHubIssue {
   html_url: string;
   repository_url: string;
   comments_url?: string;
+  updated_at?: string;
   pull_request?: { url: string };
 }
 

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -10,6 +10,7 @@ export interface GitHubIssue {
   html_url: string;
   repository_url: string;
   comments_url?: string;
+  comments?: number;
   updated_at?: string;
   pull_request?: { url: string };
 }

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -9,6 +9,7 @@ export interface GitHubIssue {
   state?: string;
   html_url: string;
   repository_url: string;
+  comments_url?: string;
   pull_request?: { url: string };
 }
 

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -310,7 +310,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
 
       let response: Response;
       try {
-        response = await fetch(GitHubMentionsProvider.withCommentQuery(issue.comments_url, page, since), {
+        response = await fetch(GitHubMentionsProvider.withCommentQuery(issue.comments_url, page, since, !!since), {
           headers: getGitHubAuthHeaders(token),
           signal: combineSignals(signal, 30_000),
         });
@@ -398,7 +398,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(login);
   }
 
-  private static withCommentQuery(url: string, page: number, since?: string): string {
+  private static withCommentQuery(url: string, page: number, since?: string, newestFirst = false): string {
     try {
       const parsed = new URL(url);
       parsed.searchParams.set('per_page', '100');
@@ -406,11 +406,16 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       if (since) {
         parsed.searchParams.set('since', since);
       }
+      if (newestFirst) {
+        parsed.searchParams.set('sort', 'created');
+        parsed.searchParams.set('direction', 'desc');
+      }
       return parsed.toString();
     } catch {
       const separator = url.includes('?') ? '&' : '?';
       const sinceQuery = since ? `&since=${encodeURIComponent(since)}` : '';
-      return `${url}${separator}per_page=100&page=${page}${sinceQuery}`;
+      const orderQuery = newestFirst ? '&sort=created&direction=desc' : '';
+      return `${url}${separator}per_page=100&page=${page}${sinceQuery}${orderQuery}`;
     }
   }
 

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -30,6 +30,8 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
   readonly label = 'GitHub Mentions';
 
   private readonly _context: vscode.ExtensionContext;
+  private readonly mentionCommentCache = new Map<string, { issueUpdatedAt?: string; resurfaceVersion?: string }>();
+  private cachedLogin?: string;
 
   constructor(context: vscode.ExtensionContext) {
     super();
@@ -51,8 +53,8 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       ? itemsWithRepo.filter(({ repoName }) => matchesRepoPatterns(repoName, patterns))
       : itemsWithRepo;
 
-    const shouldInspectComments = filtered.some(({ issue }) => !!issue.comments_url);
-    const currentLogin = shouldInspectComments ? await this.getCurrentLogin(accessToken, signal) : undefined;
+    const shouldComputeMentionVersions = filtered.some(({ issue }) => issue.comments_url || issue.body || issue.title);
+    const currentLogin = shouldComputeMentionVersions ? await this.getCurrentLogin(accessToken, signal) : undefined;
     // Search results are updated by any comment; only mentioning comments should trigger resurfacing.
     const resurfaceVersions = currentLogin
       ? await this.fetchMentionResurfaceVersions(filtered, accessToken, currentLogin, signal)
@@ -172,6 +174,10 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
   }
 
   private async getCurrentLogin(token: string, signal?: AbortSignal): Promise<string | undefined> {
+    if (this.cachedLogin) {
+      return this.cachedLogin;
+    }
+
     try {
       const response = await fetch('https://api.github.com/user', {
         headers: getGitHubAuthHeaders(token),
@@ -181,6 +187,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
         const data = await response.json() as { login?: unknown };
         const login = typeof data.login === 'string' ? data.login.trim() : undefined;
         if (login && GitHubMentionsProvider.isValidGitHubLogin(login)) {
+          this.cachedLogin = login;
           return login;
         }
       } else {
@@ -194,7 +201,11 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     try {
       const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: false });
       const label = session?.account?.label?.trim();
-      return label && GitHubMentionsProvider.isValidGitHubLogin(label) ? label : undefined;
+      if (label && GitHubMentionsProvider.isValidGitHubLogin(label)) {
+        this.cachedLogin = label;
+        return label;
+      }
+      return undefined;
     } catch (err) {
       logger.debug('Could not determine fallback GitHub login for mention comment filtering', err);
       return undefined;
@@ -209,10 +220,13 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
   ): Promise<Map<string, string>> {
     const results = await runWorkerPoolSettled(
       items,
-      async ({ issue, repoName }) => ({
-        externalId: `${repoName}#${issue.number}`,
-        resurfaceVersion: await this.fetchLatestMentionCommentVersion(issue, token, currentLogin, signal),
-      }),
+      async ({ issue, repoName }) => {
+        const externalId = `${repoName}#${issue.number}`;
+        return {
+          externalId,
+          resurfaceVersion: await this.getMentionResurfaceVersion(issue, externalId, token, currentLogin, signal),
+        };
+      },
       COMMENT_FETCH_CONCURRENCY,
     );
 
@@ -227,6 +241,27 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       }
     }
     return versions;
+  }
+
+  private async getMentionResurfaceVersion(
+    issue: GitHubIssue,
+    externalId: string,
+    token: string,
+    currentLogin: string,
+    signal?: AbortSignal,
+  ): Promise<string | undefined> {
+    const bodyMentionVersion = GitHubMentionsProvider.getIssueBodyMentionVersion(issue, currentLogin);
+    const cached = this.mentionCommentCache.get(externalId);
+    if (cached && cached.issueUpdatedAt === issue.updated_at) {
+      return cached.resurfaceVersion ?? bodyMentionVersion;
+    }
+
+    const commentVersion = await this.fetchLatestMentionCommentVersion(issue, token, currentLogin, signal);
+    this.mentionCommentCache.set(externalId, {
+      issueUpdatedAt: issue.updated_at,
+      resurfaceVersion: commentVersion,
+    });
+    return commentVersion ?? bodyMentionVersion;
   }
 
   private async fetchLatestMentionCommentVersion(
@@ -274,6 +309,13 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     }
 
     return undefined;
+  }
+
+  private static getIssueBodyMentionVersion(issue: GitHubIssue, login: string): string | undefined {
+    if (!GitHubMentionsProvider.mentionsUser(`${issue.title}\n${issue.body ?? ''}`, login)) {
+      return undefined;
+    }
+    return `issue:${issue.number}`;
   }
 
   private static mentionsUser(body: string | null | undefined, login: string): boolean {

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { DiscoveredItem, combineSignals, safeDecodeComponent, type ResolvedItem } from '@devdocket/shared';
+import { DiscoveredItem, combineSignals, runWorkerPoolSettled, safeDecodeComponent, type ResolvedItem } from '@devdocket/shared';
 import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
@@ -7,6 +7,14 @@ import { matchesRepoPatterns } from './repoPattern';
 import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
 
 const MENTIONS_ACTIVATED_KEY = 'mentionsActivatedAt';
+const COMMENT_FETCH_CONCURRENCY = 3;
+
+interface GitHubIssueComment {
+  id: number;
+  body?: string | null;
+  updated_at?: string;
+  created_at?: string;
+}
 
 /**
  * DevDocket provider that discovers GitHub issues and pull requests
@@ -42,10 +50,19 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       ? itemsWithRepo.filter(({ repoName }) => matchesRepoPatterns(repoName, patterns))
       : itemsWithRepo;
 
+    const shouldInspectComments = filtered.some(({ issue }) => !!issue.comments_url);
+    const currentLogin = shouldInspectComments ? await this.getCurrentLogin(accessToken, signal) : undefined;
+    // Search results are updated by any comment; only mentioning comments should trigger resurfacing.
+    const resurfaceVersions = currentLogin
+      ? await this.fetchMentionResurfaceVersions(filtered, accessToken, currentLogin, signal)
+      : new Map<string, string>();
+
     const items: DiscoveredItem[] = filtered.map(({ issue, repoName }) => {
       const isPr = !!issue.pull_request;
+      const externalId = `${repoName}#${issue.number}`;
+      const resurfaceVersion = resurfaceVersions.get(externalId);
       return {
-        externalId: `${repoName}#${issue.number}`,
+        externalId,
         title: `#${issue.number}: ${issue.title}`,
         description: issue.body ?? undefined,
         url: issue.html_url,
@@ -58,6 +75,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
           ...buildIssueStateBadge(issue.state),
         ],
         ...(issue.state ? { state: issue.state } : {}),
+        ...(resurfaceVersion ? { resurfaceVersion } : {}),
       };
     });
 
@@ -150,6 +168,140 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     }
     await this._context.globalState.update(MENTIONS_ACTIVATED_KEY, now);
     return now;
+  }
+
+  private async getCurrentLogin(token: string, signal?: AbortSignal): Promise<string | undefined> {
+    try {
+      const response = await fetch('https://api.github.com/user', {
+        headers: getGitHubAuthHeaders(token),
+        signal: combineSignals(signal, 30_000),
+      });
+      if (response.ok) {
+        const data = await response.json() as { login?: unknown };
+        const login = typeof data.login === 'string' ? data.login.trim() : undefined;
+        if (login && GitHubMentionsProvider.isValidGitHubLogin(login)) {
+          return login;
+        }
+      } else {
+        logger.debug(`Failed to fetch GitHub user login: ${response.status}`);
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === 'AbortError' && signal?.aborted) { throw err; }
+      logger.debug('Could not fetch GitHub user login for mention comment filtering', err);
+    }
+
+    try {
+      const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: false });
+      const label = session?.account?.label?.trim();
+      return label && GitHubMentionsProvider.isValidGitHubLogin(label) ? label : undefined;
+    } catch (err) {
+      logger.debug('Could not determine fallback GitHub login for mention comment filtering', err);
+      return undefined;
+    }
+  }
+
+  private async fetchMentionResurfaceVersions(
+    items: Array<{ issue: GitHubIssue; repoName: string }>,
+    token: string,
+    currentLogin: string,
+    signal?: AbortSignal,
+  ): Promise<Map<string, string>> {
+    const results = await runWorkerPoolSettled(
+      items,
+      async ({ issue, repoName }) => ({
+        externalId: `${repoName}#${issue.number}`,
+        resurfaceVersion: await this.fetchLatestMentionCommentVersion(issue, token, currentLogin, signal),
+      }),
+      COMMENT_FETCH_CONCURRENCY,
+    );
+
+    const versions = new Map<string, string>();
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        logger.debug('Failed to inspect GitHub mention comments', result.reason);
+        continue;
+      }
+      if (result.value.resurfaceVersion) {
+        versions.set(result.value.externalId, result.value.resurfaceVersion);
+      }
+    }
+    return versions;
+  }
+
+  private async fetchLatestMentionCommentVersion(
+    issue: GitHubIssue,
+    token: string,
+    currentLogin: string,
+    signal?: AbortSignal,
+  ): Promise<string | undefined> {
+    if (!issue.comments_url) {
+      return undefined;
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(GitHubMentionsProvider.withPerPage(issue.comments_url), {
+        headers: getGitHubAuthHeaders(token),
+        signal: combineSignals(signal, 30_000),
+      });
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === 'AbortError' && signal?.aborted) { throw err; }
+      logger.debug(`Failed to fetch comments for mention ${issue.html_url}`, err);
+      return undefined;
+    }
+
+    if (!response.ok) {
+      logger.debug(`Failed to fetch comments for mention ${issue.html_url}: ${response.status}`);
+      return undefined;
+    }
+
+    const comments = await response.json() as GitHubIssueComment[];
+    let latestMention: { id: number; timestamp: string; time: number } | undefined;
+    for (const comment of comments) {
+      if (!GitHubMentionsProvider.mentionsUser(comment.body, currentLogin)) {
+        continue;
+      }
+      const timestamp = comment.updated_at ?? comment.created_at;
+      if (!timestamp) {
+        continue;
+      }
+      const time = Date.parse(timestamp);
+      if (Number.isNaN(time)) {
+        continue;
+      }
+      if (!latestMention || time > latestMention.time) {
+        latestMention = { id: comment.id, timestamp, time };
+      }
+    }
+
+    return latestMention
+      ? `comment:${latestMention.id}:${latestMention.timestamp}`
+      : undefined;
+  }
+
+  private static mentionsUser(body: string | null | undefined, login: string): boolean {
+    if (!body) {
+      return false;
+    }
+    const escapedLogin = login.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`(^|[^A-Za-z0-9_-])@${escapedLogin}(?![A-Za-z0-9_-])`, 'i').test(body);
+  }
+
+  private static isValidGitHubLogin(login: string): boolean {
+    return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(login);
+  }
+
+  private static withPerPage(url: string): string {
+    try {
+      const parsed = new URL(url);
+      parsed.searchParams.set('per_page', '100');
+      parsed.searchParams.set('sort', 'updated');
+      parsed.searchParams.set('direction', 'desc');
+      return parsed.toString();
+    } catch {
+      const separator = url.includes('?') ? '&' : '?';
+      return `${url}${separator}per_page=100&sort=updated&direction=desc`;
+    }
   }
 
   private async fetchAllMentions(

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -298,6 +298,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
 
     const since = GitHubMentionsProvider.getCommentVersionTimestamp(previousCommentVersion);
     const pageCount = since ? undefined : GitHubMentionsProvider.getCommentPageCount(issue.comments);
+    const newestFirst = !!since || pageCount === undefined;
     let latestMention: { id: number; createdAt: string; time: number } | undefined;
     let lastPageWasFull = false;
     let scannedPages = 0;
@@ -310,7 +311,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
 
       let response: Response;
       try {
-        response = await fetch(GitHubMentionsProvider.withCommentQuery(issue.comments_url, page, since, !!since), {
+        response = await fetch(GitHubMentionsProvider.withCommentQuery(issue.comments_url, page, since, newestFirst), {
           headers: getGitHubAuthHeaders(token),
           signal: combineSignals(signal, 30_000),
         });
@@ -344,7 +345,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
         }
       }
 
-      if (latestMention && (since || pageCount)) {
+      if (latestMention && (newestFirst || pageCount)) {
         break;
       }
       if (pageCount) {

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -31,6 +31,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
 
   private readonly _context: vscode.ExtensionContext;
   private readonly mentionCommentCache = new Map<string, { issueUpdatedAt?: string; resurfaceVersion?: string }>();
+  private mentionCommentCacheLogin?: string;
   private cachedLogin?: { accessToken: string; login: string };
 
   constructor(context: vscode.ExtensionContext) {
@@ -60,6 +61,10 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
 
     const shouldComputeMentionVersions = filtered.some(({ issue }) => issue.comments_url || issue.body || issue.title);
     const currentLogin = shouldComputeMentionVersions ? await this.getCurrentLogin(accessToken, signal) : undefined;
+    if (currentLogin && this.mentionCommentCacheLogin !== currentLogin) {
+      this.mentionCommentCache.clear();
+      this.mentionCommentCacheLogin = currentLogin;
+    }
     // Search results are updated by any comment; only mentioning comments should trigger resurfacing.
     const resurfaceVersions = currentLogin
       ? await this.fetchMentionResurfaceVersions(filtered, accessToken, currentLogin, signal)

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -521,12 +521,14 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
         return;
       case 'escape':
         return;
-      case 'link':
-        if (GitHubMentionsProvider.isAutolinkToken(token)) {
+      case 'link': {
+        const linkToken = GitHubMentionsProvider.asLinkToken(token);
+        if (!linkToken || GitHubMentionsProvider.isAutolinkToken(linkToken)) {
           return;
         }
-        yield* GitHubMentionsProvider.markdownTextSegments(token.tokens);
+        yield* GitHubMentionsProvider.markdownTextSegments(linkToken.tokens);
         return;
+      }
       case 'text':
         if (token.tokens?.length) {
           yield* GitHubMentionsProvider.markdownTextSegments(token.tokens);
@@ -556,6 +558,14 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
         }
       }
     }
+  }
+
+  private static asLinkToken(token: Token): Tokens.Link | undefined {
+    const candidate = token as Partial<Tokens.Link>;
+    if (typeof candidate.href !== 'string' || !Array.isArray(candidate.tokens)) {
+      return undefined;
+    }
+    return candidate as Tokens.Link;
   }
 
   private static isAutolinkToken(token: Tokens.Link): boolean {

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { Lexer, type Token, type Tokens } from 'marked';
 import { DiscoveredItem, combineSignals, runWorkerPoolSettled, safeDecodeComponent, type ResolvedItem } from '@devdocket/shared';
 import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
@@ -9,12 +10,20 @@ import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCa
 const MENTIONS_ACTIVATED_KEY = 'mentionsActivatedAt';
 const COMMENT_FETCH_CONCURRENCY = 3;
 const COMMENT_PAGE_LIMIT = 10;
+const TEAM_MENTION_CACHE_TTL_MS = 30 * 60 * 1000;
 
 interface GitHubIssueComment {
   id: number;
   body?: string | null;
   updated_at?: string;
   created_at?: string;
+}
+
+interface GitHubTeamMembership {
+  slug?: unknown;
+  organization?: {
+    login?: unknown;
+  } | null;
 }
 
 /**
@@ -29,14 +38,21 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
   readonly id = 'github-mentions';
   readonly label = 'GitHub Mentions';
 
+  private static readonly AUTH_SCOPES = ['repo', 'read:org'];
+
   private readonly _context: vscode.ExtensionContext;
   private readonly mentionCommentCache = new Map<string, { issueUpdatedAt?: string; resurfaceVersion?: string }>();
   private mentionCommentCacheLogin?: string;
   private cachedLogin?: { accessToken: string; login: string };
+  private teamMentionCache?: { accessToken: string; login: string; expiresAtMs: number; teams: Set<string> };
 
   constructor(context: vscode.ExtensionContext) {
     super();
     this._context = context;
+  }
+
+  protected override getAuthenticationScopes(): string[] {
+    return GitHubMentionsProvider.AUTH_SCOPES;
   }
 
   protected async fetchAndPublish(accessToken: string, isUserTriggered: boolean, signal?: AbortSignal): Promise<void> {
@@ -60,13 +76,18 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     }
 
     const currentLogin = filtered.length > 0 ? await this.getCurrentLogin(accessToken, signal) : undefined;
-    if (currentLogin && this.mentionCommentCacheLogin !== currentLogin) {
-      this.mentionCommentCache.clear();
-      this.mentionCommentCacheLogin = currentLogin;
+    let teamMentions = new Set<string>();
+    if (currentLogin) {
+      if (this.mentionCommentCacheLogin !== currentLogin) {
+        this.mentionCommentCache.clear();
+        this.teamMentionCache = undefined;
+        this.mentionCommentCacheLogin = currentLogin;
+      }
+      teamMentions = await this.getCurrentUserTeamMentions(accessToken, currentLogin, signal);
     }
     // Search results are updated by any comment; only mentioning comments should trigger resurfacing.
     const resurfaceVersions = currentLogin
-      ? await this.fetchMentionResurfaceVersions(filtered, accessToken, currentLogin, signal)
+      ? await this.fetchMentionResurfaceVersions(filtered, accessToken, currentLogin, teamMentions, signal)
       : new Map<string, string>();
 
     const items: DiscoveredItem[] = filtered.map(({ issue, repoName }) => {
@@ -208,7 +229,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     }
 
     try {
-      const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: false });
+      const session = await vscode.authentication.getSession('github', GitHubMentionsProvider.AUTH_SCOPES, { createIfNone: false });
       const label = session?.account?.label?.trim();
       if (label && GitHubMentionsProvider.isValidGitHubLogin(label)) {
         this.cachedLogin = { accessToken: token, login: label };
@@ -219,6 +240,71 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     } catch (err) {
       logger.warn('Could not determine fallback GitHub login for mention comment filtering', err);
       return undefined;
+    }
+  }
+
+  private async getCurrentUserTeamMentions(token: string, login: string, signal?: AbortSignal): Promise<Set<string>> {
+    const now = Date.now();
+    const cached = this.teamMentionCache;
+    if (cached && cached.accessToken === token && cached.login === login && cached.expiresAtMs > now) {
+      return cached.teams;
+    }
+
+    const teams = await this.fetchCurrentUserTeamMentions(token, signal);
+    this.teamMentionCache = {
+      accessToken: token,
+      login,
+      expiresAtMs: now + TEAM_MENTION_CACHE_TTL_MS,
+      teams,
+    };
+    return teams;
+  }
+
+  private async fetchCurrentUserTeamMentions(token: string, signal?: AbortSignal): Promise<Set<string>> {
+    const teams = new Set<string>();
+
+    for (let page = 1; ; page++) {
+      let response: Response | undefined;
+      try {
+        response = await fetch(`https://api.github.com/user/teams?per_page=100&page=${page}`, {
+          headers: getGitHubAuthHeaders(token),
+          signal: combineSignals(signal, 30_000),
+        });
+      } catch (err: unknown) {
+        if (err instanceof Error && err.name === 'AbortError' && signal?.aborted) { throw err; }
+        logger.warn('Could not fetch GitHub team memberships for mention filtering', err);
+        return new Set<string>();
+      }
+
+      if (!response?.ok) {
+        logger.warn(`Could not fetch GitHub team memberships for mention filtering: ${response?.status ?? 'no response'}`);
+        return new Set<string>();
+      }
+
+      let data: GitHubTeamMembership[];
+      try {
+        data = await response.json() as GitHubTeamMembership[];
+      } catch (err) {
+        logger.warn('Could not parse GitHub team memberships for mention filtering', err);
+        return new Set<string>();
+      }
+      if (!Array.isArray(data)) {
+        logger.warn('Could not parse GitHub team memberships for mention filtering');
+        return new Set<string>();
+      }
+
+      for (const team of data) {
+        const orgLogin = typeof team.organization?.login === 'string' ? team.organization.login.trim() : '';
+        const teamSlug = typeof team.slug === 'string' ? team.slug.trim() : '';
+        if (!GitHubMentionsProvider.isValidGitHubLogin(orgLogin) || !GitHubMentionsProvider.isValidTeamSlug(teamSlug)) {
+          continue;
+        }
+        teams.add(GitHubMentionsProvider.normalizeTeamMention(orgLogin, teamSlug));
+      }
+
+      if (data.length < 100) {
+        return teams;
+      }
     }
   }
 
@@ -234,6 +320,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     items: Array<{ issue: GitHubIssue; repoName: string }>,
     token: string,
     currentLogin: string,
+    teamMentions: Set<string>,
     signal?: AbortSignal,
   ): Promise<Map<string, string>> {
     const results = await runWorkerPoolSettled(
@@ -242,7 +329,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
         const externalId = `${repoName}#${issue.number}`;
         return {
           externalId,
-          resurfaceVersion: await this.getMentionResurfaceVersion(issue, externalId, token, currentLogin, signal),
+          resurfaceVersion: await this.getMentionResurfaceVersion(issue, externalId, token, currentLogin, teamMentions, signal),
         };
       },
       COMMENT_FETCH_CONCURRENCY,
@@ -266,16 +353,17 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     externalId: string,
     token: string,
     currentLogin: string,
+    teamMentions: Set<string>,
     signal?: AbortSignal,
   ): Promise<string | undefined> {
-    const bodyMentionVersion = GitHubMentionsProvider.getIssueBodyMentionVersion(issue, currentLogin);
+    const bodyMentionVersion = GitHubMentionsProvider.getIssueBodyMentionVersion(issue, currentLogin, teamMentions);
     const cached = this.mentionCommentCache.get(externalId);
     if (cached && issue.updated_at && cached.issueUpdatedAt === issue.updated_at) {
       return cached.resurfaceVersion ?? bodyMentionVersion;
     }
 
     const previousCommentVersion = cached?.resurfaceVersion;
-    const commentVersion = await this.fetchLatestMentionCommentVersion(issue, token, currentLogin, previousCommentVersion, signal);
+    const commentVersion = await this.fetchLatestMentionCommentVersion(issue, token, currentLogin, teamMentions, previousCommentVersion, signal);
     const resurfaceVersion = commentVersion ?? previousCommentVersion;
     this.mentionCommentCache.set(externalId, {
       issueUpdatedAt: issue.updated_at,
@@ -288,6 +376,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     issue: GitHubIssue,
     token: string,
     currentLogin: string,
+    teamMentions: Set<string>,
     previousCommentVersion?: string,
     signal?: AbortSignal,
   ): Promise<string | undefined> {
@@ -329,7 +418,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       const comments = await response.json() as GitHubIssueComment[];
       lastPageWasFull = comments.length >= 100;
       for (const comment of comments) {
-        if (!GitHubMentionsProvider.mentionsUser(comment.body, currentLogin)) {
+        if (!GitHubMentionsProvider.mentionsUser(comment.body, currentLogin, teamMentions)) {
           continue;
         }
         if (!comment.created_at) {
@@ -370,8 +459,8 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       : undefined;
   }
 
-  private static getIssueBodyMentionVersion(issue: GitHubIssue, login: string): string | undefined {
-    if (!GitHubMentionsProvider.mentionsUser(`${issue.title}\n${issue.body ?? ''}`, login)) {
+  private static getIssueBodyMentionVersion(issue: GitHubIssue, login: string, teamMentions: Set<string>): string | undefined {
+    if (!GitHubMentionsProvider.mentionsUser(`${issue.title}\n${issue.body ?? ''}`, login, teamMentions)) {
       return undefined;
     }
     return `issue:${issue.number}`;
@@ -389,16 +478,116 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     return Math.ceil(commentCount / 100);
   }
 
-  private static mentionsUser(body: string | null | undefined, login: string): boolean {
+  private static mentionsUser(body: string | null | undefined, login: string, teamMentions: Set<string>): boolean {
     if (!body) {
       return false;
     }
-    const escapedLogin = login.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    return new RegExp(`(^|[^A-Za-z0-9_-])@${escapedLogin}(?![A-Za-z0-9_-])`, 'i').test(body);
+
+    let tokens: Token[];
+    try {
+      tokens = Lexer.lex(body);
+    } catch (err) {
+      logger.debug('Could not parse GitHub markdown for mention filtering', err);
+      return false;
+    }
+
+    for (const text of GitHubMentionsProvider.markdownTextSegments(tokens)) {
+      if (GitHubMentionsProvider.textMentionsUser(text, login, teamMentions)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static *markdownTextSegments(tokens: readonly Token[]): Generator<string> {
+    for (const token of tokens) {
+      yield* GitHubMentionsProvider.tokenTextSegments(token);
+    }
+  }
+
+  private static *tokenTextSegments(token: Token): Generator<string> {
+    switch (token.type) {
+      case 'code':
+      case 'codespan':
+      case 'def':
+      case 'html':
+      case 'image':
+        return;
+      case 'escape':
+        return;
+      case 'link':
+        if (GitHubMentionsProvider.isAutolinkToken(token)) {
+          return;
+        }
+        yield* GitHubMentionsProvider.markdownTextSegments(token.tokens);
+        return;
+      case 'text':
+        if (token.tokens?.length) {
+          yield* GitHubMentionsProvider.markdownTextSegments(token.tokens);
+        } else {
+          yield token.text;
+        }
+        return;
+      case 'list':
+        for (const item of token.items) {
+          yield* GitHubMentionsProvider.tokenTextSegments(item);
+        }
+        return;
+      case 'table':
+        for (const cell of token.header) {
+          yield* GitHubMentionsProvider.markdownTextSegments(cell.tokens);
+        }
+        for (const row of token.rows) {
+          for (const cell of row) {
+            yield* GitHubMentionsProvider.markdownTextSegments(cell.tokens);
+          }
+        }
+        return;
+      default: {
+        const nested = (token as Tokens.Generic).tokens;
+        if (nested?.length) {
+          yield* GitHubMentionsProvider.markdownTextSegments(nested);
+        }
+      }
+    }
+  }
+
+  private static isAutolinkToken(token: Tokens.Link): boolean {
+    return token.raw === token.href || token.raw === `<${token.href}>`;
+  }
+
+  private static readonly MENTION_PATTERN = /(^|[^A-Za-z0-9_])@([A-Za-z0-9][A-Za-z0-9-]{0,38})(?:\/([A-Za-z0-9](?:[A-Za-z0-9-]{0,253}[A-Za-z0-9])?))?(?![A-Za-z0-9-/])/gi;
+
+  private static textMentionsUser(text: string, login: string, teamMentions: Set<string>): boolean {
+    const normalizedLogin = login.toLowerCase();
+    GitHubMentionsProvider.MENTION_PATTERN.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = GitHubMentionsProvider.MENTION_PATTERN.exec(text)) !== null) {
+      const [, , userOrOrg, teamSlug] = match;
+      if (teamSlug) {
+        if (teamMentions.has(GitHubMentionsProvider.normalizeTeamMention(userOrOrg, teamSlug))) {
+          return true;
+        }
+        continue;
+      }
+
+      if (GitHubMentionsProvider.isValidGitHubLogin(userOrOrg) && userOrOrg.toLowerCase() === normalizedLogin) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static normalizeTeamMention(orgLogin: string, teamSlug: string): string {
+    return `${orgLogin.toLowerCase()}/${teamSlug.toLowerCase()}`;
   }
 
   private static isValidGitHubLogin(login: string): boolean {
-    return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(login);
+    return /^(?!.*--)[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(login);
+  }
+
+  private static isValidTeamSlug(slug: string): boolean {
+    return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,253}[A-Za-z0-9])?$/.test(slug);
   }
 
   private static withCommentQuery(url: string, page: number, since?: string, newestFirst = false): string {

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -344,6 +344,9 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
         }
       }
 
+      if (since && latestMention) {
+        break;
+      }
       if (pageCount) {
         if (page === 1) {
           break;

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -8,6 +8,7 @@ import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCa
 
 const MENTIONS_ACTIVATED_KEY = 'mentionsActivatedAt';
 const COMMENT_FETCH_CONCURRENCY = 3;
+const COMMENT_PAGE_LIMIT = 5;
 
 interface GitHubIssueComment {
   id: number;
@@ -238,45 +239,41 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       return undefined;
     }
 
-    let response: Response;
-    try {
-      response = await fetch(GitHubMentionsProvider.withPerPage(issue.comments_url), {
-        headers: getGitHubAuthHeaders(token),
-        signal: combineSignals(signal, 30_000),
-      });
-    } catch (err: unknown) {
-      if (err instanceof Error && err.name === 'AbortError' && signal?.aborted) { throw err; }
-      logger.debug(`Failed to fetch comments for mention ${issue.html_url}`, err);
-      return undefined;
+    for (let page = 1; page <= COMMENT_PAGE_LIMIT; page++) {
+      let response: Response;
+      try {
+        response = await fetch(GitHubMentionsProvider.withCommentQuery(issue.comments_url, page), {
+          headers: getGitHubAuthHeaders(token),
+          signal: combineSignals(signal, 30_000),
+        });
+      } catch (err: unknown) {
+        if (err instanceof Error && err.name === 'AbortError' && signal?.aborted) { throw err; }
+        logger.debug(`Failed to fetch comments for mention ${issue.html_url}`, err);
+        return undefined;
+      }
+
+      if (!response.ok) {
+        logger.debug(`Failed to fetch comments for mention ${issue.html_url}: ${response.status}`);
+        return undefined;
+      }
+
+      const comments = await response.json() as GitHubIssueComment[];
+      for (const comment of comments) {
+        if (!GitHubMentionsProvider.mentionsUser(comment.body, currentLogin)) {
+          continue;
+        }
+        if (!comment.created_at || Number.isNaN(Date.parse(comment.created_at))) {
+          continue;
+        }
+        return `comment:${comment.id}:${comment.created_at}`;
+      }
+
+      if (comments.length < 100) {
+        break;
+      }
     }
 
-    if (!response.ok) {
-      logger.debug(`Failed to fetch comments for mention ${issue.html_url}: ${response.status}`);
-      return undefined;
-    }
-
-    const comments = await response.json() as GitHubIssueComment[];
-    let latestMention: { id: number; timestamp: string; time: number } | undefined;
-    for (const comment of comments) {
-      if (!GitHubMentionsProvider.mentionsUser(comment.body, currentLogin)) {
-        continue;
-      }
-      const timestamp = comment.updated_at ?? comment.created_at;
-      if (!timestamp) {
-        continue;
-      }
-      const time = Date.parse(timestamp);
-      if (Number.isNaN(time)) {
-        continue;
-      }
-      if (!latestMention || time > latestMention.time) {
-        latestMention = { id: comment.id, timestamp, time };
-      }
-    }
-
-    return latestMention
-      ? `comment:${latestMention.id}:${latestMention.timestamp}`
-      : undefined;
+    return undefined;
   }
 
   private static mentionsUser(body: string | null | undefined, login: string): boolean {
@@ -291,16 +288,17 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(login);
   }
 
-  private static withPerPage(url: string): string {
+  private static withCommentQuery(url: string, page: number): string {
     try {
       const parsed = new URL(url);
       parsed.searchParams.set('per_page', '100');
-      parsed.searchParams.set('sort', 'updated');
+      parsed.searchParams.set('sort', 'created');
       parsed.searchParams.set('direction', 'desc');
+      parsed.searchParams.set('page', String(page));
       return parsed.toString();
     } catch {
       const separator = url.includes('?') ? '&' : '?';
-      return `${url}${separator}per_page=100&sort=updated&direction=desc`;
+      return `${url}${separator}per_page=100&sort=created&direction=desc&page=${page}`;
     }
   }
 

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -291,7 +291,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     previousCommentVersion?: string,
     signal?: AbortSignal,
   ): Promise<string | undefined> {
-    if (!issue.comments_url) {
+    if (!issue.comments_url || issue.comments === 0) {
       return undefined;
     }
 

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -344,7 +344,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
         }
       }
 
-      if (since && latestMention) {
+      if (latestMention && (since || pageCount)) {
         break;
       }
       if (pageCount) {
@@ -361,7 +361,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
 
     const moreForwardPages = !pageCount && lastPageWasFull;
     const moreBackwardPages = pageCount !== undefined && pageCount > scannedPages;
-    if (scannedPages === COMMENT_PAGE_LIMIT && (moreForwardPages || moreBackwardPages)) {
+    if (!latestMention && scannedPages === COMMENT_PAGE_LIMIT && (moreForwardPages || moreBackwardPages)) {
       logger.warn(`Comment scan capped at ${COMMENT_PAGE_LIMIT} pages for ${issue.html_url}`);
     }
 

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -8,7 +8,7 @@ import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCa
 
 const MENTIONS_ACTIVATED_KEY = 'mentionsActivatedAt';
 const COMMENT_FETCH_CONCURRENCY = 3;
-const COMMENT_PAGE_LIMIT = 5;
+const COMMENT_PAGE_LIMIT = 10;
 
 interface GitHubIssueComment {
   id: number;
@@ -31,7 +31,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
 
   private readonly _context: vscode.ExtensionContext;
   private readonly mentionCommentCache = new Map<string, { issueUpdatedAt?: string; resurfaceVersion?: string }>();
-  private cachedLogin?: string;
+  private cachedLogin?: { accessToken: string; login: string };
 
   constructor(context: vscode.ExtensionContext) {
     super();
@@ -52,6 +52,11 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     const filtered = patterns.length > 0
       ? itemsWithRepo.filter(({ repoName }) => matchesRepoPatterns(repoName, patterns))
       : itemsWithRepo;
+
+    const activeExternalIds = new Set(filtered.map(({ issue, repoName }) => `${repoName}#${issue.number}`));
+    if (failures.length === 0) {
+      this.pruneMentionCommentCache(activeExternalIds);
+    }
 
     const shouldComputeMentionVersions = filtered.some(({ issue }) => issue.comments_url || issue.body || issue.title);
     const currentLogin = shouldComputeMentionVersions ? await this.getCurrentLogin(accessToken, signal) : undefined;
@@ -174,8 +179,8 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
   }
 
   private async getCurrentLogin(token: string, signal?: AbortSignal): Promise<string | undefined> {
-    if (this.cachedLogin) {
-      return this.cachedLogin;
+    if (this.cachedLogin?.accessToken === token) {
+      return this.cachedLogin.login;
     }
 
     try {
@@ -187,7 +192,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
         const data = await response.json() as { login?: unknown };
         const login = typeof data.login === 'string' ? data.login.trim() : undefined;
         if (login && GitHubMentionsProvider.isValidGitHubLogin(login)) {
-          this.cachedLogin = login;
+          this.cachedLogin = { accessToken: token, login };
           return login;
         }
       } else {
@@ -202,13 +207,22 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: false });
       const label = session?.account?.label?.trim();
       if (label && GitHubMentionsProvider.isValidGitHubLogin(label)) {
-        this.cachedLogin = label;
+        this.cachedLogin = { accessToken: token, login: label };
         return label;
       }
+      logger.warn('Could not determine GitHub login for mention comment filtering');
       return undefined;
     } catch (err) {
-      logger.debug('Could not determine fallback GitHub login for mention comment filtering', err);
+      logger.warn('Could not determine fallback GitHub login for mention comment filtering', err);
       return undefined;
+    }
+  }
+
+  private pruneMentionCommentCache(activeExternalIds: Set<string>): void {
+    for (const externalId of this.mentionCommentCache.keys()) {
+      if (!activeExternalIds.has(externalId)) {
+        this.mentionCommentCache.delete(externalId);
+      }
     }
   }
 
@@ -252,32 +266,46 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
   ): Promise<string | undefined> {
     const bodyMentionVersion = GitHubMentionsProvider.getIssueBodyMentionVersion(issue, currentLogin);
     const cached = this.mentionCommentCache.get(externalId);
-    if (cached && cached.issueUpdatedAt === issue.updated_at) {
+    if (cached && issue.updated_at && cached.issueUpdatedAt === issue.updated_at) {
       return cached.resurfaceVersion ?? bodyMentionVersion;
     }
 
-    const commentVersion = await this.fetchLatestMentionCommentVersion(issue, token, currentLogin, signal);
+    const previousCommentVersion = cached?.resurfaceVersion;
+    const commentVersion = await this.fetchLatestMentionCommentVersion(issue, token, currentLogin, previousCommentVersion, signal);
+    const resurfaceVersion = commentVersion ?? previousCommentVersion;
     this.mentionCommentCache.set(externalId, {
       issueUpdatedAt: issue.updated_at,
-      resurfaceVersion: commentVersion,
+      resurfaceVersion,
     });
-    return commentVersion ?? bodyMentionVersion;
+    return resurfaceVersion ?? bodyMentionVersion;
   }
 
   private async fetchLatestMentionCommentVersion(
     issue: GitHubIssue,
     token: string,
     currentLogin: string,
+    previousCommentVersion?: string,
     signal?: AbortSignal,
   ): Promise<string | undefined> {
     if (!issue.comments_url) {
       return undefined;
     }
 
-    for (let page = 1; page <= COMMENT_PAGE_LIMIT; page++) {
+    const since = GitHubMentionsProvider.getCommentVersionTimestamp(previousCommentVersion);
+    const pageCount = since ? undefined : GitHubMentionsProvider.getCommentPageCount(issue.comments);
+    let latestMention: { id: number; createdAt: string; time: number } | undefined;
+    let lastPageWasFull = false;
+    let scannedPages = 0;
+
+    for (let index = 0; index < COMMENT_PAGE_LIMIT; index++) {
+      const page = pageCount ? pageCount - index : index + 1;
+      if (page < 1) {
+        break;
+      }
+
       let response: Response;
       try {
-        response = await fetch(GitHubMentionsProvider.withCommentQuery(issue.comments_url, page), {
+        response = await fetch(GitHubMentionsProvider.withCommentQuery(issue.comments_url, page, since), {
           headers: getGitHubAuthHeaders(token),
           signal: combineSignals(signal, 30_000),
         });
@@ -292,23 +320,46 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
         return undefined;
       }
 
+      scannedPages++;
       const comments = await response.json() as GitHubIssueComment[];
+      lastPageWasFull = comments.length >= 100;
       for (const comment of comments) {
         if (!GitHubMentionsProvider.mentionsUser(comment.body, currentLogin)) {
           continue;
         }
-        if (!comment.created_at || Number.isNaN(Date.parse(comment.created_at))) {
+        if (!comment.created_at) {
           continue;
         }
-        return `comment:${comment.id}:${comment.created_at}`;
+        const time = Date.parse(comment.created_at);
+        if (Number.isNaN(time)) {
+          continue;
+        }
+        if (!latestMention || time > latestMention.time) {
+          latestMention = { id: comment.id, createdAt: comment.created_at, time };
+        }
       }
 
-      if (comments.length < 100) {
+      if (pageCount) {
+        if (page === 1) {
+          break;
+        }
+        if (comments.length === 0) {
+          continue;
+        }
+      } else if (comments.length === 0 || comments.length < 100) {
         break;
       }
     }
 
-    return undefined;
+    const moreForwardPages = !pageCount && lastPageWasFull;
+    const moreBackwardPages = pageCount !== undefined && pageCount > scannedPages;
+    if (scannedPages === COMMENT_PAGE_LIMIT && (moreForwardPages || moreBackwardPages)) {
+      logger.warn(`Comment scan capped at ${COMMENT_PAGE_LIMIT} pages for ${issue.html_url}`);
+    }
+
+    return latestMention
+      ? `comment:${latestMention.id}:${latestMention.createdAt}`
+      : undefined;
   }
 
   private static getIssueBodyMentionVersion(issue: GitHubIssue, login: string): string | undefined {
@@ -316,6 +367,18 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       return undefined;
     }
     return `issue:${issue.number}`;
+  }
+
+  private static getCommentVersionTimestamp(version: string | undefined): string | undefined {
+    const match = version?.match(/^comment:\d+:(.+)$/);
+    return match?.[1];
+  }
+
+  private static getCommentPageCount(commentCount: number | undefined): number | undefined {
+    if (commentCount === undefined || !Number.isFinite(commentCount) || commentCount <= 0) {
+      return undefined;
+    }
+    return Math.ceil(commentCount / 100);
   }
 
   private static mentionsUser(body: string | null | undefined, login: string): boolean {
@@ -330,17 +393,19 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(login);
   }
 
-  private static withCommentQuery(url: string, page: number): string {
+  private static withCommentQuery(url: string, page: number, since?: string): string {
     try {
       const parsed = new URL(url);
       parsed.searchParams.set('per_page', '100');
-      parsed.searchParams.set('sort', 'created');
-      parsed.searchParams.set('direction', 'desc');
       parsed.searchParams.set('page', String(page));
+      if (since) {
+        parsed.searchParams.set('since', since);
+      }
       return parsed.toString();
     } catch {
       const separator = url.includes('?') ? '&' : '?';
-      return `${url}${separator}per_page=100&sort=created&direction=desc&page=${page}`;
+      const sinceQuery = since ? `&since=${encodeURIComponent(since)}` : '';
+      return `${url}${separator}per_page=100&page=${page}${sinceQuery}`;
     }
   }
 

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -30,6 +30,12 @@ type TeamMentionFetchResult =
   | { ok: true; teams: Set<string> }
   | { ok: false; teams: Set<string> };
 
+type MentionCommentFetchResult = {
+  resurfaceVersion?: string;
+  latestScannedAt?: string;
+  scanCapped: boolean;
+};
+
 /**
  * DevDocket provider that discovers GitHub issues and pull requests
  * where the current user is @mentioned.
@@ -45,7 +51,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
   private static readonly AUTH_SCOPES = ['repo', 'read:org'];
 
   private readonly _context: vscode.ExtensionContext;
-  private readonly mentionCommentCache = new Map<string, { issueUpdatedAt?: string; resurfaceVersion?: string }>();
+  private readonly mentionCommentCache = new Map<string, { issueUpdatedAt?: string; resurfaceVersion?: string; commentScanSince?: string }>();
   private mentionCommentCacheLogin?: string;
   private cachedLogin?: { accessToken: string; login: string };
   private teamMentionCache?: { accessToken: string; login: string; expiresAtMs: number; teams: Set<string> };
@@ -368,14 +374,22 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       return cached.resurfaceVersion ?? bodyMentionVersion;
     }
 
-    const previousCommentVersion = cached?.resurfaceVersion;
-    const commentVersion = await this.fetchLatestMentionCommentVersion(issue, token, currentLogin, teamMentions, previousCommentVersion, signal);
-    const resurfaceVersion = commentVersion ?? previousCommentVersion;
+    const previousResurfaceVersion = cached?.resurfaceVersion;
+    const previousCommentSince = cached?.commentScanSince ?? GitHubMentionsProvider.getCommentVersionTimestamp(previousResurfaceVersion);
+    const commentResult = await this.fetchLatestMentionCommentVersion(issue, token, currentLogin, teamMentions, previousCommentSince, signal);
+    const resurfaceVersion = commentResult.resurfaceVersion
+      ?? previousResurfaceVersion
+      ?? bodyMentionVersion
+      ?? (commentResult.scanCapped ? GitHubMentionsProvider.getCappedCommentScanVersion(issue) : undefined);
+    const commentScanSince = commentResult.latestScannedAt
+      ?? GitHubMentionsProvider.getCommentVersionTimestamp(resurfaceVersion)
+      ?? previousCommentSince;
     this.mentionCommentCache.set(externalId, {
       issueUpdatedAt: issue.updated_at,
       resurfaceVersion,
+      commentScanSince,
     });
-    return resurfaceVersion ?? bodyMentionVersion;
+    return resurfaceVersion;
   }
 
   private async fetchLatestMentionCommentVersion(
@@ -383,17 +397,18 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     token: string,
     currentLogin: string,
     teamMentions: Set<string>,
-    previousCommentVersion?: string,
+    previousCommentSince?: string,
     signal?: AbortSignal,
-  ): Promise<string | undefined> {
+  ): Promise<MentionCommentFetchResult> {
     if (!issue.comments_url || issue.comments === 0) {
-      return undefined;
+      return { scanCapped: false };
     }
 
-    const since = GitHubMentionsProvider.getCommentVersionTimestamp(previousCommentVersion);
+    const since = previousCommentSince;
     const pageCount = since ? undefined : GitHubMentionsProvider.getCommentPageCount(issue.comments);
     const newestFirst = !!since || pageCount === undefined;
     let latestMention: { id: number; createdAt: string; time: number } | undefined;
+    let latestScannedComment: { createdAt: string; time: number } | undefined;
     let lastPageWasFull = false;
     let scannedPages = 0;
 
@@ -412,30 +427,31 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       } catch (err: unknown) {
         if (err instanceof Error && err.name === 'AbortError' && signal?.aborted) { throw err; }
         logger.debug(`Failed to fetch comments for mention ${issue.html_url}`, err);
-        return undefined;
+        return { scanCapped: false };
       }
 
       if (!response.ok) {
         logger.debug(`Failed to fetch comments for mention ${issue.html_url}: ${response.status}`);
-        return undefined;
+        return { scanCapped: false };
       }
 
       scannedPages++;
       const comments = await response.json() as GitHubIssueComment[];
       lastPageWasFull = comments.length >= 100;
       for (const comment of comments) {
+        const createdAt = comment.created_at;
+        const time = createdAt ? Date.parse(createdAt) : Number.NaN;
+        if (createdAt && !Number.isNaN(time) && (!latestScannedComment || time > latestScannedComment.time)) {
+          latestScannedComment = { createdAt, time };
+        }
         if (!GitHubMentionsProvider.mentionsUser(comment.body, currentLogin, teamMentions)) {
           continue;
         }
-        if (!comment.created_at) {
-          continue;
-        }
-        const time = Date.parse(comment.created_at);
-        if (Number.isNaN(time)) {
+        if (!createdAt || Number.isNaN(time)) {
           continue;
         }
         if (!latestMention || time > latestMention.time) {
-          latestMention = { id: comment.id, createdAt: comment.created_at, time };
+          latestMention = { id: comment.id, createdAt, time };
         }
       }
 
@@ -456,13 +472,20 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
 
     const moreForwardPages = !pageCount && lastPageWasFull;
     const moreBackwardPages = pageCount !== undefined && pageCount > scannedPages;
-    if (!latestMention && scannedPages === COMMENT_PAGE_LIMIT && (moreForwardPages || moreBackwardPages)) {
+    const scanCapped = !latestMention && scannedPages === COMMENT_PAGE_LIMIT && (moreForwardPages || moreBackwardPages);
+    if (scanCapped) {
       logger.warn(`Comment scan capped at ${COMMENT_PAGE_LIMIT} pages for ${issue.html_url}`);
     }
 
-    return latestMention
-      ? `comment:${latestMention.id}:${latestMention.createdAt}`
-      : undefined;
+    return {
+      resurfaceVersion: latestMention ? `comment:${latestMention.id}:${latestMention.createdAt}` : undefined,
+      latestScannedAt: latestScannedComment?.createdAt,
+      scanCapped,
+    };
+  }
+
+  private static getCappedCommentScanVersion(issue: GitHubIssue): string {
+    return `comments-capped:${issue.number}`;
   }
 
   private static getIssueBodyMentionVersion(issue: GitHubIssue, login: string, teamMentions: Set<string>): string | undefined {

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -59,8 +59,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       this.pruneMentionCommentCache(activeExternalIds);
     }
 
-    const shouldComputeMentionVersions = filtered.some(({ issue }) => issue.comments_url || issue.body || issue.title);
-    const currentLogin = shouldComputeMentionVersions ? await this.getCurrentLogin(accessToken, signal) : undefined;
+    const currentLogin = filtered.length > 0 ? await this.getCurrentLogin(accessToken, signal) : undefined;
     if (currentLogin && this.mentionCommentCacheLogin !== currentLogin) {
       this.mentionCommentCache.clear();
       this.mentionCommentCacheLogin = currentLogin;

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -26,6 +26,10 @@ interface GitHubTeamMembership {
   } | null;
 }
 
+type TeamMentionFetchResult =
+  | { ok: true; teams: Set<string> }
+  | { ok: false; teams: Set<string> };
+
 /**
  * DevDocket provider that discovers GitHub issues and pull requests
  * where the current user is @mentioned.
@@ -250,17 +254,19 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       return cached.teams;
     }
 
-    const teams = await this.fetchCurrentUserTeamMentions(token, signal);
-    this.teamMentionCache = {
-      accessToken: token,
-      login,
-      expiresAtMs: now + TEAM_MENTION_CACHE_TTL_MS,
-      teams,
-    };
-    return teams;
+    const result = await this.fetchCurrentUserTeamMentions(token, signal);
+    if (result.ok) {
+      this.teamMentionCache = {
+        accessToken: token,
+        login,
+        expiresAtMs: now + TEAM_MENTION_CACHE_TTL_MS,
+        teams: result.teams,
+      };
+    }
+    return result.teams;
   }
 
-  private async fetchCurrentUserTeamMentions(token: string, signal?: AbortSignal): Promise<Set<string>> {
+  private async fetchCurrentUserTeamMentions(token: string, signal?: AbortSignal): Promise<TeamMentionFetchResult> {
     const teams = new Set<string>();
 
     for (let page = 1; ; page++) {
@@ -273,12 +279,12 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       } catch (err: unknown) {
         if (err instanceof Error && err.name === 'AbortError' && signal?.aborted) { throw err; }
         logger.warn('Could not fetch GitHub team memberships for mention filtering', err);
-        return new Set<string>();
+        return { ok: false, teams };
       }
 
       if (!response?.ok) {
         logger.warn(`Could not fetch GitHub team memberships for mention filtering: ${response?.status ?? 'no response'}`);
-        return new Set<string>();
+        return { ok: false, teams };
       }
 
       let data: GitHubTeamMembership[];
@@ -286,11 +292,11 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
         data = await response.json() as GitHubTeamMembership[];
       } catch (err) {
         logger.warn('Could not parse GitHub team memberships for mention filtering', err);
-        return new Set<string>();
+        return { ok: false, teams };
       }
       if (!Array.isArray(data)) {
         logger.warn('Could not parse GitHub team memberships for mention filtering');
-        return new Set<string>();
+        return { ok: false, teams };
       }
 
       for (const team of data) {
@@ -303,7 +309,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
       }
 
       if (data.length < 100) {
-        return teams;
+        return { ok: true, teams };
       }
     }
   }

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -547,6 +547,57 @@ describe('GitHubMentionsProvider', () => {
     expect(incrementalCommentsUrl.searchParams.get('direction')).toBe('desc');
   });
 
+  it('stops incremental comment scans after finding the newest mention', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 100, body: 'Initial ping @testuser', created_at: '2024-02-01T00:00:00Z' },
+        ]),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: 200, body: 'New ping @testuser', created_at: '2024-02-03T00:00:00Z' },
+          ...Array.from({ length: 99 }, (_, i) => ({
+            id: 201 + i,
+            body: 'older non-mention update',
+            created_at: '2024-02-02T00:00:00Z',
+          })),
+        ],
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+    await provider.refresh();
+
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+    expect(listener.mock.calls[1][0][0].resurfaceVersion).toBe('comment:200:2024-02-03T00:00:00Z');
+  });
+
   it('preserves cached comment versions when the search refresh fails', async () => {
     const issue = {
       ...createMockIssue(10, 'Bug report', 'org/repo'),

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -1018,6 +1018,30 @@ describe('GitHubMentionsProvider', () => {
     expect(listener.mock.calls[0][0][0].resurfaceVersion).toBe('comment:901:2024-04-01T00:00:00Z');
   });
 
+  it('retries team lookup after a team API failure instead of caching the empty result', async () => {
+    const issue = {
+      ...createMockIssue(10, 'Bug report', 'org/repo'),
+      body: 'Please review, @org/platform.',
+      comments: 0,
+      comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+    };
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [issue] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ login: 'testuser' }) })
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [issue] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ slug: 'platform', organization: { login: 'org' } }] });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+    await provider.refresh();
+
+    expect(mockFetch.mock.calls.filter(call => String(call[0]).includes('/user/teams'))).toHaveLength(2);
+    expect(listener.mock.calls[0][0][0].resurfaceVersion).toBeUndefined();
+    expect(listener.mock.calls[1][0][0].resurfaceVersion).toBe('issue:10');
+  });
+
   it('clears the team cache when the authenticated login changes', async () => {
     vi.mocked(authentication.getSession)
       .mockResolvedValueOnce({ accessToken: 'alice-token', id: 'session-1', scopes: ['repo', 'read:org'], account: { id: '1', label: 'alice' } } as any)

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -880,6 +880,61 @@ describe('GitHubMentionsProvider', () => {
     expect(items[0].resurfaceVersion).toBeUndefined();
   });
 
+  it('uses a capped comment-scan sentinel until a newer mention is found', async () => {
+    const commentsUrl = 'https://api.github.com/repos/org/repo/issues/10/comments';
+    const initialIssue = {
+      ...createMockIssue(10, 'Bug report', 'org/repo'),
+      body: 'No mention here',
+      comments: 1100,
+      comments_url: commentsUrl,
+      updated_at: '2024-04-01T00:00:00Z',
+    };
+    const updatedIssue = {
+      ...initialIssue,
+      comments: 1101,
+      updated_at: '2024-04-02T00:00:00Z',
+    };
+
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [initialIssue] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ login: 'testuser' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] });
+    for (let page = 0; page < 10; page++) {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => Array.from({ length: 100 }, (_, i) => ({
+          id: 1000 + (page * 100) + i,
+          body: 'non-mention update',
+          created_at: '2024-04-01T00:00:00Z',
+        })),
+      });
+    }
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [updatedIssue] }) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 2200, body: 'New ping @testuser', created_at: '2024-04-02T00:00:00Z' },
+        ]),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+    await provider.refresh();
+
+    expect(listener.mock.calls[0][0][0].resurfaceVersion).toBe('comments-capped:10');
+    expect(listener.mock.calls[1][0][0].resurfaceVersion).toBe('comment:2200:2024-04-02T00:00:00Z');
+
+    const firstCappedPageUrl = new URL(mockFetch.mock.calls[3][0] as string);
+    const firstUpdatedPageUrl = new URL(mockFetch.mock.calls[14][0] as string);
+    expect(firstCappedPageUrl.searchParams.get('page')).toBe('11');
+    expect(firstUpdatedPageUrl.searchParams.get('page')).toBe('1');
+    expect(firstUpdatedPageUrl.searchParams.get('since')).toBe('2024-04-01T00:00:00Z');
+    expect(firstUpdatedPageUrl.searchParams.get('sort')).toBe('created');
+    expect(firstUpdatedPageUrl.searchParams.get('direction')).toBe('desc');
+  });
+
   it('counts a mention in plain prose', async () => {
     const item = await refreshWithSingleComment('Please take a look, @testuser.');
 

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -128,8 +128,8 @@ describe('GitHubMentionsProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ([
-          { id: 100, body: 'Initial ping @testuser', updated_at: '2024-02-01T00:00:00Z' },
-          { id: 101, body: 'Follow-up without a mention', updated_at: '2024-02-02T00:00:00Z' },
+          { id: 100, body: 'Initial ping @testuser', created_at: '2024-02-01T00:00:00Z', updated_at: '2024-02-05T00:00:00Z' },
+          { id: 101, body: 'Follow-up without a mention', created_at: '2024-02-02T00:00:00Z' },
         ]),
       });
 
@@ -142,8 +142,51 @@ describe('GitHubMentionsProvider', () => {
 
     const commentsFetchUrl = new URL(mockFetch.mock.calls[2][0] as string);
     expect(commentsFetchUrl.searchParams.get('per_page')).toBe('100');
-    expect(commentsFetchUrl.searchParams.get('sort')).toBe('updated');
+    expect(commentsFetchUrl.searchParams.get('sort')).toBe('created');
     expect(commentsFetchUrl.searchParams.get('direction')).toBe('desc');
+  });
+
+  it('finds a mention on a later comments page', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => Array.from({ length: 100 }, (_, i) => ({
+          id: 200 + i,
+          body: 'non-mention update',
+          created_at: `2024-03-${String(30 - Math.floor(i / 4)).padStart(2, '0')}T00:00:00Z`,
+        })),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 100, body: 'Older ping @testuser', created_at: '2024-02-01T00:00:00Z' },
+        ]),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items[0].resurfaceVersion).toBe('comment:100:2024-02-01T00:00:00Z');
+
+    const firstPageUrl = new URL(mockFetch.mock.calls[2][0] as string);
+    const secondPageUrl = new URL(mockFetch.mock.calls[3][0] as string);
+    expect(firstPageUrl.searchParams.get('page')).toBe('1');
+    expect(secondPageUrl.searchParams.get('page')).toBe('2');
   });
 
   it('changes resurfaceVersion when a later comment mentions the current user', async () => {
@@ -164,8 +207,8 @@ describe('GitHubMentionsProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ([
-          { id: 100, body: 'Initial ping @testuser', updated_at: '2024-02-01T00:00:00Z' },
-          { id: 102, body: 'New ping @testuser', updated_at: '2024-02-03T00:00:00Z' },
+          { id: 102, body: 'New ping @testuser', created_at: '2024-02-03T00:00:00Z' },
+          { id: 100, body: 'Initial ping @testuser', created_at: '2024-02-01T00:00:00Z' },
         ]),
       });
 
@@ -202,7 +245,7 @@ describe('GitHubMentionsProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ([
-          { id: 100, body: 'Initial ping @testuser', updated_at: '2024-02-01T00:00:00Z' },
+          { id: 100, body: 'Initial ping @testuser', created_at: '2024-02-01T00:00:00Z' },
         ]),
       });
 
@@ -232,7 +275,7 @@ describe('GitHubMentionsProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ([
-          { id: 101, body: 'Follow-up without a mention', updated_at: '2024-02-02T00:00:00Z' },
+          { id: 101, body: 'Follow-up without a mention', created_at: '2024-02-02T00:00:00Z' },
         ]),
       });
 

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -362,6 +362,67 @@ describe('GitHubMentionsProvider', () => {
     expect(items[0].resurfaceVersion).toBe('comment:100:2024-02-01T00:00:00Z');
   });
 
+  it('clears cached comment versions when the authenticated login changes', async () => {
+    vi.mocked(authentication.getSession)
+      .mockResolvedValueOnce({
+        accessToken: 'alice-token',
+        id: 'session-1',
+        scopes: ['repo'],
+        account: { id: '1', label: 'alice' },
+      } as any)
+      .mockResolvedValueOnce({
+        accessToken: 'bob-token',
+        id: 'session-2',
+        scopes: ['repo'],
+        account: { id: '2', label: 'bob' },
+      } as any);
+
+    const issue = {
+      ...createMockIssue(10, 'Bug report', 'org/repo'),
+      comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+      updated_at: '2024-02-02T00:00:00Z',
+    };
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [issue] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'alice' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 100, body: 'Initial ping @alice', created_at: '2024-02-01T00:00:00Z' },
+        ]),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [issue] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'bob' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 101, body: 'New ping @bob', created_at: '2024-02-03T00:00:00Z' },
+        ]),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+    await provider.refresh();
+
+    expect(mockFetch).toHaveBeenCalledTimes(6);
+    expect(listener.mock.calls[0][0][0].resurfaceVersion).toBe('comment:100:2024-02-01T00:00:00Z');
+    expect(listener.mock.calls[1][0][0].resurfaceVersion).toBe('comment:101:2024-02-03T00:00:00Z');
+  });
+
   it('uses issue body mention as a stable baseline when comments do not mention the current user', async () => {
     mockFetch
       .mockResolvedValueOnce({

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -499,6 +499,32 @@ describe('GitHubMentionsProvider', () => {
     expect(listener.mock.calls[1][0][0].resurfaceVersion).toBe('comment:101:2024-02-03T00:00:00Z');
   });
 
+  it('skips comment fetching when the issue has no comments', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            body: 'Original body ping @testuser',
+            comments: 0,
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(listener.mock.calls[0][0][0].resurfaceVersion).toBe('issue:10');
+  });
+
   it('uses issue body mention as a stable baseline when comments do not mention the current user', async () => {
     mockFetch
       .mockResolvedValueOnce({

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -67,12 +67,56 @@ describe('GitHubMentionsProvider', () => {
 
   afterEach(() => {
     provider.dispose();
+    vi.useRealTimers();
     vi.unstubAllGlobals();
   });
+
+  async function refreshWithSingleComment(commentBody: string, teams: unknown[] = [], login = 'testuser') {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => teams,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 900, body: commentBody, created_at: '2024-04-01T00:00:00Z' },
+        ]),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+    return listener.mock.calls[0][0][0];
+  }
 
   it('has correct id and label', () => {
     expect(provider.id).toBe('github-mentions');
     expect(provider.label).toBe('GitHub Mentions');
+  });
+
+  it('requests read:org scope for team mention detection', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [] }),
+    });
+
+    await provider.refresh();
+
+    expect(authentication.getSession).toHaveBeenCalledWith('github', ['repo', 'read:org'], { createIfNone: true });
   });
 
   it('discovers mentioned issues and PRs', async () => {
@@ -128,6 +172,10 @@ describe('GitHubMentionsProvider', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => ([
           { id: 100, body: 'Initial ping @testuser', created_at: '2024-02-01T00:00:00Z', updated_at: '2024-02-05T00:00:00Z' },
           { id: 101, body: 'Follow-up without a mention', created_at: '2024-02-02T00:00:00Z' },
@@ -141,7 +189,7 @@ describe('GitHubMentionsProvider', () => {
     const items = listener.mock.calls[0][0];
     expect(items[0].resurfaceVersion).toBe('comment:100:2024-02-01T00:00:00Z');
 
-    const commentsFetchUrl = new URL(mockFetch.mock.calls[2][0] as string);
+    const commentsFetchUrl = new URL(mockFetch.mock.calls[3][0] as string);
     expect(commentsFetchUrl.searchParams.get('per_page')).toBe('100');
     expect(commentsFetchUrl.searchParams.get('sort')).toBeNull();
     expect(commentsFetchUrl.searchParams.get('direction')).toBeNull();
@@ -164,6 +212,10 @@ describe('GitHubMentionsProvider', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => [
           { id: 200, body: 'Newest visible ping @testuser', created_at: '2024-03-01T00:00:00Z' },
           ...Array.from({ length: 99 }, (_, i) => ({
@@ -178,10 +230,10 @@ describe('GitHubMentionsProvider', () => {
     provider.onDidDiscoverItems(listener);
     await provider.refresh();
 
-    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockFetch).toHaveBeenCalledTimes(4);
     expect(listener.mock.calls[0][0][0].resurfaceVersion).toBe('comment:200:2024-03-01T00:00:00Z');
 
-    const commentsFetchUrl = new URL(mockFetch.mock.calls[2][0] as string);
+    const commentsFetchUrl = new URL(mockFetch.mock.calls[3][0] as string);
     expect(commentsFetchUrl.searchParams.get('sort')).toBe('created');
     expect(commentsFetchUrl.searchParams.get('direction')).toBe('desc');
   });
@@ -200,6 +252,10 @@ describe('GitHubMentionsProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -223,8 +279,8 @@ describe('GitHubMentionsProvider', () => {
     const items = listener.mock.calls[0][0];
     expect(items[0].resurfaceVersion).toBe('comment:100:2024-02-01T00:00:00Z');
 
-    const firstPageUrl = new URL(mockFetch.mock.calls[2][0] as string);
-    const secondPageUrl = new URL(mockFetch.mock.calls[3][0] as string);
+    const firstPageUrl = new URL(mockFetch.mock.calls[3][0] as string);
+    const secondPageUrl = new URL(mockFetch.mock.calls[4][0] as string);
     expect(firstPageUrl.searchParams.get('page')).toBe('1');
     expect(secondPageUrl.searchParams.get('page')).toBe('2');
   });
@@ -247,6 +303,10 @@ describe('GitHubMentionsProvider', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => [
           { id: 300, body: 'Newest-page ping @testuser', created_at: '2024-03-01T00:00:00Z' },
           ...Array.from({ length: 49 }, (_, i) => ({
@@ -261,7 +321,7 @@ describe('GitHubMentionsProvider', () => {
     provider.onDidDiscoverItems(listener);
     await provider.refresh();
 
-    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockFetch).toHaveBeenCalledTimes(4);
     expect(listener.mock.calls[0][0][0].resurfaceVersion).toBe('comment:300:2024-03-01T00:00:00Z');
   });
 
@@ -280,6 +340,10 @@ describe('GitHubMentionsProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -316,8 +380,8 @@ describe('GitHubMentionsProvider', () => {
     const items = listener.mock.calls[0][0];
     expect(items[0].resurfaceVersion).toBe('comment:200:2024-02-01T00:00:00Z');
 
-    const lastPageUrl = new URL(mockFetch.mock.calls[2][0] as string);
-    const previousPageUrl = new URL(mockFetch.mock.calls[3][0] as string);
+    const lastPageUrl = new URL(mockFetch.mock.calls[3][0] as string);
+    const previousPageUrl = new URL(mockFetch.mock.calls[4][0] as string);
     expect(lastPageUrl.searchParams.get('page')).toBe('3');
     expect(previousPageUrl.searchParams.get('page')).toBe('2');
   });
@@ -337,6 +401,10 @@ describe('GitHubMentionsProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -364,8 +432,8 @@ describe('GitHubMentionsProvider', () => {
     const items = listener.mock.calls[0][0];
     expect(items[0].resurfaceVersion).toBe('comment:200:2024-02-01T00:00:00Z');
 
-    const staleLastPageUrl = new URL(mockFetch.mock.calls[2][0] as string);
-    const previousPageUrl = new URL(mockFetch.mock.calls[3][0] as string);
+    const staleLastPageUrl = new URL(mockFetch.mock.calls[3][0] as string);
+    const previousPageUrl = new URL(mockFetch.mock.calls[4][0] as string);
     expect(staleLastPageUrl.searchParams.get('page')).toBe('3');
     expect(previousPageUrl.searchParams.get('page')).toBe('2');
   });
@@ -384,6 +452,10 @@ describe('GitHubMentionsProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -422,6 +494,10 @@ describe('GitHubMentionsProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -470,6 +546,10 @@ describe('GitHubMentionsProvider', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => ([
           { id: 100, body: 'Initial ping @alice', created_at: '2024-02-01T00:00:00Z' },
         ]),
@@ -484,6 +564,10 @@ describe('GitHubMentionsProvider', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => ([
           { id: 101, body: 'New ping @bob', created_at: '2024-02-03T00:00:00Z' },
         ]),
@@ -494,7 +578,7 @@ describe('GitHubMentionsProvider', () => {
     await provider.refresh();
     await provider.refresh();
 
-    expect(mockFetch).toHaveBeenCalledTimes(6);
+    expect(mockFetch).toHaveBeenCalledTimes(8);
     expect(listener.mock.calls[0][0][0].resurfaceVersion).toBe('comment:100:2024-02-01T00:00:00Z');
     expect(listener.mock.calls[1][0][0].resurfaceVersion).toBe('comment:101:2024-02-03T00:00:00Z');
   });
@@ -521,7 +605,7 @@ describe('GitHubMentionsProvider', () => {
     provider.onDidDiscoverItems(listener);
     await provider.refresh();
 
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
     expect(listener.mock.calls[0][0][0].resurfaceVersion).toBe('issue:10');
   });
 
@@ -540,6 +624,10 @@ describe('GitHubMentionsProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -574,6 +662,10 @@ describe('GitHubMentionsProvider', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => ([
           { id: 100, body: 'Initial ping @testuser', created_at: '2024-02-01T00:00:00Z' },
         ]),
@@ -594,7 +686,7 @@ describe('GitHubMentionsProvider', () => {
     await provider.refresh();
     await provider.refresh();
 
-    expect(mockFetch).toHaveBeenCalledTimes(4);
+    expect(mockFetch).toHaveBeenCalledTimes(5);
     expect(listener.mock.calls[1][0][0].resurfaceVersion).toBe('comment:100:2024-02-01T00:00:00Z');
   });
 
@@ -612,6 +704,10 @@ describe('GitHubMentionsProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -640,10 +736,10 @@ describe('GitHubMentionsProvider', () => {
     await provider.refresh();
     await provider.refresh();
 
-    expect(mockFetch).toHaveBeenCalledTimes(5);
+    expect(mockFetch).toHaveBeenCalledTimes(6);
     expect(listener.mock.calls[1][0][0].resurfaceVersion).toBe('comment:102:2024-02-03T00:00:00Z');
 
-    const incrementalCommentsUrl = new URL(mockFetch.mock.calls[4][0] as string);
+    const incrementalCommentsUrl = new URL(mockFetch.mock.calls[5][0] as string);
     expect(incrementalCommentsUrl.searchParams.get('since')).toBe('2024-02-01T00:00:00Z');
     expect(incrementalCommentsUrl.searchParams.get('sort')).toBe('created');
     expect(incrementalCommentsUrl.searchParams.get('direction')).toBe('desc');
@@ -663,6 +759,10 @@ describe('GitHubMentionsProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -696,7 +796,7 @@ describe('GitHubMentionsProvider', () => {
     await provider.refresh();
     await provider.refresh();
 
-    expect(mockFetch).toHaveBeenCalledTimes(5);
+    expect(mockFetch).toHaveBeenCalledTimes(6);
     expect(listener.mock.calls[1][0][0].resurfaceVersion).toBe('comment:200:2024-02-03T00:00:00Z');
   });
 
@@ -715,6 +815,10 @@ describe('GitHubMentionsProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -737,7 +841,7 @@ describe('GitHubMentionsProvider', () => {
     await provider.refresh();
     await provider.refresh();
 
-    expect(mockFetch).toHaveBeenCalledTimes(5);
+    expect(mockFetch).toHaveBeenCalledTimes(6);
     expect(listener.mock.calls[2][0][0].resurfaceVersion).toBe('comment:100:2024-02-01T00:00:00Z');
   });
 
@@ -759,6 +863,10 @@ describe('GitHubMentionsProvider', () => {
       })
       .mockResolvedValueOnce({
         ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
         json: async () => ([
           { id: 101, body: 'Follow-up without a mention', created_at: '2024-02-02T00:00:00Z' },
         ]),
@@ -770,6 +878,173 @@ describe('GitHubMentionsProvider', () => {
 
     const items = listener.mock.calls[0][0];
     expect(items[0].resurfaceVersion).toBeUndefined();
+  });
+
+  it('counts a mention in plain prose', async () => {
+    const item = await refreshWithSingleComment('Please take a look, @testuser.');
+
+    expect(item.resurfaceVersion).toBe('comment:900:2024-04-01T00:00:00Z');
+  });
+
+  it('ignores a mention inside inline code', async () => {
+    const item = await refreshWithSingleComment('This example `@testuser` should not resurface.');
+
+    expect(item.resurfaceVersion).toBeUndefined();
+  });
+
+  it('ignores a mention inside a fenced code block', async () => {
+    const item = await refreshWithSingleComment('```ts\n@testuser\n```');
+
+    expect(item.resurfaceVersion).toBeUndefined();
+  });
+
+  it('counts a mention inside a blockquote', async () => {
+    const item = await refreshWithSingleComment('> Please take a look, @testuser.');
+
+    expect(item.resurfaceVersion).toBe('comment:900:2024-04-01T00:00:00Z');
+  });
+
+  it('counts mentions in link text but not link URLs or autolink targets', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ login: 'testuser' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 901, body: 'Display text [@testuser](https://example.com/profile)', created_at: '2024-04-01T00:00:00Z' },
+          { id: 902, body: 'URL target [profile](https://example.com/@testuser)', created_at: '2024-04-02T00:00:00Z' },
+          { id: 903, body: 'Autolink https://example.com/@testuser', created_at: '2024-04-03T00:00:00Z' },
+        ]),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener.mock.calls[0][0][0].resurfaceVersion).toBe('comment:901:2024-04-01T00:00:00Z');
+  });
+
+  it('counts a team mention when the current user belongs to that team', async () => {
+    const item = await refreshWithSingleComment('Please review, @org/platform.', [
+      { slug: 'platform', organization: { login: 'org' } },
+    ]);
+
+    expect(item.resurfaceVersion).toBe('comment:900:2024-04-01T00:00:00Z');
+  });
+
+  it('ignores a team mention when the current user is not on that team', async () => {
+    const item = await refreshWithSingleComment('Please review, @org/platform.', [
+      { slug: 'other-team', organization: { login: 'org' } },
+    ]);
+
+    expect(item.resurfaceVersion).toBeUndefined();
+  });
+
+  it('caches team memberships across comment scans and refreshes them after the TTL', async () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_000);
+    const issueOne = {
+      ...createMockIssue(10, 'First', 'org/repo'),
+      comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+    };
+    const issueTwo = {
+      ...createMockIssue(11, 'Second', 'org/repo'),
+      comments_url: 'https://api.github.com/repos/org/repo/issues/11/comments',
+    };
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [issueOne, issueTwo] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ login: 'testuser' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ slug: 'platform', organization: { login: 'org' } }] })
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 901, body: '@org/platform', created_at: '2024-04-01T00:00:00Z' }] })
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 902, body: '@org/platform', created_at: '2024-04-02T00:00:00Z' }] })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [issueOne, issueTwo] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ slug: 'platform', organization: { login: 'org' } }] })
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 903, body: '@org/platform', created_at: '2024-04-03T00:00:00Z' }] })
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ id: 904, body: '@org/platform', created_at: '2024-04-04T00:00:00Z' }] });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+    expect(mockFetch.mock.calls.filter(call => String(call[0]).includes('/user/teams'))).toHaveLength(1);
+
+    nowSpy.mockReturnValue(1_000 + 30 * 60 * 1000 + 1);
+    await provider.refresh();
+
+    expect(mockFetch.mock.calls.filter(call => String(call[0]).includes('/user/teams'))).toHaveLength(2);
+    expect(listener.mock.calls[0][0].map((item: any) => item.resurfaceVersion)).toEqual([
+      'comment:901:2024-04-01T00:00:00Z',
+      'comment:902:2024-04-02T00:00:00Z',
+    ]);
+    expect(listener.mock.calls[1][0].map((item: any) => item.resurfaceVersion)).toEqual([
+      'comment:903:2024-04-03T00:00:00Z',
+      'comment:904:2024-04-04T00:00:00Z',
+    ]);
+    nowSpy.mockRestore();
+  });
+
+  it('ignores team mentions after a team API failure but still counts user mentions', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ login: 'testuser' }) })
+      .mockResolvedValueOnce({ ok: false, status: 404 })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 901, body: '@testuser', created_at: '2024-04-01T00:00:00Z' },
+          { id: 902, body: '@org/platform', created_at: '2024-04-02T00:00:00Z' },
+        ]),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener.mock.calls[0][0][0].resurfaceVersion).toBe('comment:901:2024-04-01T00:00:00Z');
+  });
+
+  it('clears the team cache when the authenticated login changes', async () => {
+    vi.mocked(authentication.getSession)
+      .mockResolvedValueOnce({ accessToken: 'alice-token', id: 'session-1', scopes: ['repo', 'read:org'], account: { id: '1', label: 'alice' } } as any)
+      .mockResolvedValueOnce({ accessToken: 'bob-token', id: 'session-2', scopes: ['repo', 'read:org'], account: { id: '2', label: 'bob' } } as any);
+
+    const issue = {
+      ...createMockIssue(10, 'Bug report', 'org/repo'),
+      body: 'Please review, @org/platform.',
+      comments: 0,
+      comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+    };
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [issue] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ login: 'alice' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [{ slug: 'platform', organization: { login: 'org' } }] })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ items: [issue] }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ login: 'bob' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+    await provider.refresh();
+
+    expect(mockFetch.mock.calls.filter(call => String(call[0]).includes('/user/teams'))).toHaveLength(2);
+    expect(listener.mock.calls[0][0][0].resurfaceVersion).toBe('issue:10');
+    expect(listener.mock.calls[1][0][0].resurfaceVersion).toBeUndefined();
   });
 
   it('sets canonicalId with github:issue prefix for issues', async () => {

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -189,6 +189,42 @@ describe('GitHubMentionsProvider', () => {
     expect(secondPageUrl.searchParams.get('page')).toBe('2');
   });
 
+  it('stops initial backward scans after finding the newest mention', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments: 250,
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: 300, body: 'Newest-page ping @testuser', created_at: '2024-03-01T00:00:00Z' },
+          ...Array.from({ length: 49 }, (_, i) => ({
+            id: 301 + i,
+            body: 'newer non-mention comment',
+            created_at: '2024-03-01T00:00:00Z',
+          })),
+        ],
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(listener.mock.calls[0][0][0].resurfaceVersion).toBe('comment:300:2024-03-01T00:00:00Z');
+  });
+
   it('continues scanning backward after a partial last page', async () => {
     mockFetch
       .mockResolvedValueOnce({

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -110,6 +110,140 @@ describe('GitHubMentionsProvider', () => {
     }));
   });
 
+  it('sets resurfaceVersion from the latest comment that mentions the current user', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 100, body: 'Initial ping @testuser', updated_at: '2024-02-01T00:00:00Z' },
+          { id: 101, body: 'Follow-up without a mention', updated_at: '2024-02-02T00:00:00Z' },
+        ]),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items[0].resurfaceVersion).toBe('comment:100:2024-02-01T00:00:00Z');
+
+    const commentsFetchUrl = new URL(mockFetch.mock.calls[2][0] as string);
+    expect(commentsFetchUrl.searchParams.get('per_page')).toBe('100');
+    expect(commentsFetchUrl.searchParams.get('sort')).toBe('updated');
+    expect(commentsFetchUrl.searchParams.get('direction')).toBe('desc');
+  });
+
+  it('changes resurfaceVersion when a later comment mentions the current user', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 100, body: 'Initial ping @testuser', updated_at: '2024-02-01T00:00:00Z' },
+          { id: 102, body: 'New ping @testuser', updated_at: '2024-02-03T00:00:00Z' },
+        ]),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items[0].resurfaceVersion).toBe('comment:102:2024-02-03T00:00:00Z');
+  });
+
+  it('uses the authenticated GitHub login instead of the display label for mention matching', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValue({
+      accessToken: 'test-token',
+      id: 'session-1',
+      scopes: ['repo'],
+      account: { id: '1', label: 'Test User' },
+    } as any);
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 100, body: 'Initial ping @testuser', updated_at: '2024-02-01T00:00:00Z' },
+        ]),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items[0].resurfaceVersion).toBe('comment:100:2024-02-01T00:00:00Z');
+  });
+
+  it('does not derive resurfaceVersion from comments that do not mention the current user', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 101, body: 'Follow-up without a mention', updated_at: '2024-02-02T00:00:00Z' },
+        ]),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items[0].resurfaceVersion).toBeUndefined();
+  });
+
   it('sets canonicalId with github:issue prefix for issues', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -540,6 +540,11 @@ describe('GitHubMentionsProvider', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(5);
     expect(listener.mock.calls[1][0][0].resurfaceVersion).toBe('comment:102:2024-02-03T00:00:00Z');
+
+    const incrementalCommentsUrl = new URL(mockFetch.mock.calls[4][0] as string);
+    expect(incrementalCommentsUrl.searchParams.get('since')).toBe('2024-02-01T00:00:00Z');
+    expect(incrementalCommentsUrl.searchParams.get('sort')).toBe('created');
+    expect(incrementalCommentsUrl.searchParams.get('direction')).toBe('desc');
   });
 
   it('preserves cached comment versions when the search refresh fails', async () => {

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -117,6 +117,7 @@ describe('GitHubMentionsProvider', () => {
         json: async () => ({
           items: [{
             ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments: 2,
             comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
           }],
         }),
@@ -144,6 +145,45 @@ describe('GitHubMentionsProvider', () => {
     expect(commentsFetchUrl.searchParams.get('per_page')).toBe('100');
     expect(commentsFetchUrl.searchParams.get('sort')).toBeNull();
     expect(commentsFetchUrl.searchParams.get('direction')).toBeNull();
+  });
+
+  it('uses newest-first initial scans when the comment count is unavailable', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: 200, body: 'Newest visible ping @testuser', created_at: '2024-03-01T00:00:00Z' },
+          ...Array.from({ length: 99 }, (_, i) => ({
+            id: 201 + i,
+            body: 'older non-mention comment',
+            created_at: '2024-02-01T00:00:00Z',
+          })),
+        ],
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(listener.mock.calls[0][0][0].resurfaceVersion).toBe('comment:200:2024-03-01T00:00:00Z');
+
+    const commentsFetchUrl = new URL(mockFetch.mock.calls[2][0] as string);
+    expect(commentsFetchUrl.searchParams.get('sort')).toBe('created');
+    expect(commentsFetchUrl.searchParams.get('direction')).toBe('desc');
   });
 
   it('finds a mention on a later comments page', async () => {

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -142,8 +142,8 @@ describe('GitHubMentionsProvider', () => {
 
     const commentsFetchUrl = new URL(mockFetch.mock.calls[2][0] as string);
     expect(commentsFetchUrl.searchParams.get('per_page')).toBe('100');
-    expect(commentsFetchUrl.searchParams.get('sort')).toBe('created');
-    expect(commentsFetchUrl.searchParams.get('direction')).toBe('desc');
+    expect(commentsFetchUrl.searchParams.get('sort')).toBeNull();
+    expect(commentsFetchUrl.searchParams.get('direction')).toBeNull();
   });
 
   it('finds a mention on a later comments page', async () => {
@@ -189,6 +189,111 @@ describe('GitHubMentionsProvider', () => {
     expect(secondPageUrl.searchParams.get('page')).toBe('2');
   });
 
+  it('continues scanning backward after a partial last page', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments: 250,
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => Array.from({ length: 50 }, (_, i) => ({
+          id: 300 + i,
+          body: 'newer non-mention comment',
+          created_at: '2024-03-01T00:00:00Z',
+        })),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: 200, body: 'Middle-page ping @testuser', created_at: '2024-02-01T00:00:00Z' },
+          ...Array.from({ length: 99 }, (_, i) => ({
+            id: 201 + i,
+            body: 'middle-page non-mention comment',
+            created_at: '2024-02-01T00:00:00Z',
+          })),
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => Array.from({ length: 100 }, (_, i) => ({
+          id: 100 + i,
+          body: 'old non-mention comment',
+          created_at: '2024-01-01T00:00:00Z',
+        })),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items[0].resurfaceVersion).toBe('comment:200:2024-02-01T00:00:00Z');
+
+    const lastPageUrl = new URL(mockFetch.mock.calls[2][0] as string);
+    const previousPageUrl = new URL(mockFetch.mock.calls[3][0] as string);
+    expect(lastPageUrl.searchParams.get('page')).toBe('3');
+    expect(previousPageUrl.searchParams.get('page')).toBe('2');
+  });
+
+  it('continues scanning backward after an empty stale last page', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments: 250,
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { id: 200, body: 'Middle-page ping @testuser', created_at: '2024-02-01T00:00:00Z' },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => Array.from({ length: 100 }, (_, i) => ({
+          id: 100 + i,
+          body: 'old non-mention comment',
+          created_at: '2024-01-01T00:00:00Z',
+        })),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items[0].resurfaceVersion).toBe('comment:200:2024-02-01T00:00:00Z');
+
+    const staleLastPageUrl = new URL(mockFetch.mock.calls[2][0] as string);
+    const previousPageUrl = new URL(mockFetch.mock.calls[3][0] as string);
+    expect(staleLastPageUrl.searchParams.get('page')).toBe('3');
+    expect(previousPageUrl.searchParams.get('page')).toBe('2');
+  });
+
   it('changes resurfaceVersion when a later comment mentions the current user', async () => {
     mockFetch
       .mockResolvedValueOnce({
@@ -207,8 +312,8 @@ describe('GitHubMentionsProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ([
-          { id: 102, body: 'New ping @testuser', created_at: '2024-02-03T00:00:00Z' },
           { id: 100, body: 'Initial ping @testuser', created_at: '2024-02-01T00:00:00Z' },
+          { id: 102, body: 'New ping @testuser', created_at: '2024-02-03T00:00:00Z' },
         ]),
       });
 
@@ -328,6 +433,93 @@ describe('GitHubMentionsProvider', () => {
 
     expect(mockFetch).toHaveBeenCalledTimes(4);
     expect(listener.mock.calls[1][0][0].resurfaceVersion).toBe('comment:100:2024-02-01T00:00:00Z');
+  });
+
+  it('refetches comments when issue updated_at is absent', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 100, body: 'Initial ping @testuser', created_at: '2024-02-01T00:00:00Z' },
+        ]),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 102, body: 'New ping @testuser', created_at: '2024-02-03T00:00:00Z' },
+        ]),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+    await provider.refresh();
+
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+    expect(listener.mock.calls[1][0][0].resurfaceVersion).toBe('comment:102:2024-02-03T00:00:00Z');
+  });
+
+  it('preserves cached comment versions when the search refresh fails', async () => {
+    const issue = {
+      ...createMockIssue(10, 'Bug report', 'org/repo'),
+      comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+      updated_at: '2024-02-02T00:00:00Z',
+    };
+
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [issue] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 100, body: 'Initial ping @testuser', created_at: '2024-02-01T00:00:00Z' },
+        ]),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ items: [issue] }),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+    await provider.refresh();
+    await provider.refresh();
+
+    expect(mockFetch).toHaveBeenCalledTimes(5);
+    expect(listener.mock.calls[2][0][0].resurfaceVersion).toBe('comment:100:2024-02-01T00:00:00Z');
   });
 
   it('does not derive resurfaceVersion from comments that do not mention the current user', async () => {

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -257,6 +257,79 @@ describe('GitHubMentionsProvider', () => {
     expect(items[0].resurfaceVersion).toBe('comment:100:2024-02-01T00:00:00Z');
   });
 
+  it('uses issue body mention as a stable baseline when comments do not mention the current user', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            body: 'Original body ping @testuser',
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 101, body: 'Follow-up without a mention', created_at: '2024-02-02T00:00:00Z' },
+        ]),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items[0].resurfaceVersion).toBe('issue:10');
+  });
+
+  it('reuses cached resurfaceVersion when the issue has not changed', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+            updated_at: '2024-02-02T00:00:00Z',
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ login: 'testuser' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([
+          { id: 100, body: 'Initial ping @testuser', created_at: '2024-02-01T00:00:00Z' },
+        ]),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
+            updated_at: '2024-02-02T00:00:00Z',
+          }],
+        }),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+    await provider.refresh();
+
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+    expect(listener.mock.calls[1][0][0].resurfaceVersion).toBe('comment:100:2024-02-01T00:00:00Z');
+  });
+
   it('does not derive resurfaceVersion from comments that do not mention the current user', async () => {
     mockFetch
       .mockResolvedValueOnce({
@@ -264,6 +337,7 @@ describe('GitHubMentionsProvider', () => {
         json: async () => ({
           items: [{
             ...createMockIssue(10, 'Bug report', 'org/repo'),
+            body: 'No mention here',
             comments_url: 'https://api.github.com/repos/org/repo/issues/10/comments',
           }],
         }),

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -56,7 +56,7 @@ export interface DiscoveredItem {
   version?: string;
   /**
    * Optional secondary version for "hard" resurfacing.
-   * When a previously accepted item reappears with a different
+   * When a previously accepted or dismissed item reappears with a different
    * resurfaceVersion, it is **always** resurfaced in the Inbox as unseen,
    * regardless of the linked work item's state.
    */

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -56,9 +56,9 @@ export interface DiscoveredItem {
   version?: string;
   /**
    * Optional secondary version for "hard" resurfacing.
-   * When a previously accepted or dismissed item reappears with a different
-   * resurfaceVersion, it is **always** resurfaced in the Inbox as unseen,
-   * regardless of the linked work item's state.
+   * After the core records an item's first seen resurfaceVersion, later
+   * changes for previously accepted or dismissed items always resurface the
+   * item in the Inbox as unseen, regardless of linked work item state.
    */
   resurfaceVersion?: string;
   /**

--- a/packages/start-git-work/package.json
+++ b/packages/start-git-work/package.json
@@ -6,7 +6,7 @@
   "publisher": "mthalman",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.85.0"
+    "vscode": "^1.92.0"
   },
   "categories": [
     "Other"
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
-    "@types/vscode": "^1.85.0",
+    "@types/vscode": "^1.92.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "esbuild": "^0.25.0",


### PR DESCRIPTION
## Summary
- Derive GitHub mention resurface versions from the latest comment that directly mentions the authenticated GitHub login or one of the user's GitHub teams, rather than from issue updates.
- Parse GitHub-flavored markdown with `marked` 18 before mention matching so inline code, fenced code blocks, link URLs, and autolink targets do not create false-positive mentions.
- Allow `resurfaceVersion` changes to hard-resurface dismissed items while keeping version soft-resurfacing accepted-only.
- Align core, provider, and git-worktree extension VS Code engine requirements with the `marked` 18 runtime requirement.
- Add tests for the accepted/dismissed × mention/non-mention matrix, markdown mention filtering, team mention handling, capped comment-scan baselines, team cache TTL behavior, API failure handling, and login-change cache invalidation.

## Notes
Dismissed items that predate this change and have no stored `resurfaceVersion` are backfilled on first observation instead of resurfaced. Future mention comments then resurface normally. This avoids a one-time false-positive wave from historical mentions.

Team mention detection uses `GET /user/teams` and caches the authenticated user's `{org, team}` memberships in memory for 30 minutes. If the team API fails or the token lacks access, team mentions are ignored for that scan while direct user mentions continue to work.

When a comment scan is capped before finding an older mention, the Mentions provider emits a stable `comments-capped:<issue>` baseline so dismissed items do not swallow the next newly detected mention. In the same session, it keeps an internal `since` watermark from the newest scanned comment so later refreshes look forward for new mentions.

The GitHub extension and DevDocket core/provider/git-worktree extensions now target VS Code `^1.92.0` so their extension hosts satisfy `marked` 18's Node.js requirement. The README documents this minimum and keeps the AI reviewer extension's existing VS Code `^1.96.0` requirement explicit.

## OAuth scopes
- Adds the GitHub `read:org` scope for the Mentions provider so DevDocket can resolve the current user's team memberships for `@org/team` mention detection.

## Testing
- `npm run build`
- `npm run test` (1,792 passed)
- `npm run build -w devdocket-github`
- `npm run test --workspace devdocket-github -- --run src/test/githubMentionsProvider.test.ts` (48 passed)
- `npx tsc --noEmit` from `packages/github`
- `npx eslint src/baseGithubProvider.ts src/githubMentionsProvider.ts src/test/githubMentionsProvider.test.ts --no-warn-ignored` from `packages/github`
- `npm run lint` / `npm run lint -w devdocket` / `npm run lint -w devdocket-github` still fail on pre-existing unrelated lint issues outside this change, including core webview tsconfig coverage issues and `packages/github/src/githubPrReviewProvider.ts`.

Closes #456
