### PR TITLE
Migrate weekly review workflows to Copilot CLI

### DIFF
--- a/.github/prompts/weekly-review.md
+++ b/.github/prompts/weekly-review.md
@@ -11,8 +11,7 @@ Act as a senior VS Code extension developer reviewing this codebase for the firs
 1. Use your built-in knowledge of the VS Code extension API documentation when evaluating the codebase; treat <https://code.visualstudio.com/api> as a reference link only.
 2. Use your built-in knowledge of the VS Code extension API reference for platform behavior; treat <https://code.visualstudio.com/api/references/vscode-api> as a reference link only.
 3. If `AGENTS.md` exists, read it for project architecture, conventions, and GitHub posting safety rules.
-4. If `.squad/team.md` exists, read it for team context.
-5. Inspect the repository enough to understand the core extension, provider extensions, action extensions, shared API surface, and persisted storage model.
+4. Inspect the repository enough to understand the core extension, provider extensions, action extensions, shared API surface, and persisted storage model.
 
 ## Review scope
 

--- a/.github/prompts/weekly-review.md
+++ b/.github/prompts/weekly-review.md
@@ -61,7 +61,7 @@ Follow the repository's backtick-safety convention when posting text to GitHub:
 
 1. Use the allowlisted file-write tool to write the full issue body to a temporary body file before calling `gh`; do not build the body with shell heredocs, `echo`, Python, or inline shell strings.
 2. Pass that file with `--body-file`.
-3. Delete the body file after the issue is created.
+3. Reuse or overwrite the body file as needed; do not require deletion when no cleanup tool is available.
 4. Never pass Markdown containing backticks through `--body`, `--fill`, inline shell arguments, Python strings, or PowerShell strings.
 
 Use a command shape like:

--- a/.github/prompts/weekly-review.md
+++ b/.github/prompts/weekly-review.md
@@ -1,0 +1,85 @@
+# Weekly Codebase Review
+
+You are GitHub Copilot CLI running in programmatic mode from the scheduled Weekly Review workflow for the DevDocket VS Code extension.
+
+## Objective
+
+Act as a senior VS Code extension developer reviewing this codebase for the first time. Identify implementation patterns, API correctness risks, and product decisions that create real maintenance burden, correctness risk, or mismatch with VS Code extension best practices.
+
+## Required context
+
+1. Read the latest VS Code extension API documentation before evaluating the codebase: <https://code.visualstudio.com/api>.
+2. Read the VS Code extension API reference for exact platform behavior: <https://code.visualstudio.com/api/references/vscode-api>.
+3. If `AGENTS.md` exists, read it for project architecture, conventions, and GitHub posting safety rules.
+4. If `.squad/team.md` exists, read it for team context.
+5. Inspect the repository enough to understand the core extension, provider extensions, action extensions, shared API surface, and persisted storage model.
+
+## Review scope
+
+Focus on substantive implementation and product concerns:
+
+- Resource lifecycle and disposal correctness.
+- VS Code API correctness and platform fit.
+- Storage and state-model decisions.
+- Public extension API compatibility and provider/action contracts.
+- Code organization that creates real maintenance burden.
+- Product complexity, workflows, missing capabilities, or UX model decisions that conflict with VS Code conventions.
+
+Skip style nits, naming preferences, linting-level concerns, purely cosmetic UX, and anything working fine.
+
+## Finding quality bar
+
+For each candidate finding, be concrete:
+
+- Name the pattern, API usage, or product decision.
+- Point to specific files and behaviors.
+- Explain the concrete downside, correctness risk, or maintenance burden.
+- Describe what you would do instead.
+- Explain why the suggested direction better fits VS Code extension best practices or DevDocket's architecture.
+
+## Deduplication before filing
+
+Before creating an issue for any finding, search existing open and recently closed issues. Use a short, stable title prefix and search both open and closed issues with `gh issue list --search ... --state all --limit 200`.
+
+Use titles with this format:
+
+`[Weekly Review] <short finding statement>`
+
+For each candidate, run a search similar to:
+
+`gh issue list --search "\"[Weekly Review] <short finding statement>\" in:title label:weekly-review" --state all --limit 200`
+
+If an existing issue title has the same short prefix or clearly covers the same implementation/API/product concern, skip filing a duplicate, even if the issue is closed.
+
+## Filing issues
+
+Create zero pull requests. Do not create branches, commits, or PRs. Findings are filed only as GitHub issues.
+
+File one issue per novel finding, with labels `weekly-review` and `go:needs-research`. Cap this run at 8 created issues. If you find more than 8, choose the 8 highest-impact concerns and skip the rest.
+
+Follow the repository's backtick-safety convention when posting text to GitHub:
+
+1. Write the full issue body to a temporary body file before calling `gh`.
+2. Pass that file with `--body-file`.
+3. Delete the body file after the issue is created.
+4. Never pass Markdown containing backticks through `--body`, `--fill`, inline shell arguments, Python strings, or PowerShell strings.
+
+Use a command shape like:
+
+`gh issue create --title "[Weekly Review] <short finding statement>" --body-file <tmpfile> --label weekly-review --label go:needs-research`
+
+Each issue body should include:
+
+- `## Finding`
+- `## Evidence`
+- `## Risk or downside`
+- `## Suggested direction`
+- `## Research notes`
+
+## Summary
+
+At the end, report the count of issues created. Print a final machine-readable line exactly like this, replacing `<count>` with an integer from 0 to 8:
+
+`WEEKLY_REVIEW_ISSUES_CREATED=<count>`
+
+Also append a one-line human-readable summary to `$GITHUB_STEP_SUMMARY` if the available tool permissions allow it.

