### PR TITLE
Drop retainContextWhenHidden from main sidebar webview

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -421,7 +421,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     vscode.window.registerWebviewViewProvider(
       MainViewProvider.viewId,
       mainProvider,
-      { webviewOptions: { retainContextWhenHidden: true } },
     ),
     wg.onDidChange(safeHandler('mc:workGraph', () => mainProvider.scheduleRefresh())),
     pr.onDidChangeDiscoveredItems(safeHandler('mc:discovered', () => mainProvider.scheduleRefresh())),

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -95,11 +95,15 @@ describe('activate()', () => {
   // ------------------------------------------------------------------
   it('registers the DevDocket webview provider', async () => {
     await activate(context);
+
     expect(vscode.window.registerWebviewViewProvider).toHaveBeenCalledWith(
       'devdocket.main',
       expect.any(MainViewProvider),
-      expect.objectContaining({ webviewOptions: { retainContextWhenHidden: true } }),
     );
+    const call = (vscode.window.registerWebviewViewProvider as ReturnType<typeof vi.fn>).mock.calls.find(
+      ([viewId]) => viewId === 'devdocket.main',
+    );
+    expect(call?.[2]).toBeUndefined();
   });
 
   // ------------------------------------------------------------------

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -96,14 +96,15 @@ describe('activate()', () => {
   it('registers the DevDocket webview provider', async () => {
     await activate(context);
 
-    expect(vscode.window.registerWebviewViewProvider).toHaveBeenCalledWith(
-      'devdocket.main',
-      expect.any(MainViewProvider),
-    );
     const call = (vscode.window.registerWebviewViewProvider as ReturnType<typeof vi.fn>).mock.calls.find(
       ([viewId]) => viewId === 'devdocket.main',
     );
-    expect(call?.[2]).toBeUndefined();
+    expect(call).toBeDefined();
+    if (!call) {
+      throw new Error('DevDocket webview provider was not registered');
+    }
+    expect(call[1]).toBeInstanceOf(MainViewProvider);
+    expect(call[2]?.webviewOptions?.retainContextWhenHidden).not.toBe(true);
   });
 
   // ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Removes `retainContextWhenHidden: true` from the main DevDocket sidebar webview. The CI Watches panel did not actually have this option set despite the issue description suggesting it did, so no change there.

The main sidebar webview already calls `scheduleRefresh()` from `MainViewProvider.resolveWebviewView()`, which posts fresh `updateItems` and `updateSources` data on every reveal. Retaining the DOM between hides was therefore a small UX improvement (instant re-render before refresh data arrives) at a non-trivial memory cost. Per VS Code's own guidance, this option should be used sparingly.

## Why

VS Code's `retainContextWhenHidden` option keeps the entire webview DOM alive in memory whenever the user hides the panel. For the sidebar, that means the full Preact tree of every Incoming, In Progress, Ready to Start, Paused, Done, and Sources item is held the entire VS Code session, even when DevDocket is not the active activity bar panel. Since the data is rebuilt from `globalState` on every reveal anyway, retention provided no data-fidelity benefit.

## Changes

- `packages/core/src/extension.ts`: drop `webviewOptions: { retainContextWhenHidden: true }` from the `registerWebviewViewProvider` call for `MainViewProvider`.
- `packages/core/src/test/extension.test.ts`: updated assertion to confirm the option is no longer set.

## Verification

`npm run build && npm run test` passes in `packages/core`.

Closes #474
