### PR TITLE
Skip Incoming resurface when work item is already active

### DIFF
--- a/.github/instructions/services.instructions.md
+++ b/.github/instructions/services.instructions.md
@@ -35,11 +35,9 @@ Provider refreshes are separate — they happen on a periodic schedule or via ex
 
 ## Version-Based Resurfacing
 
-`DiscoveredItem.version` enables **soft resurfacing**: when an `accepted` item's stored version differs from the incoming version, state resets to `unseen`. Suppressed for items in `New`/`InProgress`/`Paused` states.
+`DiscoveredItem.version` enables resurfacing for `accepted` items: when the stored version differs from the incoming version, state resets to `unseen` only if no linked work item exists or the linked work item is `Done`/`Archived`. For linked work items in `New`/`InProgress`/`Paused`, update the stored version silently and keep the inbox state unchanged.
 
-`DiscoveredItem.resurfaceVersion` enables **hard resurfacing**: always resurfaces regardless of WorkItem state.
-
-Dismissed items are never resurfaced by either mechanism.
+`DiscoveredItem.resurfaceVersion` enables resurfacing for `accepted` and `dismissed` items with the same lifecycle gate: resurface only when no linked work item exists or the linked work item is `Done`/`Archived`; otherwise silently update the stored resurface version.
 
 ## 3-Strike Failure Handling
 

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -16,6 +16,10 @@ export interface ProviderHealthStatus {
   lastError?: string;
 }
 