--- a/.github/prompts/weekly-review.md
+++ b/.github/prompts/weekly-review.md
@@ -81,5 +81,3 @@ Each issue body should include:
 At the end, report the count of issues created. Print a final machine-readable line exactly like this, replacing `<count>` with an integer from 0 to 8:
 
 `WEEKLY_REVIEW_ISSUES_CREATED=<count>`
-
-Also append a one-line human-readable summary to `$GITHUB_STEP_SUMMARY` if the available tool permissions allow it.

--- a/.github/prompts/weekly-review.md
+++ b/.github/prompts/weekly-review.md
@@ -59,7 +59,7 @@ File one issue per novel finding, with labels `weekly-review` and `go:needs-rese
 
 Follow the repository's backtick-safety convention when posting text to GitHub:
 
-1. Write the full issue body to a temporary body file before calling `gh`.
+1. Use the allowlisted file-write tool to write the full issue body to a temporary body file before calling `gh`; do not build the body with shell heredocs, `echo`, Python, or inline shell strings.
 2. Pass that file with `--body-file`.
 3. Delete the body file after the issue is created.
 4. Never pass Markdown containing backticks through `--body`, `--fill`, inline shell arguments, Python strings, or PowerShell strings.

--- a/.github/prompts/weekly-review.md
+++ b/.github/prompts/weekly-review.md
@@ -8,8 +8,8 @@ Act as a senior VS Code extension developer reviewing this codebase for the firs
 
 ## Required context
 
-1. Read the latest VS Code extension API documentation before evaluating the codebase: <https://code.visualstudio.com/api>.
-2. Read the VS Code extension API reference for exact platform behavior: <https://code.visualstudio.com/api/references/vscode-api>.
+1. Use your built-in knowledge of the VS Code extension API documentation when evaluating the codebase; treat <https://code.visualstudio.com/api> as a reference link only.
+2. Use your built-in knowledge of the VS Code extension API reference for platform behavior; treat <https://code.visualstudio.com/api/references/vscode-api> as a reference link only.
 3. If `AGENTS.md` exists, read it for project architecture, conventions, and GitHub posting safety rules.
 4. If `.squad/team.md` exists, read it for team context.
 5. Inspect the repository enough to understand the core extension, provider extensions, action extensions, shared API surface, and persisted storage model.

--- a/.github/prompts/weekly-ux-review.md
+++ b/.github/prompts/weekly-ux-review.md
@@ -79,5 +79,3 @@ Each issue body should include:
 At the end, report the count of issues created. Print a final machine-readable line exactly like this, replacing `<count>` with an integer from 0 to 8:
 
 `WEEKLY_UX_REVIEW_ISSUES_CREATED=<count>`
-
-Also append a one-line human-readable summary to `$GITHUB_STEP_SUMMARY` if the available tool permissions allow it.

--- a/.github/prompts/weekly-ux-review.md
+++ b/.github/prompts/weekly-ux-review.md
@@ -59,7 +59,7 @@ Follow the repository's backtick-safety convention when posting text to GitHub:
 
 1. Use the allowlisted file-write tool to write the full issue body to a temporary body file before calling `gh`; do not build the body with shell heredocs, `echo`, Python, or inline shell strings.
 2. Pass that file with `--body-file`.
-3. Delete the body file after the issue is created.
+3. Reuse or overwrite the body file as needed; do not require deletion when no cleanup tool is available.
 4. Never pass Markdown containing backticks through `--body`, `--fill`, inline shell arguments, Python strings, or PowerShell strings.
 
 Use a command shape like:

--- a/.github/prompts/weekly-ux-review.md
+++ b/.github/prompts/weekly-ux-review.md
@@ -57,7 +57,7 @@ File one issue per novel finding, with the label `weekly-ux-review`. Cap this ru
 
 Follow the repository's backtick-safety convention when posting text to GitHub:
 
-1. Write the full issue body to a temporary body file before calling `gh`.
+1. Use the allowlisted file-write tool to write the full issue body to a temporary body file before calling `gh`; do not build the body with shell heredocs, `echo`, Python, or inline shell strings.
 2. Pass that file with `--body-file`.
 3. Delete the body file after the issue is created.
 4. Never pass Markdown containing backticks through `--body`, `--fill`, inline shell arguments, Python strings, or PowerShell strings.

--- a/.github/prompts/weekly-ux-review.md
+++ b/.github/prompts/weekly-ux-review.md
@@ -1,0 +1,83 @@
+# Weekly UX Review
+
+You are GitHub Copilot CLI running in programmatic mode from the scheduled Weekly UX Review workflow for the DevDocket VS Code extension.
+
+## Objective
+
+Act as a senior UX designer who specializes in developer tools and VS Code extensions. Review DevDocket for workflow-level UX problems that create real user friction. Do not file cosmetic findings.
+
+## Required context
+
+1. Read the latest VS Code UX Guidelines before evaluating the product: <https://code.visualstudio.com/api/ux-guidelines/overview>.
+2. Read the VS Code extension API documentation for platform context: <https://code.visualstudio.com/api>.
+3. Inspect the repository enough to understand the extension's main workflows, UI model, commands, views, and provider/action architecture.
+
+## Review scope
+
+Focus on workflow-level UX problems, not minor polish:
+
+- Workflow completeness and efficiency.
+- Cognitive load and discoverability.
+- Feedback, state visibility, and information architecture.
+- Error handling and edge cases.
+- Accessibility and inclusivity.
+- Platform fit for VS Code.
+
+Skip icon choices, color preferences, wording tweaks, naming preferences, lint-level issues, and anything already working well.
+
+## Finding quality bar
+
+For each candidate finding, be concrete:
+
+- Name the UX problem.
+- Describe the current user experience.
+- Explain the user impact and why it causes real friction.
+- Describe what the experience should be instead.
+- Point to relevant files, commands, views, or documentation when possible.
+
+## Deduplication before filing
+
+Before creating an issue for any finding, search existing open and recently closed issues. Use a short, stable title prefix and search both open and closed issues with `gh issue list --search ... --state all --limit 200`.
+
+Use titles with this format:
+
+`[Weekly UX] <short problem statement>`
+
+For each candidate, run a search similar to:
+
+`gh issue list --search "\"[Weekly UX] <short problem statement>\" in:title label:weekly-ux-review" --state all --limit 200`
+
+If an existing issue title has the same short prefix or clearly covers the same UX problem, skip filing a duplicate, even if the issue is closed.
+
+## Filing issues
+
+Create zero pull requests. Do not create branches, commits, or PRs. Findings are filed only as GitHub issues.
+
+File one issue per novel finding, with the label `weekly-ux-review`. Cap this run at 8 created issues. If you find more than 8, choose the 8 highest-impact workflow-level problems and skip the rest.
+
+Follow the repository's backtick-safety convention when posting text to GitHub:
+
+1. Write the full issue body to a temporary body file before calling `gh`.
+2. Pass that file with `--body-file`.
+3. Delete the body file after the issue is created.
+4. Never pass Markdown containing backticks through `--body`, `--fill`, inline shell arguments, Python strings, or PowerShell strings.
+
+Use a command shape like:
+
+`gh issue create --title "[Weekly UX] <short problem statement>" --body-file <tmpfile> --label weekly-ux-review`
+
+Each issue body should include:
+
+- `## Problem`
+- `## Current experience`
+- `## Impact`
+- `## Suggested direction`
+- `## Evidence`
+
+## Summary
+
+At the end, report the count of issues created. Print a final machine-readable line exactly like this, replacing `<count>` with an integer from 0 to 8:
+
+`WEEKLY_UX_REVIEW_ISSUES_CREATED=<count>`
+
+Also append a one-line human-readable summary to `$GITHUB_STEP_SUMMARY` if the available tool permissions allow it.

