### PR TITLE
Prune stale read-state and discovered-state records after provider refresh

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -446,6 +446,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     ws.onDidChangeWatchedRuns(safeHandler('mc:watchedRuns', () => mainProvider.scheduleRefresh())),
     ws.onDidChangePRWatches(safeHandler('mc:watchedPRs', () => mainProvider.scheduleRefresh())),
     readStateStore.onDidChange(safeHandler('mc:readState', () => mainProvider.scheduleRefresh())),
+    pr.onDidRefreshProvider(safeHandler('mc:prune', async () => {
+      const active = pr.getAllDiscoveredItems();
+      try {
+        const ssPruned = await ss.prune(active);
+        const rsPruned = await readStateStore.prune(active);
+        if (ssPruned > 0 || rsPruned > 0) {
+          logger.debug(`Pruned ${ssPruned} discovered-state and ${rsPruned} read-state records`);
+        }
+      } catch (err) {
+        logger.error('DevDocket: prune failed', err);
+      }
+    })),
     ws.onDidChangeWatchedRuns(safeHandler('watch-panel:runs', () => watchPanelProvider.refresh())),
     ws.onDidChangePRWatches(safeHandler('watch-panel:prs', () => watchPanelProvider.refresh())),
   );

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -446,13 +446,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     ws.onDidChangeWatchedRuns(safeHandler('mc:watchedRuns', () => mainProvider.scheduleRefresh())),
     ws.onDidChangePRWatches(safeHandler('mc:watchedPRs', () => mainProvider.scheduleRefresh())),
     readStateStore.onDidChange(safeHandler('mc:readState', () => mainProvider.scheduleRefresh())),
