### PR TITLE
Dismiss childless PR watches

### DIFF
--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -360,10 +360,11 @@ export class WatcherService implements vscode.Disposable {
   dismissAllCompleted(): number {
     let dismissedCount = 0;
     const affectedPRKeys = new Set<string>();
+    const runToPRKeys = this.buildActiveChildRunIndex();
 
     for (const [key, watch] of this.watches.entries()) {
       if (watch.status.overallState === 'completed' && !watch.dismissed) {
-        for (const prKey of this.getPRKeysForRun(key, watch)) {
+        for (const prKey of this.getPRKeysForRun(key, watch, runToPRKeys)) {
           affectedPRKeys.add(prKey);
         }
         watch.dismissed = true;
@@ -412,11 +413,12 @@ export class WatcherService implements vscode.Disposable {
     const dismissedRunKeys = new Set<string>();
     const dismissedPRKeys = new Set<string>();
     const affectedPRKeys = new Set<string>();
+    const runToPRKeys = this.buildActiveChildRunIndex();
 
     for (const [key, watch] of this.watches.entries()) {
       if (!watch.dismissed && watch.status.overallState === 'completed') {
         dismissedRunKeys.add(key);
-        for (const prKey of this.getPRKeysForRun(key, watch)) {
+        for (const prKey of this.getPRKeysForRun(key, watch, runToPRKeys)) {
           affectedPRKeys.add(prKey);
         }
         count++;
@@ -603,17 +605,32 @@ export class WatcherService implements vscode.Disposable {
     return Array.from(childRuns.values());
   }
 
-  private getPRKeysForRun(runKey: string, watch: WatchedRun): Set<string> {
+  private getPRKeysForRun(
+    runKey: string,
+    watch: WatchedRun,
+    runToPRKeys = this.buildActiveChildRunIndex(),
+  ): Set<string> {
     const prKeys = new Set<string>();
     if (watch.parentPRKey) {
       prKeys.add(watch.parentPRKey);
     }
-    for (const [prKey, prWatch] of this.prWatches.entries()) {
-      if (!prWatch.dismissed && prWatch.childRunKeys.includes(runKey)) {
-        prKeys.add(prKey);
-      }
+    for (const prKey of runToPRKeys.get(runKey) ?? []) {
+      prKeys.add(prKey);
     }
     return prKeys;
+  }
+
+  private buildActiveChildRunIndex(): Map<string, Set<string>> {
+    const runToPRKeys = new Map<string, Set<string>>();
+    for (const [prKey, prWatch] of this.prWatches.entries()) {
+      if (prWatch.dismissed) continue;
+      for (const childKey of prWatch.childRunKeys) {
+        const prKeys = runToPRKeys.get(childKey) ?? new Set<string>();
+        prKeys.add(prKey);
+        runToPRKeys.set(childKey, prKeys);
+      }
+    }
+    return runToPRKeys;
   }
 
   private dismissChildlessPRWatches(prKeys: Iterable<string>, options?: { assumeObserved?: boolean }): number {

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -311,11 +311,16 @@ export class WatcherService implements vscode.Disposable {
     const key = this.getWatchKey(identifier);
     const watch = this.watches.get(key);
     if (watch) {
+      const affectedPRKeys = this.getPRKeysForRun(key, watch);
       watch.dismissed = true;
       // Drop the acknowledgement so a re-watch (or recovery + re-failure)
       // can alert again.
       this.acknowledgedFailedRunKeys.delete(key);
+      const dismissedPRCount = this.dismissChildlessPRWatches(affectedPRKeys);
       this.logger.info(`Dismissed watch: ${identifier.displayName}`);
+      if (dismissedPRCount > 0) {
+        this._onDidChangePRWatches.fire();
+      }
       this._onDidChangeWatchedRuns.fire(this.getAllWatches());
       this.persistWatches();
     }
@@ -354,14 +359,20 @@ export class WatcherService implements vscode.Disposable {
    */
   dismissAllCompleted(): number {
     let dismissedCount = 0;
+    const affectedPRKeys = new Set<string>();
+
     for (const [key, watch] of this.watches.entries()) {
       if (watch.status.overallState === 'completed' && !watch.dismissed) {
+        for (const prKey of this.getPRKeysForRun(key, watch)) {
+          affectedPRKeys.add(prKey);
+        }
         watch.dismissed = true;
         // Drop the ack so a re-watch can alert again. Mirrors dismissWatch.
         this.acknowledgedFailedRunKeys.delete(key);
         dismissedCount++;
       }
     }
+
     for (const prWatch of this.prWatches.values()) {
       if ((prWatch.prState === 'merged' || prWatch.prState === 'closed') && !prWatch.dismissed) {
         const key = this.getPRWatchKey(prWatch.identifier);
@@ -379,6 +390,9 @@ export class WatcherService implements vscode.Disposable {
         dismissedCount++;
       }
     }
+
+    dismissedCount += this.dismissChildlessPRWatches(affectedPRKeys);
+
     if (dismissedCount > 0) {
       this.logger.info(`Dismissed ${dismissedCount} completed watch(es)`);
       this._onDidChangePRWatches.fire();
@@ -395,12 +409,49 @@ export class WatcherService implements vscode.Disposable {
    */
   countCompletedActiveWatches(): number {
     let count = 0;
-    for (const watch of this.watches.values()) {
-      if (!watch.dismissed && watch.status.overallState === 'completed') count++;
+    const dismissedRunKeys = new Set<string>();
+    const dismissedPRKeys = new Set<string>();
+    const affectedPRKeys = new Set<string>();
+
+    for (const [key, watch] of this.watches.entries()) {
+      if (!watch.dismissed && watch.status.overallState === 'completed') {
+        dismissedRunKeys.add(key);
+        for (const prKey of this.getPRKeysForRun(key, watch)) {
+          affectedPRKeys.add(prKey);
+        }
+        count++;
+      }
     }
-    for (const prWatch of this.prWatches.values()) {
-      if (!prWatch.dismissed && (prWatch.prState === 'merged' || prWatch.prState === 'closed')) count++;
+
+    for (const [prKey, prWatch] of this.prWatches.entries()) {
+      if (!prWatch.dismissed && (prWatch.prState === 'merged' || prWatch.prState === 'closed')) {
+        dismissedPRKeys.add(prKey);
+        count++;
+        for (const childKey of prWatch.childRunKeys) {
+          const childWatch = this.watches.get(childKey);
+          if (
+            childWatch
+            && !childWatch.dismissed
+            && childWatch.parentPRKey === prKey
+            && !dismissedRunKeys.has(childKey)
+          ) {
+            dismissedRunKeys.add(childKey);
+            count++;
+          }
+        }
+      }
     }
+
+    // Every affected PR was reached from an active completed child run, so the
+    // observed-child guard is already satisfied for this simulated cascade.
+    for (const prKey of affectedPRKeys) {
+      if (dismissedPRKeys.has(prKey)) continue;
+      const activeChildKeys = this.getActiveChildRunKeys(prKey);
+      if (activeChildKeys.length > 0 && activeChildKeys.every(childKey => dismissedRunKeys.has(childKey))) {
+        count++;
+      }
+    }
+
     return count;
   }
 
@@ -524,21 +575,72 @@ export class WatcherService implements vscode.Disposable {
    */
   getChildRuns(prKey: string): WatchedRun[] {
     const childRuns = new Map<string, WatchedRun>();
+    for (const childRunKey of this.getActiveChildRunKeys(prKey)) {
+      const watch = this.watches.get(childRunKey);
+      if (watch) {
+        childRuns.set(childRunKey, watch);
+      }
+    }
+    return Array.from(childRuns.values());
+  }
+
+  private getActiveChildRunKeys(prKey: string): string[] {
+    const childRuns = new Set<string>();
     // Include runs tracked via childRunKeys (covers linked standalone watches)
     const prWatch = this.prWatches.get(prKey);
     for (const childRunKey of prWatch?.childRunKeys ?? []) {
       const watch = this.watches.get(childRunKey);
       if (watch && !watch.dismissed) {
-        childRuns.set(childRunKey, watch);
+        childRuns.add(childRunKey);
       }
     }
     // Also include any runs explicitly parented by this PR
     for (const [watchKey, watch] of this.watches.entries()) {
       if (!watch.dismissed && watch.parentPRKey === prKey) {
-        childRuns.set(watchKey, watch);
+        childRuns.add(watchKey);
       }
     }
     return Array.from(childRuns.values());
+  }
+
+  private getPRKeysForRun(runKey: string, watch: WatchedRun): Set<string> {
+    const prKeys = new Set<string>();
+    if (watch.parentPRKey) {
+      prKeys.add(watch.parentPRKey);
+    }
+    for (const [prKey, prWatch] of this.prWatches.entries()) {
+      if (!prWatch.dismissed && prWatch.childRunKeys.includes(runKey)) {
+        prKeys.add(prKey);
+      }
+    }
+    return prKeys;
+  }
+
+  private dismissChildlessPRWatches(prKeys: Iterable<string>, options?: { assumeObserved?: boolean }): number {
+    let dismissedCount = 0;
+    for (const prKey of prKeys) {
+      const prWatch = this.prWatches.get(prKey);
+      if (!prWatch || prWatch.dismissed) continue;
+      if (!options?.assumeObserved && !this.hasObservedChildRun(prKey, prWatch)) continue;
+      if (this.getActiveChildRunKeys(prKey).length > 0) continue;
+
+      prWatch.dismissed = true;
+      dismissedCount++;
+      this.logger.info(`Dismissed childless PR watch: ${prWatch.identifier.displayName}`);
+    }
+    return dismissedCount;
+  }
+
+  private hasObservedChildRun(prKey: string, prWatch: WatchedPR): boolean {
+    if (prWatch.childRunKeys.length > 0) {
+      return true;
+    }
+    for (const watch of this.watches.values()) {
+      if (watch.parentPRKey === prKey) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -726,6 +828,7 @@ export class WatcherService implements vscode.Disposable {
         }
 
         // Remove orphaned child runs (only dismiss runs owned by this PR)
+        const hadObservedChildren = currentRunKeys.size > 0 || this.hasObservedChildRun(key, prWatch);
         for (const childKey of currentRunKeys) {
           if (!newRunKeys.has(childKey)) {
             const childWatch = this.watches.get(childKey);
@@ -735,6 +838,13 @@ export class WatcherService implements vscode.Disposable {
             }
             prWatch.childRunKeys = prWatch.childRunKeys.filter(k => k !== childKey);
           }
+        }
+        if (
+          hadObservedChildren
+          && this.getActiveChildRunKeys(key).length === 0
+          && this.dismissChildlessPRWatches([key], { assumeObserved: true }) > 0
+        ) {
+          prChanged = true;
         }
 
         // Check PR state transitions

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -845,6 +845,7 @@ export class WatcherService implements vscode.Disposable {
           && this.dismissChildlessPRWatches([key], { assumeObserved: true }) > 0
         ) {
           prChanged = true;
+          continue;
         }
 
         // Check PR state transitions

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -479,14 +479,7 @@ describe('WatcherService', () => {
       expect(service.isPRActive(createPRIdentifier())).toBe(true);
     });
 
-    it('re-creates child runs when called with forceRecreate for an active PR', async () => {
-      // Reproduces the user-visible bug where a PR ends up invisible in the
-      // watch panel because all its child runs were dismissed: the runs are
-      // dismissed=true but stay in childRunKeys, so the polling loop's
-      // 'already a child?' check skips re-adding them. The panel filter
-      // (runs.length > 0) then hides the parent. The manual "Watch URL"
-      // command passes forceRecreate so it can recover by wiping the old
-      // owned children and starting fresh.
+    it('re-creates child runs when called with forceRecreate for a dismissed childless PR', async () => {
       const runWatcher = createMockWatcher('github-actions');
       registry.register(runWatcher);
 
@@ -506,13 +499,10 @@ describe('WatcherService', () => {
       await service.startPRWatch(identifier);
       expect(service.getActiveWatches()).toHaveLength(1);
 
-      // Simulate the user dismissing the child run via the watch panel.
       const childRun = service.getActiveWatches()[0];
       service.dismissWatch(childRun.identifier);
       expect(service.getActiveWatches()).toHaveLength(0);
-      // The PR is still "active" (not dismissed), but has no visible runs —
-      // exactly the state that hides it from the panel filter.
-      expect(service.isPRActive(identifier)).toBe(true);
+      expect(service.isPRActive(identifier)).toBe(false);
       expect(service.getChildRuns(service.getPRWatchKey(identifier))).toHaveLength(0);
 
       // Manual "Watch URL" with forceRecreate — wipes and rebuilds.
@@ -546,6 +536,141 @@ describe('WatcherService', () => {
       expect(result.childRunKeys).toHaveLength(1);
       expect(service.getActiveWatches()).toHaveLength(1);
       expect(service.getActiveWatches()[0].parentPRKey).toBeDefined();
+    });
+
+    it('dismisses a PR watch when its last visible child run is dismissed', async () => {
+      const runWatcher = createMockWatcher('github-actions');
+      registry.register(runWatcher);
+
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [
+          {
+            providerId: 'github-actions',
+            runId: 'run-1',
+            displayName: 'CI Build 1',
+            url: 'https://example.com/run/1',
+            repo: 'owner/repo',
+          },
+          {
+            providerId: 'github-actions',
+            runId: 'run-2',
+            displayName: 'CI Build 2',
+            url: 'https://example.com/run/2',
+            repo: 'owner/repo',
+          },
+        ],
+      }));
+      prRegistry.register(prWatcher);
+
+      const identifier = createPRIdentifier();
+      await service.startPRWatch(identifier);
+      const [firstChild, secondChild] = service.getActiveWatches();
+      const prChangeSpy = vi.fn();
+      service.onDidChangePRWatches(prChangeSpy);
+
+      service.dismissWatch(firstChild.identifier);
+      expect(prChangeSpy).not.toHaveBeenCalled();
+      expect(service.isPRActive(identifier)).toBe(true);
+      expect(service.getChildRuns(service.getPRWatchKey(identifier))).toHaveLength(1);
+
+      service.dismissWatch(secondChild.identifier);
+      expect(prChangeSpy).toHaveBeenCalledTimes(1);
+      expect(service.isPRActive(identifier)).toBe(false);
+      expect(service.getChildRuns(service.getPRWatchKey(identifier))).toHaveLength(0);
+    });
+
+    it('dismissAllCompleted cascades to an open PR when all visible child runs are dismissed', async () => {
+      const runWatcher = createMockWatcher('github-actions', async () => ({
+        overallState: 'completed' as const,
+        conclusion: 'success' as const,
+        jobs: [],
+      }));
+      registry.register(runWatcher);
+
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [
+          {
+            providerId: 'github-actions',
+            runId: 'run-1',
+            displayName: 'CI Build 1',
+            url: 'https://example.com/run/1',
+            repo: 'owner/repo',
+          },
+          {
+            providerId: 'github-actions',
+            runId: 'run-2',
+            displayName: 'CI Build 2',
+            url: 'https://example.com/run/2',
+            repo: 'owner/repo',
+          },
+        ],
+      }));
+      prRegistry.register(prWatcher);
+
+      const identifier = createPRIdentifier();
+      await service.startPRWatch(identifier);
+
+      expect(service.countCompletedActiveWatches()).toBe(3);
+      expect(service.dismissAllCompleted()).toBe(3);
+      expect(service.getActiveWatches()).toHaveLength(0);
+      expect(service.isPRActive(identifier)).toBe(false);
+    });
+
+    it('does not dismiss a PR watch that has never observed a child run', async () => {
+      const completedWatcher = createMockWatcher('completed', async () => ({
+        overallState: 'completed' as const,
+        conclusion: 'success' as const,
+        jobs: [],
+      }));
+      registry.register(completedWatcher);
+
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [],
+      }));
+      prRegistry.register(prWatcher);
+
+      const identifier = createPRIdentifier();
+      await service.startPRWatch(identifier);
+      await service.startWatch(createIdentifier('completed'));
+
+      expect(service.dismissAllCompleted()).toBe(1);
+      expect(service.isPRActive(identifier)).toBe(true);
+    });
+
+    it('dismisses a PR watch when polling removes its last observed child run', async () => {
+      const runWatcher = createMockWatcher('github-actions');
+      registry.register(runWatcher);
+
+      let callCount = 0;
+      const prWatcher = createMockPRWatcher('test-pr', async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            prState: 'open',
+            runs: [{
+              providerId: 'github-actions',
+              runId: 'run-1',
+              displayName: 'CI Build',
+              url: 'https://example.com/run/1',
+              repo: 'owner/repo',
+            }],
+          };
+        }
+        return { prState: 'open', runs: [] };
+      });
+      prRegistry.register(prWatcher);
+
+      const identifier = createPRIdentifier();
+      await service.startPRWatch(identifier);
+      expect(service.getActiveWatches()).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(60000);
+
+      expect(service.getActiveWatches()).toHaveLength(0);
+      expect(service.isPRActive(identifier)).toBe(false);
     });
 
     it('dismisses PR watch and its child runs', async () => {


### PR DESCRIPTION
## Summary
- Cascade-dismiss PR watches when dismissal/removal of child runs leaves no visible children
- Preserve PR watches that have never observed child runs to avoid transient empty-state dismissals
- Add watcher service tests for direct dismiss, bulk dismiss, never-observed, and polling removal cases

## Validation
- npm run lint
- npm run build
- npm run test

Closes #455