--- a/.github/prompts/weekly-ux-review.md
+++ b/.github/prompts/weekly-ux-review.md
@@ -8,8 +8,8 @@ Act as a senior UX designer who specializes in developer tools and VS Code exten
 
 ## Required context
 
-1. Read the latest VS Code UX Guidelines before evaluating the product: <https://code.visualstudio.com/api/ux-guidelines/overview>.
-2. Read the VS Code extension API documentation for platform context: <https://code.visualstudio.com/api>.
+1. Use your built-in knowledge of the VS Code UX Guidelines when evaluating the product; treat <https://code.visualstudio.com/api/ux-guidelines/overview> as a reference link only.
+2. Use your built-in knowledge of the VS Code extension API documentation for platform context; treat <https://code.visualstudio.com/api> as a reference link only.
 3. Inspect the repository enough to understand the extension's main workflows, UI model, commands, views, and provider/action architecture.
 
 ## Review scope

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -52,6 +52,7 @@ jobs:
             --allow-tool='shell(gh:*)' \
             --allow-tool='shell(git:*)' \
             --allow-tool=read \
+            --allow-tool=write \
             --no-ask-user | tee weekly-review.log
 
       - name: Summary

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -37,7 +37,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Copilot CLI
-        run: npm install -g @github/copilot
+        run: npm install -g @github/copilot@1.0.42
 
       - name: Run weekly review
         env:

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -50,7 +50,6 @@ jobs:
           copilot -p "$(cat .github/prompts/weekly-review.md)" \
             --model claude-opus-4.7 \
             --allow-tool='shell(gh:*)' \