-    pr.onDidRefreshProvider(safeHandler('mc:prune', async () => {
-      const active = pr.getAllDiscoveredItems();
+    pr.onDidRefreshProvider(safeHandler('mc:prune', async (providerId) => {
+      if (pr.wasLastRefreshTruncated(providerId)) {
+        logger.debug(`Skipping prune for provider ${providerId} because the latest refresh was truncated`);
+        return;
+      }
+
+      const active = new Map([[providerId, pr.getDiscoveredItems(providerId)]]);
       try {
         const ssPruned = await ss.prune(active);
         const rsPruned = await readStateStore.prune(active);
         if (ssPruned > 0 || rsPruned > 0) {
-          logger.debug(`Pruned ${ssPruned} discovered-state and ${rsPruned} read-state records`);
+          logger.debug(`Pruned ${ssPruned} discovered-state and ${rsPruned} read-state records for provider ${providerId}`);
         }
       } catch (err) {
         logger.error('DevDocket: prune failed', err);

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import type { Memento } from 'vscode';
+import type { DiscoveredItem } from '../api/types';
 import { logger } from '../services/logger';
 
 const STORAGE_KEY = 'devdocket.read-state';
@@ -16,7 +17,7 @@ export class ReadStateStore {
   private readonly items = new Set<string>();
   private loaded = false;
   private readonly _onDidChange = new vscode.EventEmitter<void>();
-  /** Fires whenever the set of read keys changes (add, addMany, deleteMany). */
+  /** Fires whenever the set of read keys changes (add, addMany, deleteMany, prune). */
   readonly onDidChange = this._onDidChange.event;
 
   constructor(globalState: Memento) {
@@ -73,6 +74,49 @@ export class ReadStateStore {
       await this.persist();
       this._onDidChange.fire();
     }
+  }
+
+  /**
+   * Removes persisted read keys for items that are no longer reported by
+   * their provider. Providers with empty item arrays are skipped to avoid
+   * pruning during transient API failures.
+   *
+   * @returns The number of records removed.
+   */
+  async prune(activeItems: Map<string, DiscoveredItem[]>): Promise<number> {
+    if (!this.loaded) { await this.load(); }
+
+    const activeKeys = new Set<string>();
+    const activeProviderIds = new Set<string>();
+    for (const [providerId, items] of activeItems) {
+      if (items.length === 0) { continue; }
+      activeProviderIds.add(providerId);
+      for (const item of items) {
+        activeKeys.add(`${providerId}::${item.externalId}`);
+      }
+    }
+
+    if (activeProviderIds.size === 0) { return 0; }
+
+    const staleKeys: string[] = [];
+    for (const key of this.items) {
+      const delimiterIndex = key.indexOf('::');
+      if (delimiterIndex === -1) { continue; }
+      const providerId = key.slice(0, delimiterIndex);
+      if (activeProviderIds.has(providerId) && !activeKeys.has(key)) {
+        staleKeys.push(key);
+      }
+    }
+
+    if (staleKeys.length === 0) { return 0; }
+
+    for (const key of staleKeys) {
+      this.items.delete(key);
+    }
+
+    await this.persist();
+    this._onDidChange.fire();
+    return staleKeys.length;
   }
 
   async load(): Promise<void> {

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { MockMemento } from 'vscode';
 import { activate, autoWatchAuthoredPRs, deactivate, logger } from '../extension';
 import { ReadStateStore } from '../storage/readStateStore';
+import { ProviderRegistry } from '../services/providerRegistry';
 import { MainViewProvider } from '../views/mainViewProvider';
 import { WatchPanelProvider } from '../views/watchPanelProvider';
 import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
@@ -249,6 +250,95 @@ describe('activate()', () => {
       ]);
     } finally {
       pruneSpy.mockRestore();
+    }
+  });
+
+  it('scopes prune to the provider that emitted the refresh signal', async () => {
+    const globalState = context.globalState as InstanceType<typeof MockMemento>;
+    await globalState.update('devdocket.migrated', true);
+    const pruneSpy = vi.spyOn(ReadStateStore.prototype, 'prune');
+
+    try {
+      const api = await activate(context);
+      const otherEmitter = new (vscode.EventEmitter as any)();
+      const refreshedEmitter = new (vscode.EventEmitter as any)();
+      const otherItem = { externalId: 'other-active', title: 'Other Active' };
+      const refreshedItem = { externalId: 'refreshed-active', title: 'Refreshed Active' };
+
+      api.registerProvider({
+        id: 'other-provider',
+        label: 'Other Provider',
+        onDidDiscoverItems: otherEmitter.event,
+        refresh: vi.fn(async () => {
+          otherEmitter.fire([otherItem]);
+        }),
+      } as any);
+
+      await vi.waitFor(() => expect(pruneSpy).toHaveBeenCalled());
+      pruneSpy.mockClear();
+
+      api.registerProvider({
+        id: 'refreshed-provider',
+        label: 'Refreshed Provider',
+        onDidDiscoverItems: refreshedEmitter.event,
+        refresh: vi.fn(async () => {
+          refreshedEmitter.fire([refreshedItem]);
+        }),
+      } as any);
+
+      await vi.waitFor(() => expect(pruneSpy).toHaveBeenCalled());
+
+      const active = pruneSpy.mock.calls.at(-1)?.[0] as Map<string, unknown[]>;
+      expect([...active.keys()]).toEqual(['refreshed-provider']);
+      expect(active.get('refreshed-provider')).toEqual([refreshedItem]);
+      expect(active.has('other-provider')).toBe(false);
+    } finally {
+      pruneSpy.mockRestore();
+    }
+  });
+
+  it('skips prune after a truncated provider refresh', async () => {
+    const globalState = context.globalState as InstanceType<typeof MockMemento>;
+    await globalState.update('devdocket.migrated', true);
+    await globalState.update('devdocket.discovered-state', [
+      { providerId: 'truncated-provider', externalId: 'stale', inboxState: 'accepted' },
+    ]);
+    await globalState.update('devdocket.read-state', ['truncated-provider::stale']);
+    const originalMaxItems = ProviderRegistry.MAX_ITEMS_PER_PROVIDER;
+    const pruneSpy = vi.spyOn(ReadStateStore.prototype, 'prune');
+
+    try {
+      Object.defineProperty(ProviderRegistry, 'MAX_ITEMS_PER_PROVIDER', { value: 2, configurable: true });
+
+      const api = await activate(context);
+      const itemEmitter = new (vscode.EventEmitter as any)();
+
+      api.registerProvider({
+        id: 'truncated-provider',
+        label: 'Truncated Provider',
+        onDidDiscoverItems: itemEmitter.event,
+        refresh: vi.fn(async () => {
+          itemEmitter.fire([
+            { externalId: 'one', title: 'One' },
+            { externalId: 'two', title: 'Two' },
+            { externalId: 'three', title: 'Three' },
+          ]);
+        }),
+      } as any);
+
+      await vi.waitFor(() => {
+        const records = globalState.get<Array<{ providerId: string; externalId: string }>>('devdocket.discovered-state') ?? [];
+        expect(records.some(record => record.providerId === 'truncated-provider' && record.externalId === 'one')).toBe(true);
+      });
+      await flushMicrotasks();
+
+      expect(pruneSpy).not.toHaveBeenCalled();
+      expect(globalState.get<string[]>('devdocket.read-state')).toEqual(['truncated-provider::stale']);
+      const discoveredRecords = globalState.get<Array<{ providerId: string; externalId: string }>>('devdocket.discovered-state') ?? [];
+      expect(discoveredRecords.some(record => record.providerId === 'truncated-provider' && record.externalId === 'stale')).toBe(true);
+    } finally {
+      pruneSpy.mockRestore();
+      Object.defineProperty(ProviderRegistry, 'MAX_ITEMS_PER_PROVIDER', { value: originalMaxItems, configurable: true });
     }
   });
 

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import * as vscode from 'vscode';
 import { MockMemento } from 'vscode';
 import { activate, autoWatchAuthoredPRs, deactivate, logger } from '../extension';
+import { ReadStateStore } from '../storage/readStateStore';
 import { MainViewProvider } from '../views/mainViewProvider';
 import { WatchPanelProvider } from '../views/watchPanelProvider';
 import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
@@ -164,6 +165,91 @@ describe('activate()', () => {
     await getCommandHandler('devdocket.showWatchesQuickPick')();
 
     expect(openSpy).toHaveBeenCalled();
+  });
+
+  it('prunes stale read-state and discovered-state records after non-empty provider refresh', async () => {
+    const globalState = context.globalState as InstanceType<typeof MockMemento>;
+    await globalState.update('devdocket.migrated', true);
+    await globalState.update('devdocket.discovered-state', [
+      { providerId: 'prune-provider', externalId: 'keep', inboxState: 'accepted' },
+      { providerId: 'prune-provider', externalId: 'stale', inboxState: 'dismissed' },
+      { providerId: 'other-provider', externalId: 'stale', inboxState: 'accepted' },
+    ]);
+    await globalState.update('devdocket.read-state', [
+      'prune-provider::keep',
+      'prune-provider::stale',
+      'other-provider::stale',
+    ]);
+    const pruneSpy = vi.spyOn(ReadStateStore.prototype, 'prune');
+
+    try {
+      const api = await activate(context);
+      const itemEmitter = new (vscode.EventEmitter as any)();
+      const activeItem = { externalId: 'keep', title: 'Keep' };
+
+      api.registerProvider({
+        id: 'prune-provider',
+        label: 'Prune Provider',
+        onDidDiscoverItems: itemEmitter.event,
+        refresh: vi.fn(async () => {
+          itemEmitter.fire([activeItem]);
+        }),
+      } as any);
+
+      await vi.waitFor(() => {
+        expect(pruneSpy).toHaveBeenCalled();
+        expect(globalState.get<string[]>('devdocket.read-state')).toEqual([
+          'prune-provider::keep',
+          'other-provider::stale',
+        ]);
+      });
+
+      const active = pruneSpy.mock.calls.at(-1)?.[0] as Map<string, unknown[]>;
+      expect(active.get('prune-provider')).toEqual([activeItem]);
+
+      const discoveredRecords = globalState.get<Array<{ providerId: string; externalId: string }>>('devdocket.discovered-state') ?? [];
+      expect(discoveredRecords.map(record => `${record.providerId}::${record.externalId}`).sort()).toEqual([
+        'other-provider::stale',
+        'prune-provider::keep',
+      ]);
+    } finally {
+      pruneSpy.mockRestore();
+    }
+  });
+
+  it('leaves read-state and discovered-state records untouched after empty provider refresh', async () => {
+    const globalState = context.globalState as InstanceType<typeof MockMemento>;
+    await globalState.update('devdocket.migrated', true);
+    await globalState.update('devdocket.discovered-state', [
+      { providerId: 'empty-provider', externalId: 'stale', inboxState: 'accepted' },
+    ]);
+    await globalState.update('devdocket.read-state', ['empty-provider::stale']);
+    const pruneSpy = vi.spyOn(ReadStateStore.prototype, 'prune');
+
+    try {
+      const api = await activate(context);
+      const itemEmitter = new (vscode.EventEmitter as any)();
+
+      api.registerProvider({
+        id: 'empty-provider',
+        label: 'Empty Provider',
+        onDidDiscoverItems: itemEmitter.event,
+        refresh: vi.fn(async () => {
+          itemEmitter.fire([]);
+        }),
+      } as any);
+
+      await vi.waitFor(() => expect(pruneSpy).toHaveBeenCalled());
+
+      const active = pruneSpy.mock.calls.at(-1)?.[0] as Map<string, unknown[]>;
+      expect(active.get('empty-provider')).toEqual([]);
+      expect(globalState.get<string[]>('devdocket.read-state')).toEqual(['empty-provider::stale']);
+      expect(globalState.get<Array<{ providerId: string; externalId: string }>>('devdocket.discovered-state')).toEqual([
+        { providerId: 'empty-provider', externalId: 'stale', inboxState: 'accepted' },
+      ]);
+    } finally {
+      pruneSpy.mockRestore();
+    }
   });
 
   // ------------------------------------------------------------------

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { MockMemento } from 'vscode';
+import type { DiscoveredItem } from '../api/types';
 import { ReadStateStore } from '../storage/readStateStore';
 
 describe('ReadStateStore', () => {
@@ -9,6 +10,10 @@ describe('ReadStateStore', () => {
   beforeEach(() => {
     memento = new MockMemento();
     store = new ReadStateStore(memento);
+  });
+
+  afterEach(() => {
+    store.dispose();
   });
 
   it('should return false for has() when no data exists on load', async () => {
@@ -134,5 +139,135 @@ describe('ReadStateStore', () => {
     await store.load();
     const result = await store.addMany([]);
     expect(result).toEqual([]);
+  });
+
+  describe('prune', () => {
+    it('removes only stale keys belonging to providers that returned items', async () => {
+      await store.addMany(['gh::keep', 'gh::stale', 'jira::stale']);
+
+      const activeItems = new Map<string, DiscoveredItem[]>([
+        ['gh', [{ externalId: 'keep', title: 'Keep' }]],
+      ]);
+
+      const pruned = await store.prune(activeItems);
+
+      expect(pruned).toBe(1);
+      expect(store.has('gh::keep')).toBe(true);
+      expect(store.has('gh::stale')).toBe(false);
+      expect(store.has('jira::stale')).toBe(true);
+    });
+
+    it('skips providers whose item array is empty', async () => {
+      await store.add('gh::stale');
+
+      const activeItems = new Map<string, DiscoveredItem[]>([
+        ['gh', []],
+      ]);
+
+      const pruned = await store.prune(activeItems);
+
+      expect(pruned).toBe(0);
+      expect(store.has('gh::stale')).toBe(true);
+    });
+
+    it('returns 0 and does not fire onDidChange when no providers returned items', async () => {
+      await store.addMany(['gh::stale', 'jira::stale']);
+      const listener = vi.fn();
+      store.onDidChange(listener);
+
+      const activeItems = new Map<string, DiscoveredItem[]>([
+        ['gh', []],
+        ['jira', []],
+      ]);
+
+      const pruned = await store.prune(activeItems);
+
+      expect(pruned).toBe(0);
+      expect(listener).not.toHaveBeenCalled();
+      expect(store.has('gh::stale')).toBe(true);
+      expect(store.has('jira::stale')).toBe(true);
+    });
+
+    it('returns 0 and does not fire onDidChange when nothing is stale', async () => {
+      await store.addMany(['gh::keep-1', 'gh::keep-2']);
+      const listener = vi.fn();
+      store.onDidChange(listener);
+
+      const activeItems = new Map<string, DiscoveredItem[]>([
+        ['gh', [
+          { externalId: 'keep-1', title: 'Keep 1' },
+          { externalId: 'keep-2', title: 'Keep 2' },
+        ]],
+      ]);
+
+      const pruned = await store.prune(activeItems);
+
+      expect(pruned).toBe(0);
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('fires onDidChange exactly once when one or more keys are removed', async () => {
+      await store.addMany(['gh::keep', 'gh::stale-1', 'gh::stale-2']);
+      const listener = vi.fn();
+      store.onDidChange(listener);
+
+      const activeItems = new Map<string, DiscoveredItem[]>([
+        ['gh', [{ externalId: 'keep', title: 'Keep' }]],
+      ]);
+
+      const pruned = await store.prune(activeItems);
+
+      expect(pruned).toBe(2);
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it('lazy-loads on first call', async () => {
+      await memento.update('devdocket.read-state', ['gh::keep', 'gh::stale']);
+
+      const freshStore = new ReadStateStore(memento);
+      const activeItems = new Map<string, DiscoveredItem[]>([
+        ['gh', [{ externalId: 'keep', title: 'Keep' }]],
+      ]);
+
+      const pruned = await freshStore.prune(activeItems);
+
+      expect(pruned).toBe(1);
+      expect(freshStore.has('gh::keep')).toBe(true);
+      expect(freshStore.has('gh::stale')).toBe(false);
+      expect(memento.get<string[]>('devdocket.read-state')).toEqual(['gh::keep']);
+      freshStore.dispose();
+    });
+
+    it('ignores legacy stored keys without the provider delimiter', async () => {
+      await memento.update('devdocket.read-state', ['legacy-key', 'gh::stale']);
+
+      const freshStore = new ReadStateStore(memento);
+      const activeItems = new Map<string, DiscoveredItem[]>([
+        ['gh', [{ externalId: 'keep', title: 'Keep' }]],
+      ]);
+
+      const pruned = await freshStore.prune(activeItems);
+
+      expect(pruned).toBe(1);
+      expect([...freshStore.keys()]).toEqual(['legacy-key']);
+      expect(memento.get<string[]>('devdocket.read-state')).toEqual(['legacy-key']);
+      freshStore.dispose();
+    });
+
+    it('scopes per-provider when another provider returned no items', async () => {
+      await store.addMany(['provider-a::keep', 'provider-a::stale', 'provider-b::stale']);
+
+      const activeItems = new Map<string, DiscoveredItem[]>([
+        ['provider-a', [{ externalId: 'keep', title: 'Keep' }]],
+        ['provider-b', []],
+      ]);
+
+      const pruned = await store.prune(activeItems);
+
+      expect(pruned).toBe(1);
+      expect(store.has('provider-a::keep')).toBe(true);
+      expect(store.has('provider-a::stale')).toBe(false);
+      expect(store.has('provider-b::stale')).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary

This fixes stale read-state growth by pruning provider-scoped read-state keys after provider refreshes, using the same active discovered-items map as discovered-state cleanup.

## Details

- Add `ReadStateStore.prune(activeItems)` with the same safety semantics as `DiscoveredStateStore.prune`: lazy load, skip providers that returned empty arrays, prune only records for providers with non-empty refresh results, return the removed count, and fire `onDidChange` only when records are removed.
- Wire both `DiscoveredStateStore.prune` and `ReadStateStore.prune` from the production `ProviderRegistry.onDidRefreshProvider` path.
- Reconnect `DiscoveredStateStore.prune`, which was orphaned when the old `InboxTreeProvider` refresh path was retired.
- Cover read-state pruning behavior with unit tests and verify the extension-level refresh wiring for non-empty and empty provider refreshes.

## Validation

- `cd packages\core ; npm run build`
- `npm run test`

Closes #475
