### PR TITLE
Trim redundant onCommand activation events

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,25 +12,7 @@
     "Other"
   ],
   "activationEvents": [
-    "onView:devdocket.main",
-    "onCommand:devdocket.refresh",
-    "onCommand:devdocket.dismissFromSources",
-    "onCommand:devdocket.deleteItem",
-    "onCommand:devdocket.createItemFromUrl",
-    "onCommand:devdocket.clearHistory",
-    "onCommand:devdocket.watchRun",
-    "onCommand:devdocket.watchPR",
-    "onCommand:devdocket.watchPRFromItem",
-    "onCommand:devdocket.dismissWatch",
-    "onCommand:devdocket.dismissAllCompletedWatches",
-    "onCommand:devdocket.openWatchUrl",
-    "onCommand:devdocket.showWatchesQuickPick",
-    "onCommand:devdocket.showProviderHealthQuickPick",
-    "onCommand:devdocket.addActivity",
-    "onCommand:devdocket.createItem",
-    "onCommand:devdocket.acceptToFocus",
-    "onCommand:devdocket.acceptToFocusFromInbox",
-    "onCommand:devdocket.completeItem"
+    "onView:devdocket.main"
   ],
   "main": "./dist/extension.js",
   "contributes": {


### PR DESCRIPTION
## Summary

- Removes redundant `onCommand` activation events from package manifests because VS Code 1.74+ auto-generates command activation events, and this extension requires `engines.vscode` `^1.92.0`.
- Retains `onView:devdocket.main` because view activation events are not auto-generated and the DevDocket sidebar still needs explicit activation.

Closes #472