-            --allow-tool='shell(git:*)' \
             --allow-tool=read \
             --allow-tool=write \
             --no-ask-user | tee weekly-review.log

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -1,5 +1,10 @@
 name: Weekly Review
 
+# Authentication: this workflow runs GitHub Copilot CLI in programmatic mode.
+# Configure the shared COPILOT_CLI_PAT repository secret with a licensed Copilot
+# user's PAT that can make Copilot requests and create issues. Rotate that one
+# secret when the service identity changes; both COPILOT_GITHUB_TOKEN and GH_TOKEN
+# are sourced from it so Copilot CLI and gh authenticate as the same identity.
 on:
   # Run every Monday at 9:00 AM UTC
   schedule:
@@ -13,61 +18,45 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  issues: write
   contents: read
+  issues: write
 
 jobs:
   expert-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Build issue body
-        id: build-body
-        uses: actions/github-script@v7
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          script: |
-            const dateStr = new Date().toISOString().slice(0, 10);
+          fetch-depth: 0
 
-            const body = [
-              '### 🔍 Automated Weekly Code Review',
-              '',
-              'This issue tracks the weekly automated expert review of the codebase.',
-              '',
-              '**Review Scope:**',
-              '- Implementation patterns and architectural decisions',
-              '- Resource lifecycle and API correctness',
-              '- Product decisions and UX model',
-              '- VS Code extension best practices',
-              '',
-              '**Instructions for the Copilot coding agent (`copilot-swe-agent[bot]`):**',
-              '',
-              "First, review the latest VS Code extension API documentation (https://code.visualstudio.com/api) to understand the full set of platform capabilities available. Then, act as a senior VS Code extension developer reviewing this codebase for the first time. Identify concrete areas where you disagree with the implementation approach or product decisions — not style nits, but structural decisions that create real maintenance burden, correctness risks, or violate VS Code extension best practices. Before reporting a finding, check the GitHub issue tracker (open and closed) to see if it's already been filed. Skip anything already tracked. For each finding: name the pattern/decision, point to specific files, explain the concrete downside, describe what you'd do instead. Focus areas: implementation (resource lifecycle, API correctness, storage, code organization, platform API usage) and product (feature set, complexity, workflows, missing capabilities, UX model vs VS Code conventions). Skip linting-level concerns, naming preferences, and anything working fine.",
-              '',
-              '**Note:** Issue de-duplication and per-finding issue creation are handled entirely by the agent — the workflow only creates this tracking issue and assigns it.'
-            ].join('\n');
+      - name: Set up Node.js environment
+        uses: actions/setup-node@v4
 
