### PR TITLE
Wire Incoming floating accept button to Ready to Start

### DIFF
--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -486,6 +486,46 @@ describe('MainViewProvider', () => {
     expect(workGraph.createItem).not.toHaveBeenCalled();
   });
 
+  it('routes incoming acceptToFocus messages through the accept-to-focus-from-inbox command', async () => {
+    vi.useFakeTimers();
+    const workGraph = createMockWorkGraph();
+    const providerRegistry = createProviderRegistry({
+      github: [
+        {
+          externalId: 'incoming-start',
+          title: 'Incoming start',
+          description: 'Start details',
+          url: 'https://example.com/incoming/start',
+          group: 'repo',
+          canonicalId: 'canonical-start',
+        },
+      ],
+    });
+    const provider = createProvider(workGraph, providerRegistry, createStateStore());
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    await vi.advanceTimersByTimeAsync(50);
+    vi.clearAllMocks();
+
+    await mockView.simulateMessage({ type: 'acceptToFocus', providerId: 'github', externalId: 'incoming-start' });
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      'devdocket.acceptToFocusFromInbox',
+      {
+        kind: 'item',
+        providerId: 'github',
+        externalId: 'incoming-start',
+        title: 'Incoming start',
+        description: 'Start details',
+        url: 'https://example.com/incoming/start',
+        group: 'repo',
+        canonicalId: 'canonical-start',
+      },
+    );
+    expect(workGraph.createItem).not.toHaveBeenCalled();
+  });
+
   it('handles onboarding command messages through the webview message switch', async () => {
     vi.useFakeTimers();
     const provider = createProvider(

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -429,14 +429,61 @@ describe('MainViewProvider', () => {
       );
       expect(vscode.env.openExternal).not.toHaveBeenCalledWith(expect.objectContaining({ path: 'https://example.com/provider/1' }));
       expect(vscode.env.openExternal).toHaveBeenCalledWith(expect.objectContaining({ path: 'https://example.com/manual/2' }));
-      expect(workGraph.createItem).toHaveBeenCalledWith(
-        { title: 'Incoming item', description: 'Desc' },
-        { providerId: 'github', externalId: 'incoming-99', url: 'https://example.com/incoming/99', group: 'repo' },
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        'devdocket.acceptFromInbox',
+        {
+          kind: 'item',
+          providerId: 'github',
+          externalId: 'incoming-99',
+          title: 'Incoming item',
+          description: 'Desc',
+          url: 'https://example.com/incoming/99',
+          group: 'repo',
+        },
       );
-      expect(stateStore.setState).toHaveBeenCalledWith('github', 'incoming-99', 'accepted');
       expect(stateStore.setState).toHaveBeenCalledWith('github', 'incoming-99', 'dismissed');
       expect(workGraph.transitionState).toHaveBeenCalledWith('existing-item', WorkItemState.Done);
     });
+  });
+
+  it('routes incoming accept messages through the accept-from-inbox command', async () => {
+    vi.useFakeTimers();
+    const workGraph = createMockWorkGraph();
+    const providerRegistry = createProviderRegistry({
+      github: [
+        {
+          externalId: 'incoming-accept',
+          title: 'Incoming accept',
+          description: 'Acceptance details',
+          url: 'https://example.com/incoming/accept',
+          group: 'repo',
+          canonicalId: 'canonical-accept',
+        },
+      ],
+    });
+    const provider = createProvider(workGraph, providerRegistry, createStateStore());
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    await vi.advanceTimersByTimeAsync(50);
+    vi.clearAllMocks();
+
+    await mockView.simulateMessage({ type: 'acceptItem', providerId: 'github', externalId: 'incoming-accept' });
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+      'devdocket.acceptFromInbox',
+      {
+        kind: 'item',
+        providerId: 'github',
+        externalId: 'incoming-accept',
+        title: 'Incoming accept',
+        description: 'Acceptance details',
+        url: 'https://example.com/incoming/accept',
+        group: 'repo',
+        canonicalId: 'canonical-accept',
+      },
+    );
+    expect(workGraph.createItem).not.toHaveBeenCalled();
   });
 
   it('handles reorderItems messages through the webview message switch', async () => {

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -490,27 +490,22 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
 
   private async handleAcceptItem(providerId: string, externalId: string): Promise<void> {
     try {
-      const existing = this.workGraph.findItemByProvenance(providerId, externalId);
-      if (!existing) {
-        const discoveredItem = this.providerRegistry.getDiscoveredItems(providerId).find(item => item.externalId === externalId);
-        if (!discoveredItem) {
-          logger.warn(`DevDocket: discovered item ${providerId}/${externalId} not found for accept`);
-          return;
-        }
-        await this.workGraph.createItem(
-          {
-            title: discoveredItem.title,
-            description: discoveredItem.description,
-          },
-          {
-            providerId,
-            externalId,
-            url: discoveredItem.url,
-            ...(discoveredItem.group ? { group: discoveredItem.group } : {}),
-          },
-        );
+      const discoveredItem = this.providerRegistry.getDiscoveredItems(providerId).find(item => item.externalId === externalId);
+      if (!discoveredItem) {
+        logger.warn(`DevDocket: discovered item ${providerId}/${externalId} not found for accept`);
+        return;
       }
-      await this.stateStore.setState(providerId, externalId, 'accepted');
+
+      await vscode.commands.executeCommand('devdocket.acceptFromInbox', {
+        kind: 'item',
+        providerId,
+        externalId,
+        title: discoveredItem.title,
+        description: discoveredItem.description,
+        url: discoveredItem.url,
+        ...(discoveredItem.group ? { group: discoveredItem.group } : {}),
+        ...(discoveredItem.canonicalId ? { canonicalId: discoveredItem.canonicalId } : {}),
+      });
     } catch (err) {
       logger.error('DevDocket: accept failed', err);
       void vscode.window.showErrorMessage(`Failed to accept item: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -536,7 +536,22 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     // Ready to Start tier). Lets the user pull an inbox item directly into
     // active work without opening the editor first.
     try {
-      await vscode.commands.executeCommand('devdocket.acceptToFocusFromInbox', { providerId, externalId });
+      const discoveredItem = this.providerRegistry.getDiscoveredItems(providerId).find(item => item.externalId === externalId);
+      if (!discoveredItem) {
+        logger.warn(`DevDocket: discovered item ${providerId}/${externalId} not found for acceptToFocus`);
+        return;
+      }
+
+      await vscode.commands.executeCommand('devdocket.acceptToFocusFromInbox', {
+        kind: 'item',
+        providerId,
+        externalId,
+        title: discoveredItem.title,
+        description: discoveredItem.description,
+        url: discoveredItem.url,
+        ...(discoveredItem.group ? { group: discoveredItem.group } : {}),
+        ...(discoveredItem.canonicalId ? { canonicalId: discoveredItem.canonicalId } : {}),
+      });
     } catch (err) {
       logger.error('DevDocket: acceptToFocus failed', err);
       void vscode.window.showErrorMessage(`Failed to start item: ${err instanceof Error ? err.message : String(err)}`);


### PR DESCRIPTION
## Summary

- Fixes the Incoming-tier floating accept button by routing the `acceptItem` webview message through `devdocket.acceptFromInbox`.
- Builds the same inbox item payload used by the keyboard/context-menu accept path, including canonical IDs.
- Adds `MainViewProvider` coverage for the accept message routing.

## Root Cause

The floating button already posted `acceptItem`, but the host handled it with a separate webview-only accept implementation instead of the existing Incoming accept command path, causing divergent behavior from the working keyboard/context-menu route.

## Validation

- `cd packages\core ; npm run build`
- `cd packages\core ; npm run test`
- `npm run test`
- `superpowers:code-reviewer` pre-PR review: no Critical or Important findings

Closes #477
