### PR TITLE
Push start-git-work disposables onto context.subscriptions

### DIFF
--- a/packages/start-git-work/src/extension.ts
+++ b/packages/start-git-work/src/extension.ts
@@ -49,5 +49,5 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 }
 
 export function deactivate(): void {
-  logger.info('DevDocket Start Git Work deactivated');
+  // Resources disposed via subscriptions
 }

--- a/packages/start-git-work/src/test/extension.test.ts
+++ b/packages/start-git-work/src/test/extension.test.ts
@@ -77,7 +77,7 @@ describe('Start Git Work extension activation', () => {
     expect(mockApi.onDidTransitionState).toHaveBeenCalledTimes(1);
     expect(disposables).toContain(actionDisposable);
     expect(disposables).toContain(transitionDisposable);
-    expect(disposables).toHaveLength(3);
+    expect(disposables.length).toBeGreaterThanOrEqual(2);
   });
 
   it('lets context subscriptions dispose registrations', async () => {

--- a/packages/start-git-work/src/test/extension.test.ts
+++ b/packages/start-git-work/src/test/extension.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { extensions, window } from 'vscode';
 import { activate, deactivate } from '../extension';
+import { setLogger } from '../logger';
+
+const noopLogger = {
+  debug: () => undefined,
+  info: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};
 
 describe('Start Git Work extension activation', () => {
   let mockContext: any;
@@ -73,6 +81,7 @@ describe('Start Git Work extension activation', () => {
     disposeContextSubscriptions();
     createOutputChannelSpy?.mockRestore();
     createOutputChannelSpy = undefined;
+    setLogger(noopLogger);
   });
 
   it('pushes activation disposables onto subscriptions', async () => {

--- a/packages/start-git-work/src/test/extension.test.ts
+++ b/packages/start-git-work/src/test/extension.test.ts
@@ -9,6 +9,7 @@ describe('Start Git Work extension activation', () => {
   let actionDisposable: any;
   let transitionDisposable: any;
   let outputChannel: any;
+  let createOutputChannelSpy: { mockRestore: () => void } | undefined;
 
   const disposeContextSubscriptions = () => {
     const currentDisposables = disposables;
@@ -40,7 +41,7 @@ describe('Start Git Work extension activation', () => {
       logLevel: 2,
       onDidChangeLogLevel: vi.fn(),
     };
-    (window as any).createOutputChannel = vi.fn(() => outputChannel);
+    createOutputChannelSpy = vi.spyOn(window, 'createOutputChannel').mockReturnValue(outputChannel as any);
 
     disposables = [];
     actionDisposable = { dispose: vi.fn() };
@@ -70,6 +71,8 @@ describe('Start Git Work extension activation', () => {
 
   afterEach(() => {
     disposeContextSubscriptions();
+    createOutputChannelSpy?.mockRestore();
+    createOutputChannelSpy = undefined;
   });
 
   it('pushes activation disposables onto subscriptions', async () => {

--- a/packages/start-git-work/src/test/extension.test.ts
+++ b/packages/start-git-work/src/test/extension.test.ts
@@ -8,6 +8,7 @@ describe('Start Git Work extension activation', () => {
   let disposables: any[];
   let actionDisposable: any;
   let transitionDisposable: any;
+  let outputChannel: any;
 
   const disposeContextSubscriptions = () => {
     const currentDisposables = disposables;
@@ -22,7 +23,7 @@ describe('Start Git Work extension activation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    (window as any).createOutputChannel = vi.fn(() => ({
+    outputChannel = {
       info: vi.fn(),
       debug: vi.fn(),
       warn: vi.fn(),
@@ -38,7 +39,8 @@ describe('Start Git Work extension activation', () => {
       replace: vi.fn(),
       logLevel: 2,
       onDidChangeLogLevel: vi.fn(),
-    }));
+    };
+    (window as any).createOutputChannel = vi.fn(() => outputChannel);
 
     disposables = [];
     actionDisposable = { dispose: vi.fn() };
@@ -70,14 +72,15 @@ describe('Start Git Work extension activation', () => {
     disposeContextSubscriptions();
   });
 
-  it('pushes action and transition disposables onto subscriptions', async () => {
+  it('pushes activation disposables onto subscriptions', async () => {
     await activate(mockContext);
 
     expect(mockApi.registerAction).toHaveBeenCalledTimes(1);
     expect(mockApi.onDidTransitionState).toHaveBeenCalledTimes(1);
+    expect(disposables).toContain(outputChannel);
     expect(disposables).toContain(actionDisposable);
     expect(disposables).toContain(transitionDisposable);
-    expect(disposables.length).toBeGreaterThanOrEqual(2);
+    expect(disposables.length).toBeGreaterThanOrEqual(3);
   });
 
   it('lets context subscriptions dispose registrations', async () => {
@@ -85,6 +88,7 @@ describe('Start Git Work extension activation', () => {
 
     disposeContextSubscriptions();
 
+    expect(outputChannel.dispose).toHaveBeenCalledTimes(1);
     expect(actionDisposable.dispose).toHaveBeenCalledTimes(1);
     expect(transitionDisposable.dispose).toHaveBeenCalledTimes(1);
   });

--- a/packages/start-git-work/src/test/extension.test.ts
+++ b/packages/start-git-work/src/test/extension.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { extensions, window } from 'vscode';
+import { activate, deactivate } from '../extension';
+
+describe('Start Git Work extension activation', () => {
+  let mockContext: any;
+  let mockApi: any;
+  let disposables: any[];
+  let actionDisposable: any;
+  let transitionDisposable: any;
+
+  const disposeContextSubscriptions = () => {
+    const currentDisposables = disposables;
+    disposables = [];
+    for (const disposable of currentDisposables) {
+      if (disposable && typeof disposable.dispose === 'function') {
+        disposable.dispose();
+      }
+    }
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    (window as any).createOutputChannel = vi.fn(() => ({
+      info: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      trace: vi.fn(),
+      appendLine: vi.fn(),
+      append: vi.fn(),
+      clear: vi.fn(),
+      show: vi.fn(),
+      hide: vi.fn(),
+      dispose: vi.fn(),
+      name: 'DevDocket Start Git Work',
+      replace: vi.fn(),
+      logLevel: 2,
+      onDidChangeLogLevel: vi.fn(),
+    }));
+
+    disposables = [];
+    actionDisposable = { dispose: vi.fn() };
+    transitionDisposable = { dispose: vi.fn() };
+    mockContext = {
+      globalState: {
+        get: vi.fn((_key: string, defaultValue?: unknown) => defaultValue),
+        update: vi.fn(),
+      },
+      subscriptions: {
+        push: (...items: any[]) => disposables.push(...items),
+      },
+    };
+
+    mockApi = {
+      registerAction: vi.fn(() => actionDisposable),
+      onDidTransitionState: vi.fn(() => transitionDisposable),
+      addActivity: vi.fn(),
+    };
+
+    vi.mocked(extensions.getExtension).mockReturnValue({
+      isActive: true,
+      exports: mockApi,
+      activate: vi.fn(),
+    } as any);
+  });
+
+  afterEach(() => {
+    disposeContextSubscriptions();
+  });
+
+  it('pushes action and transition disposables onto subscriptions', async () => {
+    await activate(mockContext);
+
+    expect(mockApi.registerAction).toHaveBeenCalledTimes(1);
+    expect(mockApi.onDidTransitionState).toHaveBeenCalledTimes(1);
+    expect(disposables).toContain(actionDisposable);
+    expect(disposables).toContain(transitionDisposable);
+    expect(disposables).toHaveLength(3);
+  });
+
+  it('lets context subscriptions dispose registrations', async () => {
+    await activate(mockContext);
+
+    disposeContextSubscriptions();
+
+    expect(actionDisposable.dispose).toHaveBeenCalledTimes(1);
+    expect(transitionDisposable.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns early when core extension is not found', async () => {
+    vi.mocked(extensions.getExtension).mockReturnValue(undefined as any);
+
+    await activate(mockContext);
+
+    expect(mockApi.registerAction).not.toHaveBeenCalled();
+  });
+
+  it('deactivate is a no-op', () => {
+    expect(() => deactivate()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Aligns `start-git-work` with the rest of the repo by pushing all extension disposables onto `context.subscriptions` and reducing `deactivate()` to a no-op. Audited the other provider/action extensions (`github`, `ado`, `ai-reviewer`) — they already follow the correct pattern, so no changes were needed there.

## Why

VS Code only guarantees disposal of `context.subscriptions`. Module-scoped `let` references that are only torn down inside `deactivate()` can leak if `deactivate()` throws, and they survive soft re-activation in some toolchains (vitest watch, Extension Development Host hot reload). Aligning with the pattern already used in `packages/core/src/extension.ts` removes a subtle hot-reload footgun and makes the lifecycle uniform across the repo.

## Changes

- `packages/start-git-work/src/extension.ts` — push every registration disposable into `context.subscriptions`; `deactivate()` is now a no-op.
- `packages/start-git-work/src/test/extension.test.ts` — added activation tests asserting that disposals fire via subscription teardown.

## Audited but unchanged

- `packages/github/src/extension.ts` — already pushes registrations into `context.subscriptions`.
- `packages/ado/src/extension.ts` — already pushes registrations and uses a per-config Disposable slot for the reconfigure path.
- `packages/ai-reviewer/src/extension.ts` — already pushes registrations.

## Verification

- `cd packages/start-git-work && npm run build && npm run test` — passes.
- `npm run build && npm run test` from the worktree root — passes.

Closes #508