-            core.setOutput('body', body);
-            core.setOutput('title', `Weekly Expert Codebase Review — ${dateStr}`);
+      - name: Install Copilot CLI
+        run: npm install -g @github/copilot
 
-      - name: Create issue and assign Copilot agent
-        id: create-issue
-        uses: ./.github/actions/create-copilot-issue
-        with:
-          issue-title: ${{ steps.build-body.outputs.title }}
-          issue-body: ${{ steps.build-body.outputs.body }}
-          issue-labels: 'weekly-review,go:needs-research'
-          dedup-labels: 'weekly-review'
-          dedup-title: ${{ steps.build-body.outputs.title }}
-          custom-instructions: |
-            Read AGENTS.md for project architecture and conventions, and .squad/team.md for team context. Focus on creating separate issues for each novel finding. Before creating an issue, search both open and closed issues to avoid duplicates.
-          copilot-assign-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run weekly review
+        env:
+          # Shared PAT for both Copilot CLI and gh. Rotate COPILOT_CLI_PAT instead
+          # of configuring workflow-specific tokens.
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_PAT }}
+          GH_TOKEN: ${{ secrets.COPILOT_CLI_PAT }}
+        run: |
+          set -o pipefail
+          copilot -p "$(cat .github/prompts/weekly-review.md)" \
+            --model claude-opus-4.7 \
+            --allow-tool='shell(gh:*)' \
+            --allow-tool='shell(git:*)' \
+            --allow-tool=read \
+            --no-ask-user | tee weekly-review.log
 
       - name: Summary
+        if: always()
         run: |
-          if [ "${{ steps.create-issue.outputs.created }}" = "false" ]; then
-            echo "ℹ️ Weekly code review tracking issue #${{ steps.create-issue.outputs.issue-number }} already existed and was reused"
+          count="$(grep -Eo 'WEEKLY_REVIEW_ISSUES_CREATED=[0-8]' weekly-review.log 2>/dev/null | tail -n 1 | cut -d= -f2 || true)"
+          if [ -z "$count" ]; then
+            echo "⚠️ Weekly review completed, but no issue-count marker was found." >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "✅ Weekly code review tracking issue #${{ steps.create-issue.outputs.issue-number }} created and assigned to copilot-swe-agent[bot]"
+            echo "Weekly review issues created: $count" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -49,7 +49,7 @@ jobs:
           set -o pipefail
           copilot -p "$(cat .github/prompts/weekly-review.md)" \
             --model claude-opus-4.7 \
-            --allow-tool='shell(gh:*)' \
+            --allow-tool='shell(gh issue:*)' \
             --allow-tool=read \
             --allow-tool=write \
             --no-ask-user | tee weekly-review.log

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -51,6 +51,7 @@ jobs:
             --model claude-opus-4.7 \
             --allow-tool='shell(gh issue:*)' \
             --allow-tool=read \
+            --allow-tool=create \
             --allow-tool=write \
             --no-ask-user | tee weekly-review.log
 

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -37,7 +37,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Copilot CLI
-        run: npm install -g @github/copilot@1.0.42
+        run: npm install -g @github/copilot
 
       - name: Run weekly review
         env:

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -32,6 +32,9 @@ jobs:
 
       - name: Set up Node.js environment
         uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
 
       - name: Install Copilot CLI
         run: npm install -g @github/copilot

--- a/.github/workflows/weekly-ux-review.yml
+++ b/.github/workflows/weekly-ux-review.yml
@@ -36,7 +36,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Copilot CLI
-        run: npm install -g @github/copilot
+        run: npm install -g @github/copilot@1.0.42
 
       - name: Run weekly UX review
         env:

--- a/.github/workflows/weekly-ux-review.yml
+++ b/.github/workflows/weekly-ux-review.yml
@@ -49,7 +49,6 @@ jobs:
           copilot -p "$(cat .github/prompts/weekly-ux-review.md)" \
             --model claude-opus-4.7 \
             --allow-tool='shell(gh:*)' \
-            --allow-tool='shell(git:*)' \
             --allow-tool=read \
             --allow-tool=write \
             --no-ask-user | tee weekly-ux-review.log

