### PR TITLE
Stop prefixing accepted item titles with provider group

### DIFF
--- a/packages/core/src/commands/commandUtils.ts
+++ b/packages/core/src/commands/commandUtils.ts
@@ -22,10 +22,8 @@ export function resolveItemIds(item?: { id?: string }, selectedItems?: { id?: st
   return [];
 }
 
-/** Builds a work-item title, optionally prefixed with the provider group. */
 export function formatItemTitle(item: { group?: string; title: string }): string {
-  const trimmedGroup = item.group?.trim();
-  return trimmedGroup ? `${trimmedGroup} ${item.title}` : item.title;
+  return item.title;
 }
 
 /** Log the error and show a user-facing message. */

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -57,10 +57,8 @@ function resolveSourceItems(item?: SourcesElement, selectedItems?: SourcesElemen
   return [];
 }
 
-/** Builds a work-item title, optionally prefixed with the provider group. */
 function formatItemTitle(item: { group?: string; title: string }): string {
-  const trimmedGroup = item.group?.trim();
-  return trimmedGroup ? `${trimmedGroup} ${item.title}` : item.title;
+  return item.title;
 }
 
 // isSafeUrl is imported from ../utils/url.

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -826,19 +826,19 @@ describe('registerCommands', () => {
       expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
     });
 
-    it('prefixes group to title when group is present', async () => {
+    it('keeps title unprefixed and passes group when group is present', async () => {
       const inboxItem = makeInboxItem({ group: 'org/repo' });
       workGraph.findItemByProvenance.mockReturnValue(undefined);
 
       await invoke('devdocket.acceptFromInbox', inboxItem);
 
       expect(workGraph.createItem).toHaveBeenCalledWith(
-        { title: 'org/repo Inbox Issue' },
-        expect.any(Object),
+        { title: 'Inbox Issue' },
+        expect.objectContaining({ group: 'org/repo' }),
       );
     });
 
-    it('does not prefix group when group is empty/whitespace', async () => {
+    it('does not pass group when group is empty/whitespace', async () => {
       const inboxItem = makeInboxItem({ group: '  ' });
       workGraph.findItemByProvenance.mockReturnValue(undefined);
 
@@ -1191,11 +1191,11 @@ describe('registerCommands', () => {
       await invoke('devdocket.acceptFromInbox', items[0], items);
 
       expect(workGraph.createItem).toHaveBeenCalledWith(
-        { title: 'octocat/repo Issue 1' },
+        { title: 'Issue 1' },
         expect.objectContaining({ providerId: 'github', externalId: 'ext-1', group: 'octocat/repo' }),
       );
       expect(workGraph.createItem).toHaveBeenCalledWith(
-        { title: 'octocat/other Issue 2' },
+        { title: 'Issue 2' },
         expect.objectContaining({ providerId: 'github', externalId: 'ext-2', group: 'octocat/other' }),
       );
     });
@@ -1431,6 +1431,14 @@ describe('registerCommands', () => {
         { providerId: 'github', externalId: 'ext-1', state: 'accepted' },
         { providerId: 'github', externalId: 'ext-2', state: 'accepted' },
       ]);
+      expect(workGraph.createItem).toHaveBeenCalledWith(
+        { title: 'Issue 1', description: undefined },
+        expect.objectContaining({ providerId: 'github', externalId: 'ext-1', group: 'My Mentions' }),
+      );
+      expect(workGraph.createItem).toHaveBeenCalledWith(
+        { title: 'Issue 2', description: undefined },
+        expect.objectContaining({ providerId: 'github', externalId: 'ext-2', group: 'My Mentions' }),
+      );
     });
 
     it('accepts all provider items to In Progress after confirmation', async () => {
@@ -1480,6 +1488,14 @@ describe('registerCommands', () => {
         'Accept 2 items from "GitHub > My Mentions" to In Progress?',
         { modal: true },
         'Accept All to In Progress',
+      );
+      expect(workGraph.createItem).toHaveBeenCalledWith(
+        { title: 'Issue 1', description: undefined },
+        expect.objectContaining({ providerId: 'github', externalId: 'ext-1', group: 'My Mentions' }),
+      );
+      expect(workGraph.createItem).toHaveBeenCalledWith(
+        { title: 'Issue 2', description: undefined },
+        expect.objectContaining({ providerId: 'github', externalId: 'ext-2', group: 'My Mentions' }),
       );
       expect(workGraph.transitionState).toHaveBeenCalledWith('wc-1', WorkItemState.InProgress);
       expect(workGraph.transitionState).toHaveBeenCalledWith('wc-2', WorkItemState.InProgress);
@@ -1658,6 +1674,21 @@ describe('registerCommands', () => {
       );
       expect(stateStore.setState).toHaveBeenCalledWith('github', 'ext-1', 'accepted');
       expect(workGraph.transitionState).toHaveBeenCalledWith('wc-new-1', WorkItemState.InProgress);
+    });
+
+    it('keeps title unprefixed and passes group when accepting a new item to InProgress', async () => {
+      const inboxItem = makeInboxItem({ group: 'org/repo' });
+      const created = createWorkItem({ id: 'wc-new-group' });
+      workGraph.findItemByProvenance.mockReturnValue(undefined);
+      workGraph.createItem.mockResolvedValue(created);
+
+      await invoke('devdocket.acceptToFocusFromInbox', inboxItem);
+
+      expect(workGraph.createItem).toHaveBeenCalledWith(
+        { title: 'Inbox Issue' },
+        expect.objectContaining({ providerId: 'github', externalId: 'ext-1', group: 'org/repo' }),
+      );
+      expect(workGraph.transitionState).toHaveBeenCalledWith('wc-new-group', WorkItemState.InProgress);
     });
 
     it('sets state to accepted and transitions existing New item to InProgress', async () => {
@@ -2548,15 +2579,15 @@ describe('registerCommands', () => {
       );
     });
 
-    it('prefixes group to title for source items with group', async () => {
+    it('keeps title unprefixed and passes group for source items with group', async () => {
       const sourceItem = makeSourceItem({ group: 'myorg/myrepo' });
       workGraph.findItemByProvenance.mockReturnValue(undefined);
 
       await invoke('devdocket.acceptFromSources', sourceItem);
 
       expect(workGraph.createItem).toHaveBeenCalledWith(
-        { title: 'myorg/myrepo Source Issue' },
-        expect.any(Object),
+        { title: 'Source Issue' },
+        expect.objectContaining({ group: 'myorg/myrepo' }),
       );
     });
 

--- a/packages/core/src/test/titleSync.test.ts
+++ b/packages/core/src/test/titleSync.test.ts
@@ -47,6 +47,22 @@ describe('syncProviderTitles', () => {
     expect(workGraph.updateItem).not.toHaveBeenCalled();
   });
 
+  it('does not update a just-accepted grouped item created with the provider title', async () => {
+    providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
+      ['github', [{ externalId: 'owner/repo#42', title: 'Fix the thing', group: 'owner/repo' }]],
+    ]));
+    workGraph.findItemByProvenance.mockReturnValue({
+      id: 'item-1',
+      title: 'Fix the thing',
+      provenance: { providerId: 'github', externalId: 'owner/repo#42', group: 'owner/repo' },
+    });
+
+    await syncProviderTitles('github', providerRegistry as any, workGraph as any);
+
+    expect(workGraph.findItemByProvenance).toHaveBeenCalledWith('github', 'owner/repo#42');
+    expect(workGraph.updateItem).not.toHaveBeenCalled();
+  });
+
   it('skips discovered items without matching WorkItem', async () => {
     providerRegistry.getAllDiscoveredItems.mockReturnValue(new Map([
       ['github', [{ externalId: '99', title: 'Orphan' }]],


### PR DESCRIPTION
## Summary

Stops prefixing accepted-item titles with the provider `group` value, eliminating the brief "title flicker" the user sees right after accepting an Incoming item.

## Why

Two pieces of logic disagreed about whether the group should be part of the WorkItem title:

1. **Acceptance path** — `commandUtils.formatItemTitle()` returned `${group} ${title}` when group was present, so newly created WorkItems got prefixed titles.
2. **Title sync path** — `services/titleSync.ts` later compared the persisted (prefixed) title against the discovered (un-prefixed) title and rewrote it to the un-prefixed form on the next provider refresh.

The visible result was a brief "owner/repo#123 Fix the thing" followed by a re-render to "Fix the thing".

The sidebar already renders `group` separately as a `repoAnnotation` badge alongside the title, so the prefix was redundant — the steady state correctly is the un-prefixed title.

## Fix

`formatItemTitle` now returns `item.title` directly. The `group` field continues to be passed to `workGraph.createItem`, so the badge keeps rendering. No migration needed for existing WorkItems whose persisted title still has the legacy prefix — `syncProviderTitles` already fixes those on the next refresh.

## Changes

- `packages/core/src/commands/commandUtils.ts` — drop the prefix from `formatItemTitle`.
- `packages/core/src/commands/commands.ts` — adjust call sites to keep behavior consistent.
- `packages/core/src/test/commands.test.ts` — update assertions to expect un-prefixed titles.
- `packages/core/src/test/titleSync.test.ts` — regression test ensuring `syncProviderTitles` does not fire `updateItem` immediately after acceptance for the just-created item.

## Verification

`cd packages/core && npm run build && npm run test` — passes.

Closes #504
