### PR TITLE
Skip unregistered child runs to silence CodeQL warn-spam

### DIFF
--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -250,6 +250,7 @@ export class WatcherService implements vscode.Disposable {
         }
       }
       this.prWatches.delete(key);
+      this.forgetSkippedUnregisteredChildRuns(key);
     } else if (existing && !existing.dismissed) {
       // Already actively watching — return existing unchanged. Used by the
       // auto-watch path (which checks isPRWatched first anyway); keeps the
@@ -258,6 +259,7 @@ export class WatcherService implements vscode.Disposable {
     } else if (existing) {
       // Previously dismissed — delete and recreate fresh.
       this.prWatches.delete(key);
+      this.forgetSkippedUnregisteredChildRuns(key);
     }
 
     const prWatcher = this.prWatcherRegistry.get(identifier.providerId);
@@ -350,6 +352,7 @@ export class WatcherService implements vscode.Disposable {
           this.acknowledgedFailedRunKeys.delete(childKey);
         }
       }
+      this.forgetSkippedUnregisteredChildRuns(key);
       this.logger.info(`Dismissed PR watch: ${identifier.displayName}`);
       this._onDidChangePRWatches.fire();
       this._onDidChangeWatchedRuns.fire(this.getAllWatches());
@@ -393,6 +396,7 @@ export class WatcherService implements vscode.Disposable {
             dismissedCount++;
           }
         }
+        this.forgetSkippedUnregisteredChildRuns(key);
         dismissedCount++;
       }
     }
@@ -647,6 +651,7 @@ export class WatcherService implements vscode.Disposable {
       if (this.getActiveChildRunKeys(prKey).length > 0) continue;
 
       prWatch.dismissed = true;
+      this.forgetSkippedUnregisteredChildRuns(prKey);
       dismissedCount++;
       this.logger.info(`Dismissed childless PR watch: ${prWatch.identifier.displayName}`);
     }
@@ -1057,6 +1062,15 @@ export class WatcherService implements vscode.Disposable {
     this.logger.debug(`Skipping child run with no registered watcher: ${runIdentifier.providerId}/${runIdentifier.runId}`);
   }
 
+  private forgetSkippedUnregisteredChildRuns(prKey: string): void {
+    const prefix = `${prKey}::`;
+    for (const skipKey of this.skippedUnregisteredChildRuns) {
+      if (skipKey.startsWith(prefix)) {
+        this.skippedUnregisteredChildRuns.delete(skipKey);
+      }
+    }
+  }
+
   private isNoWatcherRegisteredError(err: unknown): boolean {
     const message = err instanceof Error ? err.message : String(err);
     return message.includes('No watcher registered for provider:');
@@ -1142,6 +1156,7 @@ export class WatcherService implements vscode.Disposable {
     this.prWatches.clear();
     this.consecutiveFailures.clear();
     this.acknowledgedFailedRunKeys.clear();
+    this.skippedUnregisteredChildRuns.clear();
     this.persistedPRWatchKeys = undefined;
   }
 }

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -3,6 +3,7 @@ import type { RunIdentifier, RunStatus, JobStatus, PRIdentifier, PRState } from 
 import { WatcherRegistry } from './watcherRegistry';
 import { PRWatcherRegistry } from './prWatcherRegistry';
 import { WatchStore } from '../storage/watchStore';
+import type { Logger } from './logger';
 
 /**
  * A watched pipeline run with its current status.
@@ -72,6 +73,7 @@ export class WatcherService implements vscode.Disposable {
    * regression can re-alert the user.
    */
   private persistFailureNotified = false;
+  private readonly skippedUnregisteredChildRuns = new Set<string>();
   
   private readonly _onDidChangeWatchedRuns = new vscode.EventEmitter<WatchedRun[]>();
   readonly onDidChangeWatchedRuns = this._onDidChangeWatchedRuns.event;