--- a/.github/workflows/weekly-ux-review.yml
+++ b/.github/workflows/weekly-ux-review.yml
@@ -31,6 +31,9 @@ jobs:
 
       - name: Set up Node.js environment
         uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
 
       - name: Install Copilot CLI
         run: npm install -g @github/copilot

--- a/.github/workflows/weekly-ux-review.yml
+++ b/.github/workflows/weekly-ux-review.yml
@@ -51,6 +51,7 @@ jobs:
             --allow-tool='shell(gh:*)' \
             --allow-tool='shell(git:*)' \
             --allow-tool=read \
+            --allow-tool=write \
             --no-ask-user | tee weekly-ux-review.log
 
       - name: Summary

--- a/.github/workflows/weekly-ux-review.yml
+++ b/.github/workflows/weekly-ux-review.yml
@@ -36,7 +36,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Copilot CLI
-        run: npm install -g @github/copilot@1.0.42
+        run: npm install -g @github/copilot
 
       - name: Run weekly UX review
         env:

--- a/.github/workflows/weekly-ux-review.yml
+++ b/.github/workflows/weekly-ux-review.yml
@@ -1,5 +1,10 @@
 name: Weekly UX Review
 
+# Authentication: this workflow runs GitHub Copilot CLI in programmatic mode.
+# Configure the shared COPILOT_CLI_PAT repository secret with a licensed Copilot
+# user's PAT that can make Copilot requests and create issues. Rotate that one
+# secret when the service identity changes; both COPILOT_GITHUB_TOKEN and GH_TOKEN
+# are sourced from it so Copilot CLI and gh authenticate as the same identity.
 on:
   # Run every Wednesday at 10:00 AM UTC (offset from implementation review)
   schedule:
@@ -12,95 +17,45 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  issues: write
   contents: read
+  issues: write
 
 jobs:
-  create-ux-review-issue:
+  weekly-ux-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Build issue body
-        id: build-body
-        uses: actions/github-script@v7
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          script: |
-            const uxPrompt = `First, review the latest VS Code UX guidelines (https://code.visualstudio.com/api/ux-guidelines/overview) and the VS Code extension API documentation (https://code.visualstudio.com/api). Then, act as a senior UX designer who specializes in developer tools and VS Code extensions, reviewing this extension for the first time. Identify concrete areas where the user experience is confusing, inefficient, or inconsistent — not minor polish items, but workflow-level problems that cause real user friction. Before reporting a finding, check the GitHub issue tracker to see if it's already filed. For each finding: name the UX problem, describe current user experience, explain concrete impact, describe what it should be instead. Focus areas: workflow completeness, cognitive load, discoverability, feedback & state visibility, efficiency for repeat use, information architecture, error & edge cases, platform fit, accessibility & inclusivity. Skip icon choices, color preferences, wording tweaks.`;
+          fetch-depth: 0
 
-            const body = [
-              '## 🎨 Weekly UX Expert Review',
-              '',
-              'This issue was created automatically by the scheduled UX review workflow.',
-              '',
-              '### Task',
-              '',
-              'Analyze the DevDocket extension UX using the UX review methodology embedded below.',
-              '',
-              '**Instructions:**',
-              '- Follow the complete UX review prompt included in this issue',
-              '- Review the latest VS Code UX guidelines and extension API documentation',
-              '- Act as a senior UX designer specializing in developer tools',
-              '- Identify concrete UX problems that cause real user friction',
-              '- Before filing findings, search existing issues (open and closed) to avoid duplicates',
-              '- Create individual issues for each novel UX problem with clear titles and details',
-              '- Reference this tracking issue in each finding',
-              '- Close this issue once all findings are filed',
-              '',
-              '### Scope',
-              '',
-              'Focus on workflow-level problems, not cosmetic issues:',
-              '- Workflow completeness and efficiency',
-              '- Cognitive load and discoverability',
-              '- Feedback, state visibility, and information architecture',
-              '- Error handling and edge cases',
-              '- Accessibility and inclusivity',
-              '- Platform fit for VS Code',
-              '',
-              '### Exit Criteria',
-              '',
-              '- If no UX problems are found, close this issue with a comment explaining the analysis',
-              '- If findings are identified, create individual issues for each and reference this tracker',
-              '',
-              '### UX Review Prompt',
-              '',
-              uxPrompt,
-              '',
-              '---',
-              '',
-              '_Scheduled UX review run triggered at ' + new Date().toISOString() + '_'
-            ].join('\n');
+      - name: Set up Node.js environment
+        uses: actions/setup-node@v4
 
