### PR TITLE
Drop redundant coreExtension.activate() guard in provider extensions

### DIFF
--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -5,7 +5,7 @@ import { AdoMyPrsProvider } from './adoMyPrsProvider';
 import { AdoPipelineWatcher } from './adoPipelineWatcher';
 import { AdoPRWatcher } from './adoPRWatcher';
 import { parseAdoProjectsConfig } from './configParser';
-import { validateRefreshInterval } from '@devdocket/shared';
+import { validateRefreshInterval, type DevDocketApi } from '@devdocket/shared';
 import { initLogger, setLogLevel, logger, resolveLogLevel } from './logger';
 
 let workItemProvider: AdoWorkItemProvider | undefined;
@@ -48,17 +48,7 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
     return;
   }
 
-  let api;
-  try {
-    api = coreExtension.isActive
-      ? coreExtension.exports
-      : await coreExtension.activate();
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    logger.error(`Failed to activate core extension — ${message}`);
-    void vscode.window.showErrorMessage(`DevDocket ADO: Failed to activate core extension — ${message}`);
-    return;
-  }
+  const api = coreExtension.exports as DevDocketApi;
 
   if (!api || typeof api.registerProvider !== 'function') {
     logger.error('Core extension API not available');

--- a/packages/ado/src/test/extension.test.ts
+++ b/packages/ado/src/test/extension.test.ts
@@ -75,19 +75,18 @@ describe('extension activation', () => {
     expect(mockApi.registerProvider).not.toHaveBeenCalled();
   });
 
-  it('shows error and returns when core extension fails to activate', async () => {
+  it('reads the core extension exports directly without invoking activate', async () => {
+    const mockActivate = vi.fn();
     vi.mocked(extensions.getExtension).mockReturnValue({
       isActive: false,
-      exports: undefined,
-      activate: vi.fn().mockRejectedValue(new Error('Activation failed')),
+      exports: mockApi,
+      activate: mockActivate,
     } as any);
 
     await activate(mockContext);
 
-    expect(window.showErrorMessage).toHaveBeenCalledWith(
-      expect.stringContaining('Failed to activate core extension'),
-    );
-    expect(mockApi.registerProvider).not.toHaveBeenCalled();
+    expect(mockActivate).not.toHaveBeenCalled();
+    expect(mockApi.registerProvider).toHaveBeenCalledTimes(3);
   });
 
   it('returns when core extension API is missing registerProvider', async () => {
@@ -112,20 +111,6 @@ describe('extension activation', () => {
     await activate(mockContext);
 
     expect(mockApi.registerProvider).not.toHaveBeenCalled();
-  });
-
-  it('activates core extension when not yet active', async () => {
-    const mockActivate = vi.fn().mockResolvedValue(mockApi);
-    vi.mocked(extensions.getExtension).mockReturnValue({
-      isActive: false,
-      exports: undefined,
-      activate: mockActivate,
-    } as any);
-
-    await activate(mockContext);
-
-    expect(mockActivate).toHaveBeenCalled();
-    expect(mockApi.registerProvider).toHaveBeenCalledTimes(3);
   });
 
   it('registers three providers when organization is configured', async () => {

--- a/packages/ai-reviewer/src/extension.ts
+++ b/packages/ai-reviewer/src/extension.ts
@@ -21,18 +21,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     return;
   }
 
-  let api: DevDocketApi | undefined;
-  try {
-    api = coreExtension.isActive
-      ? coreExtension.exports
-      : await coreExtension.activate();
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    log.error(`Failed to activate core extension: ${message}`);
-    console.error(`DevDocket AI Reviewer: Failed to activate core extension — ${message}`);
-    vscode.window.showErrorMessage(`DevDocket AI Reviewer: Failed to activate core extension — ${message}`);
-    return;
-  }
+  const api = coreExtension.exports as DevDocketApi;
 
   if (!api || typeof api.registerAction !== 'function') {
     const msg = 'DevDocket AI Reviewer: core extension API not available';

--- a/packages/github/src/extension.ts
+++ b/packages/github/src/extension.ts
@@ -5,7 +5,7 @@ import { GitHubActionsWatcher } from './githubActionsWatcher';
 import { GitHubPRWatcher } from './githubPRWatcher';
 import { GitHubMyPrsProvider } from './githubMyPrsProvider';
 import { GitHubMentionsProvider } from './githubMentionsProvider';
-import { validateRefreshInterval } from '@devdocket/shared';
+import { validateRefreshInterval, type DevDocketApi } from '@devdocket/shared';
 import { initLogger, setLogLevel, logger, resolveLogLevel } from './logger';
 
 let issueProvider: GitHubIssueProvider | undefined;
@@ -50,17 +50,7 @@ export async function activate(_context: vscode.ExtensionContext): Promise<void>
     return;
   }
 
-  let api;
-  try {
-    api = coreExtension.isActive
-      ? coreExtension.exports
-      : await coreExtension.activate();
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    logger.error(`Failed to activate core extension — ${message}`);
-    void vscode.window.showErrorMessage(`DevDocket GitHub: Failed to activate core extension — ${message}`);
-    return;
-  }
+  const api = coreExtension.exports as DevDocketApi;
 
   if (!api || typeof api.registerProvider !== 'function') {
     logger.error('Core extension API not available');

--- a/packages/start-git-work/src/extension.ts
+++ b/packages/start-git-work/src/extension.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode';
 import { StartWorkAction } from './startWorkAction';
 import { promptGitCleanup } from './gitCleanup';
 import { initLogger, setLogLevel, logger, resolveLogLevel } from './logger';
-import type { StateTransitionEvent, ActivityType } from '@devdocket/shared';
+import type { StateTransitionEvent, ActivityType, DevDocketApi } from '@devdocket/shared';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const outputChannel = vscode.window.createOutputChannel('DevDocket Start Git Work');
@@ -34,15 +34,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     return;
   }
 
-  let api;
-  try {
-    api = coreExtension.isActive ? coreExtension.exports : await coreExtension.activate();
-  } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
-    logger.error(`Failed to activate core extension — ${message}`);
-    void vscode.window.showErrorMessage(`DevDocket Start Git Work: Failed to activate core extension — ${message}`);
-    return;
-  }
+  const api = coreExtension.exports as DevDocketApi;
 
   if (!api || typeof api.registerAction !== 'function') {
     logger.error('Core extension API not available');


### PR DESCRIPTION
## Summary
- Remove redundant coreExtension.activate() fallbacks from the GitHub, ADO, Start Git Work, and AI Reviewer extension activation paths.
- Keep the coreExtension null checks and API-shape guards intact.
- Reframe the obsolete ADO activation test to assert the extension reads coreExtension.exports directly without invoking activate; no equivalent Promise-returning activate tests existed in the other three packages.

## Validation
- packages/github: npm install --no-audit --no-fund --prefer-offline; npm run build; 349/349 tests passed across 80 files.
- packages/ado: npm install --no-audit --no-fund --prefer-offline; npm run build; 252/252 tests passed across 69 files.
- packages/start-git-work: npm install --no-audit --no-fund --prefer-offline; npm run build; 87/87 tests passed across 15 files.
- packages/ai-reviewer: npm install --no-audit --no-fund --prefer-offline; npm run build; 228/228 tests passed across 65 files.
- superpowers:code-reviewer completed with no Critical or Important findings.

Closes #473