@@ -92,7 +94,7 @@ export class WatcherService implements vscode.Disposable {
     private watcherRegistry: WatcherRegistry,
     private prWatcherRegistry: PRWatcherRegistry,
     private watchStore: WatchStore,
-    private logger: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void }
+    private logger: Logger
   ) {
     this.configSubscription = vscode.workspace.onDidChangeConfiguration(e => {
       if (e.affectsConfiguration('devDocket.watches.pollingIntervalSeconds') && this.pollTimer) {
@@ -287,6 +289,9 @@ export class WatcherService implements vscode.Disposable {
     // Add initial runs as child watches (batched — single event/persist after)
     for (const runId of snapshot.runs) {
       const resolved = this.resolveRunIdentifier(runId);
+      if (this.shouldSkipUnregisteredChildRun(key, resolved)) {
+        continue;
+      }
       await this.addChildRun(key, watchedPR, resolved, {
         suppressEvents: true,
         suppressPersist: true,
@@ -830,6 +835,9 @@ export class WatcherService implements vscode.Disposable {
         const newRunKeys = new Set<string>();
         for (const runId of snapshot.runs) {
           const resolved = this.resolveRunIdentifier(runId);
+          if (this.shouldSkipUnregisteredChildRun(key, resolved)) {
+            continue;
+          }
           const runKey = this.getWatchKey(resolved);
           newRunKeys.add(runKey);
           if (!currentRunKeys.has(runKey)) {
@@ -1020,9 +1028,38 @@ export class WatcherService implements vscode.Disposable {
       }
       return false;
     } catch (err) {
+      if (this.isNoWatcherRegisteredError(err)) {
+        this.logSkippedUnregisteredChildRun(prKey, runIdentifier);
+        return false;
+      }
       this.logger.warn(`Failed to add child run ${runIdentifier.displayName} for PR ${prWatch.identifier.displayName}: ${err}`);
       return false;
     }
+  }
+
+  private shouldSkipUnregisteredChildRun(prKey: string, runIdentifier: RunIdentifier): boolean {
+    if (this.watcherRegistry.get(runIdentifier.providerId)) {
+      return false;
+    }
+
+    this.logSkippedUnregisteredChildRun(prKey, runIdentifier);
+    return true;
+  }
+
+  private logSkippedUnregisteredChildRun(prKey: string, runIdentifier: RunIdentifier): void {
+    const runKey = this.getWatchKey(runIdentifier);
+    const skipKey = `${prKey}::${runKey}`;
+    if (this.skippedUnregisteredChildRuns.has(skipKey)) {
+      return;
+    }
+
+    this.skippedUnregisteredChildRuns.add(skipKey);
+    this.logger.debug(`Skipping child run with no registered watcher: ${runIdentifier.providerId}/${runIdentifier.runId}`);
+  }
+
+  private isNoWatcherRegisteredError(err: unknown): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    return message.includes('No watcher registered for provider:');
   }
 
   /**

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -7,6 +7,7 @@ import type { DevDocketRunWatcher, RunIdentifier, RunStatus } from '@devdocket/s
 
 function createMockLogger() {
   return {
+    debug: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
@@ -538,6 +539,49 @@ describe('WatcherService', () => {
       expect(service.getActiveWatches()[0].parentPRKey).toBeDefined();
     });
 
+    it('keeps registered PR child runs while skipping unregistered providers without warning', async () => {
+      const runWatcher = createMockWatcher('github-actions');
+      (runWatcher.canWatch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => url.startsWith('https://example.com/run/'));
+      registry.register(runWatcher);
+
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [
+          {
+            providerId: 'github-actions',
+            runId: 'run-1',
+            displayName: 'CI Build',
+            url: 'https://example.com/run/1',
+            repo: 'owner/repo',
+          },
+          {
+            providerId: 'github-advanced-security',
+            runId: 'codeql-1',
+            displayName: 'CodeQL',
+            url: 'https://github.com/owner/repo/security/code-scanning',
+            repo: 'owner/repo',
+          },
+        ],
+      }));
+      prRegistry.register(prWatcher);
+
+      const result = await service.startPRWatch(createPRIdentifier());
+
+      expect(result.childRunKeys).toHaveLength(1);
+      expect(service.getActiveWatches()).toHaveLength(1);
+      expect(service.getActiveWatches()[0].identifier.providerId).toBe('github-actions');
+      expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('Failed to add child run'));
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Skipping child run with no registered watcher'));
+
+      (logger.debug as ReturnType<typeof vi.fn>).mockClear();
+      await vi.advanceTimersByTimeAsync(60000);
+
+      expect(service.getActiveWatches()).toHaveLength(1);
+      expect(service.getActiveWatches()[0].identifier.providerId).toBe('github-actions');
+      expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('Failed to add child run'));
+      expect(logger.debug).not.toHaveBeenCalledWith(expect.stringContaining('Skipping child run with no registered watcher'));
+    });
+
     it('dismisses a PR watch when its last visible child run is dismissed', async () => {
       const runWatcher = createMockWatcher('github-actions');
       registry.register(runWatcher);
@@ -828,7 +872,7 @@ describe('WatcherService', () => {
       expect(service.getActiveWatches()[0].identifier.runId).toBe('555');
     });
 
-    it('skips run identifiers when no watcher matches providerId or URL', async () => {
+    it('skips run identifiers when no watcher matches providerId or URL without warning', async () => {
       // No run watchers registered — unresolvable run
       const prWatcher = createMockPRWatcher('test-pr', async () => ({
         prState: 'open',
@@ -844,10 +888,12 @@ describe('WatcherService', () => {
 
       const result = await service.startPRWatch(createPRIdentifier());
 
-      // Child run should not be added (no matching watcher)
+      // Child run should not be added (no matching watcher), but the PR watch still succeeds.
       expect(result.childRunKeys).toHaveLength(0);
+      expect(service.getActivePRWatches()).toHaveLength(1);
       expect(service.getActiveWatches()).toHaveLength(0);
-      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to add child run'));
+      expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('Failed to add child run'));
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Skipping child run with no registered watcher'));
     });
   });
 

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -582,6 +582,56 @@ describe('WatcherService', () => {
       expect(logger.debug).not.toHaveBeenCalledWith(expect.stringContaining('Skipping child run with no registered watcher'));
     });
 
+    it('clears skipped unregistered child run cache when a PR watch is dismissed', async () => {
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [{
+          providerId: 'github-advanced-security',
+          runId: 'codeql-1',
+          displayName: 'CodeQL',
+          url: 'https://github.com/owner/repo/security/code-scanning',
+          repo: 'owner/repo',
+        }],
+      }));
+      prRegistry.register(prWatcher);
+
+      const identifier = createPRIdentifier();
+      await service.startPRWatch(identifier);
+      const skipCache = (service as any).skippedUnregisteredChildRuns as Set<string>;
+      expect(skipCache.size).toBe(1);
+
+      service.dismissPRWatch(identifier);
+      expect(skipCache.size).toBe(0);
+
+      (logger.debug as ReturnType<typeof vi.fn>).mockClear();
+      await service.startPRWatch(identifier);
+
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('Skipping child run with no registered watcher'));
+      expect(skipCache.size).toBe(1);
+    });
+
+    it('clears skipped unregistered child run cache on dispose', async () => {
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [{
+          providerId: 'github-advanced-security',
+          runId: 'codeql-1',
+          displayName: 'CodeQL',
+          url: 'https://github.com/owner/repo/security/code-scanning',
+          repo: 'owner/repo',
+        }],
+      }));
+      prRegistry.register(prWatcher);
+
+      await service.startPRWatch(createPRIdentifier());
+      const skipCache = (service as any).skippedUnregisteredChildRuns as Set<string>;
+      expect(skipCache.size).toBe(1);
+
+      service.dispose();
+
+      expect(skipCache.size).toBe(0);
+    });
+
     it('dismisses a PR watch when its last visible child run is dismissed', async () => {
       const runWatcher = createMockWatcher('github-actions');
       registry.register(runWatcher);


### PR DESCRIPTION
## Summary

Stops the per-poll `[WARN] Failed to add child run` log spam emitted whenever a watched PR has CodeQL (or any other GitHub-platform check) whose `providerId` is not registered with DevDocket's run watcher registry.

## Why

`WatchedPRSnapshot.runs` includes ALL check runs that GitHub reports for the PR — including CodeQL runs whose providerId is `github-advanced-security`. DevDocket has no run watcher for that provider, so `addChildRun` -> `startWatch` -> `WatcherRegistry.get` threw `Error: No watcher registered for provider: github-advanced-security`, which `addChildRun`'s catch arm logged as a WARN. This fires every poll, drowning the CI Watches log.

A real `github-advanced-security` watcher is out of scope (the issue lists it as a follow-up).

## Fix

In both code paths that call `addChildRun` (the initial `startPRWatch` snapshot and the polling path), after `resolveRunIdentifier`, the code now checks whether `WatcherRegistry.get(resolved.providerId)` is defined. If not, the run is skipped silently — except for a single deduped `debug` log per `(prKey, runKey)` per session so support diagnostics are still possible. The existing WARN behavior in `addChildRun`'s catch arm is preserved for all other error classes (auth failures, network errors, etc.).

## Changes

- `packages/core/src/services/watcherService.ts` — filter unregistered runs at both `addChildRun` call sites; per-session de-dupe `Set` for the new `debug` log.
- `packages/core/src/test/watcherService.test.ts` — new test asserting that a snapshot containing a run for an unregistered provider does not call `addChildRun`, the watch still succeeds, and no WARN is emitted.

## Verification

`cd packages/core && npm run build && npm run test` — passes (788 tests across 31 files).

Closes #503
