### PR TITLE
Drop retainContextWhenHidden from CI Watches panel

### DIFF
--- a/packages/core/src/test/watchPanelProvider.test.ts
+++ b/packages/core/src/test/watchPanelProvider.test.ts
@@ -108,7 +108,7 @@ describe('WatchPanelProvider', () => {
       'devdocket.watchPanel',
       'CI Watches',
       vscode.ViewColumn.Beside,
-      expect.objectContaining({ enableScripts: true, retainContextWhenHidden: true }),
+      expect.objectContaining({ enableScripts: true }),
     );
     expect(mockPanel.panel.title).toBe('CI Watches (2)');
     expect(mockPanel.panel.webview.html).toContain('watchPanel.js');

--- a/packages/core/src/views/watchPanelProvider.ts
+++ b/packages/core/src/views/watchPanelProvider.ts
@@ -30,7 +30,6 @@ export class WatchPanelProvider implements vscode.Disposable {
       vscode.ViewColumn.Beside,
       {
         enableScripts: true,
-        retainContextWhenHidden: true,
         localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'webview-dist')],
       },
     );


### PR DESCRIPTION
## Summary

This narrows issue #474 to the CI Watches panel only. The panel no longer sets `retainContextWhenHidden: true`, reducing hidden webview memory use where retention does not add user value.

The main DevDocket sidebar intentionally keeps retention for now. A previous broader change removed it there too, but review found two High-risk sidebar issues:

1. The sidebar does not have a `webviewReady` handshake, so its initial `updateItems` post can race the webview script load and leave users with an empty sidebar until another refresh event fires.
2. The sidebar keeps important client-only Preact state in `useState` (`activeTab`, per-tier `collapsed`, and `selectedItemId`). Without retention, that state would reset on every hide/show.

## Why the watch panel is safe

The CI Watches panel already re-receives full state through `WatchPanelProvider.refresh()` when the webview posts its existing `watchPanelReady` message from `WatchApp`. That means a recreated watch panel is hydrated with the current run and PR watch state after it loads.

## Follow-up

The sidebar removal is deferred until a follow-up adds `workspaceState` persistence for `activeTab`, per-tier `collapsed`, and `selectedItemId` so hiding/showing the sidebar does not regress user-visible UI state.

Refs #474