-            core.setOutput('body', body);
+      - name: Install Copilot CLI
+        run: npm install -g @github/copilot
 
-      - name: Create issue and assign Copilot agent
-        # Dedup: skips creation if an open issue with the dedup label already exists.
-        # Once the previous tracking issue is closed, the next run creates a fresh one.
-        # This is intentional — week-aware dedup is unnecessary since the cron
-        # schedule already gates frequency, and open-issue dedup prevents duplicates
-        # from manual re-runs or overlapping schedules.
-        uses: ./.github/actions/create-copilot-issue
-        with:
-          issue-title: 'Automated weekly UX review'
-          issue-body: ${{ steps.build-body.outputs.body }}
-          issue-labels: 'copilot,weekly-ux-review'
-          dedup-labels: 'weekly-ux-review'
-          custom-instructions: |
-            Follow the complete UX review prompt embedded in the issue body.
+      - name: Run weekly UX review
+        env:
+          # Shared PAT for both Copilot CLI and gh. Rotate COPILOT_CLI_PAT instead
+          # of configuring workflow-specific tokens.
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_PAT }}
+          GH_TOKEN: ${{ secrets.COPILOT_CLI_PAT }}
+        run: |
+          set -o pipefail
+          copilot -p "$(cat .github/prompts/weekly-ux-review.md)" \
+            --model claude-opus-4.7 \
+            --allow-tool='shell(gh:*)' \
+            --allow-tool='shell(git:*)' \
+            --allow-tool=read \
+            --no-ask-user | tee weekly-ux-review.log
 
-            The issue contains the full UX review methodology including:
-            1. Review Scope — focus on workflow-level UX problems
-            2. User Impact Analysis — concrete problems causing real friction
-            3. Exit Criteria — close when analysis is complete
-
-            Key principles:
-            - Review the latest VS Code UX guidelines and extension API docs
-            - Act as a senior UX designer reviewing this extension for the first time
-            - Search existing issues (open and closed) to avoid duplicates before filing findings
-            - Create individual issues for each novel UX problem with clear titles
-            - Reference this tracking issue in each finding
-
-            If no UX problems are found, close this issue with an explanation.
-            If findings are identified, create individual issues and reference this tracker.
-          copilot-assign-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Summary
+        if: always()
+        run: |
+          count="$(grep -Eo 'WEEKLY_UX_REVIEW_ISSUES_CREATED=[0-8]' weekly-ux-review.log 2>/dev/null | tail -n 1 | cut -d= -f2 || true)"
+          if [ -z "$count" ]; then
+            echo "⚠️ Weekly UX review completed, but no issue-count marker was found." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Weekly UX review issues created: $count" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/weekly-ux-review.yml
+++ b/.github/workflows/weekly-ux-review.yml
@@ -48,7 +48,7 @@ jobs:
           set -o pipefail
           copilot -p "$(cat .github/prompts/weekly-ux-review.md)" \
             --model claude-opus-4.7 \
-            --allow-tool='shell(gh:*)' \
+            --allow-tool='shell(gh issue:*)' \
             --allow-tool=read \
             --allow-tool=write \
             --no-ask-user | tee weekly-ux-review.log

--- a/.github/workflows/weekly-ux-review.yml
+++ b/.github/workflows/weekly-ux-review.yml
@@ -50,6 +50,7 @@ jobs:
             --model claude-opus-4.7 \
             --allow-tool='shell(gh issue:*)' \
             --allow-tool=read \
+            --allow-tool=create \
             --allow-tool=write \
             --no-ask-user | tee weekly-ux-review.log
 


### PR DESCRIPTION
## Summary

- Migrates both `weekly-ux-review.yml` and `weekly-review.yml` to run Copilot CLI in programmatic mode.
- Keeps findings filed as individual GitHub issues while eliminating the auto-generated PR side-effect from the previous `actions/github-script` + `create-copilot-issue` workflow pattern.
- Uses a constrained Copilot CLI tool allowlist and pinned model for scheduled review runs.

## Prompt files

- `.github/prompts/weekly-ux-review.md`
- `.github/prompts/weekly-review.md`

## Deployment note

Before the next scheduled run, configure a new repository secret named `COPILOT_CLI_PAT`. The token needs access for Copilot Requests, Issues:Write, and Contents:Read so the workflows can run Copilot CLI and file review findings as issues.

Closes #485
