### PR TITLE
Make provider health warning in Sources tab clickable

### DIFF
--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -439,6 +439,20 @@ describe('MainViewProvider', () => {
     });
   });
 
+  it('handles provider health messages through the webview message switch', async () => {
+    vi.useFakeTimers();
+    const provider = createProvider(createMockWorkGraph(), createProviderRegistry({}), createStateStore());
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    await vi.advanceTimersByTimeAsync(50);
+    vi.clearAllMocks();
+
+    await mockView.simulateMessage({ type: 'showProviderHealth', providerId: 'github-issues' });
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.showProviderHealthQuickPick');
+  });
+
   it('handles reorderItems messages through the webview message switch', async () => {
     vi.useFakeTimers();
     const workGraph = createMockWorkGraph([

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -10,6 +10,7 @@ export type ExtensionMessage =
 export type WebviewMessage =
   | { type: 'openItem'; itemId: string; providerId?: string; externalId?: string }
   | { type: 'openSourceItem'; providerId: string; externalId: string }
+  | { type: 'showProviderHealth'; providerId: string }
   | { type: 'acceptItem'; providerId: string; externalId: string }
   | { type: 'acceptToFocus'; providerId: string; externalId: string }
   | { type: 'acceptAll' }

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -804,7 +804,6 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     .tier-header-main:focus-visible,
     .tier-toggle-button:focus-visible,
     .tier-header-action:focus-visible,
-    .source-provider-header:focus-visible,
     .source-provider-toggle-button:focus-visible,
     .source-group-header:focus-visible,
     .source-item:focus-visible,

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -805,6 +805,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     .tier-toggle-button:focus-visible,
     .tier-header-action:focus-visible,
     .source-provider-header:focus-visible,
+    .source-provider-toggle-button:focus-visible,
     .source-group-header:focus-visible,
     .source-item:focus-visible,
     .item-action-btn:focus-visible {

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -429,6 +429,9 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
         }
         break;
       }
+      case 'showProviderHealth':
+        await vscode.commands.executeCommand('devdocket.showProviderHealthQuickPick');
+        break;
       case 'acceptItem':
         await this.handleAcceptItem(message.providerId, message.externalId);
         break;
@@ -840,10 +843,16 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     .source-provider.unhealthy {
       border-left-color: var(--vscode-problemsWarningIcon-foreground, var(--vscode-editorWarning-foreground));
     }
-    .source-provider-header,
-    .source-group-header {
+    .source-provider-header {
       width: 100%;
       display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .source-group-header,
+    .source-provider-toggle-button,
+    .health-warning-button {
+      display: inline-flex;
       align-items: center;
       gap: 6px;
       background: transparent;
@@ -853,6 +862,12 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       padding: 0;
       text-align: left;
       font: inherit;
+    }
+    .source-group-header {
+      width: 100%;
+    }
+    .source-provider-title-button {
+      min-width: 0;
     }
     .source-provider-title,
     .source-group-title {
@@ -935,6 +950,14 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     .source-empty {
       color: var(--vscode-descriptionForeground);
       font-style: italic;
+    }
+    .health-warning-button {
+      line-height: inherit;
+    }
+    .health-warning-button:focus-visible {
+      outline: 1px solid var(--vscode-focusBorder);
+      outline-offset: 2px;
+      border-radius: 2px;
     }
     .health-warning {
       color: var(--vscode-problemsWarningIcon-foreground, var(--vscode-editorWarning-foreground));

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -93,6 +93,9 @@ export function App() {
               onOpenItem={(providerId, externalId) =>
                 postMessage({ type: 'openSourceItem', providerId, externalId })
               }
+              onShowProviderHealth={(providerId) =>
+                postMessage({ type: 'showProviderHealth', providerId })
+              }
             />
           </div>
         ) : (

--- a/packages/core/src/webview/sidebar/components/SourcesView.tsx
+++ b/packages/core/src/webview/sidebar/components/SourcesView.tsx
@@ -68,7 +68,7 @@ function ProviderSection({ provider, onOpenItem, onShowProviderHealth }: Provide
               type="button"
               class="health-warning health-warning-button"
               onClick={() => onShowProviderHealth(provider.providerId)}
-              aria-label={`Provider ${provider.label} unhealthy — click for details`}
+              aria-label={`Provider ${provider.label} unhealthy — show details`}
             >
               ⚠
             </button>

--- a/packages/core/src/webview/sidebar/components/SourcesView.tsx
+++ b/packages/core/src/webview/sidebar/components/SourcesView.tsx
@@ -5,9 +5,10 @@ import { SourceItem } from './SourceItem';
 interface SourcesViewProps {
   providers: SourceProviderData[];
   onOpenItem: (providerId: string, externalId: string) => void;
+  onShowProviderHealth: (providerId: string) => void;
 }
 
-export function SourcesView({ providers, onOpenItem }: SourcesViewProps) {
+export function SourcesView({ providers, onOpenItem, onShowProviderHealth }: SourcesViewProps) {
   if (providers.length === 0) {
     return <div class="empty-state">No sources yet</div>;
   }
@@ -20,6 +21,7 @@ export function SourcesView({ providers, onOpenItem }: SourcesViewProps) {
             key={provider.providerId}
             provider={provider}
             onOpenItem={onOpenItem}
+            onShowProviderHealth={onShowProviderHealth}
           />
         ))}
       </div>
@@ -30,9 +32,10 @@ export function SourcesView({ providers, onOpenItem }: SourcesViewProps) {
 interface ProviderSectionProps {
   provider: SourceProviderData;
   onOpenItem: (providerId: string, externalId: string) => void;
+  onShowProviderHealth: (providerId: string) => void;
 }
 
-function ProviderSection({ provider, onOpenItem }: ProviderSectionProps) {
+function ProviderSection({ provider, onOpenItem, onShowProviderHealth }: ProviderSectionProps) {
   const [collapsed, setCollapsed] = useState(false);
   const itemCount = provider.groups.reduce((total, group) => total + group.items.length, 0);
 
@@ -42,21 +45,38 @@ function ProviderSection({ provider, onOpenItem }: ProviderSectionProps) {
       role="group"
       aria-label={provider.label}
     >
-      <button
-        type="button"
-        class="source-provider-header"
-        onClick={() => setCollapsed(value => !value)}
-        aria-expanded={!collapsed}
-      >
+      <div class="source-provider-header">
         <span class="source-provider-title">
-          <span>{provider.label}</span>
-          {!provider.isHealthy ? <span class="health-warning" aria-label="Provider unhealthy">⚠</span> : null}
+          <button
+            type="button"
+            class="source-provider-toggle-button source-provider-title-button"
+            onClick={() => setCollapsed(value => !value)}
+            aria-expanded={!collapsed}
+          >
+            <span>{provider.label}</span>
+          </button>
+          {!provider.isHealthy ? (
+            <button
+              type="button"
+              class="health-warning health-warning-button"
+              onClick={() => onShowProviderHealth(provider.providerId)}
+              aria-label={`Provider ${provider.label} unhealthy — click for details`}
+            >
+              ⚠
+            </button>
+          ) : null}
         </span>
-        <span class="source-provider-meta">
+        <button
+          type="button"
+          class="source-provider-toggle-button source-provider-meta"
+          onClick={() => setCollapsed(value => !value)}
+          aria-expanded={!collapsed}
+          aria-label={`${collapsed ? 'Expand' : 'Collapse'} ${provider.label} source items`}
+        >
           <span>({itemCount})</span>
           <span class="source-provider-toggle" aria-hidden="true">{collapsed ? '▸' : '▾'}</span>
-        </span>
-      </button>
+        </button>
+      </div>
       {!collapsed ? (
         <div class="source-provider-groups">
           {provider.groups.length === 0 ? (


### PR DESCRIPTION
## Summary
- Replace the non-interactive Sources tab provider health warning span with a keyboard-accessible button.
- Route the button through the webview message handler to invoke `devdocket.showProviderHealthQuickPick`.
- Preserve the warning icon styling and add a VS Code focus-border outline for keyboard users.

## Notes
- The existing `devdocket.showProviderHealthQuickPick` command handler does not currently accept a provider id, so the new handler invokes it without arguments. The webview message still includes the provider id for future command support.

## Tests
- `cd packages\core ; npm run build`
- `cd packages\core ; npm run test`

Closes #482
