### PR TITLE
Add search/filter to My Work and Sources sidebar tabs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -391,24 +391,35 @@
         "command": "devdocket.openWalkthrough",
         "title": "Open Walkthrough",
         "category": "DevDocket"
+      },
+      {
+        "command": "devdocket.toggleSearch",
+        "title": "Toggle Search",
+        "category": "DevDocket",
+        "icon": "$(search)"
       }
     ],
     "menus": {
       "view/title": [
         {
+          "command": "devdocket.toggleSearch",
+          "when": "view == devdocket.main",
+          "group": "navigation@1"
+        },
+        {
           "command": "devdocket.createItem",
           "when": "view == devdocket.main",
-          "group": "navigation"
+          "group": "navigation@2"
         },
         {
           "command": "devdocket.createItemFromUrl",
           "when": "view == devdocket.main",
-          "group": "navigation"
+          "group": "navigation@3"
         },
         {
           "command": "devdocket.refresh",
           "when": "view == devdocket.main",
-          "group": "navigation"
+          "group": "navigation@4"
         }
       ],
       "commandPalette": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -439,6 +439,12 @@
     },
     "keybindings": [
       {
+        "command": "devdocket.toggleSearch",
+        "key": "ctrl+f",
+        "mac": "cmd+f",
+        "when": "focusedView == devdocket.main"
+      },
+      {
         "command": "devdocket.createItem",
         "key": "ctrl+alt+d n",
         "when": "focusedView =~ /devdocket/"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -442,7 +442,7 @@
         "command": "devdocket.toggleSearch",
         "key": "ctrl+f",
         "mac": "cmd+f",
-        "when": "focusedView == devdocket.main"
+        "when": "focusedView == devdocket.main || webviewId == 'devdocket.main'"
       },
       {
         "command": "devdocket.createItem",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -442,7 +442,7 @@
         "command": "devdocket.toggleSearch",
         "key": "ctrl+f",
         "mac": "cmd+f",
-        "when": "focusedView == devdocket.main || webviewId == 'devdocket.main'"
+        "when": "focusedView == devdocket.main"
       },
       {
         "command": "devdocket.createItem",

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -749,10 +749,13 @@ export function registerCommands(
   prWatcherRegistry: PRWatcherRegistry,
   watcherService: WatcherService,
   watchPanelProvider: WatchPanelProvider,
+  toggleMainSearch: () => void,
 ): void {
   context.subscriptions.push(
     vscode.commands.registerCommand('devdocket.refresh',
       wrapCommand('Failed to refresh', () => handleRefresh(providerRegistry))),
+    vscode.commands.registerCommand('devdocket.toggleSearch',
+      wrapCommand('Failed to toggle search', () => toggleMainSearch())),
     vscode.commands.registerCommand('devdocket.openWalkthrough',
       wrapCommand('Failed to open walkthrough', () =>
         vscode.commands.executeCommand(

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -500,6 +500,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
 
   const commandRegStart = performance.now();
   registerCommands(context, wg, ar, ss, readStateStore, pr, labelCache, wr, pwr, ws, watchPanelProvider);
+  context.subscriptions.push(
+    vscode.commands.registerCommand('devdocket.toggleSearch', () => {
+      mainProvider.toggleSearch();
+    }),
+  );
   logger.info(`Command registration took ${Math.round(performance.now() - commandRegStart)}ms`);
 
   logger.info(`DevDocket activated in ${Math.round(performance.now() - activationStart)}ms`);

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -499,12 +499,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   );
 
   const commandRegStart = performance.now();
-  registerCommands(context, wg, ar, ss, readStateStore, pr, labelCache, wr, pwr, ws, watchPanelProvider);
-  context.subscriptions.push(
-    vscode.commands.registerCommand('devdocket.toggleSearch', () => {
-      mainProvider.toggleSearch();
-    }),
-  );
+  registerCommands(context, wg, ar, ss, readStateStore, pr, labelCache, wr, pwr, ws, watchPanelProvider, () => mainProvider.toggleSearch());
   logger.info(`Command registration took ${Math.round(performance.now() - commandRegStart)}ms`);
 
   logger.info(`DevDocket activated in ${Math.round(performance.now() - activationStart)}ms`);

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -170,6 +170,7 @@ describe('registerCommands', () => {
       {} as PRWatcherRegistry,
       {} as WatcherService,
       watchPanelProvider as any,
+      vi.fn(),
     );
   });
 

--- a/packages/core/src/test/filter.test.ts
+++ b/packages/core/src/test/filter.test.ts
@@ -170,4 +170,18 @@ describe('splitOnMatches', () => {
       { text: 'résumé', isMatch: true },
     ]);
   });
+
+  it('keeps original slice positions when lowercase expansion shifts match indexes', () => {
+    expect(splitOnMatches('İSTANBUL issue', 'issue')).toEqual([
+      { text: 'İSTANBUL ', isMatch: false },
+      { text: 'issue', isMatch: true },
+    ]);
+  });
+
+  it('highlights original text for matches inside lowercase-expanded characters', () => {
+    expect(splitOnMatches('İssue', 'i')).toEqual([
+      { text: 'İ', isMatch: true },
+      { text: 'ssue', isMatch: false },
+    ]);
+  });
 });

--- a/packages/core/src/test/filter.test.ts
+++ b/packages/core/src/test/filter.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { SourceProviderData, TierData } from '../views/mainTypes';
 import { filterProviders, filterTiers, getGroupTotalCountKey, matchesQuery, splitOnMatches } from '../webview/sidebar/filter';
+import { hiddenSearchBoxes, isSearchBoxEffectivelyVisible, type TabQueries } from '../webview/sidebar/searchVisibility';
 
 const badge = { label: 'GitHub', type: 'provider' as const, variant: 'github' };
 
@@ -123,6 +124,23 @@ describe('filterProviders', () => {
     expect(result.totalCounts.get('github')).toBe(3);
     expect(result.totalCounts.get(getGroupTotalCountKey('github', 'devdocket/devdocket'))).toBe(2);
     expect(result.totalCounts.get(getGroupTotalCountKey('github', 'owner/tools'))).toBe(1);
+  });
+});
+
+describe('isSearchBoxEffectivelyVisible', () => {
+  const empty: TabQueries = { myWork: '', sources: '' };
+
+  it('stays hidden when the toggle is collapsed and queries are empty', () => {
+    expect(isSearchBoxEffectivelyVisible('myWork', hiddenSearchBoxes, empty, empty)).toBe(false);
+  });
+
+  it('shows when the tab toggle is expanded', () => {
+    expect(isSearchBoxEffectivelyVisible('sources', { ...hiddenSearchBoxes, sources: true }, empty, empty)).toBe(true);
+  });
+
+  it('auto-shows when a pending or applied query is non-empty', () => {
+    expect(isSearchBoxEffectivelyVisible('myWork', hiddenSearchBoxes, { ...empty, myWork: 'review' }, empty)).toBe(true);
+    expect(isSearchBoxEffectivelyVisible('sources', hiddenSearchBoxes, empty, { ...empty, sources: 'pipeline' })).toBe(true);
   });
 });
 

