### PR TITLE
Add onboarding empty state to My Work and Sources tabs

### DIFF
--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -439,6 +439,26 @@ describe('MainViewProvider', () => {
     });
   });
 
+  it('handles onboarding command messages through the webview message switch', async () => {
+    vi.useFakeTimers();
+    const provider = createProvider(
+      createMockWorkGraph(),
+      createProviderRegistry({}),
+      createStateStore(),
+    );
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    await vi.advanceTimersByTimeAsync(50);
+    vi.clearAllMocks();
+
+    await mockView.simulateMessage({ type: 'createItem' });
+    await mockView.simulateMessage({ type: 'openWalkthrough' });
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.createItem');
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.openWalkthrough');
+  });
+
   it('handles reorderItems messages through the webview message switch', async () => {
     vi.useFakeTimers();
     const workGraph = createMockWorkGraph([

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -17,6 +17,7 @@ export type WebviewMessage =
   | { type: 'transitionState'; itemId: string; targetState: string }
   | { type: 'reorderItems'; itemIds: string[] }
   | { type: 'createItem' }
+  | { type: 'openWalkthrough' }
   | { type: 'clearHistory' }
   | { type: 'runAction'; itemId: string }
   | { type: 'openUrl'; url: string }

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -453,6 +453,9 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       case 'createItem':
         await vscode.commands.executeCommand('devdocket.createItem');
         break;
+      case 'openWalkthrough':
+        await vscode.commands.executeCommand('devdocket.openWalkthrough');
+        break;
       case 'clearHistory':
         await vscode.commands.executeCommand('devdocket.clearHistory');
         break;
@@ -804,7 +807,8 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     .source-provider-header:focus-visible,
     .source-group-header:focus-visible,
     .source-item:focus-visible,
-    .item-action-btn:focus-visible {
+    .item-action-btn:focus-visible,
+    .onboarding-empty-state-button:focus-visible {
       outline: 1px solid var(--vscode-focusBorder);
       outline-offset: 2px;
     }
@@ -935,6 +939,52 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     .source-empty {
       color: var(--vscode-descriptionForeground);
       font-style: italic;
+    }
+    .onboarding-empty-state {
+      max-width: 360px;
+      margin: 32px auto;
+      padding: 24px 16px;
+      text-align: center;
+      color: var(--vscode-foreground);
+      border: 1px solid var(--vscode-widget-border, rgba(127, 127, 127, 0.24));
+      border-radius: 8px;
+      background: var(--vscode-editorWidget-background, var(--vscode-sideBar-background));
+    }
+    .onboarding-empty-state-title {
+      margin: 0 0 8px;
+      font-size: 14px;
+      font-weight: 600;
+    }
+    .onboarding-empty-state-description {
+      margin: 0;
+      color: var(--vscode-descriptionForeground);
+      line-height: 1.45;
+    }
+    .onboarding-empty-state-actions {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 8px;
+      margin-top: 16px;
+    }
+    .onboarding-empty-state-button {
+      border: 1px solid var(--vscode-button-border, transparent);
+      border-radius: 2px;
+      padding: 4px 10px;
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+      cursor: pointer;
+      font: inherit;
+    }
+    .onboarding-empty-state-button:hover {
+      background: var(--vscode-button-hoverBackground);
+    }
+    .onboarding-empty-state-button-secondary {
+      background: var(--vscode-button-secondaryBackground, transparent);
+      color: var(--vscode-button-secondaryForeground, var(--vscode-foreground));
+    }
+    .onboarding-empty-state-button-secondary:hover {
+      background: var(--vscode-button-secondaryHoverBackground, var(--vscode-toolbar-hoverBackground));
     }
     .health-warning {
       color: var(--vscode-problemsWarningIcon-foreground, var(--vscode-editorWarning-foreground));

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'preact/hooks';
 import type { ExtensionMessage, SourceProviderData, TierData } from '../shared/types';
 import { postMessage } from '../shared/messaging';
 import { useThemeChangeCounter } from '../shared/theme';
+import { OnboardingEmptyState } from './components/OnboardingEmptyState';
 import { SourcesView } from './components/SourcesView';
 import { TabBar } from './components/TabBar';
 import { TierSection } from './components/TierSection';
@@ -10,6 +11,7 @@ export function App() {
   const [activeTab, setActiveTab] = useState<'myWork' | 'sources'>('myWork');
   const [tiers, setTiers] = useState<TierData[]>([]);
   const [sources, setSources] = useState<SourceProviderData[]>([]);
+  const [hasReceivedItems, setHasReceivedItems] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const [announcement, setAnnouncement] = useState('');
   const previousTiersRef = useRef<TierData[] | undefined>(undefined);
@@ -44,6 +46,7 @@ export function App() {
             announce(buildLiveAnnouncement(previousTiers, nextTiers));
           }
           previousTiersRef.current = nextTiers;
+          setHasReceivedItems(true);
           setTiers(nextTiers);
           break;
         }
@@ -103,7 +106,13 @@ export function App() {
             aria-labelledby="mission-control-tab-my-work"
           >
             {tiers.length === 0 ? (
-              <div class="empty-state">No items yet</div>
+              hasReceivedItems ? (
+                <EmptyMyWork />
+              ) : (
+                <div class="empty-state">No items yet</div>
+              )
+            ) : tiers.every(tier => tier.items.length === 0) ? (
+              <EmptyMyWork />
             ) : (
               <div class="tiers">
                 {tiers.map(tier => (
@@ -153,6 +162,15 @@ export function App() {
         )}
       </div>
     </div>
+  );
+}
+
+function EmptyMyWork() {
+  return (
+    <OnboardingEmptyState
+      titleId="my-work-empty-state-title"
+      description="Create a work item manually, or install a provider extension to automatically discover GitHub issues, Azure DevOps tasks, PR reviews, and more."
+    />
   );
 }
 

--- a/packages/core/src/webview/sidebar/components/OnboardingEmptyState.tsx
+++ b/packages/core/src/webview/sidebar/components/OnboardingEmptyState.tsx
@@ -1,0 +1,31 @@
+import { postMessage } from '../../shared/messaging';
+
+interface OnboardingEmptyStateProps {
+  description: string;
+  titleId: string;
+}
+
+export function OnboardingEmptyState({ description, titleId }: OnboardingEmptyStateProps) {
+  return (
+    <section class="onboarding-empty-state" aria-labelledby={titleId}>
+      <h2 id={titleId} class="onboarding-empty-state-title">Nothing here yet.</h2>
+      <p class="onboarding-empty-state-description">{description}</p>
+      <div class="onboarding-empty-state-actions">
+        <button
+          type="button"
+          class="onboarding-empty-state-button"
+          onClick={() => postMessage({ type: 'createItem' })}
+        >
+          Create Work Item
+        </button>
+        <button
+          type="button"
+          class="onboarding-empty-state-button onboarding-empty-state-button-secondary"
+          onClick={() => postMessage({ type: 'openWalkthrough' })}
+        >
+          Open Walkthrough
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/packages/core/src/webview/sidebar/components/SourcesView.tsx
+++ b/packages/core/src/webview/sidebar/components/SourcesView.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'preact/hooks';
 import type { SourceGroupData, SourceProviderData } from '../../shared/types';
+import { OnboardingEmptyState } from './OnboardingEmptyState';
 import { SourceItem } from './SourceItem';
 
 interface SourcesViewProps {
@@ -9,7 +10,14 @@ interface SourcesViewProps {
 
 export function SourcesView({ providers, onOpenItem }: SourcesViewProps) {
   if (providers.length === 0) {
-    return <div class="empty-state">No sources yet</div>;
+    return (
+      <div class="sources-tab">
+        <OnboardingEmptyState
+          titleId="sources-empty-state-title"
+          description="Create a work item manually, or install a provider extension to populate Sources with GitHub issues, Azure DevOps tasks, PR reviews, and more."
+        />
+      </div>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary

- Add an actionable onboarding empty state for the My Work tab when no work tiers have items.
- Replace the Sources tab no-provider message with the same create/walkthrough call to action.
- Wire the new webview walkthrough message to the existing DevDocket command and cover both onboarding message handlers with tests.

## Verification

- npm run build -w devdocket
- npm run test -w devdocket
- npm run build
- npm run test
- superpowers:code-reviewer: no critical or important findings

Closes #484