+function isActiveWorkItemState(state: WorkItemState | undefined): boolean {
+  return state === WorkItemState.New || state === WorkItemState.InProgress || state === WorkItemState.Paused;
+}
+
 /**
  * Central registry for {@link DevDocketProvider} instances.
  *
@@ -84,7 +88,8 @@ export class ProviderRegistry {
     private readonly stateStore: DiscoveredStateStore,
     private readonly labelCache?: ProviderLabelCache,
     private readonly getWorkItemState?: (providerId: string, externalId: string) => WorkItemState | undefined,
-    private readonly addActivity?: (providerId: string, externalId: string, type: ActivityType, detail?: string) => Promise<void>,
+    // Kept for constructor compatibility; suppressed version bumps no longer log activity.
+    _addActivity?: (providerId: string, externalId: string, type: ActivityType, detail?: string) => Promise<void>,
   ) {}
 
   /**
@@ -408,7 +413,6 @@ export class ProviderRegistry {
 
     const newUnseenUpdates: Array<{ providerId: string; externalId: string; state: 'unseen'; version?: string; resurfaceVersion?: string }> = [];
     const versionBackfills: Array<{ providerId: string; externalId: string; state: InboxState; version?: string; resurfaceVersion?: string }> = [];
-    const activityEntries: Array<{ providerId: string; externalId: string }> = [];
 
     for (const item of items) {
       const existing = this.stateStore.getState(providerId, item.externalId);
@@ -445,32 +449,27 @@ export class ProviderRegistry {
           }
         }
 
-        // resurfaceVersion always resurfaces (hard); version checks work item state (soft)
-        let shouldResurface = resurfaceVersionTriggered;
-        let suppressedVersionChange = false;
-        if (existing === 'accepted' && versionTriggered && !shouldResurface) {
-          const wiState = this.getWorkItemState?.(providerId, item.externalId);
-          if (wiState === WorkItemState.New || wiState === WorkItemState.InProgress || wiState === WorkItemState.Paused) {
-            // Suppress: backfill version instead of resurfacing
-            suppressedVersionChange = true;
-          } else {
-            shouldResurface = true;
-          }
-        }
+        const hasTrigger = versionTriggered || resurfaceVersionTriggered;
+        const suppressForActiveWorkItem = hasTrigger && isActiveWorkItemState(this.getWorkItemState?.(providerId, item.externalId));
+        const shouldResurface = hasTrigger && !suppressForActiveWorkItem;
 
         if (shouldResurface) {
           const update: typeof newUnseenUpdates[number] = { providerId, externalId: item.externalId, state: 'unseen' };
           if (item.version !== undefined) { update.version = item.version; }
           if (item.resurfaceVersion !== undefined) { update.resurfaceVersion = item.resurfaceVersion; }
           newUnseenUpdates.push(update);
-        } else if (existing === 'accepted' && (suppressedVersionChange || needsAcceptedBackfill)) {
+        } else if (existing === 'accepted' && (suppressForActiveWorkItem || needsAcceptedBackfill)) {
           const update: typeof versionBackfills[number] = { providerId, externalId: item.externalId, state: 'accepted' };
           if (item.version !== undefined) { update.version = item.version; }
           if (item.resurfaceVersion !== undefined) { update.resurfaceVersion = item.resurfaceVersion; }
           versionBackfills.push(update);
-          if (suppressedVersionChange) {
-            activityEntries.push({ providerId, externalId: item.externalId });
-          }
+        } else if (existing === 'dismissed' && suppressForActiveWorkItem) {
+          versionBackfills.push({
+            providerId,
+            externalId: item.externalId,
+            state: 'dismissed',
+            resurfaceVersion: item.resurfaceVersion,
+          });
         } else if (needsDismissedResurfaceVersionBackfill) {
           versionBackfills.push({
             providerId,
@@ -501,20 +500,6 @@ export class ProviderRegistry {
         await this.stateStore.setStates(allUpdates);
         if (!this._disposed && newUnseenUpdates.length > 0) {
           this._onDidAddNewUnseenItems.fire(newUnseenUpdates.length);
-        }
-
-        // Log activity only after state was successfully persisted
-        if (!this._disposed && this.addActivity && activityEntries.length > 0) {
-          const results = await Promise.allSettled(
-            activityEntries.map(entry =>
-              this.addActivity!(entry.providerId, entry.externalId, 'version-updated'),
-            ),
-          );
-          for (const result of results) {
-            if (result.status === 'rejected') {
-              logger.error('Failed to log version-updated activity', result.reason);
-            }
-          }
         }
       } catch (err) {
         logger.error('Failed to persist discovered states', err);

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -1473,9 +1473,20 @@ describe('ProviderRegistry', () => {
     });
   });
 
-  describe('soft version resurfacing with work item state', () => {
-    it('suppresses version resurfacing when work item is InProgress', async () => {
-      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.InProgress);
+  describe('resurfacing with work item state', () => {
+    const activeWorkItemStates = [
+      WorkItemState.New,
+      WorkItemState.InProgress,
+      WorkItemState.Paused,
+    ];
+    const completedOrMissingWorkItemStates = [
+      WorkItemState.Done,
+      WorkItemState.Archived,
+      undefined,
+    ];
+
+    it.each(activeWorkItemStates)('suppresses accepted version resurfacing when work item is %s', async (workItemState) => {
+      const getWorkItemState = vi.fn().mockReturnValue(workItemState);
       const addActivityFn = vi.fn().mockResolvedValue(undefined);
       const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState, addActivityFn);
       const provider = createMockProvider('gh');
@@ -1492,182 +1503,158 @@ describe('ProviderRegistry', () => {
       ]);
 
       await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
-      // Should backfill version, not resurface
       expect(stateStore.setStates).toHaveBeenCalledWith([
         { providerId: 'gh', externalId: 'pr-1', state: 'accepted', version: 'sha-new' },
       ]);
+      expect(stateStore.getVersion('gh', 'pr-1')).toBe('sha-new');
       expect(listener).not.toHaveBeenCalled();
-      expect(getWorkItemState).toHaveBeenCalledWith('gh', 'pr-1');
-      // Activity log should be called
-      await vi.waitFor(() => expect(addActivityFn).toHaveBeenCalledWith('gh', 'pr-1', 'version-updated'));
-
-      reg.dispose();
-    });
-
-    it('suppresses version resurfacing when work item is Paused', async () => {
-      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.Paused);
-      const addActivityFn = vi.fn().mockResolvedValue(undefined);
-      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState, addActivityFn);
-      const provider = createMockProvider('gh');
-      reg.register(provider);
-
-      stateStore._set('gh', 'pr-1', 'accepted');
-      stateStore._setVersion('gh', 'pr-1', 'sha-old');
-
-      provider.fireItems([
-        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
-      ]);
-
-      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
-      expect(stateStore.setStates).toHaveBeenCalledWith([
-        { providerId: 'gh', externalId: 'pr-1', state: 'accepted', version: 'sha-new' },
-      ]);
-
-      reg.dispose();
-    });
-
-    it('suppresses version resurfacing when work item is New', async () => {
-      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.New);
-      const addActivityFn = vi.fn().mockResolvedValue(undefined);
-      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState, addActivityFn);
-      const provider = createMockProvider('gh');
-      reg.register(provider);
-
-      stateStore._set('gh', 'pr-1', 'accepted');
-      stateStore._setVersion('gh', 'pr-1', 'sha-old');
-
-      provider.fireItems([
-        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
-      ]);
-
-      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
-      expect(stateStore.setStates).toHaveBeenCalledWith([
-        { providerId: 'gh', externalId: 'pr-1', state: 'accepted', version: 'sha-new' },
-      ]);
-
-      reg.dispose();
-    });
-
-    it('resurfaces when version changes and work item is Done', async () => {
-      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.Done);
-      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
-      const provider = createMockProvider('gh');
-      reg.register(provider);
-
-      stateStore._set('gh', 'pr-1', 'accepted');
-      stateStore._setVersion('gh', 'pr-1', 'sha-old');
-
-      const listener = vi.fn();
-      reg.onDidAddNewUnseenItems(listener);
-
-      provider.fireItems([
-        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
-      ]);
-
-      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
-      expect(stateStore.setStates).toHaveBeenCalledWith([
-        { providerId: 'gh', externalId: 'pr-1', state: 'unseen', version: 'sha-new' },
-      ]);
-      await vi.waitFor(() => expect(listener).toHaveBeenCalledWith(1));
-
-      reg.dispose();
-    });
-
-    it('resurfaces when version changes and work item is Archived', async () => {
-      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.Archived);
-      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
-      const provider = createMockProvider('gh');
-      reg.register(provider);
-
-      stateStore._set('gh', 'pr-1', 'accepted');
-      stateStore._setVersion('gh', 'pr-1', 'sha-old');
-
-      provider.fireItems([
-        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
-      ]);
-
-      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
-      expect(stateStore.setStates).toHaveBeenCalledWith([
-        { providerId: 'gh', externalId: 'pr-1', state: 'unseen', version: 'sha-new' },
-      ]);
-
-      reg.dispose();
-    });
-
-    it('resurfaces when version changes and no work item exists', async () => {
-      const getWorkItemState = vi.fn().mockReturnValue(undefined);
-      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
-      const provider = createMockProvider('gh');
-      reg.register(provider);
-
-      stateStore._set('gh', 'pr-1', 'accepted');
-      stateStore._setVersion('gh', 'pr-1', 'sha-old');
-
-      provider.fireItems([
-        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
-      ]);
-
-      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
-      expect(stateStore.setStates).toHaveBeenCalledWith([
-        { providerId: 'gh', externalId: 'pr-1', state: 'unseen', version: 'sha-new' },
-      ]);
-
-      reg.dispose();
-    });
-
-    it('resurfaceVersion always resurfaces even when work item is InProgress', async () => {
-      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.InProgress);
-      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
-      const provider = createMockProvider('gh');
-      reg.register(provider);
-
-      stateStore._set('gh', 'pr-1', 'accepted');
-      stateStore._setResurfaceVersion('gh', 'pr-1', 'rr-old');
-
-      const listener = vi.fn();
-      reg.onDidAddNewUnseenItems(listener);
-
-      provider.fireItems([
-        { externalId: 'pr-1', title: 'PR 1', resurfaceVersion: 'rr-new' },
-      ]);
-
-      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
-      expect(stateStore.setStates).toHaveBeenCalledWith([
-        { providerId: 'gh', externalId: 'pr-1', state: 'unseen', resurfaceVersion: 'rr-new' },
-      ]);
-      await vi.waitFor(() => expect(listener).toHaveBeenCalledWith(1));
-
-      reg.dispose();
-    });
-
-    it('resurfaceVersion overrides suppressed version change', async () => {
-      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.InProgress);
-      const addActivityFn = vi.fn().mockResolvedValue(undefined);
-      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState, addActivityFn);
-      const provider = createMockProvider('gh');
-      reg.register(provider);
-
-      stateStore._set('gh', 'pr-1', 'accepted');
-      stateStore._setVersion('gh', 'pr-1', 'sha-old');
-      stateStore._setResurfaceVersion('gh', 'pr-1', 'rr-old');
-
-      provider.fireItems([
-        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new', resurfaceVersion: 'rr-new' },
-      ]);
-
-      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
-      // resurfaceVersion change should trigger full resurface
-      expect(stateStore.setStates).toHaveBeenCalledWith([
-        { providerId: 'gh', externalId: 'pr-1', state: 'unseen', version: 'sha-new', resurfaceVersion: 'rr-new' },
-      ]);
-      // No activity logged — item resurfaced, not suppressed
       expect(addActivityFn).not.toHaveBeenCalled();
+      expect(getWorkItemState).toHaveBeenCalledWith('gh', 'pr-1');
 
       reg.dispose();
     });
 
-    it('still works without getWorkItemState callback (backward compatible)', async () => {
-      // No callback provided — behaves as before (version change resurfaces)
+    it.each(completedOrMissingWorkItemStates)('resurfaces accepted item on version change when work item is %s', async (workItemState) => {
+      const getWorkItemState = vi.fn().mockReturnValue(workItemState);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+      stateStore._setVersion('gh', 'pr-1', 'sha-old');
+
+      const listener = vi.fn();
+      reg.onDidAddNewUnseenItems(listener);
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'unseen', version: 'sha-new' },
+      ]);
+      await vi.waitFor(() => expect(listener).toHaveBeenCalledWith(1));
+      expect(getWorkItemState).toHaveBeenCalledWith('gh', 'pr-1');
+
+      reg.dispose();
+    });
+
+    it.each(activeWorkItemStates)('suppresses accepted resurfaceVersion resurfacing when work item is %s', async (workItemState) => {
+      const getWorkItemState = vi.fn().mockReturnValue(workItemState);
+      const addActivityFn = vi.fn().mockResolvedValue(undefined);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState, addActivityFn);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+      stateStore._setVersion('gh', 'pr-1', 'sha-same');
+      stateStore._setResurfaceVersion('gh', 'pr-1', 'rr-old');
+
+      const listener = vi.fn();
+      reg.onDidAddNewUnseenItems(listener);
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', version: 'sha-same', resurfaceVersion: 'rr-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'accepted', version: 'sha-same', resurfaceVersion: 'rr-new' },
+      ]);
+      expect(stateStore.getResurfaceVersion('gh', 'pr-1')).toBe('rr-new');
+      expect(listener).not.toHaveBeenCalled();
+      expect(addActivityFn).not.toHaveBeenCalled();
+      expect(getWorkItemState).toHaveBeenCalledWith('gh', 'pr-1');
+
+      reg.dispose();
+    });
+
+    it.each(completedOrMissingWorkItemStates)('resurfaces accepted item on resurfaceVersion change when work item is %s', async (workItemState) => {
+      const getWorkItemState = vi.fn().mockReturnValue(workItemState);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'accepted');
+      stateStore._setVersion('gh', 'pr-1', 'sha-same');
+      stateStore._setResurfaceVersion('gh', 'pr-1', 'rr-old');
+
+      const listener = vi.fn();
+      reg.onDidAddNewUnseenItems(listener);
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', version: 'sha-same', resurfaceVersion: 'rr-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'unseen', version: 'sha-same', resurfaceVersion: 'rr-new' },
+      ]);
+      await vi.waitFor(() => expect(listener).toHaveBeenCalledWith(1));
+      expect(getWorkItemState).toHaveBeenCalledWith('gh', 'pr-1');
+
+      reg.dispose();
+    });
+
+    it.each(activeWorkItemStates)('suppresses dismissed resurfaceVersion resurfacing when work item is %s', async (workItemState) => {
+      const getWorkItemState = vi.fn().mockReturnValue(workItemState);
+      const addActivityFn = vi.fn().mockResolvedValue(undefined);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState, addActivityFn);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'dismissed');
+      stateStore._setVersion('gh', 'pr-1', 'sha-same');
+      stateStore._setResurfaceVersion('gh', 'pr-1', 'rr-old');
+
+      const listener = vi.fn();
+      reg.onDidAddNewUnseenItems(listener);
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', version: 'sha-same', resurfaceVersion: 'rr-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'dismissed', resurfaceVersion: 'rr-new' },
+      ]);
+      expect(stateStore.getResurfaceVersion('gh', 'pr-1')).toBe('rr-new');
+      expect(listener).not.toHaveBeenCalled();
+      expect(addActivityFn).not.toHaveBeenCalled();
+      expect(getWorkItemState).toHaveBeenCalledWith('gh', 'pr-1');
+
+      reg.dispose();
+    });
+
+    it.each(completedOrMissingWorkItemStates)('resurfaces dismissed item on resurfaceVersion change when work item is %s', async (workItemState) => {
+      const getWorkItemState = vi.fn().mockReturnValue(workItemState);
+      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState);
+      const provider = createMockProvider('gh');
+      reg.register(provider);
+
+      stateStore._set('gh', 'pr-1', 'dismissed');
+      stateStore._setVersion('gh', 'pr-1', 'sha-same');
+      stateStore._setResurfaceVersion('gh', 'pr-1', 'rr-old');
+
+      const listener = vi.fn();
+      reg.onDidAddNewUnseenItems(listener);
+
+      provider.fireItems([
+        { externalId: 'pr-1', title: 'PR 1', version: 'sha-same', resurfaceVersion: 'rr-new' },
+      ]);
+
+      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
+      expect(stateStore.setStates).toHaveBeenCalledWith([
+        { providerId: 'gh', externalId: 'pr-1', state: 'unseen', version: 'sha-same', resurfaceVersion: 'rr-new' },
+      ]);
+      await vi.waitFor(() => expect(listener).toHaveBeenCalledWith(1));
+      expect(getWorkItemState).toHaveBeenCalledWith('gh', 'pr-1');
+
+      reg.dispose();
+    });
+
+    it('still resurfaces accepted version changes without getWorkItemState callback', async () => {
       const reg = new ProviderRegistry(stateStore);
       const provider = createMockProvider('gh');
       reg.register(provider);
@@ -1686,31 +1673,7 @@ describe('ProviderRegistry', () => {
 
       reg.dispose();
     });
-
-    it('logs activity error gracefully without breaking flow', async () => {
-      const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.InProgress);
-      const addActivityFn = vi.fn().mockRejectedValue(new Error('activity fail'));
-      const reg = new ProviderRegistry(stateStore, undefined, getWorkItemState, addActivityFn);
-      const provider = createMockProvider('gh');
-      reg.register(provider);
-
-      stateStore._set('gh', 'pr-1', 'accepted');
-      stateStore._setVersion('gh', 'pr-1', 'sha-old');
-
-      provider.fireItems([
-        { externalId: 'pr-1', title: 'PR 1', version: 'sha-new' },
-      ]);
-
-      await vi.waitFor(() => expect(stateStore.setStates).toHaveBeenCalled());
-      // Should still backfill version even though activity fails
-      expect(stateStore.setStates).toHaveBeenCalledWith([
-        { providerId: 'gh', externalId: 'pr-1', state: 'accepted', version: 'sha-new' },
-      ]);
-
-      reg.dispose();
-    });
   });
-
   describe('accepted items without version fields', () => {
     it('does not resurface accepted item re-emitted with no version or resurfaceVersion', async () => {
       const getWorkItemState = vi.fn().mockReturnValue(WorkItemState.Done);

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -47,18 +47,19 @@ export interface DiscoveredItem {
    */
   badges?: ProviderBadge[];
   /**
-   * Optional version identifier for "soft" resurfacing.
+   * Optional version identifier for accepted-item resurfacing.
    * When a previously accepted item reappears with a different version,
-   * it is resurfaced in the Inbox as unseen **unless** the linked work item
-   * is currently in Queue or Focus (New, InProgress, Paused), in which case
-   * the version is silently updated and a `version-updated` activity is logged.
+   * it is resurfaced in Incoming as unseen only if no linked work item exists
+   * or the linked work item is Done/Archived. For linked work items in
+   * New/InProgress/Paused, the version is silently updated.
    */
   version?: string;
   /**
-   * Optional secondary version for "hard" resurfacing.
+   * Optional secondary version for accepted and dismissed item resurfacing.
    * After the core records an item's first seen resurfaceVersion, later
-   * changes for previously accepted or dismissed items always resurface the
-   * item in the Inbox as unseen, regardless of linked work item state.
+   * changes resurface the item in Incoming as unseen only if no linked work
+   * item exists or the linked work item is Done/Archived. For linked work
+   * items in New/InProgress/Paused, the resurfaceVersion is silently updated.
    */
   resurfaceVersion?: string;
   /**

--- a/packages/shared/src/workItem.ts
+++ b/packages/shared/src/workItem.ts
@@ -9,7 +9,7 @@
  * - `work-started` — a branch and/or worktree was created for this item.
  * - `cleanup` — git branch and/or worktree was cleaned up.
  * - `cleanup-dismissed` — user declined cleanup prompt for this item.
- * - `version-updated` — a provider version change was suppressed because the item is in Queue or Focus.
+ * - `version-updated` — legacy activity for a suppressed provider version change; retained for older logs.
  */
 export type ActivityType = 'created' | 'state-changed' | 'updated' | 'action-executed' | 'auto-completed' | 'work-started' | 'cleanup' | 'cleanup-dismissed' | 'version-updated';
 


### PR DESCRIPTION
## Summary

ADO PR provider items could resurface back to Incoming after a new commit changed their provider version, even when the linked DevDocket work item was already In Progress. That made active work appear as newly incoming again.

This change gates version and resurfaceVersion resurfacing on the linked work item's lifecycle state. Provider items only return to Incoming when the linked work item is Done or Archived, or when no linked work item exists for that provider provenance. For New, InProgress, and Paused work items, DevDocket silently updates the stored version baseline without changing the inbox state or firing new-unseen notifications.

The gate applies to accepted item version changes, accepted item resurfaceVersion changes, and dismissed item resurfaceVersion changes.

## Validation

- npm run build
- npm run test
- packages/core: npm run build
- packages/core: npm run test
- superpowers:code-reviewer clean

Closes #487