--- a/packages/core/src/test/filter.test.ts
+++ b/packages/core/src/test/filter.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import type { SourceProviderData, TierData } from '../views/mainTypes';
+import { filterProviders, filterTiers, getGroupTotalCountKey, matchesQuery, splitOnMatches } from '../webview/sidebar/filter';
+
+const badge = { label: 'GitHub', type: 'provider' as const, variant: 'github' };
+
+function tier(overrides: Partial<TierData> = {}): TierData {
+  return {
+    id: 'ready-to-start',
+    name: 'Ready to Start',
+    icon: '○',
+    collapsed: true,
+    items: [
+      { id: 'one', title: 'Fix sidebar layout', badges: [badge], tierType: 'readyToStart', repoAnnotation: 'devdocket/devdocket' },
+      { id: 'two', title: 'Add pipeline watcher', badges: [], tierType: 'readyToStart', repoAnnotation: 'owner/tools' },
+    ],
+    ...overrides,
+  };
+}
+
+function provider(overrides: Partial<SourceProviderData> = {}): SourceProviderData {
+  return {
+    providerId: 'github',
+    label: 'GitHub',
+    isHealthy: true,
+    groups: [
+      {
+        name: 'devdocket/devdocket',
+        items: [
+          { providerId: 'github', externalId: '1', title: 'Fix sidebar layout', badges: [badge], isAccepted: false, isDismissed: false },
+          { providerId: 'github', externalId: '2', title: 'Add health indicator', badges: [], isAccepted: true, isDismissed: false },
+        ],
+      },
+      {
+        name: 'owner/tools',
+        items: [
+          { providerId: 'github', externalId: '3', title: 'Improve watcher polling', badges: [], isAccepted: false, isDismissed: true },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('matchesQuery', () => {
+  it('treats empty and whitespace-only queries as matches', () => {
+    expect(matchesQuery('Any text', '')).toBe(true);
+    expect(matchesQuery('Any text', '   ')).toBe(true);
+  });
+
+  it('matches case-insensitively', () => {
+    expect(matchesQuery('DevDocket Sidebar', 'sidebar')).toBe(true);
+    expect(matchesQuery('DevDocket Sidebar', 'DEVDOCKET')).toBe(true);
+  });
+
+  it('returns false when the substring is absent', () => {
+    expect(matchesQuery('DevDocket Sidebar', 'pipeline')).toBe(false);
+  });
+
+  it('handles unicode with normal lower-case matching', () => {
+    expect(matchesQuery('Résumé cleanup', 'résumé')).toBe(true);
+  });
+});
+
+describe('filterTiers', () => {
+  it('drops tiers with no matching items', () => {
+    const result = filterTiers([tier({ id: 'ready' }), tier({ id: 'done', items: [{ id: 'done-1', title: 'Archive old item', badges: [], tierType: 'done' }] })], 'sidebar');
+
+    expect(result.tiers.map(t => t.id)).toEqual(['ready']);
+  });
+
+  it('preserves tier metadata while filtering items', () => {
+    const source = tier({ id: 'paused', name: 'Paused', icon: '⏸', collapsed: true });
+    const result = filterTiers([source], 'pipeline');
+
+    expect(result.tiers[0]).toMatchObject({ id: 'paused', name: 'Paused', icon: '⏸', collapsed: true });
+    expect(result.tiers[0].items.map(item => item.id)).toEqual(['two']);
+  });
+
+  it('matches against item title', () => {
+    const result = filterTiers([tier()], 'layout');
+
+    expect(result.tiers[0].items.map(item => item.title)).toEqual(['Fix sidebar layout']);
+  });
+
+  it('matches against repoAnnotation', () => {
+    const result = filterTiers([tier()], 'owner/tools');
+
+    expect(result.tiers[0].items.map(item => item.id)).toEqual(['two']);
+  });
+
+  it('reports pre-filter total counts', () => {
+    const result = filterTiers([tier({ id: 'ready' }), tier({ id: 'done', items: [] })], 'layout');
+
+    expect(result.totalCounts.get('ready')).toBe(2);
+    expect(result.totalCounts.get('done')).toBe(0);
+  });
+});
+
+describe('filterProviders', () => {
+  it('drops empty groups and empty providers', () => {
+    const result = filterProviders([provider(), provider({ providerId: 'ado', label: 'ADO', groups: [{ name: 'project', items: [{ providerId: 'ado', externalId: '4', title: 'Plan sprint', badges: [], isAccepted: false, isDismissed: false }] }] })], 'watcher');
+
+    expect(result.providers.map(p => p.providerId)).toEqual(['github']);
+    expect(result.providers[0].groups.map(group => group.name)).toEqual(['owner/tools']);
+  });
+
+  it('surfaces every item in a group when the group name matches', () => {
+    const result = filterProviders([provider()], 'devdocket/devdocket');
+
+    expect(result.providers[0].groups[0].items.map(item => item.externalId)).toEqual(['1', '2']);
+  });
+
+  it('does not match provider labels', () => {
+    const result = filterProviders([provider()], 'github');
+
+    expect(result.providers).toEqual([]);
+  });
+
+  it('reports pre-filter total counts for providers and groups', () => {
+    const result = filterProviders([provider()], 'layout');
+
+    expect(result.totalCounts.get('github')).toBe(3);
+    expect(result.totalCounts.get(getGroupTotalCountKey('github', 'devdocket/devdocket'))).toBe(2);
+    expect(result.totalCounts.get(getGroupTotalCountKey('github', 'owner/tools'))).toBe(1);
+  });
+});
+
+describe('splitOnMatches', () => {
+  it('returns the original text when there are zero matches', () => {
+    expect(splitOnMatches('DevDocket', 'missing')).toEqual([{ text: 'DevDocket', isMatch: false }]);
+  });
+
+  it('splits a single match', () => {
+    expect(splitOnMatches('DevDocket', 'dock')).toEqual([
+      { text: 'Dev', isMatch: false },
+      { text: 'Dock', isMatch: true },
+      { text: 'et', isMatch: false },
+    ]);
+  });
+
+  it('splits multiple matches', () => {
+    expect(splitOnMatches('foo bar foo', 'foo')).toEqual([
+      { text: 'foo', isMatch: true },
+      { text: ' bar ', isMatch: false },
+      { text: 'foo', isMatch: true },
+    ]);
+  });
+
+  it('handles matches at the start and end of the string', () => {
+    expect(splitOnMatches('start middle start', 'start')).toEqual([
+      { text: 'start', isMatch: true },
+      { text: ' middle ', isMatch: false },
+      { text: 'start', isMatch: true },
+    ]);
+  });
+
+  it('treats regex-special characters literally', () => {
+    expect(splitOnMatches('Find .*\\(value\\) here', '.*\\(value\\)')).toEqual([
+      { text: 'Find ', isMatch: false },
+      { text: '.*\\(value\\)', isMatch: true },
+      { text: ' here', isMatch: false },
+    ]);
+  });
+
+  it('handles unicode', () => {
+    expect(splitOnMatches('Résumé cleanup résumé', 'résumé')).toEqual([
+      { text: 'Résumé', isMatch: true },
+      { text: ' cleanup ', isMatch: false },
+      { text: 'résumé', isMatch: true },
+    ]);
+  });
+});

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -32,6 +32,7 @@ export type WebviewMessage =
   | { type: 'addWatchUrl' }
   | { type: 'markSeen'; providerId: string; externalId: string }
   | { type: 'crossTierDrop'; itemId: string; targetTier: string }
+  | { type: 'requestToggleSearch' }
   | { type: 'watchPanelReady' };
 
 export interface TierData {

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -2,6 +2,7 @@ export type ExtensionMessage =
   | { type: 'updateItems'; tiers: TierData[] }
   | { type: 'updateSources'; providers: SourceProviderData[] }
   | { type: 'selectItem'; itemId: string }
+  | { type: 'toggleSearch' }
   | { type: 'updateWatches'; watches: WatchData[] }
   | { type: 'updateWatchPanel'; prWatches: PRWatchData[]; runWatches: RunWatchData[] }
   | { type: 'updateEditorItem'; item: EditorItemData }

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -32,7 +32,6 @@ export type WebviewMessage =
   | { type: 'addWatchUrl' }
   | { type: 'markSeen'; providerId: string; externalId: string }
   | { type: 'crossTierDrop'; itemId: string; targetTier: string }
-  | { type: 'requestToggleSearch' }
   | { type: 'watchPanelReady' };
 
 export interface TierData {

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -784,6 +784,13 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       outline: 1px solid var(--vscode-focusBorder);
       outline-offset: -1px;
     }
+    .search-box input::-webkit-search-cancel-button,
+    .search-box input::-webkit-search-decoration,
+    .search-box input::-webkit-search-results-button,
+    .search-box input::-webkit-search-results-decoration {
+      -webkit-appearance: none;
+      appearance: none;
+    }
     .search-box-clear {
       position: absolute;
       right: 4px;

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -958,7 +958,8 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     .source-provider-title-button {
       min-width: 0;
     }
-    .source-provider-toggle-button[aria-disabled="true"] {
+    .source-provider-toggle-button[aria-disabled="true"],
+    .source-group-header[aria-disabled="true"] {
       cursor: default;
     }
     .source-provider-title,

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -91,6 +91,10 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     void this.view?.webview.postMessage({ type: 'selectItem', itemId });
   }
 
+  toggleSearch(): void {
+    void this.view?.webview.postMessage({ type: 'toggleSearch' });
+  }
+
   private refresh(): void {
     if (!this.view) {
       return;
@@ -768,48 +772,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     }
     .my-work-tab,
     .sources-tab {
-      position: relative;
       padding: 0 12px 12px;
-    }
-    .tab-header {
-      position: absolute;
-      top: 4px;
-      right: 12px;
-      z-index: 2;
-      display: flex;
-      justify-content: flex-end;
-      align-items: center;
-      pointer-events: none;
-    }
-    .tab-header > * {
-      pointer-events: auto;
-    }
-    .search-toggle {
-      width: 20px;
-      height: 20px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      border: none;
-      border-radius: 4px;
-      background: transparent;
-      color: var(--vscode-icon-foreground);
-      cursor: pointer;
-      padding: 0;
-      font: inherit;
-      line-height: 1;
-      opacity: 0.75;
-    }
-    .search-toggle:hover {
-      background: var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.25));
-      opacity: 1;
-    }
-    .search-toggle.expanded {
-      background: var(--vscode-toolbar-activeBackground, var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.35)));
-      opacity: 1;
-    }
-    .search-toggle.expanded:hover {
-      background: var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.45));
     }
     .search-box {
       position: sticky;
@@ -925,7 +888,6 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     .tier-header-main:focus-visible,
     .tier-toggle-button:focus-visible,
     .tier-header-action:focus-visible,
-    .search-toggle:focus-visible,
     .source-provider-toggle-button:focus-visible,
     .source-group-header:focus-visible,
     .source-item:focus-visible,

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -775,7 +775,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     }
     .my-work-tab,
     .sources-tab {
-      padding: 0 12px 12px;
+      padding: 12px;
     }
     .search-box {
       position: sticky;

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -752,7 +752,57 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     }
     .my-work-tab,
     .sources-tab {
-      padding: 12px;
+      padding: 0 12px 12px;
+    }
+    .search-box {
+      position: sticky;
+      top: 0;
+      z-index: 1;
+      padding: 8px 0;
+      background: var(--vscode-sideBar-background, var(--vscode-editor-background));
+      border-bottom: 1px solid var(--vscode-sideBarSectionHeader-border, transparent);
+    }
+    .search-box-input-wrap {
+      position: relative;
+      display: flex;
+      align-items: center;
+    }
+    .search-box input {
+      width: 100%;
+      min-width: 0;
+      background: var(--vscode-input-background);
+      color: var(--vscode-input-foreground);
+      border: 1px solid var(--vscode-input-border, transparent);
+      border-radius: 2px;
+      padding: 4px 28px 4px 6px;
+      font: inherit;
+    }
+    .search-box input:focus {
+      outline: 1px solid var(--vscode-focusBorder);
+      outline-offset: -1px;
+    }
+    .search-box-clear {
+      position: absolute;
+      right: 4px;
+      background: transparent;
+      color: var(--vscode-icon-foreground);
+      border: none;
+      cursor: pointer;
+      padding: 2px 6px;
+      font: inherit;
+      line-height: 1;
+    }
+    .search-box-clear:hover {
+      background: var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.25));
+    }
+    .search-box-clear:focus-visible {
+      outline: 1px solid var(--vscode-focusBorder);
+      outline-offset: -1px;
+    }
+    mark {
+      background: var(--vscode-editor-findMatchHighlightBackground);
+      color: inherit;
+      border-radius: 2px;
     }
     .tiers,
     .sources-list {
@@ -793,6 +843,14 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     }
     .tier-header-action:hover {
       text-decoration: underline;
+    }
+    .tier-header-action:disabled {
+      color: var(--vscode-disabledForeground, var(--vscode-descriptionForeground));
+      cursor: default;
+      opacity: 0.65;
+    }
+    .tier-header-action:disabled:hover {
+      text-decoration: none;
     }
     .tier-toggle-button {
       display: inline-flex;
@@ -1107,6 +1165,22 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       color: var(--vscode-descriptionForeground);
       text-align: center;
       font-style: italic;
+    }
+    .empty-state-link {
+      background: transparent;
+      border: none;
+      color: var(--vscode-textLink-foreground, var(--vscode-foreground));
+      cursor: pointer;
+      font: inherit;
+      font-style: inherit;
+      padding: 0;
+    }
+    .empty-state-link:hover {
+      text-decoration: underline;
+    }
+    .empty-state-link:focus-visible {
+      outline: 1px solid var(--vscode-focusBorder);
+      outline-offset: 2px;
     }
     :root {
       ${buildTierColorCss('dark')}

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -770,6 +770,38 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     .sources-tab {
       padding: 0 12px 12px;
     }
+    .tab-header {
+      display: flex;
+      justify-content: flex-end;
+      align-items: center;
+      padding: 8px 0;
+      background: var(--vscode-sideBar-background, var(--vscode-editor-background));
+    }
+    .search-toggle {
+      width: 24px;
+      height: 24px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border: 1px solid transparent;
+      border-radius: 4px;
+      background: transparent;
+      color: var(--vscode-icon-foreground);
+      cursor: pointer;
+      padding: 0;
+      font: inherit;
+      line-height: 1;
+    }
+    .search-toggle:hover {
+      background: var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.25));
+    }
+    .search-toggle.expanded {
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+    }
+    .search-toggle.expanded:hover {
+      background: var(--vscode-button-hoverBackground, var(--vscode-button-background));
+    }
     .search-box {
       position: sticky;
       top: 0;
@@ -884,6 +916,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     .tier-header-main:focus-visible,
     .tier-toggle-button:focus-visible,
     .tier-header-action:focus-visible,
+    .search-toggle:focus-visible,
     .source-provider-toggle-button:focus-visible,
     .source-group-header:focus-visible,
     .source-item:focus-visible,

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -958,6 +958,9 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     .source-provider-title-button {
       min-width: 0;
     }
+    .source-provider-toggle-button[aria-disabled="true"] {
+      cursor: default;
+    }
     .source-provider-title,
     .source-group-title {
       display: inline-flex;

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -885,6 +885,10 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       display: inline-flex;
       align-items: center;
     }
+    .tier-header-main[aria-disabled="true"],
+    .tier-toggle-button[aria-disabled="true"] {
+      cursor: default;
+    }
     .tier-header-main:focus-visible,
     .tier-toggle-button:focus-visible,
     .tier-header-action:focus-visible,

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -484,6 +484,9 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       }
       case 'switchTab':
         break;
+      case 'requestToggleSearch':
+        this.toggleSearch();
+        break;
       case 'markSeen':
         await this.handleMarkSeen(message.providerId, message.externalId);
         break;

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -768,22 +768,29 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     }
     .my-work-tab,
     .sources-tab {
+      position: relative;
       padding: 0 12px 12px;
     }
     .tab-header {
+      position: absolute;
+      top: 4px;
+      right: 12px;
+      z-index: 2;
       display: flex;
       justify-content: flex-end;
       align-items: center;
-      padding: 8px 0;
-      background: var(--vscode-sideBar-background, var(--vscode-editor-background));
+      pointer-events: none;
+    }
+    .tab-header > * {
+      pointer-events: auto;
     }
     .search-toggle {
-      width: 24px;
-      height: 24px;
+      width: 20px;
+      height: 20px;
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      border: 1px solid transparent;
+      border: none;
       border-radius: 4px;
       background: transparent;
       color: var(--vscode-icon-foreground);
@@ -791,16 +798,18 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       padding: 0;
       font: inherit;
       line-height: 1;
+      opacity: 0.75;
     }
     .search-toggle:hover {
       background: var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.25));
+      opacity: 1;
     }
     .search-toggle.expanded {
-      background: var(--vscode-button-background);
-      color: var(--vscode-button-foreground);
+      background: var(--vscode-toolbar-activeBackground, var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.35)));
+      opacity: 1;
     }
     .search-toggle.expanded:hover {
-      background: var(--vscode-button-hoverBackground, var(--vscode-button-background));
+      background: var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.45));
     }
     .search-box {
       position: sticky;

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -847,12 +847,14 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     .tier-header-action:hover {
       text-decoration: underline;
     }
-    .tier-header-action:disabled {
+    .tier-header-action:disabled,
+    .tier-header-action[aria-disabled="true"] {
       color: var(--vscode-disabledForeground, var(--vscode-descriptionForeground));
       cursor: default;
       opacity: 0.65;
     }
-    .tier-header-action:disabled:hover {
+    .tier-header-action:disabled:hover,
+    .tier-header-action[aria-disabled="true"]:hover {
       text-decoration: none;
     }
     .tier-toggle-button {

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -484,9 +484,6 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       }
       case 'switchTab':
         break;
-      case 'requestToggleSearch':
-        this.toggleSearch();
-        break;
       case 'markSeen':
         await this.handleMarkSeen(message.providerId, message.externalId);
         break;

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -183,7 +183,6 @@ export function App() {
         aria-label={label}
         title={label}
         aria-expanded={visible}
-        aria-pressed={visible}
         onClick={() => toggleSearchBox(tab, visible)}
       >
         ⋯

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -140,8 +140,20 @@ export function App() {
 
     window.addEventListener('message', handler);
 
+    const keydownHandler = (event: KeyboardEvent) => {
+      const isFindShortcut = (event.ctrlKey || event.metaKey) && !event.altKey && !event.shiftKey && (event.key === 'f' || event.key === 'F');
+      if (!isFindShortcut) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      postMessage({ type: 'requestToggleSearch' });
+    };
+    window.addEventListener('keydown', keydownHandler);
+
     return () => {
       window.removeEventListener('message', handler);
+      window.removeEventListener('keydown', keydownHandler);
       if (announcementFrameRef.current !== undefined) {
         cancelAnimationFrame(announcementFrameRef.current);
       }

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -1,21 +1,65 @@
-import { useEffect, useRef, useState } from 'preact/hooks';
+import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
 import type { ExtensionMessage, SourceProviderData, TierData } from '../shared/types';
 import { postMessage } from '../shared/messaging';
 import { useThemeChangeCounter } from '../shared/theme';
+import { SearchBox } from './components/SearchBox';
 import { SourcesView } from './components/SourcesView';
 import { TabBar } from './components/TabBar';
 import { TierSection } from './components/TierSection';
+import { filterProviders, filterTiers } from './filter';
+
+type SidebarTab = 'myWork' | 'sources';
+type TabQueries = Record<SidebarTab, string>;
+
+const emptyQueries: TabQueries = { myWork: '', sources: '' };
 
 export function App() {
-  const [activeTab, setActiveTab] = useState<'myWork' | 'sources'>('myWork');
+  const [activeTab, setActiveTab] = useState<SidebarTab>('myWork');
   const [tiers, setTiers] = useState<TierData[]>([]);
   const [sources, setSources] = useState<SourceProviderData[]>([]);
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
+  const [queries, setQueries] = useState<TabQueries>(emptyQueries);
+  const [appliedQueries, setAppliedQueries] = useState<TabQueries>(emptyQueries);
   const [announcement, setAnnouncement] = useState('');
   const previousTiersRef = useRef<TierData[] | undefined>(undefined);
   const announcementFrameRef = useRef<number | undefined>(undefined);
+  const myWorkFilterActiveRef = useRef(false);
+  const lastNoResultsAnnouncementRef = useRef<TabQueries>(emptyQueries);
   // Re-render on VS Code theme changes so badge / tier colors update live.
   useThemeChangeCounter();
+
+  const myWorkQuery = appliedQueries.myWork;
+  const sourcesQuery = appliedQueries.sources;
+  const isMyWorkFilterActive = myWorkQuery.trim() !== '';
+  const isSourcesFilterActive = sourcesQuery.trim() !== '';
+  const filteredTiers = useMemo(() => filterTiers(tiers, myWorkQuery), [tiers, myWorkQuery]);
+  const filteredSources = useMemo(() => filterProviders(sources, sourcesQuery), [sources, sourcesQuery]);
+  const myWorkVisibleCount = getTierItemCount(filteredTiers.tiers);
+  const sourcesVisibleCount = getProviderItemCount(filteredSources.providers);
+
+  useEffect(() => {
+    myWorkFilterActiveRef.current = isMyWorkFilterActive;
+  }, [isMyWorkFilterActive]);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setAppliedQueries(current => {
+        let changed = false;
+        const next: TabQueries = { ...current };
+
+        for (const tab of ['myWork', 'sources'] as const) {
+          if (current[tab] !== queries[tab]) {
+            next[tab] = queries[tab];
+            changed = true;
+          }
+        }
+
+        return changed ? next : current;
+      });
+    }, 150);
+
+    return () => window.clearTimeout(timer);
+  }, [queries]);
 
   const announce = (message?: string) => {
     if (!message) {
@@ -34,13 +78,21 @@ export function App() {
   };
 
   useEffect(() => {
+    announceNoResults('myWork', myWorkQuery, myWorkVisibleCount, announce, lastNoResultsAnnouncementRef);
+  }, [myWorkQuery, myWorkVisibleCount]);
+
+  useEffect(() => {
+    announceNoResults('sources', sourcesQuery, sourcesVisibleCount, announce, lastNoResultsAnnouncementRef);
+  }, [sourcesQuery, sourcesVisibleCount]);
+
+  useEffect(() => {
     const handler = (event: MessageEvent<ExtensionMessage>) => {
       const msg = event.data;
       switch (msg.type) {
         case 'updateItems': {
           const nextTiers = msg.tiers;
           const previousTiers = previousTiersRef.current;
-          if (previousTiers) {
+          if (previousTiers && !myWorkFilterActiveRef.current) {
             announce(buildLiveAnnouncement(previousTiers, nextTiers));
           }
           previousTiersRef.current = nextTiers;
@@ -67,9 +119,19 @@ export function App() {
     };
   }, []);
 
-  const handleTabSwitch = (tab: 'myWork' | 'sources') => {
+  const handleTabSwitch = (tab: SidebarTab) => {
     setActiveTab(tab);
     postMessage({ type: 'switchTab', tab });
+  };
+
+  const handleQueryChange = (tab: SidebarTab, query: string) => {
+    setQueries(current => ({ ...current, [tab]: query }));
+  };
+
+  const clearQuery = (tab: SidebarTab) => {
+    setQueries(current => ({ ...current, [tab]: '' }));
+    setAppliedQueries(current => ({ ...current, [tab]: '' }));
+    setAnnouncement('');
   };
 
   return (
@@ -84,16 +146,30 @@ export function App() {
       <div class="tab-content">
         {activeTab === 'sources' ? (
           <div
+            class="sources-tab"
             role="tabpanel"
             id="mission-control-panel-sources"
             aria-labelledby="mission-control-tab-sources"
           >
-            <SourcesView
-              providers={sources}
-              onOpenItem={(providerId, externalId) =>
-                postMessage({ type: 'openSourceItem', providerId, externalId })
-              }
+            <SearchBox
+              label="Search Sources"
+              query={queries.sources}
+              onChange={(query) => handleQueryChange('sources', query)}
+              onClear={() => clearQuery('sources')}
             />
+            {isSourcesFilterActive && sourcesVisibleCount === 0 ? (
+              <NoMatches query={sourcesQuery} onClear={() => clearQuery('sources')} />
+            ) : (
+              <SourcesView
+                providers={filteredSources.providers}
+                forceExpanded={isSourcesFilterActive}
+                totalCounts={isSourcesFilterActive ? filteredSources.totalCounts : undefined}
+                query={isSourcesFilterActive ? sourcesQuery : undefined}
+                onOpenItem={(providerId, externalId) =>
+                  postMessage({ type: 'openSourceItem', providerId, externalId })
+                }
+              />
+            )}
           </div>
         ) : (
           <div
@@ -102,11 +178,19 @@ export function App() {
             id="mission-control-panel-my-work"
             aria-labelledby="mission-control-tab-my-work"
           >
-            {tiers.length === 0 ? (
+            <SearchBox
+              label="Search My Work"
+              query={queries.myWork}
+              onChange={(query) => handleQueryChange('myWork', query)}
+              onClear={() => clearQuery('myWork')}
+            />
+            {isMyWorkFilterActive && myWorkVisibleCount === 0 ? (
+              <NoMatches query={myWorkQuery} onClear={() => clearQuery('myWork')} />
+            ) : filteredTiers.tiers.length === 0 ? (
               <div class="empty-state">No items yet</div>
             ) : (
               <div class="tiers">
-                {tiers.map(tier => (
+                {filteredTiers.tiers.map(tier => (
                   <TierSection
                     key={tier.id}
                     tier={{
@@ -116,6 +200,11 @@ export function App() {
                         isSelected: item.id === selectedItemId,
                       })),
                     }}
+                    forceExpanded={isMyWorkFilterActive}
+                    totalCount={isMyWorkFilterActive ? filteredTiers.totalCounts.get(tier.id) : undefined}
+                    query={isMyWorkFilterActive ? myWorkQuery : undefined}
+                    disableDragReorder={isMyWorkFilterActive}
+                    isFilterActive={isMyWorkFilterActive}
                     onItemClick={(id) => {
                       // For incoming items, also mark them seen so the unread
                       // indicator clears once the user opens the editor.
@@ -160,6 +249,46 @@ interface ItemLocation {
   title: string;
   tierId: string;
   tierName: string;
+}
+
+function NoMatches({ query, onClear }: { query: string; onClear: () => void }) {
+  return (
+    <div class="empty-state">
+      No matches for {query}.{' '}
+      <button type="button" class="empty-state-link" onClick={onClear}>Clear filter.</button>
+    </div>
+  );
+}
+
+function announceNoResults(
+  tab: SidebarTab,
+  query: string,
+  visibleCount: number,
+  announce: (message?: string) => void,
+  lastNoResultsAnnouncementRef: { current: TabQueries },
+): void {
+  if (query.trim() && visibleCount === 0) {
+    if (lastNoResultsAnnouncementRef.current[tab] !== query) {
+      announce(`No results for ${query}`);
+      lastNoResultsAnnouncementRef.current = { ...lastNoResultsAnnouncementRef.current, [tab]: query };
+    }
+    return;
+  }
+
+  if (lastNoResultsAnnouncementRef.current[tab]) {
+    lastNoResultsAnnouncementRef.current = { ...lastNoResultsAnnouncementRef.current, [tab]: '' };
+  }
+}
+
+function getTierItemCount(tiers: TierData[]): number {
+  return tiers.reduce((total, tier) => total + tier.items.length, 0);
+}
+
+function getProviderItemCount(providers: SourceProviderData[]): number {
+  return providers.reduce(
+    (providerTotal, provider) => providerTotal + provider.groups.reduce((groupTotal, group) => groupTotal + group.items.length, 0),
+    0,
+  );
 }
 
 function buildLiveAnnouncement(previousTiers: TierData[], nextTiers: TierData[]): string | undefined {

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -174,7 +174,8 @@ export function App() {
   };
 
   const renderSearchToggle = (tab: SidebarTab, visible: boolean) => {
-    const label = visible ? 'Hide search' : 'Show search';
+    const hasQuery = queries[tab] !== '' || appliedQueries[tab] !== '';
+    const label = visible ? (hasQuery ? 'Hide search and clear filter' : 'Hide search') : 'Show search';
 
     return (
       <button

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -216,6 +216,7 @@ export function App() {
                 query={queries.sources}
                 onChange={(query) => handleQueryChange('sources', query)}
                 onClear={() => clearQuery('sources')}
+                onClose={() => clearAndHideSearchBox('sources')}
                 autoFocus
               />
             ) : null}
@@ -249,6 +250,7 @@ export function App() {
                 query={queries.myWork}
                 onChange={(query) => handleQueryChange('myWork', query)}
                 onClear={() => clearQuery('myWork')}
+                onClose={() => clearAndHideSearchBox('myWork')}
                 autoFocus
               />
             ) : null}

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -139,8 +139,21 @@ export function App() {
     };
 
     window.addEventListener('message', handler);
+
+    const keydownHandler = (event: KeyboardEvent) => {
+      const isFindShortcut = (event.ctrlKey || event.metaKey) && !event.altKey && !event.shiftKey && (event.key === 'f' || event.key === 'F');
+      if (!isFindShortcut) {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      postMessage({ type: 'requestToggleSearch' });
+    };
+    window.addEventListener('keydown', keydownHandler);
+
     return () => {
       window.removeEventListener('message', handler);
+      window.removeEventListener('keydown', keydownHandler);
       if (announcementFrameRef.current !== undefined) {
         cancelAnimationFrame(announcementFrameRef.current);
       }

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -263,9 +263,11 @@ interface ItemLocation {
 }
 
 function NoMatches({ query, onClear }: { query: string; onClear: () => void }) {
+  const displayQuery = query.trim();
+
   return (
     <div class="empty-state">
-      No matches for {query}.{' '}
+      No matches for {displayQuery}.{' '}
       <button type="button" class="empty-state-link" onClick={onClear}>Clear filter.</button>
     </div>
   );
@@ -278,10 +280,12 @@ function announceNoResults(
   announce: (message?: string) => void,
   lastNoResultsAnnouncementRef: { current: TabQueries },
 ): void {
-  if (query.trim() && visibleCount === 0) {
-    if (lastNoResultsAnnouncementRef.current[tab] !== query) {
-      announce(`No results for ${query}`);
-      lastNoResultsAnnouncementRef.current = { ...lastNoResultsAnnouncementRef.current, [tab]: query };
+  const displayQuery = query.trim();
+
+  if (displayQuery && visibleCount === 0) {
+    if (lastNoResultsAnnouncementRef.current[tab] !== displayQuery) {
+      announce(`No results for ${displayQuery}`);
+      lastNoResultsAnnouncementRef.current = { ...lastNoResultsAnnouncementRef.current, [tab]: displayQuery };
     }
     return;
   }

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -216,12 +216,12 @@ export function App() {
                 label="Search Sources"
                 query={queries.sources}
                 onChange={(query) => handleQueryChange('sources', query)}
-                onClear={() => clearAndHideSearchBox('sources')}
+                onClear={() => clearQuery('sources')}
                 autoFocus
               />
             ) : null}
             {isSourcesFilterActive && sourcesVisibleCount === 0 ? (
-              <NoMatches query={sourcesQuery} onClear={() => clearAndHideSearchBox('sources')} />
+              <NoMatches query={sourcesQuery} onClear={() => clearQuery('sources')} />
             ) : (
               <SourcesView
                 providers={visibleSources}
@@ -252,12 +252,12 @@ export function App() {
                 label="Search My Work"
                 query={queries.myWork}
                 onChange={(query) => handleQueryChange('myWork', query)}
-                onClear={() => clearAndHideSearchBox('myWork')}
+                onClear={() => clearQuery('myWork')}
                 autoFocus
               />
             ) : null}
             {isMyWorkFilterActive && myWorkVisibleCount === 0 ? (
-              <NoMatches query={myWorkQuery} onClear={() => clearAndHideSearchBox('myWork')} />
+              <NoMatches query={myWorkQuery} onClear={() => clearQuery('myWork')} />
             ) : !isMyWorkFilterActive && !hasReceivedItems ? (
               <div class="empty-state">No items yet</div>
             ) : !isMyWorkFilterActive && tiers.every(tier => tier.items.length === 0) ? (

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -35,10 +35,18 @@ export function App() {
   const isMyWorkFilterActive = myWorkQuery.trim() !== '';
   const isSourcesFilterActive = sourcesQuery.trim() !== '';
   myWorkFilterActiveRef.current = isMyWorkFilterActive;
-  const filteredTiers = useMemo(() => filterTiers(tiers, myWorkQuery), [tiers, myWorkQuery]);
-  const filteredSources = useMemo(() => filterProviders(sources, sourcesQuery), [sources, sourcesQuery]);
-  const myWorkVisibleCount = getTierItemCount(filteredTiers.tiers);
-  const sourcesVisibleCount = getProviderItemCount(filteredSources.providers);
+  const filteredTiers = useMemo(
+    () => (isMyWorkFilterActive ? filterTiers(tiers, myWorkQuery) : undefined),
+    [isMyWorkFilterActive, tiers, myWorkQuery],
+  );
+  const filteredSources = useMemo(
+    () => (isSourcesFilterActive ? filterProviders(sources, sourcesQuery) : undefined),
+    [isSourcesFilterActive, sources, sourcesQuery],
+  );
+  const visibleTiers = filteredTiers?.tiers ?? tiers;
+  const visibleSources = filteredSources?.providers ?? sources;
+  const myWorkVisibleCount = getTierItemCount(visibleTiers);
+  const sourcesVisibleCount = getProviderItemCount(visibleSources);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -169,9 +177,9 @@ export function App() {
               <NoMatches query={sourcesQuery} onClear={() => clearQuery('sources')} />
             ) : (
               <SourcesView
-                providers={filteredSources.providers}
+                providers={visibleSources}
                 forceExpanded={isSourcesFilterActive}
-                totalCounts={isSourcesFilterActive ? filteredSources.totalCounts : undefined}
+                totalCounts={filteredSources?.totalCounts}
                 query={isSourcesFilterActive ? sourcesQuery : undefined}
                 onOpenItem={(providerId, externalId) =>
                   postMessage({ type: 'openSourceItem', providerId, externalId })
@@ -200,7 +208,7 @@ export function App() {
               <EmptyMyWork />
             ) : (
               <div class="tiers">
-                {filteredTiers.tiers.map(tier => (
+                {visibleTiers.map(tier => (
                   <TierSection
                     key={tier.id}
                     tier={{
@@ -211,7 +219,7 @@ export function App() {
                       })),
                     }}
                     forceExpanded={isMyWorkFilterActive}
-                    totalCount={isMyWorkFilterActive ? filteredTiers.totalCounts.get(tier.id) : undefined}
+                    totalCount={filteredTiers?.totalCounts.get(tier.id)}
                     query={isMyWorkFilterActive ? myWorkQuery : undefined}
                     disableDragReorder={isMyWorkFilterActive}
                     isFilterActive={isMyWorkFilterActive}

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -131,6 +131,10 @@ export function App() {
   const clearQuery = (tab: SidebarTab) => {
     setQueries(current => ({ ...current, [tab]: '' }));
     setAppliedQueries(current => ({ ...current, [tab]: '' }));
+    if (announcementFrameRef.current !== undefined) {
+      cancelAnimationFrame(announcementFrameRef.current);
+      announcementFrameRef.current = undefined;
+    }
     setAnnouncement('');
   };
 

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -77,12 +77,16 @@ export function App() {
   };
 
   useEffect(() => {
-    announceNoResults('myWork', myWorkQuery, myWorkVisibleCount, announce, lastNoResultsAnnouncementRef);
-  }, [myWorkQuery, myWorkVisibleCount]);
+    if (activeTab === 'myWork') {
+      announceNoResults('myWork', myWorkQuery, myWorkVisibleCount, announce, lastNoResultsAnnouncementRef);
+    }
+  }, [activeTab, myWorkQuery, myWorkVisibleCount]);
 
   useEffect(() => {
-    announceNoResults('sources', sourcesQuery, sourcesVisibleCount, announce, lastNoResultsAnnouncementRef);
-  }, [sourcesQuery, sourcesVisibleCount]);
+    if (activeTab === 'sources') {
+      announceNoResults('sources', sourcesQuery, sourcesVisibleCount, announce, lastNoResultsAnnouncementRef);
+    }
+  }, [activeTab, sourcesQuery, sourcesVisibleCount]);
 
   useEffect(() => {
     const handler = (event: MessageEvent<ExtensionMessage>) => {

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -124,6 +124,17 @@ export function App() {
           break;
         case 'updateWatches':
           break;
+        case 'toggleSearch': {
+          const tab = activeTabRef.current;
+          const currentlyVisible = isSearchBoxEffectivelyVisible(
+            tab,
+            searchBoxVisibleRef.current,
+            queriesRef.current,
+            appliedQueriesRef.current,
+          );
+          toggleSearchBox(tab, currentlyVisible);
+          break;
+        }
       }
     };
 
@@ -173,23 +184,14 @@ export function App() {
     showSearchBox(tab);
   };
 
-  const renderSearchToggle = (tab: SidebarTab, visible: boolean) => {
-    const hasQuery = queries[tab].trim() !== '' || appliedQueries[tab].trim() !== '';
-    const label = visible ? (hasQuery ? 'Hide search and clear filter' : 'Hide search') : 'Show search';
-
-    return (
-      <button
-        type="button"
-        class={`search-toggle ${visible ? 'expanded' : ''}`.trim()}
-        aria-label={label}
-        title={label}
-        aria-expanded={visible}
-        onClick={() => toggleSearchBox(tab, visible)}
-      >
-        ⋯
-      </button>
-    );
-  };
+  const activeTabRef = useRef(activeTab);
+  activeTabRef.current = activeTab;
+  const searchBoxVisibleRef = useRef(searchBoxVisible);
+  searchBoxVisibleRef.current = searchBoxVisible;
+  const queriesRef = useRef(queries);
+  queriesRef.current = queries;
+  const appliedQueriesRef = useRef(appliedQueries);
+  appliedQueriesRef.current = appliedQueries;
 
   return (
     <div class="mission-control">
@@ -208,9 +210,6 @@ export function App() {
             id="mission-control-panel-sources"
             aria-labelledby="mission-control-tab-sources"
           >
-            <div class="tab-header">
-              {renderSearchToggle('sources', sourcesSearchBoxVisible)}
-            </div>
             {sourcesSearchBoxVisible ? (
               <SearchBox
                 label="Search Sources"
@@ -244,9 +243,6 @@ export function App() {
             id="mission-control-panel-my-work"
             aria-labelledby="mission-control-tab-my-work"
           >
-            <div class="tab-header">
-              {renderSearchToggle('myWork', myWorkSearchBoxVisible)}
-            </div>
             {myWorkSearchBoxVisible ? (
               <SearchBox
                 label="Search My Work"

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -140,6 +140,13 @@ export function App() {
 
     window.addEventListener('message', handler);
 
+    // Required: VS Code's keybinding service does NOT see keystrokes that
+    // happen inside a sidebar webview view's iframe (registerWebviewViewProvider).
+    // The package.json `devdocket.toggleSearch` keybinding only fires when focus
+    // is on non-webview chrome, which is the rare case. To make Ctrl+F (Cmd+F)
+    // actually work when the user is interacting with the sidebar, we must
+    // intercept the keystroke here and forward it to the host as a message.
+    // Both paths coexist by design — they cover disjoint focus contexts.
     const keydownHandler = (event: KeyboardEvent) => {
       const isFindShortcut = (event.ctrlKey || event.metaKey) && !event.altKey && !event.shiftKey && (event.key === 'f' || event.key === 'F');
       if (!isFindShortcut) {

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -8,11 +8,13 @@ import { SourcesView } from './components/SourcesView';
 import { TabBar } from './components/TabBar';
 import { TierSection } from './components/TierSection';
 import { filterProviders, filterTiers } from './filter';
-
-type SidebarTab = 'myWork' | 'sources';
-type TabQueries = Record<SidebarTab, string>;
-
-const emptyQueries: TabQueries = { myWork: '', sources: '' };
+import {
+  emptyQueries,
+  hiddenSearchBoxes,
+  isSearchBoxEffectivelyVisible,
+  type SidebarTab,
+  type TabQueries,
+} from './searchVisibility';
 
 export function App() {
   const [activeTab, setActiveTab] = useState<SidebarTab>('myWork');
@@ -22,6 +24,7 @@ export function App() {
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const [queries, setQueries] = useState<TabQueries>(emptyQueries);
   const [appliedQueries, setAppliedQueries] = useState<TabQueries>(emptyQueries);
+  const [searchBoxVisible, setSearchBoxVisible] = useState(hiddenSearchBoxes);
   const [announcement, setAnnouncement] = useState('');
   const previousTiersRef = useRef<TierData[] | undefined>(undefined);
   const announcementFrameRef = useRef<number | undefined>(undefined);
@@ -47,6 +50,8 @@ export function App() {
   const visibleSources = filteredSources?.providers ?? sources;
   const myWorkVisibleCount = getTierItemCount(visibleTiers);
   const sourcesVisibleCount = getProviderItemCount(visibleSources);
+  const myWorkSearchBoxVisible = isSearchBoxEffectivelyVisible('myWork', searchBoxVisible, queries, appliedQueries);
+  const sourcesSearchBoxVisible = isSearchBoxEffectivelyVisible('sources', searchBoxVisible, queries, appliedQueries);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -150,6 +155,42 @@ export function App() {
     setAnnouncement('');
   };
 
+  const showSearchBox = (tab: SidebarTab) => {
+    setSearchBoxVisible(current => ({ ...current, [tab]: true }));
+  };
+
+  const clearAndHideSearchBox = (tab: SidebarTab) => {
+    clearQuery(tab);
+    setSearchBoxVisible(current => ({ ...current, [tab]: false }));
+  };
+
+  const toggleSearchBox = (tab: SidebarTab, visible: boolean) => {
+    if (visible) {
+      clearAndHideSearchBox(tab);
+      return;
+    }
+
+    showSearchBox(tab);
+  };
+
+  const renderSearchToggle = (tab: SidebarTab, visible: boolean) => {
+    const label = visible ? 'Hide search' : 'Show search';
+
+    return (
+      <button
+        type="button"
+        class={`search-toggle ${visible ? 'expanded' : ''}`.trim()}
+        aria-label={label}
+        title={label}
+        aria-expanded={visible}
+        aria-pressed={visible}
+        onClick={() => toggleSearchBox(tab, visible)}
+      >
+        ⋯
+      </button>
+    );
+  };
+
   return (
     <div class="mission-control">
       <TabBar
@@ -167,14 +208,20 @@ export function App() {
             id="mission-control-panel-sources"
             aria-labelledby="mission-control-tab-sources"
           >
-            <SearchBox
-              label="Search Sources"
-              query={queries.sources}
-              onChange={(query) => handleQueryChange('sources', query)}
-              onClear={() => clearQuery('sources')}
-            />
+            <div class="tab-header">
+              {renderSearchToggle('sources', sourcesSearchBoxVisible)}
+            </div>
+            {sourcesSearchBoxVisible ? (
+              <SearchBox
+                label="Search Sources"
+                query={queries.sources}
+                onChange={(query) => handleQueryChange('sources', query)}
+                onClear={() => clearAndHideSearchBox('sources')}
+                autoFocus
+              />
+            ) : null}
             {isSourcesFilterActive && sourcesVisibleCount === 0 ? (
-              <NoMatches query={sourcesQuery} onClear={() => clearQuery('sources')} />
+              <NoMatches query={sourcesQuery} onClear={() => clearAndHideSearchBox('sources')} />
             ) : (
               <SourcesView
                 providers={visibleSources}
@@ -197,14 +244,20 @@ export function App() {
             id="mission-control-panel-my-work"
             aria-labelledby="mission-control-tab-my-work"
           >
-            <SearchBox
-              label="Search My Work"
-              query={queries.myWork}
-              onChange={(query) => handleQueryChange('myWork', query)}
-              onClear={() => clearQuery('myWork')}
-            />
+            <div class="tab-header">
+              {renderSearchToggle('myWork', myWorkSearchBoxVisible)}
+            </div>
+            {myWorkSearchBoxVisible ? (
+              <SearchBox
+                label="Search My Work"
+                query={queries.myWork}
+                onChange={(query) => handleQueryChange('myWork', query)}
+                onClear={() => clearAndHideSearchBox('myWork')}
+                autoFocus
+              />
+            ) : null}
             {isMyWorkFilterActive && myWorkVisibleCount === 0 ? (
-              <NoMatches query={myWorkQuery} onClear={() => clearQuery('myWork')} />
+              <NoMatches query={myWorkQuery} onClear={() => clearAndHideSearchBox('myWork')} />
             ) : !isMyWorkFilterActive && !hasReceivedItems ? (
               <div class="empty-state">No items yet</div>
             ) : !isMyWorkFilterActive && tiers.every(tier => tier.items.length === 0) ? (

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -34,14 +34,11 @@ export function App() {
   const sourcesQuery = appliedQueries.sources;
   const isMyWorkFilterActive = myWorkQuery.trim() !== '';
   const isSourcesFilterActive = sourcesQuery.trim() !== '';
+  myWorkFilterActiveRef.current = isMyWorkFilterActive;
   const filteredTiers = useMemo(() => filterTiers(tiers, myWorkQuery), [tiers, myWorkQuery]);
   const filteredSources = useMemo(() => filterProviders(sources, sourcesQuery), [sources, sourcesQuery]);
   const myWorkVisibleCount = getTierItemCount(filteredTiers.tiers);
   const sourcesVisibleCount = getProviderItemCount(filteredSources.providers);
-
-  useEffect(() => {
-    myWorkFilterActiveRef.current = isMyWorkFilterActive;
-  }, [isMyWorkFilterActive]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -140,20 +140,8 @@ export function App() {
 
     window.addEventListener('message', handler);
 
-    const keydownHandler = (event: KeyboardEvent) => {
-      const isFindShortcut = (event.ctrlKey || event.metaKey) && !event.altKey && !event.shiftKey && (event.key === 'f' || event.key === 'F');
-      if (!isFindShortcut) {
-        return;
-      }
-      event.preventDefault();
-      event.stopPropagation();
-      postMessage({ type: 'requestToggleSearch' });
-    };
-    window.addEventListener('keydown', keydownHandler);
-
     return () => {
       window.removeEventListener('message', handler);
-      window.removeEventListener('keydown', keydownHandler);
       if (announcementFrameRef.current !== undefined) {
         cancelAnimationFrame(announcementFrameRef.current);
       }

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -174,7 +174,7 @@ export function App() {
   };
 
   const renderSearchToggle = (tab: SidebarTab, visible: boolean) => {
-    const hasQuery = queries[tab] !== '' || appliedQueries[tab] !== '';
+    const hasQuery = queries[tab].trim() !== '' || appliedQueries[tab].trim() !== '';
     const label = visible ? (hasQuery ? 'Hide search and clear filter' : 'Hide search') : 'Show search';
 
     return (

--- a/packages/core/src/webview/sidebar/components/HighlightedText.tsx
+++ b/packages/core/src/webview/sidebar/components/HighlightedText.tsx
@@ -7,11 +7,11 @@ interface HighlightedTextProps {
 }
 
 export function HighlightedText({ text, query = '' }: HighlightedTextProps) {
-  const segments = splitOnMatches(text, query);
-
   if (!query.trim()) {
     return <>{text}</>;
   }
+
+  const segments = splitOnMatches(text, query);
 
   return (
     <>

--- a/packages/core/src/webview/sidebar/components/HighlightedText.tsx
+++ b/packages/core/src/webview/sidebar/components/HighlightedText.tsx
@@ -1,0 +1,25 @@
+import { Fragment } from 'preact';
+import { splitOnMatches } from '../filter';
+
+interface HighlightedTextProps {
+  text: string;
+  query?: string;
+}
+
+export function HighlightedText({ text, query = '' }: HighlightedTextProps) {
+  const segments = splitOnMatches(text, query);
+
+  if (!query.trim()) {
+    return <>{text}</>;
+  }
+
+  return (
+    <>
+      {segments.map((segment, index) => segment.isMatch ? (
+        <mark key={index}>{segment.text}</mark>
+      ) : (
+        <Fragment key={index}>{segment.text}</Fragment>
+      ))}
+    </>
+  );
+}

--- a/packages/core/src/webview/sidebar/components/ItemCard.tsx
+++ b/packages/core/src/webview/sidebar/components/ItemCard.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from 'preact/hooks';
 import type { ItemCardData } from '../../shared/types';
 import { BadgePill } from './BadgePill';
+import { HighlightedText } from './HighlightedText';
 
 interface ItemCardProps {
   item: ItemCardData;
@@ -22,6 +23,8 @@ interface ItemCardProps {
    * (Ready to Start / In Progress).
    */
   onMoveItem?: (itemId: string, direction: -1 | 1) => void;
+  disableDragReorder?: boolean;
+  query?: string;
 }
 
 interface ItemAction {
@@ -46,9 +49,11 @@ export function ItemCard({
   onDragStart,
   onDragEnd,
   onMoveItem,
+  disableDragReorder = false,
+  query,
 }: ItemCardProps) {
   const actions = getItemActions(item, onAccept, onAcceptToFocus, onDismiss, onTransition);
-  const isDraggable = item.tierType === 'readyToStart' || item.tierType === 'inProgress';
+  const isDraggable = !disableDragReorder && (item.tierType === 'readyToStart' || item.tierType === 'inProgress');
   const [actionsOpen, setActionsOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
   const itemElementRef = useRef<HTMLDivElement | null>(null);
@@ -162,7 +167,7 @@ export function ItemCard({
       class={`item-card item-card--${getTierClassName(item.tierType)} ${item.isUrgent ? 'urgent' : ''} ${item.isSelected ? 'selected' : ''} ${actionsOpen ? 'actions-open' : ''} ${isDragging ? 'dragging' : ''}`.trim()}
       role="option"
       tabIndex={tabIndex}
-      draggable={isDraggable ? true : undefined}
+      draggable={isDraggable}
       aria-label={buildItemAriaLabel(item)}
       aria-selected={item.isSelected ?? false}
       aria-current={item.isSelected ? 'true' : undefined}
@@ -177,11 +182,11 @@ export function ItemCard({
         <div class="item-line-1">
           <div class="item-title-wrap">
             {item.isUnseen ? <span class="unseen-dot" aria-hidden="true">●</span> : null}
-            <span class="item-title">{item.title}</span>
+            <span class="item-title"><HighlightedText text={item.title} query={query} /></span>
           </div>
         </div>
         {item.repoAnnotation ? (
-          <div class="item-repo-annotation">{item.repoAnnotation}</div>
+          <div class="item-repo-annotation"><HighlightedText text={item.repoAnnotation} query={query} /></div>
         ) : null}
         {item.badges.length > 0 ? (
           <div class="badge-row">

--- a/packages/core/src/webview/sidebar/components/SearchBox.tsx
+++ b/packages/core/src/webview/sidebar/components/SearchBox.tsx
@@ -34,7 +34,11 @@ export function SearchBox({ label, query, onChange, onClear, autoFocus = false }
             }
 
             event.preventDefault();
-            onClear();
+            if (query.trim().length > 0) {
+              onClear();
+            } else {
+              (event.currentTarget as HTMLInputElement).blur();
+            }
           }}
         />
         {query.length > 0 ? (

--- a/packages/core/src/webview/sidebar/components/SearchBox.tsx
+++ b/packages/core/src/webview/sidebar/components/SearchBox.tsx
@@ -1,0 +1,47 @@
+interface SearchBoxProps {
+  label: string;
+  query: string;
+  onChange: (query: string) => void;
+  onClear: () => void;
+}
+
+export function SearchBox({ label, query, onChange, onClear }: SearchBoxProps) {
+  const clearLabel = `Clear ${label}`;
+
+  return (
+    <div class="search-box">
+      <div class="search-box-input-wrap">
+        <input
+          type="search"
+          value={query}
+          aria-label={label}
+          placeholder="Search"
+          onInput={(event) => onChange((event.currentTarget as HTMLInputElement).value)}
+          onKeyDown={(event) => {
+            if (event.key !== 'Escape') {
+              return;
+            }
+
+            event.preventDefault();
+            if (query.length > 0) {
+              onClear();
+            } else {
+              (event.currentTarget as HTMLInputElement).blur();
+            }
+          }}
+        />
+        {query.length > 0 ? (
+          <button
+            type="button"
+            class="search-box-clear"
+            aria-label={clearLabel}
+            title={clearLabel}
+            onClick={onClear}
+          >
+            ×
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/core/src/webview/sidebar/components/SearchBox.tsx
+++ b/packages/core/src/webview/sidebar/components/SearchBox.tsx
@@ -1,17 +1,28 @@
+import { useEffect, useRef } from 'preact/hooks';
+
 interface SearchBoxProps {
   label: string;
   query: string;
   onChange: (query: string) => void;
   onClear: () => void;
+  autoFocus?: boolean;
 }
 
-export function SearchBox({ label, query, onChange, onClear }: SearchBoxProps) {
+export function SearchBox({ label, query, onChange, onClear, autoFocus = false }: SearchBoxProps) {
   const clearLabel = `Clear ${label}`;
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (autoFocus) {
+      inputRef.current?.focus();
+    }
+  }, [autoFocus]);
 
   return (
     <div class="search-box">
       <div class="search-box-input-wrap">
         <input
+          ref={inputRef}
           type="search"
           value={query}
           aria-label={label}
@@ -23,11 +34,7 @@ export function SearchBox({ label, query, onChange, onClear }: SearchBoxProps) {
             }
 
             event.preventDefault();
-            if (query.length > 0) {
-              onClear();
-            } else {
-              (event.currentTarget as HTMLInputElement).blur();
-            }
+            onClear();
           }}
         />
         {query.length > 0 ? (

--- a/packages/core/src/webview/sidebar/components/SearchBox.tsx
+++ b/packages/core/src/webview/sidebar/components/SearchBox.tsx
@@ -5,10 +5,11 @@ interface SearchBoxProps {
   query: string;
   onChange: (query: string) => void;
   onClear: () => void;
+  onClose?: () => void;
   autoFocus?: boolean;
 }
 
-export function SearchBox({ label, query, onChange, onClear, autoFocus = false }: SearchBoxProps) {
+export function SearchBox({ label, query, onChange, onClear, onClose, autoFocus = false }: SearchBoxProps) {
   const clearLabel = `Clear ${label}`;
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -34,6 +35,10 @@ export function SearchBox({ label, query, onChange, onClear, autoFocus = false }
             }
 
             event.preventDefault();
+            if (onClose) {
+              onClose();
+              return;
+            }
             if (query.trim().length > 0) {
               onClear();
             } else {

--- a/packages/core/src/webview/sidebar/components/SourceItem.tsx
+++ b/packages/core/src/webview/sidebar/components/SourceItem.tsx
@@ -1,12 +1,14 @@
 import type { SourceItemData } from '../../shared/types';
 import { BadgePill } from './BadgePill';
+import { HighlightedText } from './HighlightedText';
 
 interface SourceItemProps {
   item: SourceItemData;
   onOpen: () => void;
+  query?: string;
 }
 
-export function SourceItem({ item, onOpen }: SourceItemProps) {
+export function SourceItem({ item, onOpen, query }: SourceItemProps) {
   // Click always opens the item: the editor for accepted items, the
   // read-only preview panel for unaccepted/dismissed items. Accept and
   // dismiss decisions happen inside the panel rather than on this row.
@@ -22,7 +24,7 @@ export function SourceItem({ item, onOpen }: SourceItemProps) {
     >
       <div class="source-item-line">
         <div class="source-item-title-wrap">
-          <span class="source-item-title">{item.title}</span>
+          <span class="source-item-title"><HighlightedText text={item.title} query={query} /></span>
         </div>
         {statusLabel ? <span class={`source-item-status ${statusClass}`.trim()}>{statusLabel}</span> : null}
       </div>

--- a/packages/core/src/webview/sidebar/components/SourcesView.tsx
+++ b/packages/core/src/webview/sidebar/components/SourcesView.tsx
@@ -56,6 +56,11 @@ function ProviderSection({ provider, onOpenItem, forceExpanded, totalCount, tota
   const itemCount = provider.groups.reduce((total, group) => total + group.items.length, 0);
   const isCollapsed = forceExpanded ? false : collapsed;
   const countLabel = totalCount === undefined ? `(${itemCount})` : `(${itemCount} of ${totalCount})`;
+  const toggleCollapsed = () => {
+    if (!forceExpanded) {
+      setCollapsed(value => !value);
+    }
+  };
 
   return (
     <section
@@ -66,7 +71,7 @@ function ProviderSection({ provider, onOpenItem, forceExpanded, totalCount, tota
       <button
         type="button"
         class="source-provider-header"
-        onClick={() => setCollapsed(value => !value)}
+        onClick={toggleCollapsed}
         aria-expanded={!isCollapsed}
       >
         <span class="source-provider-title">

--- a/packages/core/src/webview/sidebar/components/SourcesView.tsx
+++ b/packages/core/src/webview/sidebar/components/SourcesView.tsx
@@ -157,7 +157,7 @@ function GroupSection({ providerId, group, onOpenItem, forceExpanded, totalCount
         class="source-group-header"
         onClick={toggleCollapsed}
         aria-expanded={!isCollapsed}
-        disabled={forceExpanded}
+        aria-disabled={forceExpanded}
         title={collapseTitle}
       >
         <span class="source-group-title"><HighlightedText text={group.name} query={query} /></span>

--- a/packages/core/src/webview/sidebar/components/SourcesView.tsx
+++ b/packages/core/src/webview/sidebar/components/SourcesView.tsx
@@ -57,6 +57,7 @@ function ProviderSection({ provider, onOpenItem, onShowProviderHealth, forceExpa
   const itemCount = provider.groups.reduce((total, group) => total + group.items.length, 0);
   const isCollapsed = forceExpanded ? false : collapsed;
   const countLabel = totalCount === undefined ? `(${itemCount})` : `(${itemCount} of ${totalCount})`;
+  const collapseTitle = forceExpanded ? 'Clear filter to collapse' : undefined;
   const toggleCollapsed = () => {
     if (!forceExpanded) {
       setCollapsed(value => !value);
@@ -76,6 +77,8 @@ function ProviderSection({ provider, onOpenItem, onShowProviderHealth, forceExpa
             class="source-provider-toggle-button source-provider-title-button"
             onClick={toggleCollapsed}
             aria-expanded={!isCollapsed}
+            disabled={forceExpanded}
+            title={collapseTitle}
           >
             <span>{provider.label}</span>
           </button>
@@ -96,6 +99,8 @@ function ProviderSection({ provider, onOpenItem, onShowProviderHealth, forceExpa
           onClick={toggleCollapsed}
           aria-expanded={!isCollapsed}
           aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${provider.label} source items`}
+          disabled={forceExpanded}
+          title={collapseTitle}
         >
           <span>{countLabel}</span>
           <span class="source-provider-toggle" aria-hidden="true">{isCollapsed ? '▸' : '▾'}</span>

--- a/packages/core/src/webview/sidebar/components/SourcesView.tsx
+++ b/packages/core/src/webview/sidebar/components/SourcesView.tsx
@@ -16,12 +16,10 @@ interface SourcesViewProps {
 export function SourcesView({ providers, onOpenItem, forceExpanded = false, totalCounts, query }: SourcesViewProps) {
   if (providers.length === 0) {
     return (
-      <div class="sources-tab">
-        <OnboardingEmptyState
-          titleId="sources-empty-state-title"
-          description="Create a work item manually, or install a provider extension to populate Sources with GitHub issues, Azure DevOps tasks, PR reviews, and more."
-        />
-      </div>
+      <OnboardingEmptyState
+        titleId="sources-empty-state-title"
+        description="Create a work item manually, or install a provider extension to populate Sources with GitHub issues, Azure DevOps tasks, PR reviews, and more."
+      />
     );
   }
 

--- a/packages/core/src/webview/sidebar/components/SourcesView.tsx
+++ b/packages/core/src/webview/sidebar/components/SourcesView.tsx
@@ -1,28 +1,35 @@
 import { useState } from 'preact/hooks';
 import type { SourceGroupData, SourceProviderData } from '../../shared/types';
+import { getGroupTotalCountKey } from '../filter';
+import { HighlightedText } from './HighlightedText';
 import { SourceItem } from './SourceItem';
 
 interface SourcesViewProps {
   providers: SourceProviderData[];
   onOpenItem: (providerId: string, externalId: string) => void;
+  forceExpanded?: boolean;
+  totalCounts?: Map<string, number>;
+  query?: string;
 }
 
-export function SourcesView({ providers, onOpenItem }: SourcesViewProps) {
+export function SourcesView({ providers, onOpenItem, forceExpanded = false, totalCounts, query }: SourcesViewProps) {
   if (providers.length === 0) {
     return <div class="empty-state">No sources yet</div>;
   }
 
   return (
-    <div class="sources-tab">
-      <div class="sources-list">
-        {providers.map(provider => (
-          <ProviderSection
-            key={provider.providerId}
-            provider={provider}
-            onOpenItem={onOpenItem}
-          />
-        ))}
-      </div>
+    <div class="sources-list">
+      {providers.map(provider => (
+        <ProviderSection
+          key={provider.providerId}
+          provider={provider}
+          onOpenItem={onOpenItem}
+          forceExpanded={forceExpanded}
+          totalCount={totalCounts?.get(provider.providerId)}
+          totalCounts={totalCounts}
+          query={query}
+        />
+      ))}
     </div>
   );
 }
@@ -30,11 +37,17 @@ export function SourcesView({ providers, onOpenItem }: SourcesViewProps) {
 interface ProviderSectionProps {
   provider: SourceProviderData;
   onOpenItem: (providerId: string, externalId: string) => void;
+  forceExpanded: boolean;
+  totalCount?: number;
+  totalCounts?: Map<string, number>;
+  query?: string;
 }
 
-function ProviderSection({ provider, onOpenItem }: ProviderSectionProps) {
+function ProviderSection({ provider, onOpenItem, forceExpanded, totalCount, totalCounts, query }: ProviderSectionProps) {
   const [collapsed, setCollapsed] = useState(false);
   const itemCount = provider.groups.reduce((total, group) => total + group.items.length, 0);
+  const isCollapsed = forceExpanded ? false : collapsed;
+  const countLabel = totalCount === undefined ? `(${itemCount})` : `(${itemCount} of ${totalCount})`;
 
   return (
     <section
@@ -46,18 +59,18 @@ function ProviderSection({ provider, onOpenItem }: ProviderSectionProps) {
         type="button"
         class="source-provider-header"
         onClick={() => setCollapsed(value => !value)}
-        aria-expanded={!collapsed}
+        aria-expanded={!isCollapsed}
       >
         <span class="source-provider-title">
           <span>{provider.label}</span>
           {!provider.isHealthy ? <span class="health-warning" aria-label="Provider unhealthy">⚠</span> : null}
         </span>
         <span class="source-provider-meta">
-          <span>({itemCount})</span>
-          <span class="source-provider-toggle" aria-hidden="true">{collapsed ? '▸' : '▾'}</span>
+          <span>{countLabel}</span>
+          <span class="source-provider-toggle" aria-hidden="true">{isCollapsed ? '▸' : '▾'}</span>
         </span>
       </button>
-      {!collapsed ? (
+      {!isCollapsed ? (
         <div class="source-provider-groups">
           {provider.groups.length === 0 ? (
             <div class="source-empty">No items found</div>
@@ -68,6 +81,9 @@ function ProviderSection({ provider, onOpenItem }: ProviderSectionProps) {
                 providerId={provider.providerId}
                 group={group}
                 onOpenItem={onOpenItem}
+                forceExpanded={forceExpanded}
+                totalCount={totalCounts?.get(getGroupTotalCountKey(provider.providerId, group.name))}
+                query={query}
               />
             ))
           )}
@@ -81,10 +97,15 @@ interface GroupSectionProps {
   providerId: string;
   group: SourceGroupData;
   onOpenItem: (providerId: string, externalId: string) => void;
+  forceExpanded: boolean;
+  totalCount?: number;
+  query?: string;
 }
 
-function GroupSection({ providerId, group, onOpenItem }: GroupSectionProps) {
+function GroupSection({ providerId, group, onOpenItem, forceExpanded, totalCount, query }: GroupSectionProps) {
   const [collapsed, setCollapsed] = useState(false);
+  const isCollapsed = forceExpanded ? false : collapsed;
+  const countLabel = totalCount === undefined ? `(${group.items.length})` : `(${group.items.length} of ${totalCount})`;
   const itemCountLabel = `${group.name}, ${group.items.length} item${group.items.length === 1 ? '' : 's'}`;
 
   return (
@@ -93,20 +114,21 @@ function GroupSection({ providerId, group, onOpenItem }: GroupSectionProps) {
         type="button"
         class="source-group-header"
         onClick={() => setCollapsed(value => !value)}
-        aria-expanded={!collapsed}
+        aria-expanded={!isCollapsed}
       >
-        <span class="source-group-title">{group.name}</span>
+        <span class="source-group-title"><HighlightedText text={group.name} query={query} /></span>
         <span class="source-group-meta">
-          <span>({group.items.length})</span>
-          <span class="source-group-toggle" aria-hidden="true">{collapsed ? '▸' : '▾'}</span>
+          <span>{countLabel}</span>
+          <span class="source-group-toggle" aria-hidden="true">{isCollapsed ? '▸' : '▾'}</span>
         </span>
       </button>
-      {!collapsed ? (
+      {!isCollapsed ? (
         <div class="source-group-items">
           {group.items.map(item => (
             <SourceItem
               key={`${item.providerId}-${item.externalId}`}
               item={item}
+              query={query}
               onOpen={() => onOpenItem(providerId, item.externalId)}
             />
           ))}

--- a/packages/core/src/webview/sidebar/components/SourcesView.tsx
+++ b/packages/core/src/webview/sidebar/components/SourcesView.tsx
@@ -77,7 +77,7 @@ function ProviderSection({ provider, onOpenItem, onShowProviderHealth, forceExpa
             onClick={toggleCollapsed}
             aria-expanded={!isCollapsed}
           >
-            <HighlightedText text={provider.label} query={query} />
+            <span>{provider.label}</span>
           </button>
           {!provider.isHealthy ? (
             <button

--- a/packages/core/src/webview/sidebar/components/SourcesView.tsx
+++ b/packages/core/src/webview/sidebar/components/SourcesView.tsx
@@ -77,7 +77,7 @@ function ProviderSection({ provider, onOpenItem, onShowProviderHealth, forceExpa
             class="source-provider-toggle-button source-provider-title-button"
             onClick={toggleCollapsed}
             aria-expanded={!isCollapsed}
-            disabled={forceExpanded}
+            aria-disabled={forceExpanded}
             title={collapseTitle}
           >
             <span>{provider.label}</span>
@@ -99,7 +99,7 @@ function ProviderSection({ provider, onOpenItem, onShowProviderHealth, forceExpa
           onClick={toggleCollapsed}
           aria-expanded={!isCollapsed}
           aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${provider.label} source items`}
-          disabled={forceExpanded}
+          aria-disabled={forceExpanded}
           title={collapseTitle}
         >
           <span>{countLabel}</span>

--- a/packages/core/src/webview/sidebar/components/SourcesView.tsx
+++ b/packages/core/src/webview/sidebar/components/SourcesView.tsx
@@ -143,6 +143,7 @@ function GroupSection({ providerId, group, onOpenItem, forceExpanded, totalCount
   const isCollapsed = forceExpanded ? false : collapsed;
   const countLabel = totalCount === undefined ? `(${group.items.length})` : `(${group.items.length} of ${totalCount})`;
   const itemCountLabel = `${group.name}, ${group.items.length} item${group.items.length === 1 ? '' : 's'}`;
+  const collapseTitle = forceExpanded ? 'Clear filter to collapse' : undefined;
   const toggleCollapsed = () => {
     if (!forceExpanded) {
       setCollapsed(value => !value);
@@ -156,6 +157,8 @@ function GroupSection({ providerId, group, onOpenItem, forceExpanded, totalCount
         class="source-group-header"
         onClick={toggleCollapsed}
         aria-expanded={!isCollapsed}
+        disabled={forceExpanded}
+        title={collapseTitle}
       >
         <span class="source-group-title"><HighlightedText text={group.name} query={query} /></span>
         <span class="source-group-meta">

--- a/packages/core/src/webview/sidebar/components/SourcesView.tsx
+++ b/packages/core/src/webview/sidebar/components/SourcesView.tsx
@@ -120,13 +120,18 @@ function GroupSection({ providerId, group, onOpenItem, forceExpanded, totalCount
   const isCollapsed = forceExpanded ? false : collapsed;
   const countLabel = totalCount === undefined ? `(${group.items.length})` : `(${group.items.length} of ${totalCount})`;
   const itemCountLabel = `${group.name}, ${group.items.length} item${group.items.length === 1 ? '' : 's'}`;
+  const toggleCollapsed = () => {
+    if (!forceExpanded) {
+      setCollapsed(value => !value);
+    }
+  };
 
   return (
     <section class="source-group" role="group" aria-label={itemCountLabel}>
       <button
         type="button"
         class="source-group-header"
-        onClick={() => setCollapsed(value => !value)}
+        onClick={toggleCollapsed}
         aria-expanded={!isCollapsed}
       >
         <span class="source-group-title"><HighlightedText text={group.name} query={query} /></span>

--- a/packages/core/src/webview/sidebar/components/TierSection.tsx
+++ b/packages/core/src/webview/sidebar/components/TierSection.tsx
@@ -57,6 +57,7 @@ export function TierSection({
   const isReorderableTier = !disableDragReorder && (tier.id === 'ready-to-start' || tier.id === 'in-progress');
   const isCollapsed = forceExpanded ? false : collapsed;
   const countLabel = totalCount === undefined ? `(${tier.items.length})` : `(${tier.items.length} of ${totalCount})`;
+  const collapseTitle = forceExpanded ? 'Clear filter to collapse' : undefined;
   const toggleCollapsed = () => {
     if (!forceExpanded) {
       setCollapsed(value => !value);
@@ -283,6 +284,8 @@ export function TierSection({
           onClick={toggleCollapsed}
           aria-expanded={!isCollapsed}
           aria-controls={!isCollapsed ? itemsId : undefined}
+          aria-disabled={forceExpanded}
+          title={collapseTitle}
         >
           <span aria-hidden="true">{tier.icon}</span>
           <span>{tier.name}</span>
@@ -327,6 +330,8 @@ export function TierSection({
           class="tier-toggle-button"
           onClick={toggleCollapsed}
           aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${tier.name}`}
+          aria-disabled={forceExpanded}
+          title={collapseTitle}
           tabIndex={-1}
         >
           <span class="tier-toggle" aria-hidden="true">{isCollapsed ? '▸' : '▾'}</span>

--- a/packages/core/src/webview/sidebar/components/TierSection.tsx
+++ b/packages/core/src/webview/sidebar/components/TierSection.tsx
@@ -20,6 +20,11 @@ interface TierSectionProps {
   onCrossTierDrop?: (itemId: string) => void;
   onAcceptAll?: () => void;
   onClearHistory?: () => void;
+  disableDragReorder?: boolean;
+  isFilterActive?: boolean;
+  forceExpanded?: boolean;
+  totalCount?: number;
+  query?: string;
 }
 
 export function TierSection({
@@ -33,6 +38,11 @@ export function TierSection({
   onCrossTierDrop,
   onAcceptAll,
   onClearHistory,
+  disableDragReorder = false,
+  isFilterActive = false,
+  forceExpanded = false,
+  totalCount,
+  query,
 }: TierSectionProps) {
   const [collapsed, setCollapsed] = useState(tier.collapsed);
   const [activeItemId, setActiveItemId] = useState<string | undefined>(() =>
@@ -44,7 +54,9 @@ export function TierSection({
   const headerButtonRef = useRef<HTMLButtonElement>(null);
   const itemRefs = useRef<Record<string, HTMLDivElement | null>>({});
   const dragDepthRef = useRef(0);
-  const isReorderableTier = tier.id === 'ready-to-start' || tier.id === 'in-progress';
+  const isReorderableTier = !disableDragReorder && (tier.id === 'ready-to-start' || tier.id === 'in-progress');
+  const isCollapsed = forceExpanded ? false : collapsed;
+  const countLabel = totalCount === undefined ? `(${tier.items.length})` : `(${tier.items.length} of ${totalCount})`;
   const toggleCollapsed = () => setCollapsed(value => !value);
   const itemCountLabel = `${tier.name}, ${tier.items.length} item${tier.items.length === 1 ? '' : 's'}`;
   const itemsId = `mission-control-tier-${tier.id}`;
@@ -114,6 +126,12 @@ export function TierSection({
     setDropIndex(null);
     setIsDragActive(false);
   };
+
+  useEffect(() => {
+    if (!isReorderableTier) {
+      clearDropState();
+    }
+  }, [isReorderableTier]);
 
   const getDropIndexFromPointer = (clientY: number): number => {
     for (let index = 0; index < tier.items.length; index += 1) {
@@ -259,22 +277,25 @@ export function TierSection({
           class="tier-header-main"
           data-tier-header="true"
           onClick={toggleCollapsed}
-          aria-expanded={!collapsed}
-          aria-controls={!collapsed ? itemsId : undefined}
+          aria-expanded={!isCollapsed}
+          aria-controls={!isCollapsed ? itemsId : undefined}
         >
           <span aria-hidden="true">{tier.icon}</span>
           <span>{tier.name}</span>
-          <span class="tier-count">({tier.items.length})</span>
+          <span class="tier-count">{countLabel}</span>
         </button>
         {tier.id === 'incoming' && onAcceptAll ? (
           <button
             type="button"
             class="tier-header-action"
-            title="Accept all"
+            title={isFilterActive ? 'Clear filter to use Accept All' : 'Accept all'}
             aria-label="Accept all incoming items"
+            disabled={isFilterActive}
             onClick={(event) => {
               event.stopPropagation();
-              onAcceptAll();
+              if (!isFilterActive) {
+                onAcceptAll();
+              }
             }}
           >
             Accept All
@@ -284,11 +305,14 @@ export function TierSection({
           <button
             type="button"
             class="tier-header-action"
-            title="Clear history"
+            title={isFilterActive ? 'Clear filter to clear history' : 'Clear history'}
             aria-label="Clear completed items"
+            disabled={isFilterActive}
             onClick={(event) => {
               event.stopPropagation();
-              onClearHistory();
+              if (!isFilterActive) {
+                onClearHistory();
+              }
             }}
           >
             Clear
@@ -298,13 +322,13 @@ export function TierSection({
           type="button"
           class="tier-toggle-button"
           onClick={toggleCollapsed}
-          aria-label={`${collapsed ? 'Expand' : 'Collapse'} ${tier.name}`}
+          aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${tier.name}`}
           tabIndex={-1}
         >
-          <span class="tier-toggle" aria-hidden="true">{collapsed ? '▸' : '▾'}</span>
+          <span class="tier-toggle" aria-hidden="true">{isCollapsed ? '▸' : '▾'}</span>
         </button>
       </div>
-      {!collapsed ? (
+      {!isCollapsed ? (
         <div
           id={itemsId}
           class={`tier-items ${isDragActive ? 'drag-active' : ''}`.trim()}
@@ -319,9 +343,11 @@ export function TierSection({
         >
           {tier.items.map((item, index) => (
             <Fragment key={item.id}>
-              {dropIndex === index ? <div class="drop-indicator" aria-hidden="true" /> : null}
+              {isReorderableTier && dropIndex === index ? <div class="drop-indicator" aria-hidden="true" /> : null}
               <ItemCard
                 item={item}
+                query={query}
+                disableDragReorder={disableDragReorder}
                 tabIndex={item.id === activeItemId ? 0 : -1}
                 itemRef={(element) => {
                   itemRefs.current[item.id] = element;
@@ -340,7 +366,7 @@ export function TierSection({
               />
             </Fragment>
           ))}
-          {dropIndex === tier.items.length ? <div class="drop-indicator" aria-hidden="true" /> : null}
+          {isReorderableTier && dropIndex === tier.items.length ? <div class="drop-indicator" aria-hidden="true" /> : null}
         </div>
       ) : null}
     </section>

--- a/packages/core/src/webview/sidebar/components/TierSection.tsx
+++ b/packages/core/src/webview/sidebar/components/TierSection.tsx
@@ -57,7 +57,11 @@ export function TierSection({
   const isReorderableTier = !disableDragReorder && (tier.id === 'ready-to-start' || tier.id === 'in-progress');
   const isCollapsed = forceExpanded ? false : collapsed;
   const countLabel = totalCount === undefined ? `(${tier.items.length})` : `(${tier.items.length} of ${totalCount})`;
-  const toggleCollapsed = () => setCollapsed(value => !value);
+  const toggleCollapsed = () => {
+    if (!forceExpanded) {
+      setCollapsed(value => !value);
+    }
+  };
   const itemCountLabel = `${tier.name}, ${tier.items.length} item${tier.items.length === 1 ? '' : 's'}`;
   const itemsId = `mission-control-tier-${tier.id}`;
 

--- a/packages/core/src/webview/sidebar/components/TierSection.tsx
+++ b/packages/core/src/webview/sidebar/components/TierSection.tsx
@@ -311,7 +311,7 @@ export function TierSection({
             class="tier-header-action"
             title={isFilterActive ? 'Clear filter to clear history' : 'Clear history'}
             aria-label="Clear completed items"
-            disabled={isFilterActive}
+            aria-disabled={isFilterActive}
             onClick={(event) => {
               event.stopPropagation();
               if (!isFilterActive) {

--- a/packages/core/src/webview/sidebar/components/TierSection.tsx
+++ b/packages/core/src/webview/sidebar/components/TierSection.tsx
@@ -294,7 +294,7 @@ export function TierSection({
             class="tier-header-action"
             title={isFilterActive ? 'Clear filter to use Accept All' : 'Accept all'}
             aria-label="Accept all incoming items"
-            disabled={isFilterActive}
+            aria-disabled={isFilterActive}
             onClick={(event) => {
               event.stopPropagation();
               if (!isFilterActive) {

--- a/packages/core/src/webview/sidebar/filter.ts
+++ b/packages/core/src/webview/sidebar/filter.ts
@@ -73,24 +73,32 @@ export function splitOnMatches(text: string, query: string): Array<{ text: strin
     return [{ text, isMatch: false }];
   }
 
-  const lowerText = text.toLowerCase();
+  const { lowerText, originalRanges } = buildLowercaseIndex(text);
   const segments: Array<{ text: string; isMatch: boolean }> = [];
-  let searchIndex = 0;
+  let lowerSearchIndex = 0;
+  let originalSearchIndex = 0;
 
-  while (searchIndex < text.length) {
-    const matchIndex = lowerText.indexOf(normalizedQuery, searchIndex);
+  while (originalSearchIndex < text.length) {
+    const matchIndex = lowerText.indexOf(normalizedQuery, lowerSearchIndex);
     if (matchIndex === -1) {
-      segments.push({ text: text.slice(searchIndex), isMatch: false });
+      segments.push({ text: text.slice(originalSearchIndex), isMatch: false });
       break;
     }
 
-    if (matchIndex > searchIndex) {
-      segments.push({ text: text.slice(searchIndex, matchIndex), isMatch: false });
+    const matchStart = originalRanges[matchIndex].start;
+    const matchEnd = originalRanges[matchIndex + normalizedQuery.length - 1].end;
+
+    if (matchStart > originalSearchIndex) {
+      segments.push({ text: text.slice(originalSearchIndex, matchStart), isMatch: false });
     }
 
-    const matchEnd = matchIndex + normalizedQuery.length;
-    segments.push({ text: text.slice(matchIndex, matchEnd), isMatch: true });
-    searchIndex = matchEnd;
+    segments.push({ text: text.slice(matchStart, matchEnd), isMatch: true });
+    originalSearchIndex = matchEnd;
+
+    lowerSearchIndex = matchIndex + normalizedQuery.length;
+    while (lowerSearchIndex < originalRanges.length && originalRanges[lowerSearchIndex].start < matchEnd) {
+      lowerSearchIndex += 1;
+    }
   }
 
   return segments.length > 0 ? segments : [{ text, isMatch: false }];
@@ -106,6 +114,26 @@ function matchesNormalizedQuery(text: string, normalizedQuery: string): boolean 
   }
 
   return text.toLowerCase().includes(normalizedQuery);
+}
+
+function buildLowercaseIndex(text: string): { lowerText: string; originalRanges: Array<{ start: number; end: number }> } {
+  let lowerText = '';
+  const originalRanges: Array<{ start: number; end: number }> = [];
+  let originalIndex = 0;
+
+  for (const character of text) {
+    const originalEnd = originalIndex + character.length;
+    const lowerCharacter = character.toLowerCase();
+
+    lowerText += lowerCharacter;
+    for (let i = 0; i < lowerCharacter.length; i++) {
+      originalRanges.push({ start: originalIndex, end: originalEnd });
+    }
+
+    originalIndex = originalEnd;
+  }
+
+  return { lowerText, originalRanges };
 }
 
 function normalizeQuery(query: string): string {

--- a/packages/core/src/webview/sidebar/filter.ts
+++ b/packages/core/src/webview/sidebar/filter.ts
@@ -1,0 +1,113 @@
+import type { SourceProviderData, TierData } from '../shared/types';
+
+export function matchesQuery(text: string, query: string): boolean {
+  const normalizedQuery = normalizeQuery(query);
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  return text.toLowerCase().includes(normalizedQuery);
+}
+
+export function filterTiers(tiers: TierData[], query: string): { tiers: TierData[]; totalCounts: Map<string, number> } {
+  const normalizedQuery = normalizeQuery(query);
+  const totalCounts = new Map<string, number>();
+
+  for (const tier of tiers) {
+    totalCounts.set(tier.id, tier.items.length);
+  }
+
+  if (!normalizedQuery) {
+    return { tiers, totalCounts };
+  }
+
+  return {
+    tiers: tiers
+      .map(tier => ({
+        ...tier,
+        items: tier.items.filter(item =>
+          matchesQuery(item.title, normalizedQuery) || (item.repoAnnotation ? matchesQuery(item.repoAnnotation, normalizedQuery) : false),
+        ),
+      }))
+      .filter(tier => tier.items.length > 0),
+    totalCounts,
+  };
+}
+
+export function filterProviders(
+  providers: SourceProviderData[],
+  query: string,
+): { providers: SourceProviderData[]; totalCounts: Map<string, number> } {
+  const normalizedQuery = normalizeQuery(query);
+  const totalCounts = new Map<string, number>();
+
+  for (const provider of providers) {
+    totalCounts.set(provider.providerId, getProviderItemCount(provider));
+    for (const group of provider.groups) {
+      totalCounts.set(getGroupTotalCountKey(provider.providerId, group.name), group.items.length);
+    }
+  }
+
+  if (!normalizedQuery) {
+    return { providers, totalCounts };
+  }
+
+  return {
+    providers: providers
+      .map(provider => ({
+        ...provider,
+        groups: provider.groups
+          .map(group => {
+            const items = matchesQuery(group.name, normalizedQuery)
+              ? group.items
+              : group.items.filter(item => matchesQuery(item.title, normalizedQuery));
+
+            return { ...group, items };
+          })
+          .filter(group => group.items.length > 0),
+      }))
+      .filter(provider => provider.groups.some(group => group.items.length > 0)),
+    totalCounts,
+  };
+}
+
+export function splitOnMatches(text: string, query: string): Array<{ text: string; isMatch: boolean }> {
+  const normalizedQuery = normalizeQuery(query);
+  if (!normalizedQuery || text.length === 0) {
+    return [{ text, isMatch: false }];
+  }
+
+  const lowerText = text.toLowerCase();
+  const segments: Array<{ text: string; isMatch: boolean }> = [];
+  let searchIndex = 0;
+
+  while (searchIndex < text.length) {
+    const matchIndex = lowerText.indexOf(normalizedQuery, searchIndex);
+    if (matchIndex === -1) {
+      segments.push({ text: text.slice(searchIndex), isMatch: false });
+      break;
+    }
+
+    if (matchIndex > searchIndex) {
+      segments.push({ text: text.slice(searchIndex, matchIndex), isMatch: false });
+    }
+
+    const matchEnd = matchIndex + normalizedQuery.length;
+    segments.push({ text: text.slice(matchIndex, matchEnd), isMatch: true });
+    searchIndex = matchEnd;
+  }
+
+  return segments.length > 0 ? segments : [{ text, isMatch: false }];
+}
+
+export function getGroupTotalCountKey(providerId: string, groupName: string): string {
+  return `${providerId}\u0000${groupName}`;
+}
+
+function normalizeQuery(query: string): string {
+  return query.trim().toLowerCase();
+}
+
+function getProviderItemCount(provider: SourceProviderData): number {
+  return provider.groups.reduce((total, group) => total + group.items.length, 0);
+}

--- a/packages/core/src/webview/sidebar/filter.ts
+++ b/packages/core/src/webview/sidebar/filter.ts
@@ -1,12 +1,7 @@
 import type { SourceProviderData, TierData } from '../shared/types';
 
 export function matchesQuery(text: string, query: string): boolean {
-  const normalizedQuery = normalizeQuery(query);
-  if (!normalizedQuery) {
-    return true;
-  }
-
-  return text.toLowerCase().includes(normalizedQuery);
+  return matchesNormalizedQuery(text, normalizeQuery(query));
 }
 
 export function filterTiers(tiers: TierData[], query: string): { tiers: TierData[]; totalCounts: Map<string, number> } {
@@ -26,7 +21,8 @@ export function filterTiers(tiers: TierData[], query: string): { tiers: TierData
       .map(tier => ({
         ...tier,
         items: tier.items.filter(item =>
-          matchesQuery(item.title, normalizedQuery) || (item.repoAnnotation ? matchesQuery(item.repoAnnotation, normalizedQuery) : false),
+          matchesNormalizedQuery(item.title, normalizedQuery)
+          || (item.repoAnnotation ? matchesNormalizedQuery(item.repoAnnotation, normalizedQuery) : false),
         ),
       }))
       .filter(tier => tier.items.length > 0),
@@ -58,9 +54,9 @@ export function filterProviders(
         ...provider,
         groups: provider.groups
           .map(group => {
-            const items = matchesQuery(group.name, normalizedQuery)
+            const items = matchesNormalizedQuery(group.name, normalizedQuery)
               ? group.items
-              : group.items.filter(item => matchesQuery(item.title, normalizedQuery));
+              : group.items.filter(item => matchesNormalizedQuery(item.title, normalizedQuery));
 
             return { ...group, items };
           })
@@ -102,6 +98,14 @@ export function splitOnMatches(text: string, query: string): Array<{ text: strin
 
 export function getGroupTotalCountKey(providerId: string, groupName: string): string {
   return `${providerId}\u0000${groupName}`;
+}
+
+function matchesNormalizedQuery(text: string, normalizedQuery: string): boolean {
+  if (!normalizedQuery) {
+    return true;
+  }
+
+  return text.toLowerCase().includes(normalizedQuery);
 }
 
 function normalizeQuery(query: string): string {

--- a/packages/core/src/webview/sidebar/searchVisibility.ts
+++ b/packages/core/src/webview/sidebar/searchVisibility.ts
@@ -1,0 +1,15 @@
+export type SidebarTab = 'myWork' | 'sources';
+export type TabQueries = Record<SidebarTab, string>;
+export type SearchBoxVisibility = Record<SidebarTab, boolean>;
+
+export const emptyQueries: TabQueries = { myWork: '', sources: '' };
+export const hiddenSearchBoxes: SearchBoxVisibility = { myWork: false, sources: false };
+
+export function isSearchBoxEffectivelyVisible(
+  tab: SidebarTab,
+  searchBoxVisible: SearchBoxVisibility,
+  queries: TabQueries,
+  appliedQueries: TabQueries,
+): boolean {
+  return searchBoxVisible[tab] || queries[tab] !== '' || appliedQueries[tab] !== '';
+}


### PR DESCRIPTION
## Summary

- Adds sticky per-tab search inputs to the My Work and Sources sidebar tabs.
- Filters entirely in the webview with highlighted matches, force-expanded matching sections, and filtered count headers.
- Disables drag/keyboard reorder and bulk actions while filtered, with explanatory tooltips.
- Adds pure filter helpers and node-environment tests for matching, tier/provider filtering, and match splitting.

## Validation

- cd packages\core ; npm run build
- cd packages\core ; npm run test
- superpowers:code-reviewer clean after fixes

Closes #478
