### PR TITLE
Provider-supplied gitWork capability for Start Git Work

### DIFF
--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -93,6 +93,9 @@ import * as vscode from 'vscode';
 interface DevDocketApi {
   registerProvider(provider: DevDocketProvider): vscode.Disposable;
   registerAction(action: DevDocketAction): vscode.Disposable;
+
+  /** Optional accessor for live provider data, used by actions that need capabilities. */
+  getDiscoveredItem?(providerId: string, externalId: string): DiscoveredItem | undefined;
 }
 ```
 
@@ -240,6 +243,13 @@ interface DiscoveredItem {
   itemType?: 'issue' | 'pr';
 
   /**
+   * Optional provider-supplied capabilities for cross-cutting actions. For
+   * example, Start Git Work reads `capabilities.gitWork` instead of parsing
+   * URL hosts or knowing provider ids.
+   */
+  capabilities?: DiscoveredItemCapabilities;
+
+  /**
    * Optional provider-declared badges shown alongside the core's Provider /
    * Type / CI badges. Use this to surface state-like information ("Approved",
    * "Changes requested", "Mentioned", etc) — DevDocket never infers badges
@@ -274,6 +284,19 @@ interface DiscoveredItem {
   resurfaceVersion?: string;
 }
 
+interface GitWorkInfo {
+  kind: 'issue' | 'pr';
+  cloneUrl: string;
+  ref: string;
+  headCloneUrl?: string;
+  baseRef?: string;
+  repoLabel?: string;
+}
+
+interface DiscoveredItemCapabilities {
+  gitWork?: GitWorkInfo | (() => Promise<GitWorkInfo | undefined>);
+}
+
 interface ProviderBadge {
   /** Display text. Keep short — sidebar badges compete with the title. */
   label: string;
@@ -298,6 +321,7 @@ interface ProviderBadge {
 - `DiscoveredItem` data is not stored as a persisted record; DevDocket tracks only the inbox state (`unseen`, `accepted`, `dismissed`) for discovered items in the `devdocket.discovered-state` `globalState` key.
 - When a user accepts an item from the Incoming tier or Sources tab, DevDocket creates and persists a new `WorkItem` (in the `devdocket.workitems` `globalState` key) that includes a snapshot of the item's `title`, along with its `providerId`/`externalId`/`url` as provenance metadata.
 - Use `group` to organize items in the Sources tab. Items with the same group value are nested under a folder.
+- To opt into git-based actions such as Start Git Work, attach `capabilities.gitWork`. Use a literal `GitWorkInfo` when clone/ref data is already known (typical issues), or a lazy function when the provider must call its own API to resolve PR head/base data. This is a non-breaking optional addition.
 - Use `canonicalId` when the same entity might be discovered by multiple providers (e.g., a PR found by both "My PRs" and "PR Reviews"). Items sharing a `canonicalId` are deduplicated in the Incoming tier — one representative is shown and accept/dismiss propagates to all. Use a consistent format like `github:pull:owner/repo#42`. Items without `canonicalId` show individually (backward compatible). The Sources tab is unaffected.
 - Set `itemType` to `'issue'` or `'pr'` when your provider can classify the item kind. DevDocket surfaces this as a separate type pill so users can distinguish issues from pull requests at a glance. Items without `itemType` simply omit the pill — useful for generic / manual / heterogeneous sources where the kind isn't meaningful.
 - Use `badges` to surface state, reason, or any other custom annotation. The core deliberately doesn't interpret the `state` or `reason` strings any more — those are kept on `DiscoveredItem` for provenance/dedup purposes only. If you want a pill to show, declare it explicitly. Use `show: 'editor'` for verbose detail that would clutter the sidebar.

--- a/docs/provider-api.md
+++ b/docs/provider-api.md
@@ -112,6 +112,19 @@ interface Event<T> {
   (listener: (e: T) => void): Disposable;
 }
 
+interface GitWorkInfo {
+  kind: 'issue' | 'pr';
+  cloneUrl: string;
+  ref: string;
+  headCloneUrl?: string;
+  baseRef?: string;
+  repoLabel?: string;
+}
+
+interface DiscoveredItemCapabilities {
+  gitWork?: GitWorkInfo | (() => Promise<GitWorkInfo | undefined>);
+}
+
 interface DiscoveredItem {
   externalId: string;
   title: string;
@@ -127,6 +140,8 @@ interface DiscoveredItem {
   canonicalId?: string;
   itemType?: 'issue' | 'pr';
   badges?: ProviderBadge[];
+  /** Optional capabilities, such as provider-supplied git metadata for Start Git Work. */
+  capabilities?: DiscoveredItemCapabilities;
   /** Opaque "soft" version token. See provider-discovery.md#resurfacing. */
   version?: string;
   /** Opaque "always-resurface" token. See provider-discovery.md#resurfacing. */
@@ -395,6 +410,28 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 ```
 
 ---
+
+
+### Git work capability
+
+Providers can opt discovered items into Start Git Work by attaching `capabilities.gitWork`. The action is provider-agnostic: it does not parse URL hosts, provider ids, or external ids. Providers supply `GitWorkInfo` directly for issue-shaped items when all data is already known, or a lazy function for PR-shaped items when resolving the head ref or fork clone URL requires the provider's API.
+
+```ts
+const item: DiscoveredItem = {
+  externalId: 'project/TICKET-123',
+  title: 'TICKET-123: Fix login',
+  capabilities: {
+    gitWork: {
+      kind: 'issue',
+      cloneUrl: 'https://git.example.com/team/repo.git',
+      ref: 'ticket/TICKET-123',
+      repoLabel: 'team/repo',
+    },
+  },
+};
+```
+
+For PRs, return `headCloneUrl` only when the source branch lives in a fork or different repository. Returning `undefined` from a lazy capability means the item is not currently resolvable. Start Git Work is shown only after the user moves the work item to In Progress, and it uses `repoLabel` as part of its local-path/base-branch cache key, so keep that label stable for a given repository.
 
 ## Implementing an Action
 

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { BaseProvider, DiscoveredItem, type ProviderBadge, isValidUrlSegment, combineSignals, safeDecodeComponent, type ResolvedItem } from '@devdocket/shared';
+import { BaseProvider, DiscoveredItem, type GitWorkInfo, type ProviderBadge, isValidUrlSegment, combineSignals, safeDecodeComponent, type ResolvedItem } from '@devdocket/shared';
 import { logger } from './logger';
 import { OrgConfig, resolveProjectList } from './configParser';
 import { getAdoHeaders, retryAdoWithAuth, throwAdoApiError, ADO_AUTH_SCOPE } from './adoAuth';
@@ -22,6 +22,17 @@ interface AdoWorkItem {
   _links: {
     html: { href: string };
   };
+  relations?: Array<{
+    rel?: string;
+    url?: string;
+    attributes?: { name?: string };
+  }>;
+}
+
+interface AdoGitRepository {
+  name: string;
+  remoteUrl?: string;
+  webUrl?: string;
 }
 
 // Azure DevOps work item type state
@@ -50,6 +61,7 @@ export class AdoWorkItemProvider extends BaseProvider {
   readonly label = 'Azure DevOps Work Items';
 
   private _terminalStatesCache = new Map<string, Set<string>>();
+  private _repoCache = new Map<string, AdoGitRepository>();
 
   /**
    * @param orgConfigs - One or more organization configurations to query.
@@ -282,11 +294,12 @@ export class AdoWorkItemProvider extends BaseProvider {
     // Filter out items in terminal state categories
     const activeWorkItems = await this.filterActiveItems(token, org, allWorkItems, signal);
 
-    const items: DiscoveredItem[] = activeWorkItems.map((wi) => {
+    const items: DiscoveredItem[] = await Promise.all(activeWorkItems.map(async (wi) => {
       const projectName = wi.fields['System.TeamProject'];
       const wiType = wi.fields['System.WorkItemType'];
       const state = wi.fields['System.State'];
       const stateBadge: ProviderBadge[] = state ? [{ label: state, variant: 'info', show: 'editor' }] : [];
+      const gitWork = await this.resolveWorkItemGitWork(token, org, projectName, wi, signal);
       return {
         externalId: `${org}/${projectName}/${wi.id}`,
         title: `${wiType} ${wi.id}: ${wi.fields['System.Title']}`,
@@ -296,11 +309,99 @@ export class AdoWorkItemProvider extends BaseProvider {
         reason: 'assigned',
         state,
         itemType: 'issue',
+        ...(gitWork ? { capabilities: { gitWork } } : {}),
         ...(stateBadge.length > 0 ? { badges: stateBadge } : {}),
       };
-    });
+    }));
 
     return { items, failed: batchFailed };
+  }
+
+
+  private async resolveWorkItemGitWork(
+    token: string,
+    org: string,
+    project: string,
+    workItem: AdoWorkItem,
+    signal?: AbortSignal,
+  ): Promise<GitWorkInfo | undefined> {
+    const repoId = this.extractAssociatedRepoId(workItem);
+    if (!repoId) {
+      return undefined;
+    }
+
+    const repo = await this.fetchGitRepository(token, org, project, repoId, signal);
+    if (!repo) {
+      return undefined;
+    }
+
+    const cloneUrl = repo.remoteUrl
+      ?? repo.webUrl
+      ?? `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(project)}/_git/${encodeURIComponent(repo.name)}`;
+    return {
+      kind: 'issue',
+      cloneUrl,
+      ref: `issue${workItem.id}`,
+      repoLabel: `${org}/${project}/${repo.name}`,
+    };
+  }
+
+  private extractAssociatedRepoId(workItem: AdoWorkItem): string | undefined {
+    for (const relation of workItem.relations ?? []) {
+      if (relation.rel !== 'ArtifactLink') {
+        continue;
+      }
+      const relationName = relation.attributes?.name;
+      if (relationName !== 'Branch' && relationName !== 'Pull Request') {
+        continue;
+      }
+      if (!relation.url) {
+        continue;
+      }
+      const decodedUrl = safeDecodeComponent(relation.url);
+      const match = decodedUrl.match(/^vstfs:\/\/\/Git\/(?:Ref|PullRequestId)\/([^/]+)\/([^/]+)/i);
+      const repoId = match?.[2];
+      if (repoId) {
+        return repoId;
+      }
+    }
+    return undefined;
+  }
+
+  private async fetchGitRepository(
+    token: string,
+    org: string,
+    project: string,
+    repoId: string,
+    signal?: AbortSignal,
+  ): Promise<AdoGitRepository | undefined> {
+    const cacheKey = `${org}/${project}/${repoId}`;
+    const cached = this._repoCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const url = `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(repoId)}?api-version=7.1`;
+    try {
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+        signal: combineSignals(signal, 30_000),
+      });
+      if (!response.ok) {
+        logger.debug(`Failed to fetch ADO repository ${cacheKey}: ${response.status}`);
+        return undefined;
+      }
+      const repo = await response.json() as AdoGitRepository;
+      if (!repo?.name) {
+        return undefined;
+      }
+      this._repoCache.set(cacheKey, repo);
+      return repo;
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError' && signal?.aborted) { throw err; }
+      logger.debug(`Failed to fetch ADO repository ${cacheKey}: ${String(err)}`);
+      return undefined;
+    }
   }
 
   /**

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -134,6 +134,7 @@ export class AdoWorkItemProvider extends BaseProvider {
   }
 
   private async fetchAndPublishWorkItems(accessToken: string, isUserTriggered: boolean, signal?: AbortSignal): Promise<void> {
+    this._repoCache.clear();
     const allItems: DiscoveredItem[] = [];
     const failures: string[] = [];
 

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -295,13 +295,14 @@ export class AdoWorkItemProvider extends BaseProvider {
     // Filter out items in terminal state categories
     const activeWorkItems = await this.filterActiveItems(token, org, allWorkItems, signal);
 
-    const items: DiscoveredItem[] = await Promise.all(activeWorkItems.map(async (wi) => {
+    const items: DiscoveredItem[] = [];
+    for (const wi of activeWorkItems) {
       const projectName = wi.fields['System.TeamProject'];
       const wiType = wi.fields['System.WorkItemType'];
       const state = wi.fields['System.State'];
       const stateBadge: ProviderBadge[] = state ? [{ label: state, variant: 'info', show: 'editor' }] : [];
       const gitWork = await this.resolveWorkItemGitWork(token, org, projectName, wi, signal);
-      return {
+      items.push({
         externalId: `${org}/${projectName}/${wi.id}`,
         title: `${wiType} ${wi.id}: ${wi.fields['System.Title']}`,
         description: wi.fields['System.Description']?.replace(/<[^>]*(>|$)/g, '') ?? undefined,
@@ -312,8 +313,8 @@ export class AdoWorkItemProvider extends BaseProvider {
         itemType: 'issue',
         ...(gitWork ? { capabilities: { gitWork } } : {}),
         ...(stateBadge.length > 0 ? { badges: stateBadge } : {}),
-      };
-    }));
+      });
+    }
 
     return { items, failed: batchFailed };
   }

--- a/packages/ado/src/baseAdoPrProvider.ts
+++ b/packages/ado/src/baseAdoPrProvider.ts
@@ -9,6 +9,7 @@ import {
   runWorkerPool,
   safeDecodeComponent,
   type ResolvedItem,
+  type GitWorkInfo,
 } from '@devdocket/shared';
 import { logger } from './logger';
 import { OrgConfig, resolveProjectList } from './configParser';
@@ -28,7 +29,11 @@ export interface AdoPullRequest {
     name: string;
     project: { name: string };
     webUrl?: string;
+    remoteUrl?: string;
+    sshUrl?: string;
   };
+  sourceRefName?: string;
+  targetRefName?: string;
   lastMergeSourceCommit?: {
     commitId: string;
   };
@@ -386,6 +391,51 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
       url: `${repoUrl}/pullrequest/${pr.pullRequestId}`,
       group: `${projectName}/${repoName}`,
       itemType: 'pr',
+      capabilities: { gitWork: this.createPrGitWork(pr, org) },
+    };
+  }
+
+  private createPrGitWork(pr: AdoPullRequest, org: string): () => Promise<GitWorkInfo | undefined> {
+    const projectName = pr.repository.project.name;
+    const repoName = pr.repository.name;
+    const repoLabel = `${projectName}/${repoName}`;
+    const cloneUrl = pr.repository.remoteUrl
+      ?? pr.repository.webUrl
+      ?? `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(projectName)}/_git/${encodeURIComponent(repoName)}`;
+    const detailUrl = `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(projectName)}/_apis/git/repositories/${encodeURIComponent(repoName)}/pullrequests/${pr.pullRequestId}?api-version=7.1`;
+
+    return async () => {
+      // Resolve the source ref at action time so Start Git Work checks out the current PR head.
+      const headers = await getAdoHeaders();
+      const wasAuthenticated = 'Authorization' in headers;
+      let response = await fetch(detailUrl, {
+        headers,
+        signal: combineSignals(undefined, 30_000),
+      });
+      if (response.status === 401 || response.status === 403 || (response.status === 404 && !wasAuthenticated)) {
+        const retryResponse = await retryAdoWithAuth(detailUrl);
+        if (retryResponse) { response = retryResponse; }
+      }
+      if (!response.ok) {
+        logger.info(`ADO PR API returned ${response.status} while resolving git work info for ${org}/${projectName}/${repoName}/${pr.pullRequestId}`);
+        return undefined;
+      }
+
+      const detail = await response.json() as Pick<AdoPullRequest, 'sourceRefName' | 'targetRefName' | 'repository'>;
+      const sourceRefName = typeof detail.sourceRefName === 'string' ? detail.sourceRefName : pr.sourceRefName;
+      if (!sourceRefName) {
+        return undefined;
+      }
+
+      const detailCloneUrl = detail.repository?.remoteUrl ?? detail.repository?.webUrl ?? cloneUrl;
+      const targetRefName = typeof detail.targetRefName === 'string' ? detail.targetRefName : pr.targetRefName;
+      return {
+        kind: 'pr',
+        cloneUrl: detailCloneUrl,
+        ref: sourceRefName.replace(/^refs\/heads\//, ''),
+        ...(targetRefName ? { baseRef: targetRefName.replace(/^refs\/heads\//, '') } : {}),
+        repoLabel,
+      };
     };
   }
 

--- a/packages/ado/src/test/adoMyPrsProvider.test.ts
+++ b/packages/ado/src/test/adoMyPrsProvider.test.ts
@@ -139,6 +139,7 @@ describe('AdoMyPrsProvider', () => {
       reason: 'You authored this PR',
       state: 'Waiting on reviews',
       itemType: 'pr',
+      capabilities: { gitWork: expect.any(Function) },
       badges: [{ label: 'Waiting on reviews', variant: 'info', show: 'editor' }],
     });
     expect(items[0]).not.toHaveProperty('resurfaceVersion');

--- a/packages/ado/src/test/adoPrReviewProvider.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.test.ts
@@ -186,6 +186,23 @@ describe('AdoPrReviewProvider', () => {
       group: 'MyProject/myrepo',
       reason: 'review_requested',
       itemType: 'pr',
+      capabilities: { gitWork: expect.any(Function) },
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        sourceRefName: 'refs/heads/users/me/fix',
+        targetRefName: 'refs/heads/dev',
+        repository: { remoteUrl: 'https://dev.azure.com/myorg/MyProject/_git/myrepo' },
+      }),
+    });
+    await expect(items[0].capabilities.gitWork()).resolves.toEqual({
+      kind: 'pr',
+      cloneUrl: 'https://dev.azure.com/myorg/MyProject/_git/myrepo',
+      ref: 'users/me/fix',
+      baseRef: 'dev',
+      repoLabel: 'MyProject/myrepo',
     });
   });
 

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -132,6 +132,47 @@ describe('AdoWorkItemProvider', () => {
     });
   });
 
+  it('populates gitWork when a work item has an associated Git repo relation', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => createWiqlResponse([1]) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          value: [{
+            ...createWorkItemDetail(1, 'Fix login bug'),
+            relations: [{
+              rel: 'ArtifactLink',
+              url: 'vstfs:///Git/Ref/project-guid%2Frepo-guid%2FGBmain',
+              attributes: { name: 'Branch' },
+            }],
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ value: [{ name: 'Active', category: 'InProgress' }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          name: 'myrepo',
+          remoteUrl: 'https://dev.azure.com/myorg/MyProject/_git/myrepo',
+        }),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0][0].capabilities.gitWork).toEqual({
+      kind: 'issue',
+      cloneUrl: 'https://dev.azure.com/myorg/MyProject/_git/myrepo',
+      ref: 'issue1',
+      repoLabel: 'myorg/MyProject/myrepo',
+    });
+  });
+
   it('strips HTML tags from description', async () => {
     mockFetch
       .mockResolvedValueOnce({

--- a/packages/core/src/api/devDocketApi.ts
+++ b/packages/core/src/api/devDocketApi.ts
@@ -27,6 +27,10 @@ export class DevDocketApiImpl implements DevDocketApi {
     return this.actionRegistry.register(action);
   }
 
+  getDiscoveredItem(providerId: string, externalId: string) {
+    return this.providerRegistry.findDiscoveredItem(providerId, externalId);
+  }
+
   registerRunWatcher(watcher: DevDocketRunWatcher): Disposable {
     return this.watcherRegistry.register(watcher);
   }

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -1,5 +1,5 @@
 // Canonical type declarations live in @devdocket/shared; re-export for
 // existing intra-core imports (e.g. `from '../api/types'`).
-export type { Disposable, Event, DiscoveredItem, ProviderBadge, RelatedItemRef, ResolvedItem, DevDocketRunWatcher, DevDocketPRWatcher } from '@devdocket/shared';
+export type { Disposable, Event, DiscoveredItem, DiscoveredItemCapabilities, GitWorkInfo, ProviderBadge, RelatedItemRef, ResolvedItem, DevDocketRunWatcher, DevDocketPRWatcher } from '@devdocket/shared';
 export type { ActivityLogEntry, ActivityType } from '@devdocket/shared';
 export type { StateTransitionEvent, DevDocketProvider, DevDocketAction, DevDocketApi } from '@devdocket/shared';

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -233,6 +233,13 @@ export class ProviderRegistry {
   }
 
   /**
+   * Find one live discovered item by provider and external id.
+   */
+  findDiscoveredItem(providerId: string, externalId: string): DiscoveredItem | undefined {
+    return this.getDiscoveredItems(providerId).find(item => item.externalId === externalId);
+  }
+
+  /**
    * Check whether an item was in the provider's discovered-items list before
    * the most recent refresh. Used as a fallback for auto-complete when the
    * provider does not implement `getClosedItems`.

--- a/packages/core/src/test/devDocketApi.test.ts
+++ b/packages/core/src/test/devDocketApi.test.ts
@@ -125,6 +125,26 @@ describe('DevDocketApiImpl', () => {
     });
   });
 
+  describe('getDiscoveredItem', () => {
+    it('looks up the live discovered item by provider and external id', () => {
+      const emitter = new vscode.EventEmitter<DiscoveredItem[]>();
+      const provider: DevDocketProvider = {
+        id: 'test-provider',
+        label: 'Test Provider',
+        onDidDiscoverItems: emitter.event,
+        refresh: vi.fn().mockResolvedValue(undefined),
+      };
+      const item: DiscoveredItem = { externalId: 'item-1', title: 'Item 1' };
+
+      api.registerProvider(provider);
+      emitter.fire([item]);
+
+      expect(api.getDiscoveredItem('test-provider', 'item-1')).toBe(item);
+      expect(api.getDiscoveredItem('test-provider', 'missing')).toBeUndefined();
+      expect(api.getDiscoveredItem('missing-provider', 'item-1')).toBeUndefined();
+    });
+  });
+
   describe('registerAction', () => {
     it('delegates to actionRegistry.register', () => {
       const action = createMockAction('test-action');

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -108,7 +108,7 @@ function createMockProviderRegistry(discoveredByProvider: Record<string, any[]> 
   const discoveredEmitter = new EventEmitter<void>();
   const registerEmitter = new EventEmitter<void>();
 
-  return {
+  const registry: any = {
     getDiscoveredItems: vi.fn((providerId: string) => discoveredByProvider[providerId] ?? []),
     getAllDiscoveredItems: vi.fn(() => new Map(Object.entries(discoveredByProvider))),
     getProvider: vi.fn((providerId: string) => providerId ? { id: providerId, label: providerId } : undefined),
@@ -118,6 +118,9 @@ function createMockProviderRegistry(discoveredByProvider: Record<string, any[]> 
     _fireDiscoveredItemsChange: () => discoveredEmitter.fire(),
     _fireRegisterProvider: () => registerEmitter.fire(),
   };
+  registry.findDiscoveredItem = vi.fn((providerId: string, externalId: string) =>
+    registry.getDiscoveredItems(providerId).find((item: any) => item.externalId === externalId));
+  return registry;
 }
 
 function createMockActionRegistry() {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -381,9 +381,7 @@ export class WorkItemEditorPanel {
       return undefined;
     }
 
-    return this.providerRegistry
-      .getDiscoveredItems(item.providerId)
-      .find(discovered => discovered.externalId === item.externalId);
+    return this.providerRegistry.findDiscoveredItem(item.providerId, item.externalId);
   }
 
   private getHtml(item: EditorItemData): string {

--- a/packages/github/src/gitWorkCapabilities.ts
+++ b/packages/github/src/gitWorkCapabilities.ts
@@ -1,0 +1,84 @@
+import { combineSignals, type GitWorkInfo } from '@devdocket/shared';
+import { getHeaders, retryWithAuth } from './githubApiHelpers';
+import { logger } from './logger';
+
+interface GitHubPrGitWorkResponse {
+  head?: {
+    ref?: unknown;
+    repo?: {
+      full_name?: unknown;
+      clone_url?: unknown;
+    } | null;
+  };
+  base?: {
+    ref?: unknown;
+    repo?: {
+      full_name?: unknown;
+      clone_url?: unknown;
+    } | null;
+  };
+}
+
+export function createGitHubIssueGitWork(repoName: string, number: number): GitWorkInfo {
+  return {
+    kind: 'issue',
+    cloneUrl: `https://github.com/${repoName}.git`,
+    ref: `issue${number}`,
+    repoLabel: repoName,
+  };
+}
+
+export function createGitHubPrGitWork(repoName: string, number: number, prApiUrl?: string): () => Promise<GitWorkInfo | undefined> {
+  return async () => {
+    // Resolve the head repo/ref at action time so fork and branch data are current.
+    const url = prApiUrl ?? buildGitHubPrApiUrl(repoName, number);
+    const headers = await getHeaders();
+    const wasAuthenticated = 'Authorization' in headers;
+    let response = await fetch(url, {
+      headers,
+      signal: combineSignals(undefined, 30_000),
+    });
+
+    if ((response.status === 401 || response.status === 403 || (response.status === 404 && !wasAuthenticated))) {
+      const retryResponse = await retryWithAuth(url);
+      if (retryResponse) { response = retryResponse; }
+    }
+
+    if (!response.ok) {
+      logger.info(`GitHub PR API returned ${response.status} while resolving git work info for ${repoName}#${number}`);
+      return undefined;
+    }
+
+    const pr = await response.json() as GitHubPrGitWorkResponse;
+    const headRef = typeof pr.head?.ref === 'string' ? pr.head.ref : undefined;
+    const headRepo = pr.head?.repo;
+    const headRepoFullName = typeof headRepo?.full_name === 'string' ? headRepo.full_name : undefined;
+    const headCloneUrl = typeof headRepo?.clone_url === 'string' ? headRepo.clone_url : undefined;
+    const baseRepo = pr.base?.repo;
+    const baseRepoFullName = typeof baseRepo?.full_name === 'string' ? baseRepo.full_name : repoName;
+    const baseCloneUrl = typeof baseRepo?.clone_url === 'string'
+      ? baseRepo.clone_url
+      : `https://github.com/${baseRepoFullName}.git`;
+    const baseRef = typeof pr.base?.ref === 'string' ? pr.base.ref : undefined;
+
+    if (!headRef || !headCloneUrl) {
+      logger.info(`GitHub PR ${repoName}#${number} is missing head repo information`);
+      return undefined;
+    }
+
+    const isFork = !!headRepoFullName && headRepoFullName !== baseRepoFullName;
+    return {
+      kind: 'pr',
+      cloneUrl: baseCloneUrl,
+      ref: headRef,
+      ...(isFork ? { headCloneUrl } : {}),
+      ...(baseRef ? { baseRef } : {}),
+      repoLabel: baseRepoFullName,
+    };
+  };
+}
+
+function buildGitHubPrApiUrl(repoName: string, number: number): string {
+  const [owner, repo] = repoName.split('/');
+  return `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${number}`;
+}

--- a/packages/github/src/gitWorkCapabilities.ts
+++ b/packages/github/src/gitWorkCapabilities.ts
@@ -33,10 +33,18 @@ export function createGitHubIssueGitWork(repoName: string, number: number): GitW
   };
 }
 
-export function createGitHubPrGitWork(repoName: string, number: number, prApiUrl?: string): () => Promise<GitWorkInfo | undefined> {
+export function createGitHubPrGitWork(repoName: string, number: number, prApiUrl?: string): (() => Promise<GitWorkInfo | undefined>) | undefined {
+  if (!isValidGitHubRepo(repoName)) {
+    logger.warn(`Skipping GitHub PR git work for invalid repo name: ${repoName}`);
+    return undefined;
+  }
+
   return async () => {
     // Resolve the head repo/ref at action time so fork and branch data are current.
     const url = prApiUrl ?? buildGitHubPrApiUrl(repoName, number);
+    if (!url) {
+      return undefined;
+    }
     const headers = await getHeaders();
     const wasAuthenticated = 'Authorization' in headers;
     let response = await fetch(url, {
@@ -83,7 +91,10 @@ export function createGitHubPrGitWork(repoName: string, number: number, prApiUrl
   };
 }
 
-function buildGitHubPrApiUrl(repoName: string, number: number): string {
+function buildGitHubPrApiUrl(repoName: string, number: number): string | undefined {
+  if (!isValidGitHubRepo(repoName)) {
+    return undefined;
+  }
   const [owner, repo] = repoName.split('/');
   return `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${number}`;
 }

--- a/packages/github/src/gitWorkCapabilities.ts
+++ b/packages/github/src/gitWorkCapabilities.ts
@@ -1,4 +1,4 @@
-import { combineSignals, type GitWorkInfo } from '@devdocket/shared';
+import { combineSignals, isValidGitHubRepo, type GitWorkInfo } from '@devdocket/shared';
 import { getHeaders, retryWithAuth } from './githubApiHelpers';
 import { logger } from './logger';
 
@@ -19,7 +19,12 @@ interface GitHubPrGitWorkResponse {
   };
 }
 
-export function createGitHubIssueGitWork(repoName: string, number: number): GitWorkInfo {
+export function createGitHubIssueGitWork(repoName: string, number: number): GitWorkInfo | undefined {
+  if (!isValidGitHubRepo(repoName)) {
+    logger.warn(`Skipping GitHub issue git work for invalid repo name: ${repoName}`);
+    return undefined;
+  }
+
   return {
     kind: 'issue',
     cloneUrl: `https://github.com/${repoName}.git`,

--- a/packages/github/src/gitWorkCapabilities.ts
+++ b/packages/github/src/gitWorkCapabilities.ts
@@ -39,12 +39,16 @@ export function createGitHubPrGitWork(repoName: string, number: number, prApiUrl
     return undefined;
   }
 
+  const url = prApiUrl
+    ? normalizeGitHubPrApiUrl(prApiUrl, repoName, number)
+    : buildGitHubPrApiUrl(repoName, number);
+  if (!url) {
+    logger.warn(`Skipping GitHub PR git work for untrusted PR API URL: ${prApiUrl ?? repoName}`);
+    return undefined;
+  }
+
   return async () => {
     // Resolve the head repo/ref at action time so fork and branch data are current.
-    const url = prApiUrl ?? buildGitHubPrApiUrl(repoName, number);
-    if (!url) {
-      return undefined;
-    }
     const headers = await getHeaders();
     const wasAuthenticated = 'Authorization' in headers;
     let response = await fetch(url, {
@@ -97,4 +101,27 @@ function buildGitHubPrApiUrl(repoName: string, number: number): string | undefin
   }
   const [owner, repo] = repoName.split('/');
   return `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${number}`;
+}
+
+function normalizeGitHubPrApiUrl(apiUrl: string, repoName: string, number: number): string | undefined {
+  try {
+    const parsed = new URL(apiUrl);
+    if (parsed.protocol !== 'https:' || parsed.hostname !== 'api.github.com' || parsed.search || parsed.hash) {
+      return undefined;
+    }
+
+    const segments = parsed.pathname.split('/').filter(Boolean).map(segment => decodeURIComponent(segment));
+    if (segments.length !== 5 || segments[0] !== 'repos' || segments[3] !== 'pulls' || segments[4] !== String(number)) {
+      return undefined;
+    }
+
+    const parsedRepoName = `${segments[1]}/${segments[2]}`;
+    if (parsedRepoName !== repoName || !isValidGitHubRepo(parsedRepoName)) {
+      return undefined;
+    }
+
+    return buildGitHubPrApiUrl(parsedRepoName, number);
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -6,6 +6,7 @@ import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
 import { matchesRepoPatterns } from './repoPattern';
 import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
+import { createGitHubIssueGitWork, createGitHubPrGitWork } from './gitWorkCapabilities';
 
 const MENTIONS_ACTIVATED_KEY = 'mentionsActivatedAt';
 const COMMENT_FETCH_CONCURRENCY = 3;
@@ -128,6 +129,11 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
         reason: 'mentioned',
         canonicalId: `github:${isPr ? 'pull' : 'issue'}:${repoName}#${issue.number}`,
         itemType: isPr ? 'pr' : 'issue',
+        capabilities: {
+          gitWork: isPr
+            ? createGitHubPrGitWork(repoName, issue.number, issue.pull_request?.url)
+            : createGitHubIssueGitWork(repoName, issue.number),
+        },
         badges: [
           { label: 'Mentioned', variant: 'warning' },
           ...buildIssueStateBadge(issue.state),

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -4,6 +4,7 @@ import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
 import { getGitHubAuthHeaders, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
 import { matchesRepoPatterns } from './repoPattern';
+import { createGitHubPrGitWork } from './gitWorkCapabilities';
 
 /** Map a PR status string from {@link GitHubMyPrsProvider.determinePrStatus} to its UI badge. */
 function statusToBadge(status: string): ProviderBadge | undefined {
@@ -136,6 +137,7 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
         state: status,
         canonicalId: `github:pull:${repoName}#${pr.number}`,
         itemType: 'pr',
+        capabilities: { gitWork: createGitHubPrGitWork(repoName, pr.number, pr.pull_request?.url) },
         ...(relatedItems ? { relatedItems } : {}),
         ...(statusBadge ? { badges: [statusBadge] } : {}),
       });
@@ -156,6 +158,7 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
         state: status,
         canonicalId: `github:pull:${repoName}#${pr.number}`,
         itemType: 'pr',
+        capabilities: { gitWork: createGitHubPrGitWork(repoName, pr.number, pr.pull_request?.url) },
         ...(relatedItems ? { relatedItems } : {}),
         ...(statusBadge ? { badges: [statusBadge] } : {}),
       });

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -5,6 +5,7 @@ import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
 import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
 import { matchesRepoPatterns } from './repoPattern';
+import { createGitHubPrGitWork } from './gitWorkCapabilities';
 
 interface TimelineEvent {
   event?: string;
@@ -87,6 +88,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
         reason: 'review_requested',
         canonicalId: `github:pull:${repoName}#${pr.number}`,
         itemType: 'pr',
+        capabilities: { gitWork: createGitHubPrGitWork(repoName, pr.number, pr.pull_request?.url) },
         ...(relatedItems ? { relatedItems } : {}),
         badges: [
           { label: 'Review requested', variant: 'warning' },

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -4,6 +4,7 @@ import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
 import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, type GitHubIssue } from './githubApiHelpers';
 import { matchesRepoPatterns } from './repoPattern';
+import { createGitHubIssueGitWork } from './gitWorkCapabilities';
 
 /**
  * DevDocket provider that discovers GitHub issues assigned to the current user.
@@ -45,6 +46,7 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
         reason: 'assigned',
         canonicalId: `github:issue:${repoName}#${issue.number}`,
         itemType: 'issue',
+        capabilities: { gitWork: createGitHubIssueGitWork(repoName, issue.number) },
         badges: [
           { label: 'Assigned', variant: 'warning' },
           ...buildIssueStateBadge(issue.state),

--- a/packages/github/src/test/gitWorkCapabilities.test.ts
+++ b/packages/github/src/test/gitWorkCapabilities.test.ts
@@ -21,5 +21,9 @@ describe('gitWorkCapabilities', () => {
     it('does not create PR git work for unknown repo fallbacks', () => {
       expect(createGitHubPrGitWork('unknown-repo-abc123', 12)).toBeUndefined();
     });
+
+    it('does not create PR git work for untrusted PR API URLs', () => {
+      expect(createGitHubPrGitWork('owner/repo', 12, 'https://example.com/repos/owner/repo/pulls/12')).toBeUndefined();
+    });
   });
 });

--- a/packages/github/src/test/gitWorkCapabilities.test.ts
+++ b/packages/github/src/test/gitWorkCapabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createGitHubIssueGitWork } from '../gitWorkCapabilities';
+import { createGitHubIssueGitWork, createGitHubPrGitWork } from '../gitWorkCapabilities';
 
 describe('gitWorkCapabilities', () => {
   describe('createGitHubIssueGitWork', () => {
@@ -14,6 +14,12 @@ describe('gitWorkCapabilities', () => {
 
     it('does not create issue git work for unknown repo fallbacks', () => {
       expect(createGitHubIssueGitWork('unknown-repo-abc123', 12)).toBeUndefined();
+    });
+  });
+
+  describe('createGitHubPrGitWork', () => {
+    it('does not create PR git work for unknown repo fallbacks', () => {
+      expect(createGitHubPrGitWork('unknown-repo-abc123', 12)).toBeUndefined();
     });
   });
 });

--- a/packages/github/src/test/gitWorkCapabilities.test.ts
+++ b/packages/github/src/test/gitWorkCapabilities.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { createGitHubIssueGitWork } from '../gitWorkCapabilities';
+
+describe('gitWorkCapabilities', () => {
+  describe('createGitHubIssueGitWork', () => {
+    it('creates issue git work for valid GitHub repo slugs', () => {
+      expect(createGitHubIssueGitWork('owner/repo', 12)).toEqual({
+        kind: 'issue',
+        cloneUrl: 'https://github.com/owner/repo.git',
+        ref: 'issue12',
+        repoLabel: 'owner/repo',
+      });
+    });
+
+    it('does not create issue git work for unknown repo fallbacks', () => {
+      expect(createGitHubIssueGitWork('unknown-repo-abc123', 12)).toBeUndefined();
+    });
+  });
+});

--- a/packages/github/src/test/githubMyPrsProvider.test.ts
+++ b/packages/github/src/test/githubMyPrsProvider.test.ts
@@ -138,6 +138,53 @@ describe('GitHubMyPrsProvider', () => {
     expect(items[1].canonicalId).toBe('github:pull:owner/repo#2');
   });
 
+  it('populates lazy gitWork for fork PRs', async () => {
+    const pr = createMockPr(7, 'Fork PR');
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('search/issues') && url.includes('author:@me')) {
+        return mockSearchResponse([pr]);
+      }
+      if (url.includes('search/issues') && url.includes('assignee:@me')) {
+        return mockSearchResponse([]);
+      }
+      if (url.endsWith('/pulls/7/reviews')) {
+        return mockReviewsResponse([]);
+      }
+      if (url.endsWith('/pulls/7')) {
+        return {
+          ok: true,
+          json: async () => ({
+            draft: false,
+            mergeable_state: 'clean',
+            head: {
+              ref: 'contributor/topic',
+              repo: { full_name: 'contributor/repo', clone_url: 'https://github.com/contributor/repo.git' },
+            },
+            base: {
+              ref: 'dev',
+              repo: { full_name: 'owner/repo', clone_url: 'https://github.com/owner/repo.git' },
+            },
+          }),
+        };
+      }
+      return mockFailedResponse(404);
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const gitWork = await listener.mock.calls[0][0][0].capabilities.gitWork();
+    expect(gitWork).toEqual({
+      kind: 'pr',
+      cloneUrl: 'https://github.com/owner/repo.git',
+      ref: 'contributor/topic',
+      headCloneUrl: 'https://github.com/contributor/repo.git',
+      baseRef: 'dev',
+      repoLabel: 'owner/repo',
+    });
+  });
+
   it('attaches relatedItems from PR enrichment before publishing', async () => {
     vi.mocked(workspace.getConfiguration).mockReturnValue({
       get: vi.fn((key: string, defaultValue?: any) => {

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -183,6 +183,7 @@ describe('GitHubPrReviewProvider', () => {
       reason: 'review_requested',
       canonicalId: 'github:pull:org/myrepo#42',
       itemType: 'pr',
+      capabilities: { gitWork: expect.any(Function) },
       badges: [{ label: 'Review requested', variant: 'warning' }],
     });
   });

--- a/packages/github/src/test/githubProvider.test.ts
+++ b/packages/github/src/test/githubProvider.test.ts
@@ -165,6 +165,9 @@ describe('GitHubIssueProvider', () => {
       reason: 'assigned',
       canonicalId: 'github:issue:owner/repo#10',
       itemType: 'issue',
+      capabilities: {
+        gitWork: { kind: 'issue', cloneUrl: 'https://github.com/owner/repo.git', ref: 'issue10', repoLabel: 'owner/repo' },
+      },
       badges: [{ label: 'Assigned', variant: 'warning' }],
     });
   });

--- a/packages/shared/src/apiTypes.ts
+++ b/packages/shared/src/apiTypes.ts
@@ -174,7 +174,7 @@ export interface DevDocketApi {
   /**
    * Look up the live {@link DiscoveredItem} for a given (providerId, externalId)
    * pair. Returns `undefined` if the provider has not (yet) emitted a matching
-   * item — for example because the provider is still loading or the item has
+   * item â€” for example because the provider is still loading or the item has
    * been removed upstream.
    *
    * Actions use this to read provider-supplied capabilities (e.g. {@link

--- a/packages/shared/src/apiTypes.ts
+++ b/packages/shared/src/apiTypes.ts
@@ -172,6 +172,20 @@ export interface DevDocketApi {
    */
   registerAction(action: DevDocketAction): Disposable;
   /**
+   * Look up the live {@link DiscoveredItem} for a given (providerId, externalId)
+   * pair. Returns `undefined` if the provider has not (yet) emitted a matching
+   * item — for example because the provider is still loading or the item has
+   * been removed upstream.
+   *
+   * Actions use this to read provider-supplied capabilities (e.g. {@link
+   * DiscoveredItemCapabilities.gitWork}) when running against a {@link WorkItem}
+   * that was previously accepted from this provider.
+   *
+   * @param providerId - The id of the provider that emitted the item.
+   * @param externalId - The provider-scoped external id (e.g. `owner/repo#123`).
+   */
+  getDiscoveredItem?(providerId: string, externalId: string): DiscoveredItem | undefined;
+  /**
    * Register a pipeline run watcher.
    *
    * Run watchers provide status polling for CI/CD pipelines (GitHub Actions, ADO Pipelines, etc.).

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -26,6 +26,58 @@ export interface RelatedItemRef {
   itemType: 'issue' | 'pr';
 }
 
+
+/**
+ * Information a provider supplies so that the Start Git Work action (or any
+ * other git-aware action) can do its job without knowing anything about the
+ * provider's host or URL shape.
+ *
+ * Providers are responsible for fetching all underlying data (e.g. PR head
+ * ref via the host's API). Returning a function defers that work until the
+ * action actually runs.
+ */
+export interface GitWorkInfo {
+  /** 'issue' = create a new branch; 'pr' = check out an existing branch. */
+  kind: 'issue' | 'pr';
+  /**
+   * URL to clone the repo containing this work item (or its base for a PR).
+   * Must be a clone-style URL (https or git@…).
+   */
+  cloneUrl: string;
+  /**
+   * For 'issue': suggested branch name to create.
+   * For 'pr': the head ref (branch name) to check out.
+   */
+  ref: string;
+  /**
+   * For 'pr' from a fork: the head repository's clone URL when it differs
+   * from `cloneUrl`. When set, the action will fetch the head ref from this
+   * remote rather than from `cloneUrl`.
+   */
+  headCloneUrl?: string;
+  /** For 'pr': base ref the PR is targeting (informational, optional). */
+  baseRef?: string;
+  /**
+   * Optional human-readable label for the source repo, used in prompts.
+   * E.g. "owner/repo" or "ProjectName / repoName".
+   */
+  repoLabel?: string;
+}
+
+/**
+ * Capabilities a provider attaches to a discovered item to opt into
+ * cross-cutting actions (e.g. Start Git Work). All capabilities are optional.
+ */
+export interface DiscoveredItemCapabilities {
+  /**
+   * Indicates this item can be the basis for git-based development work.
+   * Either a literal {@link GitWorkInfo} (when all data is known upfront)
+   * or a thunk that resolves it lazily (when an API call is needed).
+   * Returning `undefined` from the thunk means "not currently resolvable".
+   */
+  gitWork?: GitWorkInfo | (() => Promise<GitWorkInfo | undefined>);
+}
+
 /**
  * An item discovered by a provider.
  * Provider data is kept in memory and read live â€” only the inbox state is persisted.
@@ -88,6 +140,8 @@ export interface DiscoveredItem {
    * Items without `canonicalId` always show individually (backward compatible).
    */
   canonicalId?: string;
+  /** Optional provider-supplied capabilities for cross-cutting actions. */
+  capabilities?: DiscoveredItemCapabilities;
 }
 
 /**

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -41,7 +41,7 @@ export interface GitWorkInfo {
   kind: 'issue' | 'pr';
   /**
    * URL to clone the repo containing this work item (or its base for a PR).
-   * Must be a clone-style URL (https or git@…).
+   * Must be a clone-style URL (https or git@host:owner/repo.git).
    */
   cloneUrl: string;
   /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,7 +5,7 @@
 export { createLoggerService, LogLevel, resolveLogLevel, serializeArg } from './logger';
 export type { Logger, LogOutput, LoggerService } from './logger';
 export { BaseProvider } from './baseProvider';
-export type { DiscoveredItem, Disposable, Event, EventEmitterLike, ProviderBadge, RelatedItemRef, ResolvedItem } from './baseProvider';
+export type { DiscoveredItem, DiscoveredItemCapabilities, Disposable, Event, EventEmitterLike, GitWorkInfo, ProviderBadge, RelatedItemRef, ResolvedItem } from './baseProvider';
 export { isValidUrlSegment, isValidGitHubRepo, isValidRepoSlug, sanitizeUrlSegment, safeDecodeComponent } from './urlValidation';
 export { validateRefreshInterval } from './refreshInterval';
 export type { DevDocketRunWatcher, RunIdentifier, RunStatus, JobStatus, RunState, RunConclusion, CancellationTokenLike } from './runWatcher';

--- a/packages/start-git-work/src/extension.ts
+++ b/packages/start-git-work/src/extension.ts
@@ -24,7 +24,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     return;
   }
 
-  const startWorkAction = new StartWorkAction(context.globalState);
+  const startWorkAction = new StartWorkAction(
+    context.globalState,
+    (providerId, externalId) => api.getDiscoveredItem?.(providerId, externalId),
+  );
   const actionDisposable = api.registerAction(startWorkAction);
   context.subscriptions.push(actionDisposable);
 

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -46,6 +46,11 @@ interface ParsedExternalId {
 type GitHost = 'github' | 'ado';
 type WorkItemKind = 'issue' | 'pr';
 
+interface Routing {
+  host: GitHost;
+  kind: WorkItemKind;
+}
+
 function detectGitHost(url: unknown): GitHost | undefined {
   if (typeof url !== 'string' || url.length === 0) {
     return undefined;
@@ -80,6 +85,31 @@ function getWorkItemKind(item: Readonly<WorkItem>): WorkItemKind | undefined {
     return 'issue';
   }
   return undefined;
+}
+
+function isExternalIdValidForRouting(
+  externalId: string | undefined,
+  parsed: ParsedExternalId,
+  routing: Routing,
+): boolean {
+  if (!externalId) {
+    return false;
+  }
+
+  const repoKeySegments = parsed.repoKey.split('/');
+  if (repoKeySegments.some(segment => segment.length === 0)) {
+    return false;
+  }
+
+  if (routing.host === 'github') {
+    return repoKeySegments.length === 2 && /^[^/#]+\/[^/#]+#\d+$/.test(externalId);
+  }
+
+  if (routing.kind === 'pr') {
+    return repoKeySegments.length === 3 && /^[^/#]+\/[^/#]+\/[^/#]+\/\d+$/.test(externalId);
+  }
+
+  return repoKeySegments.length === 2 && /^[^/#]+\/[^/#]+\/\d+$/.test(externalId);
 }
 
 type WorkMode = 'checkout' | 'worktree';
@@ -132,9 +162,15 @@ export class StartWorkAction implements DevDocketAction {
   }
 
   canRun(item: Readonly<WorkItem>): boolean {
-    return item.state === WorkItemState.InProgress
-      && this.getRouting(item) !== undefined
-      && this.parseExternalId(item.externalId) !== undefined;
+    if (item.state !== WorkItemState.InProgress) {
+      return false;
+    }
+
+    const routing = this.getRouting(item);
+    const parsed = this.parseExternalId(item.externalId);
+    return routing !== undefined
+      && parsed !== undefined
+      && isExternalIdValidForRouting(item.externalId, parsed, routing);
   }
 
   async run(item: Readonly<WorkItem>): Promise<void> {
@@ -145,7 +181,7 @@ export class StartWorkAction implements DevDocketAction {
     }
 
     const routing = this.getRouting(item);
-    if (!routing) {
+    if (!routing || !isExternalIdValidForRouting(item.externalId, parsed, routing)) {
       void vscode.window.showErrorMessage('DevDocket: This work item is not supported by Start Git Work.');
       return;
     }
@@ -162,7 +198,7 @@ export class StartWorkAction implements DevDocketAction {
     }
   }
 
-  private getRouting(item: Readonly<WorkItem>): { host: GitHost; kind: WorkItemKind } | undefined {
+  private getRouting(item: Readonly<WorkItem>): Routing | undefined {
     const host = detectGitHost(item.url);
     const kind = getWorkItemKind(item);
     if (!host || !kind) {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -25,7 +25,12 @@ function isValidCloneUrl(url: unknown): url is string {
   if (url.startsWith('https://')) {
     try {
       const parsed = new URL(url);
-      return parsed.protocol === 'https:' && parsed.hostname.length > 0;
+      return parsed.protocol === 'https:'
+        && parsed.hostname.length > 0
+        && !parsed.username
+        && !parsed.password
+        && !parsed.search
+        && !parsed.hash;
     } catch {
       return false;
     }

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -12,7 +12,22 @@ const execFileAsync = promisify(execFile);
 const SAFE_REF = /^[a-zA-Z0-9._\/-]+$/;
 
 function isValidRef(ref: unknown): ref is string {
-  return typeof ref === 'string' && ref.length > 0 && !ref.startsWith('-') && SAFE_REF.test(ref);
+  if (typeof ref !== 'string'
+    || ref.length === 0
+    || ref.startsWith('-')
+    || !SAFE_REF.test(ref)
+    || ref.endsWith('/')
+    || ref.endsWith('.')
+    || ref.includes('//')
+    || ref.includes('..')
+    || ref.includes('@{')
+    || ref === '@') {
+    return false;
+  }
+
+  return ref.split('/').every(segment => segment.length > 0
+    && !segment.startsWith('.')
+    && !segment.endsWith('.lock'));
 }
 
 /** Rejects whitespace and control characters in clone URLs. */

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -43,16 +43,44 @@ interface ParsedExternalId {
   itemNumber: string;
 }
 
-const SUPPORTED_PROVIDERS = [
-  'github',
-  'ado-work-items',
-  'github-my-prs',
-  'github-pr-reviews',
-  'ado-pr-reviews',
-];
+type GitHost = 'github' | 'ado';
+type WorkItemKind = 'issue' | 'pr';
 
-const PR_PROVIDERS = ['github-my-prs', 'github-pr-reviews', 'ado-pr-reviews'];
-const GITHUB_PR_PROVIDERS = ['github-my-prs', 'github-pr-reviews'];
+function detectGitHost(url: unknown): GitHost | undefined {
+  if (typeof url !== 'string' || url.length === 0) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+    if (parsed.protocol !== 'https:') {
+      return undefined;
+    }
+    if (hostname === 'github.com') {
+      return 'github';
+    }
+    if (hostname === 'dev.azure.com' || hostname.endsWith('.visualstudio.com')) {
+      return 'ado';
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+/** Treats missing itemType as issue-shaped for compatibility with older/generic items. */
+function getWorkItemKind(item: Readonly<WorkItem>): WorkItemKind | undefined {
+  const itemType: unknown = item.itemType;
+  if (itemType === 'pr' || itemType === 'issue') {
+    return itemType;
+  }
+  if (itemType === undefined) {
+    return 'issue';
+  }
+  return undefined;
+}
 
 type WorkMode = 'checkout' | 'worktree';
 
@@ -86,12 +114,12 @@ interface PrBranchInfo {
 /**
  * DevDocket action that bootstraps a development environment for a work item.
  *
- * Supports items from GitHub and Azure DevOps providers (both issues and PRs).
+ * Supports items with GitHub or Azure DevOps URLs (both issues and PRs).
  * When executed on an issue it creates a new branch and either checks out
  * or creates a worktree for it, based on user preference.
  * When executed on a PR it fetches the existing PR branch instead of creating one.
  *
- * Only available for items in the `InProgress` state from supported providers.
+ * Only available for `InProgress` items whose source URL and item shape are supported.
  */
 export class StartWorkAction implements DevDocketAction {
   readonly id = 'startGitWork';
@@ -104,7 +132,9 @@ export class StartWorkAction implements DevDocketAction {
   }
 
   canRun(item: Readonly<WorkItem>): boolean {
-    return item.state === WorkItemState.InProgress && SUPPORTED_PROVIDERS.includes(item.providerId ?? '');
+    return item.state === WorkItemState.InProgress
+      && this.getRouting(item) !== undefined
+      && this.parseExternalId(item.externalId) !== undefined;
   }
 
   async run(item: Readonly<WorkItem>): Promise<void> {
@@ -114,18 +144,31 @@ export class StartWorkAction implements DevDocketAction {
       return;
     }
 
-    const isPr = PR_PROVIDERS.includes(item.providerId ?? '');
+    const routing = this.getRouting(item);
+    if (!routing) {
+      void vscode.window.showErrorMessage('DevDocket: This work item is not supported by Start Git Work.');
+      return;
+    }
 
     const repoPath = await this.promptForRepoPath(parsed.repoKey);
     if (!repoPath) {
       return;
     }
 
-    if (isPr) {
-      await this.runPrFlow(item, parsed, repoPath);
+    if (routing.kind === 'pr') {
+      await this.runPrFlow(item, parsed, repoPath, routing.host);
     } else {
       await this.runIssueFlow(item, parsed, repoPath);
     }
+  }
+
+  private getRouting(item: Readonly<WorkItem>): { host: GitHost; kind: WorkItemKind } | undefined {
+    const host = detectGitHost(item.url);
+    const kind = getWorkItemKind(item);
+    if (!host || !kind) {
+      return undefined;
+    }
+    return { host, kind };
   }
 
   private async runIssueFlow(
@@ -274,6 +317,7 @@ export class StartWorkAction implements DevDocketAction {
     item: Readonly<WorkItem>,
     parsed: ParsedExternalId,
     repoPath: string,
+    host: GitHost,
   ): Promise<void> {
     const workMode = await this.promptForWorkMode();
     if (!workMode) {
@@ -290,9 +334,8 @@ export class StartWorkAction implements DevDocketAction {
         async (progress) => {
           progress.report({ message: 'Fetching PR branch...' });
 
-          const isGitHubPr = GITHUB_PR_PROVIDERS.includes(item.providerId ?? '');
-          logger.info(`PR flow: provider=${item.providerId}, type=${isGitHubPr ? 'GitHub' : 'ADO'}, repoKey=${parsed.repoKey}, itemNumber=${parsed.itemNumber}`);
-          const branchInfo = isGitHubPr
+          logger.info(`PR flow: provider=${item.providerId}, type=${host === 'github' ? 'GitHub' : 'ADO'}, repoKey=${parsed.repoKey}, itemNumber=${parsed.itemNumber}`);
+          const branchInfo = host === 'github'
             ? await this.fetchGitHubPrBranch(parsed, repoPath)
             : await this.fetchAdoPrBranch(parsed, repoPath);
 

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -4,7 +4,7 @@ import { promisify } from 'util';
 import * as path from 'path';
 import * as fs from 'fs';
 import { logger } from './logger';
-import { WorkItemState, type WorkItem, type DevDocketAction } from '@devdocket/shared';
+import { WorkItemState, type DiscoveredItem, type GitWorkInfo, type WorkItem, type DevDocketAction } from '@devdocket/shared';
 
 const execFileAsync = promisify(execFile);
 
@@ -38,132 +38,11 @@ const GIT_METADATA_TIMEOUT = 30_000;
 /** Timeout for heavy git operations that touch the working tree (worktree add, checkout, fetch). */
 const GIT_CHECKOUT_TIMEOUT = 300_000;
 
-interface ParsedExternalId {
-  repoKey: string;
-  itemNumber: string;
-}
+type GetDiscoveredItem = (providerId: string, externalId: string) => DiscoveredItem | undefined;
 
-type GitHost = 'github' | 'ado';
-type WorkItemKind = 'issue' | 'pr';
-
-interface Routing {
-  host: GitHost;
-  kind: WorkItemKind;
-}
-
-function detectGitHost(url: unknown): GitHost | undefined {
-  if (typeof url !== 'string' || url.length === 0) {
-    return undefined;
-  }
-
-  try {
-    const parsed = new URL(url);
-    const hostname = parsed.hostname.toLowerCase();
-    if (parsed.protocol !== 'https:') {
-      return undefined;
-    }
-    if (hostname === 'github.com') {
-      return 'github';
-    }
-    if (hostname === 'dev.azure.com' || hostname.endsWith('.visualstudio.com')) {
-      return 'ado';
-    }
-  } catch {
-    return undefined;
-  }
-
-  return undefined;
-}
-
-function inferWorkItemKindFromUrl(url: unknown, host: GitHost): WorkItemKind | undefined {
-  if (typeof url !== 'string' || url.length === 0) {
-    return undefined;
-  }
-
-  try {
-    const parsed = new URL(url);
-    const segments = parsed.pathname.toLowerCase().split('/').filter(Boolean);
-    if (host === 'github') {
-      if (segments[2] === 'pull') {
-        return 'pr';
-      }
-      if (segments[2] === 'issues') {
-        return 'issue';
-      }
-    }
-
-    if (segments.includes('pullrequest')) {
-      return 'pr';
-    }
-    if (segments.includes('_workitems') && segments.includes('edit')) {
-      return 'issue';
-    }
-  } catch {
-    return undefined;
-  }
-
-  return undefined;
-}
-
-/** Infers missing itemType from known URL shapes before falling back to issue-shaped compatibility. */
-function getWorkItemKind(item: Readonly<WorkItem>, host: GitHost): WorkItemKind | undefined {
-  const itemType: unknown = item.itemType;
-  if (itemType === 'pr' || itemType === 'issue') {
-    return itemType;
-  }
-  if (itemType === undefined) {
-    return inferWorkItemKindFromUrl(item.url, host) ?? 'issue';
-  }
-  return undefined;
-}
-
-function isExternalIdValidForRouting(
-  externalId: string | undefined,
-  parsed: ParsedExternalId,
-  routing: Routing,
-): boolean {
-  if (!externalId) {
-    return false;
-  }
-
-  const repoKeySegments = parsed.repoKey.split('/');
-  if (repoKeySegments.some(segment => segment.length === 0)) {
-    return false;
-  }
-
-  if (routing.host === 'github') {
-    return repoKeySegments.length === 2 && /^[^/#]+\/[^/#]+#\d+$/.test(externalId);
-  }
-
-  if (routing.kind === 'pr') {
-    return repoKeySegments.length === 3 && /^[^/#]+\/[^/#]+\/[^/#]+\/\d+$/.test(externalId);
-  }
-
-  return repoKeySegments.length === 2 && /^[^/#]+\/[^/#]+\/\d+$/.test(externalId);
-}
+type ResolvedGitWork = GitWorkInfo & { cloneUrl: string; ref: string };
 
 type WorkMode = 'checkout' | 'worktree';
-
-interface GitHubPrHead {
-  ref: string;
-  repo: {
-    full_name: string;
-    clone_url: string;
-  } | null;
-}
-
-interface GitHubPrResponse {
-  head: GitHubPrHead;
-  base: {
-    repo: {
-      full_name: string;
-    };
-  };
-}
-
-interface AdoPrResponse {
-  sourceRefName: string;
-}
 
 interface PrBranchInfo {
   branchName: string;
@@ -174,12 +53,9 @@ interface PrBranchInfo {
 /**
  * DevDocket action that bootstraps a development environment for a work item.
  *
- * Supports items with GitHub or Azure DevOps URLs (both issues and PRs).
- * When executed on an issue it creates a new branch and either checks out
- * or creates a worktree for it, based on user preference.
- * When executed on a PR it fetches the existing PR branch instead of creating one.
- *
- * Only available for `InProgress` items whose source URL and item shape are supported.
+ * Supports any provider that attaches a gitWork capability to its live
+ * discovered item. The action consumes only provider-supplied git metadata;
+ * it does not know about provider ids, URL hosts, or provider HTTP APIs.
  */
 export class StartWorkAction implements DevDocketAction {
   readonly id = 'startGitWork';
@@ -187,68 +63,103 @@ export class StartWorkAction implements DevDocketAction {
 
   private readonly globalState: vscode.Memento;
 
-  constructor(globalState: vscode.Memento) {
+  constructor(
+    globalState: vscode.Memento,
+    private readonly getDiscoveredItem: GetDiscoveredItem = () => undefined,
+  ) {
     this.globalState = globalState;
   }
 
   canRun(item: Readonly<WorkItem>): boolean {
-    if (item.state !== WorkItemState.InProgress) {
+    if (item.state !== WorkItemState.InProgress || !item.providerId || !item.externalId) {
       return false;
     }
 
-    const routing = this.getRouting(item);
-    const parsed = this.parseExternalId(item.externalId);
-    return routing !== undefined
-      && parsed !== undefined
-      && isExternalIdValidForRouting(item.externalId, parsed, routing);
+    return !!this.getDiscoveredItem(item.providerId, item.externalId)?.capabilities?.gitWork;
   }
 
   async run(item: Readonly<WorkItem>): Promise<void> {
-    const parsed = this.parseExternalId(item.externalId);
-    if (!parsed) {
-      void vscode.window.showErrorMessage('Could not determine work item number.');
-      return;
-    }
-
-    const routing = this.getRouting(item);
-    if (!routing || !isExternalIdValidForRouting(item.externalId, parsed, routing)) {
+    const gitWork = await this.resolveGitWork(item);
+    if (!gitWork) {
       void vscode.window.showErrorMessage('DevDocket: This work item is not supported by Start Git Work.');
       return;
     }
 
-    const repoPath = await this.promptForRepoPath(parsed.repoKey);
+    if (!this.validateGitWork(gitWork)) {
+      return;
+    }
+
+    const repoLabel = gitWork.repoLabel ?? gitWork.cloneUrl;
+    const repoPath = await this.promptForRepoPath(repoLabel);
     if (!repoPath) {
       return;
     }
 
-    if (routing.kind === 'pr') {
-      await this.runPrFlow(item, parsed, repoPath, routing.host);
+    if (gitWork.kind === 'pr') {
+      await this.runPrFlow(item, gitWork, repoPath);
     } else {
-      await this.runIssueFlow(item, parsed, repoPath);
+      await this.runIssueFlow(item, gitWork, repoPath);
     }
   }
 
-  private getRouting(item: Readonly<WorkItem>): Routing | undefined {
-    const host = detectGitHost(item.url);
-    if (!host) {
+  private async resolveGitWork(item: Readonly<WorkItem>): Promise<GitWorkInfo | undefined> {
+    if (!item.providerId || !item.externalId) {
       return undefined;
     }
 
-    const kind = getWorkItemKind(item, host);
-    if (!kind) {
+    const capability = this.getDiscoveredItem(item.providerId, item.externalId)?.capabilities?.gitWork;
+    if (!capability) {
       return undefined;
     }
-    return { host, kind };
+
+    try {
+      return typeof capability === 'function' ? await capability() : capability;
+    } catch (err) {
+      logger.error('Provider gitWork capability failed', err);
+      const message = err instanceof Error ? err.message : String(err);
+      void vscode.window.showErrorMessage(`DevDocket: Could not resolve git work information — ${message}`);
+      return undefined;
+    }
+  }
+
+  private validateGitWork(gitWork: GitWorkInfo): gitWork is ResolvedGitWork {
+    if (gitWork.kind !== 'issue' && gitWork.kind !== 'pr') {
+      logger.warn('Provider returned invalid gitWork kind');
+      void vscode.window.showErrorMessage('DevDocket: Provider returned an invalid git work kind for this item.');
+      return false;
+    }
+    if (!isValidCloneUrl(gitWork.cloneUrl)) {
+      logger.warn(`Provider returned invalid gitWork cloneUrl for ${gitWork.kind}`);
+      void vscode.window.showErrorMessage('DevDocket: Provider returned an invalid clone URL for this work item.');
+      return false;
+    }
+    if (!isValidRef(gitWork.ref)) {
+      logger.warn(`Provider returned invalid gitWork ref for ${gitWork.kind}`);
+      void vscode.window.showErrorMessage('DevDocket: Provider returned an invalid git ref for this work item.');
+      return false;
+    }
+    if (gitWork.headCloneUrl !== undefined && !isValidCloneUrl(gitWork.headCloneUrl)) {
+      logger.warn('Provider returned invalid gitWork headCloneUrl for PR');
+      void vscode.window.showErrorMessage('DevDocket: Provider returned an invalid PR source clone URL.');
+      return false;
+    }
+    if (gitWork.baseRef !== undefined && !isValidRef(gitWork.baseRef)) {
+      logger.warn('Provider returned invalid gitWork baseRef for PR');
+      void vscode.window.showErrorMessage('DevDocket: Provider returned an invalid PR base ref.');
+      return false;
+    }
+    return true;
   }
 
   private async runIssueFlow(
     item: Readonly<WorkItem>,
-    parsed: ParsedExternalId,
+    gitWork: ResolvedGitWork,
     repoPath: string,
   ): Promise<void> {
-    const branchName = `issue${parsed.itemNumber}`;
+    const branchName = gitWork.ref;
+    const repoLabel = gitWork.repoLabel ?? gitWork.cloneUrl;
 
-    const baseBranch = await this.promptForBaseBranch(parsed.repoKey);
+    const baseBranch = await this.promptForBaseBranch(repoLabel);
     if (!baseBranch) {
       return;
     }
@@ -262,12 +173,12 @@ export class StartWorkAction implements DevDocketAction {
       await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
-          title: `Starting git work for issue ${parsed.itemNumber}`,
+          title: 'Starting git work for issue',
           cancellable: false,
         },
         async (progress) => {
           if (workMode === 'worktree') {
-            await this.issueWorktreeFlow(item, parsed, repoPath, branchName, baseBranch, progress);
+            await this.issueWorktreeFlow(item, repoPath, branchName, baseBranch, progress);
           } else {
             await this.issueCheckoutFlow(item, repoPath, branchName, baseBranch, progress);
           }
@@ -282,14 +193,13 @@ export class StartWorkAction implements DevDocketAction {
 
   private async issueWorktreeFlow(
     item: Readonly<WorkItem>,
-    parsed: ParsedExternalId,
     repoPath: string,
     branchName: string,
     baseBranch: string,
     progress: vscode.Progress<{ message?: string }>,
   ): Promise<void> {
     const repoBaseName = path.basename(repoPath);
-    const worktreeDirName = `${repoBaseName}-issue${parsed.itemNumber}`;
+    const worktreeDirName = `${repoBaseName}-${this.toWorktreePathSuffix(branchName)}`;
     const worktreePath = path.join(path.dirname(repoPath), worktreeDirName);
 
     if (fs.existsSync(worktreePath)) {
@@ -385,9 +295,8 @@ export class StartWorkAction implements DevDocketAction {
 
   private async runPrFlow(
     item: Readonly<WorkItem>,
-    parsed: ParsedExternalId,
+    gitWork: ResolvedGitWork,
     repoPath: string,
-    host: GitHost,
   ): Promise<void> {
     const workMode = await this.promptForWorkMode();
     if (!workMode) {
@@ -398,23 +307,19 @@ export class StartWorkAction implements DevDocketAction {
       await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
-          title: `Starting git work for PR #${parsed.itemNumber}`,
+          title: 'Starting git work for PR',
           cancellable: false,
         },
         async (progress) => {
           progress.report({ message: 'Fetching PR branch...' });
 
-          logger.info(`PR flow: provider=${item.providerId}, type=${host === 'github' ? 'GitHub' : 'ADO'}, repoKey=${parsed.repoKey}, itemNumber=${parsed.itemNumber}`);
-          const branchInfo = host === 'github'
-            ? await this.fetchGitHubPrBranch(parsed, repoPath)
-            : await this.fetchAdoPrBranch(parsed, repoPath);
-
+          const branchInfo = await this.fetchPrBranch(gitWork, repoPath);
           if (!branchInfo) {
             return;
           }
 
           if (workMode === 'worktree') {
-            await this.prWorktreeFlow(item, parsed, repoPath, branchInfo, progress);
+            await this.prWorktreeFlow(item, repoPath, branchInfo, progress);
           } else {
             await this.prCheckoutFlow(item, repoPath, branchInfo, progress);
           }
@@ -427,115 +332,38 @@ export class StartWorkAction implements DevDocketAction {
     }
   }
 
-  /**
-   * Fetches the branch name for a GitHub PR and ensures it is available locally.
-   * Finds (or adds) the remote whose URL matches the PR head repo, then does a
-   * full fetch so all refs are available for checkout/worktree creation.
-   */
-  private async fetchGitHubPrBranch(parsed: ParsedExternalId, repoPath: string): Promise<PrBranchInfo | undefined> {
-    const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: true });
-    if (!session) {
-      void vscode.window.showErrorMessage('DevDocket: GitHub authentication required.');
-      return undefined;
-    }
+  private async fetchPrBranch(gitWork: ResolvedGitWork, repoPath: string): Promise<PrBranchInfo | undefined> {
+    const branchName = gitWork.ref;
+    const cloneUrl = gitWork.headCloneUrl ?? gitWork.cloneUrl;
 
-    const repoKeyParts = parsed.repoKey.split('/');
-    if (repoKeyParts.length !== 2 || !repoKeyParts[0] || !repoKeyParts[1]) {
-      void vscode.window.showErrorMessage(`DevDocket: Invalid GitHub repository key "${parsed.repoKey}".`);
-      return undefined;
-    }
-    const [owner, repo] = repoKeyParts;
-    const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/${parsed.itemNumber}`;
-    logger.debug(`GitHub PR API: ${url}`);
+    logger.info(`Fetching provider-supplied PR branch "${branchName}"`);
+    const remoteName = await this.findOrAddRemote(cloneUrl, gitWork.repoLabel, repoPath);
 
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${session.accessToken}`,
-        Accept: 'application/vnd.github+json',
-        'User-Agent': 'DevDocket-VSCode',
-        'X-GitHub-Api-Version': '2022-11-28',
-      },
-      signal: AbortSignal.timeout(30_000),
-    });
-
-    if (!response.ok) {
-      logger.info(`GitHub PR API returned ${response.status} for PR #${parsed.itemNumber}`);
-      if (response.status === 404) {
-        void vscode.window.showErrorMessage(`DevDocket: Could not find PR #${parsed.itemNumber}`);
-      } else {
-        void vscode.window.showErrorMessage(`DevDocket: GitHub API error (${response.status})`);
-      }
-      return undefined;
-    }
-
-    const pr = await response.json() as GitHubPrResponse;
-
-    if (
-      !pr ||
-      typeof pr !== 'object' ||
-      !pr.head ||
-      typeof pr.head.ref !== 'string' ||
-      !pr.base ||
-      !pr.base.repo ||
-      typeof pr.base.repo.full_name !== 'string'
-    ) {
-      void vscode.window.showErrorMessage('DevDocket: GitHub API returned an unexpected response shape.');
-      return undefined;
-    }
-
-    const branchName = pr.head.ref;
-
-    if (!isValidRef(branchName)) {
-      void vscode.window.showErrorMessage('DevDocket: PR branch name contains invalid characters.');
-      return undefined;
-    }
-
-    const isFork = pr.head.repo ? pr.head.repo.full_name !== pr.base.repo.full_name : false;
-    logger.debug(`GitHub PR #${parsed.itemNumber}: head.ref=${branchName}, head.repo=${pr.head.repo?.full_name ?? 'null'}, base.repo=${pr.base.repo.full_name}, isFork=${isFork}`);
-
-    if (!pr.head.repo) {
-      logger.info(`PR #${parsed.itemNumber}: source repository has been deleted`);
+    try {
+      await execFileAsync('git', ['fetch', remoteName], { cwd: repoPath, timeout: GIT_CHECKOUT_TIMEOUT });
+      logger.debug(`Fetch complete for remote "${remoteName}"`);
+    } catch {
+      logger.info(`Failed to fetch branch "${branchName}" from ${remoteName}`);
       void vscode.window.showErrorMessage(
-        `DevDocket: The source repository for PR #${parsed.itemNumber} has been deleted.`,
+        `DevDocket: Could not fetch branch '${branchName}' from ${remoteName}. The branch may have been deleted.`,
       );
       return undefined;
     }
 
-    const headCloneUrl = pr.head.repo.clone_url;
-    if (!isValidCloneUrl(headCloneUrl)) {
-      void vscode.window.showErrorMessage('DevDocket: PR source repository has an invalid clone URL.');
-      return undefined;
-    }
-    const fullName = pr.head.repo.full_name;
-    if (typeof fullName !== 'string' || !/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/.test(fullName)) {
-      void vscode.window.showErrorMessage('DevDocket: PR source repository has an invalid full name.');
-      return undefined;
-    }
-
-    logger.debug(`Looking up remote for clone URL: ${headCloneUrl}`);
-    const remoteName = await this.findOrAddRemote(headCloneUrl, fullName, repoPath);
-
-    // Full fetch to ensure all refs (including the PR branch) are available
-    logger.info(`Fetching all refs from remote "${remoteName}"`);
-    await execFileAsync('git', ['fetch', remoteName], { cwd: repoPath, timeout: GIT_CHECKOUT_TIMEOUT });
-    logger.debug(`Fetch complete for remote "${remoteName}"`);
-
     if (remoteName === 'origin') {
-      logger.info(`PR branch "${branchName}" available on origin`);
       return { branchName };
     }
-    logger.info(`PR branch available as ${remoteName}/${branchName}`);
     return { branchName, trackingRef: `${remoteName}/${branchName}` };
   }
 
   /**
    * Finds a local remote whose fetch URL matches {@link cloneUrl}, or adds a
-   * new `devdocket-fork-{owner}` remote pointing to it.
+   * new DevDocket-managed remote pointing to it.
    */
-  private async findOrAddRemote(cloneUrl: string, fullName: string, repoPath: string): Promise<string> {
+  private async findOrAddRemote(cloneUrl: string, repoLabel: string | undefined, repoPath: string): Promise<string> {
     const { stdout } = await execFileAsync('git', ['remote', '-v'], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
     for (const line of stdout.split('\n')) {
-      const match = line.match(/^(\S+)\t(\S+)\s+\(fetch\)$/);
+      const match = line.match(/^(\S+)	(\S+)\s+\(fetch\)$/);
       if (match && match[2] === cloneUrl) {
         const name = match[1];
         if (!isValidRef(name)) {
@@ -547,118 +375,38 @@ export class StartWorkAction implements DevDocketAction {
       }
     }
 
-    // No existing remote matches — add a DevDocket-managed one
-    const forkOwner = fullName.split('/')[0];
-    const forkRemoteName = `devdocket-fork-${forkOwner}`;
-    logger.debug(`No remote found for ${cloneUrl}, adding "${forkRemoteName}"`);
+    const remoteName = this.toRemoteName(cloneUrl, repoLabel);
+    logger.debug(`No remote found for ${cloneUrl}, adding "${remoteName}"`);
 
     try {
-      await execFileAsync('git', ['remote', 'add', forkRemoteName, cloneUrl], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
-      logger.info(`Added remote "${forkRemoteName}" → ${cloneUrl}`);
+      await execFileAsync('git', ['remote', 'add', remoteName, cloneUrl], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+      logger.info(`Added remote "${remoteName}" → ${cloneUrl}`);
     } catch (err) {
       try {
-        const { stdout: existingUrl } = await execFileAsync('git', ['remote', 'get-url', forkRemoteName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+        const { stdout: existingUrl } = await execFileAsync('git', ['remote', 'get-url', remoteName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
         if (existingUrl.trim() !== cloneUrl) {
-          logger.info(`Remote "${forkRemoteName}" exists with different URL, updating to "${cloneUrl}".`);
-          await execFileAsync('git', ['remote', 'set-url', forkRemoteName, cloneUrl], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+          logger.info(`Remote "${remoteName}" exists with different URL, updating to "${cloneUrl}".`);
+          await execFileAsync('git', ['remote', 'set-url', remoteName, cloneUrl], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
         } else {
-          logger.debug(`Remote "${forkRemoteName}" already exists with correct URL`);
+          logger.debug(`Remote "${remoteName}" already exists with correct URL`);
         }
       } catch {
         throw err;
       }
     }
 
-    return forkRemoteName;
-  }
-
-  /**
-   * Fetches the branch name for an ADO PR.
-   * Strips the `refs/heads/` prefix from `sourceRefName`.
-   */
-  private async fetchAdoPrBranch(parsed: ParsedExternalId, repoPath: string): Promise<PrBranchInfo | undefined> {
-    const session = await vscode.authentication.getSession(
-      'microsoft',
-      ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
-      { createIfNone: true },
-    );
-    if (!session) {
-      void vscode.window.showErrorMessage('DevDocket: Microsoft authentication required.');
-      return undefined;
-    }
-
-    // ADO PR externalId format: org/project/repo/id
-    const parts = parsed.repoKey.split('/');
-    if (parts.length < 3) {
-      void vscode.window.showErrorMessage(`DevDocket: Invalid ADO repo key "${parsed.repoKey}".`);
-      return undefined;
-    }
-    const org = parts[0];
-    const project = parts[1];
-    const adoRepo = parts[2];
-    const url = `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(project)}/_apis/git/repositories/${encodeURIComponent(adoRepo)}/pullrequests/${parsed.itemNumber}?api-version=7.1`;
-    logger.debug(`ADO PR API: ${url}`);
-
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${session.accessToken}`,
-        Accept: 'application/json',
-        'User-Agent': 'DevDocket-VSCode',
-      },
-      signal: AbortSignal.timeout(30_000),
-    });
-
-    if (!response.ok) {
-      logger.info(`ADO PR API returned ${response.status} for PR #${parsed.itemNumber}`);
-      if (response.status === 404) {
-        void vscode.window.showErrorMessage(`DevDocket: Could not find PR #${parsed.itemNumber}`);
-      } else {
-        void vscode.window.showErrorMessage(`DevDocket: ADO API error (${response.status})`);
-      }
-      return undefined;
-    }
-
-    const pr = await response.json() as AdoPrResponse;
-
-    if (typeof pr?.sourceRefName !== 'string') {
-      void vscode.window.showErrorMessage('DevDocket: ADO API returned an unexpected response shape.');
-      return undefined;
-    }
-
-    const branchName = pr.sourceRefName.replace(/^refs\/heads\//, '');
-
-    if (!isValidRef(branchName)) {
-      void vscode.window.showErrorMessage('DevDocket: PR branch name contains invalid characters.');
-      return undefined;
-    }
-
-    logger.debug(`ADO PR #${parsed.itemNumber}: sourceRefName=${pr.sourceRefName}, branchName=${branchName}`);
-
-    logger.info(`Fetching branch "${branchName}" from origin`);
-    try {
-      await execFileAsync('git', ['fetch', 'origin', branchName], { cwd: repoPath, timeout: GIT_CHECKOUT_TIMEOUT });
-      logger.debug(`Fetch complete for origin/${branchName}`);
-    } catch {
-      logger.info(`Failed to fetch branch "${branchName}" from origin`);
-      void vscode.window.showErrorMessage(
-        `DevDocket: Could not fetch branch '${branchName}' from origin. The branch may have been deleted.`,
-      );
-      return undefined;
-    }
-
-    return { branchName };
+    return remoteName;
   }
 
   private async prWorktreeFlow(
     item: Readonly<WorkItem>,
-    parsed: ParsedExternalId,
     repoPath: string,
     branchInfo: PrBranchInfo,
     progress: vscode.Progress<{ message?: string }>,
   ): Promise<void> {
     const { branchName, trackingRef } = branchInfo;
     const repoBaseName = path.basename(repoPath);
-    const worktreeDirName = `${repoBaseName}-pr${parsed.itemNumber}`;
+    const worktreeDirName = `${repoBaseName}-${this.toWorktreePathSuffix(branchName)}`;
     const worktreePath = path.join(path.dirname(repoPath), worktreeDirName);
 
     if (fs.existsSync(worktreePath)) {
@@ -893,31 +641,34 @@ export class StartWorkAction implements DevDocketAction {
     }
   }
 
-  /**
-   * Parses the externalId into repoKey and itemNumber.
-   * Supports three formats:
-   *   GitHub:      "owner/repo#123"           → repoKey="owner/repo", itemNumber="123"
-   *   ADO Issue:   "org/project/123"           → repoKey="org/project", itemNumber="123"
-   *   ADO PR:      "org/project/repo/101"      → repoKey="org/project/repo", itemNumber="101"
-   */
-  private parseExternalId(externalId: string | undefined): ParsedExternalId | undefined {
-    if (!externalId) {
+  private toWorktreePathSuffix(ref: string): string {
+    return ref.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'branch';
+  }
+
+  private toRemoteName(cloneUrl: string, repoLabel?: string): string {
+    const candidate = this.ownerLikeSegmentFromCloneUrl(cloneUrl) ?? repoLabel ?? cloneUrl;
+    const preferredOwner = candidate.includes('/') ? candidate.split('/')[0] : candidate;
+    const suffix = preferredOwner.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'source';
+    const remoteName = `devdocket-fork-${suffix}`;
+    return isValidRef(remoteName) ? remoteName : 'devdocket-fork-source';
+  }
+
+  private ownerLikeSegmentFromCloneUrl(cloneUrl: string): string | undefined {
+    if (cloneUrl.startsWith('https://')) {
+      try {
+        const segments = new URL(cloneUrl).pathname.split('/').filter(Boolean);
+        return segments.length >= 2 ? segments[segments.length - 2] : undefined;
+      } catch {
+        return undefined;
+      }
+    }
+
+    const gitPath = cloneUrl.match(/^git@[^:]+:(.+)$/)?.[1];
+    if (!gitPath) {
       return undefined;
     }
-
-    // Try GitHub format first (has #)
-    const ghMatch = externalId.match(/^(.+?)#(\d+)$/);
-    if (ghMatch) {
-      return { repoKey: ghMatch[1], itemNumber: ghMatch[2] };
-    }
-
-    // Fall back to ADO format: last /-separated segment is numeric
-    const adoMatch = externalId.match(/^(.+)\/(\d+)$/);
-    if (adoMatch) {
-      return { repoKey: adoMatch[1], itemNumber: adoMatch[2] };
-    }
-
-    return undefined;
+    const segments = gitPath.split('/').filter(Boolean);
+    return segments.length >= 2 ? segments[segments.length - 2] : undefined;
   }
 
   /**

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -162,7 +162,12 @@ export class StartWorkAction implements DevDocketAction {
       void vscode.window.showErrorMessage('DevDocket: Provider returned an invalid clone URL for this work item.');
       return false;
     }
-    if (typeof gitWork.ref === 'string' && gitWork.ref.startsWith('refs/') && !gitWork.ref.startsWith('refs/heads/')) {
+    if (typeof gitWork.ref !== 'string') {
+      logger.warn(`Provider returned invalid gitWork ref for ${gitWork.kind}`);
+      void vscode.window.showErrorMessage('DevDocket: Provider returned an invalid git ref for this work item.');
+      return false;
+    }
+    if (gitWork.ref.startsWith('refs/') && !gitWork.ref.startsWith('refs/heads/')) {
       logger.warn(`Provider returned unsupported gitWork ref: ${gitWork.ref}`);
       void vscode.window.showErrorMessage('DevDocket: Provider returned an unsupported git branch ref for this work item.');
       return false;

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -340,8 +340,12 @@ export class StartWorkAction implements DevDocketAction {
     const remoteName = await this.findOrAddRemote(cloneUrl, gitWork.repoLabel, repoPath);
 
     try {
-      await execFileAsync('git', ['fetch', remoteName], { cwd: repoPath, timeout: GIT_CHECKOUT_TIMEOUT });
-      logger.debug(`Fetch complete for remote "${remoteName}"`);
+      await execFileAsync('git', [
+        'fetch',
+        remoteName,
+        `+refs/heads/${branchName}:refs/remotes/${remoteName}/${branchName}`,
+      ], { cwd: repoPath, timeout: GIT_CHECKOUT_TIMEOUT });
+      logger.debug(`Fetch complete for branch "${branchName}" from remote "${remoteName}"`);
     } catch {
       logger.info(`Failed to fetch branch "${branchName}" from ${remoteName}`);
       void vscode.window.showErrorMessage(

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -660,8 +660,7 @@ export class StartWorkAction implements DevDocketAction {
 
   private toRemoteName(cloneUrl: string, repoLabel?: string): string {
     const candidate = this.ownerLikeSegmentFromCloneUrl(cloneUrl) ?? repoLabel ?? cloneUrl;
-    const preferredOwner = candidate.includes('/') ? candidate.split('/')[0] : candidate;
-    const suffix = preferredOwner.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'source';
+    const suffix = candidate.replace(/\.git$/i, '').replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'source';
     const remoteName = `devdocket-fork-${suffix}`;
     return isValidRef(remoteName) ? remoteName : 'devdocket-fork-source';
   }
@@ -670,6 +669,9 @@ export class StartWorkAction implements DevDocketAction {
     if (cloneUrl.startsWith('https://')) {
       try {
         const segments = new URL(cloneUrl).pathname.split('/').filter(Boolean);
+        if (segments.some(segment => segment.toLowerCase() === '_git')) {
+          return undefined;
+        }
         return segments.length >= 2 ? segments[segments.length - 2] : undefined;
       } catch {
         return undefined;

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -142,6 +142,11 @@ export class StartWorkAction implements DevDocketAction {
       void vscode.window.showErrorMessage('DevDocket: Provider returned an invalid clone URL for this work item.');
       return false;
     }
+    if (gitWork.kind === 'pr' && typeof gitWork.ref === 'string' && gitWork.ref.startsWith('refs/') && !gitWork.ref.startsWith('refs/heads/')) {
+      logger.warn(`Provider returned unsupported PR gitWork ref: ${gitWork.ref}`);
+      void vscode.window.showErrorMessage('DevDocket: Provider returned an unsupported PR branch ref for this work item.');
+      return false;
+    }
     const ref = gitWork.kind === 'pr' ? this.normalizeBranchName(gitWork.ref) : gitWork.ref;
     if (!isValidRef(ref)) {
       logger.warn(`Provider returned invalid gitWork ref for ${gitWork.kind}`);

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -346,10 +346,11 @@ export class StartWorkAction implements DevDocketAction {
         `+refs/heads/${branchName}:refs/remotes/${remoteName}/${branchName}`,
       ], { cwd: repoPath, timeout: GIT_CHECKOUT_TIMEOUT });
       logger.debug(`Fetch complete for branch "${branchName}" from remote "${remoteName}"`);
-    } catch {
-      logger.info(`Failed to fetch branch "${branchName}" from ${remoteName}`);
+    } catch (err) {
+      const details = this.formatGitError(err);
+      logger.info(`Failed to fetch branch "${branchName}" from ${remoteName}: ${details}`);
       void vscode.window.showErrorMessage(
-        `DevDocket: Could not fetch branch '${branchName}' from ${remoteName}. The branch may have been deleted.`,
+        `DevDocket: Could not fetch branch '${branchName}' from remote '${remoteName}'. ${details}`,
       );
       return undefined;
     }
@@ -643,6 +644,14 @@ export class StartWorkAction implements DevDocketAction {
         );
       }
     }
+  }
+
+  private formatGitError(error: unknown): string {
+    const gitError = error as { stderr?: string; stdout?: string; message?: string };
+    const detail = [gitError.stderr, gitError.stdout, gitError.message]
+      .map(value => value?.trim())
+      .find(Boolean);
+    return detail ?? 'Check your network connection, permissions, and whether the branch still exists.';
   }
 
   private toWorktreePathSuffix(ref: string): string {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -133,7 +133,8 @@ export class StartWorkAction implements DevDocketAction {
       void vscode.window.showErrorMessage('DevDocket: Provider returned an invalid clone URL for this work item.');
       return false;
     }
-    if (!isValidRef(gitWork.ref)) {
+    const ref = gitWork.kind === 'pr' ? this.normalizeBranchName(gitWork.ref) : gitWork.ref;
+    if (!isValidRef(ref)) {
       logger.warn(`Provider returned invalid gitWork ref for ${gitWork.kind}`);
       void vscode.window.showErrorMessage('DevDocket: Provider returned an invalid git ref for this work item.');
       return false;
@@ -332,7 +333,7 @@ export class StartWorkAction implements DevDocketAction {
   }
 
   private async fetchPrBranch(gitWork: ResolvedGitWork, repoPath: string): Promise<PrBranchInfo | undefined> {
-    const branchName = gitWork.ref;
+    const branchName = this.normalizeBranchName(gitWork.ref);
     const cloneUrl = gitWork.headCloneUrl ?? gitWork.cloneUrl;
 
     logger.info(`Fetching provider-supplied PR branch "${branchName}"`);
@@ -642,6 +643,10 @@ export class StartWorkAction implements DevDocketAction {
         );
       }
     }
+  }
+
+  private normalizeBranchName(ref: string): string {
+    return ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref;
   }
 
   private formatGitError(error: unknown): string {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -162,12 +162,12 @@ export class StartWorkAction implements DevDocketAction {
       void vscode.window.showErrorMessage('DevDocket: Provider returned an invalid clone URL for this work item.');
       return false;
     }
-    if (gitWork.kind === 'pr' && typeof gitWork.ref === 'string' && gitWork.ref.startsWith('refs/') && !gitWork.ref.startsWith('refs/heads/')) {
-      logger.warn(`Provider returned unsupported PR gitWork ref: ${gitWork.ref}`);
-      void vscode.window.showErrorMessage('DevDocket: Provider returned an unsupported PR branch ref for this work item.');
+    if (typeof gitWork.ref === 'string' && gitWork.ref.startsWith('refs/') && !gitWork.ref.startsWith('refs/heads/')) {
+      logger.warn(`Provider returned unsupported gitWork ref: ${gitWork.ref}`);
+      void vscode.window.showErrorMessage('DevDocket: Provider returned an unsupported git branch ref for this work item.');
       return false;
     }
-    const ref = gitWork.kind === 'pr' ? this.normalizeBranchName(gitWork.ref) : gitWork.ref;
+    const ref = this.normalizeBranchName(gitWork.ref);
     if (!isValidRef(ref)) {
       logger.warn(`Provider returned invalid gitWork ref for ${gitWork.kind}`);
       void vscode.window.showErrorMessage('DevDocket: Provider returned an invalid git ref for this work item.');
@@ -191,7 +191,7 @@ export class StartWorkAction implements DevDocketAction {
     gitWork: ResolvedGitWork,
     repoPath: string,
   ): Promise<void> {
-    const branchName = gitWork.ref;
+    const branchName = this.normalizeBranchName(gitWork.ref);
     const repoLabel = gitWork.repoLabel ?? gitWork.cloneUrl;
 
     const baseBranch = await this.promptForBaseBranch(repoLabel);

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -198,8 +198,7 @@ export class StartWorkAction implements DevDocketAction {
     baseBranch: string,
     progress: vscode.Progress<{ message?: string }>,
   ): Promise<void> {
-    const repoBaseName = path.basename(repoPath);
-    const worktreeDirName = `${repoBaseName}-${this.toWorktreePathSuffix(branchName)}`;
+    const worktreeDirName = this.toWorktreeDirName(repoPath, branchName, item);
     const worktreePath = path.join(path.dirname(repoPath), worktreeDirName);
 
     if (fs.existsSync(worktreePath)) {
@@ -410,8 +409,7 @@ export class StartWorkAction implements DevDocketAction {
     progress: vscode.Progress<{ message?: string }>,
   ): Promise<void> {
     const { branchName, trackingRef } = branchInfo;
-    const repoBaseName = path.basename(repoPath);
-    const worktreeDirName = `${repoBaseName}-${this.toWorktreePathSuffix(branchName)}`;
+    const worktreeDirName = this.toWorktreeDirName(repoPath, branchName, item);
     const worktreePath = path.join(path.dirname(repoPath), worktreeDirName);
 
     if (fs.existsSync(worktreePath)) {
@@ -652,6 +650,12 @@ export class StartWorkAction implements DevDocketAction {
       .map(value => value?.trim())
       .find(Boolean);
     return detail ?? 'Check your network connection, permissions, and whether the branch still exists.';
+  }
+
+  private toWorktreeDirName(repoPath: string, ref: string, item: Readonly<WorkItem>): string {
+    const repoBaseName = path.basename(repoPath);
+    const itemSuffix = this.toWorktreePathSuffix(item.externalId ?? item.id);
+    return `${repoBaseName}-${this.toWorktreePathSuffix(ref)}-${itemSuffix}`;
   }
 
   private toWorktreePathSuffix(ref: string): string {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -367,7 +367,7 @@ export class StartWorkAction implements DevDocketAction {
   private async findOrAddRemote(cloneUrl: string, repoLabel: string | undefined, repoPath: string): Promise<string> {
     const { stdout } = await execFileAsync('git', ['remote', '-v'], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
     for (const line of stdout.split('\n')) {
-      const match = line.match(/^(\S+)	(\S+)\s+\(fetch\)$/);
+      const match = line.match(/^(\S+)\t(\S+)\s+\(fetch\)$/);
       if (match && match[2] === cloneUrl) {
         const name = match[1];
         if (!isValidRef(name)) {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -75,14 +75,44 @@ function detectGitHost(url: unknown): GitHost | undefined {
   return undefined;
 }
 
-/** Treats missing itemType as issue-shaped for compatibility with older/generic items. */
-function getWorkItemKind(item: Readonly<WorkItem>): WorkItemKind | undefined {
+function inferWorkItemKindFromUrl(url: unknown, host: GitHost): WorkItemKind | undefined {
+  if (typeof url !== 'string' || url.length === 0) {
+    return undefined;
+  }
+
+  try {
+    const parsed = new URL(url);
+    const segments = parsed.pathname.toLowerCase().split('/').filter(Boolean);
+    if (host === 'github') {
+      if (segments[2] === 'pull') {
+        return 'pr';
+      }
+      if (segments[2] === 'issues') {
+        return 'issue';
+      }
+    }
+
+    if (segments.includes('pullrequest')) {
+      return 'pr';
+    }
+    if (segments.includes('_workitems') && segments.includes('edit')) {
+      return 'issue';
+    }
+  } catch {
+    return undefined;
+  }
+
+  return undefined;
+}
+
+/** Infers missing itemType from known URL shapes before falling back to issue-shaped compatibility. */
+function getWorkItemKind(item: Readonly<WorkItem>, host: GitHost): WorkItemKind | undefined {
   const itemType: unknown = item.itemType;
   if (itemType === 'pr' || itemType === 'issue') {
     return itemType;
   }
   if (itemType === undefined) {
-    return 'issue';
+    return inferWorkItemKindFromUrl(item.url, host) ?? 'issue';
   }
   return undefined;
 }
@@ -200,8 +230,12 @@ export class StartWorkAction implements DevDocketAction {
 
   private getRouting(item: Readonly<WorkItem>): Routing | undefined {
     const host = detectGitHost(item.url);
-    const kind = getWorkItemKind(item);
-    if (!host || !kind) {
+    if (!host) {
+      return undefined;
+    }
+
+    const kind = getWorkItemKind(item, host);
+    if (!kind) {
       return undefined;
     }
     return { host, kind };

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -30,7 +30,16 @@ function isValidCloneUrl(url: unknown): url is string {
       return false;
     }
   }
-  return url.startsWith('git@');
+  return isValidGitSshCloneUrl(url);
+}
+
+function isValidGitSshCloneUrl(url: string): boolean {
+  const match = url.match(/^git@([^:]+):(.+)$/);
+  if (!match) {
+    return false;
+  }
+  const [, host, repoPath] = match;
+  return /^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?$/.test(host) && repoPath.length > 0;
 }
 
 /** Timeout for lightweight git metadata commands (branch --list, status, rev-parse). */

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -322,6 +322,19 @@ describe('StartWorkAction', () => {
       expect(execFile).not.toHaveBeenCalled();
     });
 
+    it.each(['foo..bar', 'foo.', 'foo/', 'foo//bar'])('rejects git-invalid ref %s', async (ref) => {
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', async () => ({
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref, repoLabel: 'acme/repo',
+      })));
+
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith('DevDocket: Provider returned an invalid git ref for this work item.');
+      expect(window.showInputBox).not.toHaveBeenCalled();
+      expect(execFile).not.toHaveBeenCalled();
+    });
+
     it('rejects unsupported fully-qualified PR refs', async () => {
       const item = createWorkItem();
       const { action } = createAction(discovered('provider', 'item-1', async () => ({

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -335,6 +335,19 @@ describe('StartWorkAction', () => {
       expect(execFile).not.toHaveBeenCalled();
     });
 
+    it('rejects non-string provider refs without throwing', async () => {
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', async () => ({
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 123 as any, repoLabel: 'acme/repo',
+      })));
+
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith('DevDocket: Provider returned an invalid git ref for this work item.');
+      expect(window.showInputBox).not.toHaveBeenCalled();
+      expect(execFile).not.toHaveBeenCalled();
+    });
+
     it('rejects unsupported fully-qualified PR refs', async () => {
       const item = createWorkItem();
       const { action } = createAction(discovered('provider', 'item-1', async () => ({

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -208,6 +208,23 @@ describe('StartWorkAction', () => {
       ]);
     });
 
+    it('uses repoLabel for ADO _git remote names', async () => {
+      mockNoLocalBranch('origin\thttps://example.com/other/repo.git (fetch)\n');
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'pr',
+        cloneUrl: 'https://dev.azure.com/myorg/MyProject/_git/myrepo',
+        ref: 'feature/topic',
+        repoLabel: 'myorg/MyProject/myrepo',
+      }));
+
+      await action.run(item);
+
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
+        'remote', 'add', 'devdocket-fork-myorg-MyProject-myrepo', 'https://dev.azure.com/myorg/MyProject/_git/myrepo',
+      ]);
+    });
+
     it('reports fetch failures with git error details', async () => {
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         if (args[0] === 'remote' && args[1] === '-v') {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -185,7 +185,7 @@ describe('StartWorkAction', () => {
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toEqual([
         ['remote', '-v'],
         ['remote', 'add', 'devdocket-fork-contributor', 'https://example.com/contributor/repo.git'],
-        ['fetch', 'devdocket-fork-contributor'],
+        ['fetch', 'devdocket-fork-contributor', '+refs/heads/feature/topic:refs/remotes/devdocket-fork-contributor/feature/topic'],
         ['rev-parse', '--verify', 'refs/heads/feature/topic'],
         ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'devdocket-fork-contributor/feature/topic'],
       ]);
@@ -202,7 +202,7 @@ describe('StartWorkAction', () => {
 
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toEqual([
         ['remote', '-v'],
-        ['fetch', 'origin'],
+        ['fetch', 'origin', '+refs/heads/feature/topic:refs/remotes/origin/feature/topic'],
         ['rev-parse', '--verify', 'refs/heads/feature/topic'],
         ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'origin/feature/topic'],
       ]);
@@ -277,7 +277,7 @@ describe('StartWorkAction', () => {
 
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toEqual([
         ['remote', '-v'],
-        ['fetch', 'origin'],
+        ['fetch', 'origin', '+refs/heads/feature/topic:refs/remotes/origin/feature/topic'],
         ['status', '--porcelain'],
         ['rev-parse', '--verify', 'refs/heads/feature/topic'],
         ['checkout', 'feature/topic'],

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -296,6 +296,19 @@ describe('StartWorkAction', () => {
       expect(execFile).not.toHaveBeenCalled();
     });
 
+    it('rejects HTTPS clone URLs with embedded credentials or token-bearing suffixes', async () => {
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', async () => ({
+        kind: 'issue', cloneUrl: 'https://user:token@example.com/acme/repo.git?token=secret', ref: 'issue123', repoLabel: 'acme/repo',
+      })));
+
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith('DevDocket: Provider returned an invalid clone URL for this work item.');
+      expect(window.showInputBox).not.toHaveBeenCalled();
+      expect(execFile).not.toHaveBeenCalled();
+    });
+
     it('rejects an invalid ref returned by a lazy resolver', async () => {
       const item = createWorkItem();
       const { action } = createAction(discovered('provider', 'item-1', async () => ({

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -165,7 +165,7 @@ describe('StartWorkAction', () => {
       expect(vi.mocked(execFile).mock.calls[0][1]).toEqual(['branch', '--list', 'vendor/ABC-123']);
       expect(vi.mocked(execFile).mock.calls[1][1]).toEqual(['branch', 'vendor/ABC-123', 'origin/dev']);
       expect(vi.mocked(execFile).mock.calls[2][1]).toEqual([
-        'worktree', 'add', path.join('/mock', 'workspace-vendor-ABC-123'), 'vendor/ABC-123',
+        'worktree', 'add', path.join('/mock', 'workspace-vendor-ABC-123-ABC-123'), 'vendor/ABC-123',
       ]);
       expect(memento.update).toHaveBeenCalledWith('repoPath:Vendor Repo', '/mock/workspace');
     });
@@ -188,7 +188,7 @@ describe('StartWorkAction', () => {
         ['remote', 'add', 'devdocket-fork-contributor', 'https://example.com/contributor/repo.git'],
         ['fetch', 'devdocket-fork-contributor', '+refs/heads/feature/topic:refs/remotes/devdocket-fork-contributor/feature/topic'],
         ['rev-parse', '--verify', 'refs/heads/feature/topic'],
-        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'devdocket-fork-contributor/feature/topic'],
+        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic-item-1'), 'devdocket-fork-contributor/feature/topic'],
       ]);
     });
 
@@ -205,7 +205,7 @@ describe('StartWorkAction', () => {
         ['remote', '-v'],
         ['fetch', 'origin', '+refs/heads/feature/topic:refs/remotes/origin/feature/topic'],
         ['rev-parse', '--verify', 'refs/heads/feature/topic'],
-        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'origin/feature/topic'],
+        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic-item-1'), 'origin/feature/topic'],
       ]);
     });
 
@@ -249,7 +249,7 @@ describe('StartWorkAction', () => {
         "DevDocket: Could not fetch branch 'feature/topic' from remote 'origin'. Authentication failed",
       );
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).not.toContainEqual([
-        'worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'origin/feature/topic',
+        'worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic-item-1'), 'origin/feature/topic',
       ]);
     });
 
@@ -349,7 +349,7 @@ describe('StartWorkAction', () => {
       await action.run(item);
 
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
-        'worktree', 'add', '--detach', path.join('/mock', 'workspace-feature-topic'), 'devdocket-fork-contributor/feature/topic',
+        'worktree', 'add', '--detach', path.join('/mock', 'workspace-feature-topic-item-1'), 'devdocket-fork-contributor/feature/topic',
       ]);
     });
 
@@ -404,7 +404,7 @@ describe('StartWorkAction', () => {
       await action.run(item);
 
       expect(vi.mocked(execFile).mock.calls.map(call => [call[0], call[1], call[2]])).toContainEqual([
-        'npm', ['install', '--prefix', path.join('/mock', 'workspace-issue123')], { cwd: path.join('/mock', 'workspace-issue123'), timeout: 60_000 },
+        'npm', ['install', '--prefix', path.join('/mock', 'workspace-issue123-item-1')], { cwd: path.join('/mock', 'workspace-issue123-item-1'), timeout: 60_000 },
       ]);
     });
 

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -209,6 +209,23 @@ describe('StartWorkAction', () => {
       ]);
     });
 
+    it('normalizes fully-qualified PR head refs before fetching and checking out', async () => {
+      mockNoLocalBranch();
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'pr', cloneUrl: 'https://example.com/acme/repo.git', ref: 'refs/heads/feature/topic', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toEqual([
+        ['remote', '-v'],
+        ['fetch', 'origin', '+refs/heads/feature/topic:refs/remotes/origin/feature/topic'],
+        ['rev-parse', '--verify', 'refs/heads/feature/topic'],
+        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic-item-1'), 'origin/feature/topic'],
+      ]);
+    });
+
     it('uses repoLabel for ADO _git remote names', async () => {
       mockNoLocalBranch('origin\thttps://example.com/other/repo.git (fetch)\n');
       const item = createWorkItem();

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -35,15 +35,58 @@ vi.mock('fs', () => ({
 import { execFile } from 'child_process';
 import * as fs from 'fs';
 
+function hasOverride(overrides: Partial<any>, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(overrides, key);
+}
+
+function defaultItemType(providerId: unknown): 'issue' | 'pr' | undefined {
+  if (providerId === 'github-my-prs' || providerId === 'github-pr-reviews' || providerId === 'ado-pr-reviews') {
+    return 'pr';
+  }
+  if (providerId === 'github' || providerId === 'ado-work-items') {
+    return 'issue';
+  }
+  return undefined;
+}
+
+function defaultExternalId(providerId: unknown): string {
+  if (providerId === 'ado-pr-reviews') {
+    return 'org/project/repo/101';
+  }
+  if (providerId === 'ado-work-items') {
+    return 'org/project/456';
+  }
+  return 'owner/repo#123';
+}
+
+function defaultUrl(providerId: unknown, itemType: unknown): string {
+  if (providerId === 'ado-pr-reviews') {
+    return 'https://dev.azure.com/org/project/_git/repo/pullrequest/101';
+  }
+  if (providerId === 'ado-work-items') {
+    return 'https://dev.azure.com/org/project/_workitems/edit/456';
+  }
+  if (itemType === 'pr') {
+    return 'https://github.com/owner/repo/pull/123';
+  }
+  return 'https://github.com/owner/repo/issues/123';
+}
+
 function createWorkItem(overrides: Partial<any> = {}) {
+  const providerId = hasOverride(overrides, 'providerId') ? overrides.providerId : 'github';
+  const itemType = hasOverride(overrides, 'itemType') ? overrides.itemType : defaultItemType(providerId);
+  const externalId = hasOverride(overrides, 'externalId') ? overrides.externalId : defaultExternalId(providerId);
+  const url = hasOverride(overrides, 'url') ? overrides.url : defaultUrl(providerId, itemType);
+
   return {
     id: 'wc-test-1',
     title: '#123: Fix login redirect bug',
     description: 'Some description',
     state: 'InProgress',
-    providerId: 'github',
-    externalId: 'owner/repo#123',
-    url: 'https://github.com/owner/repo/issues/123',
+    providerId,
+    externalId,
+    itemType,
+    url,
     createdAt: Date.now(),
     updatedAt: Date.now(),
     ...overrides,
@@ -165,38 +208,62 @@ describe('StartWorkAction', () => {
   });
 
   describe('canRun', () => {
-    it('returns true for github provider items in InProgress state', () => {
+    it('returns true for github provider issue items in InProgress state', () => {
       const item = createWorkItem({ providerId: 'github', state: 'InProgress' });
       expect(action.canRun(item)).toBe(true);
     });
 
-    it('returns true for ado-work-items provider items in InProgress state', () => {
-      const item = createWorkItem({ providerId: 'ado-work-items', state: 'InProgress', externalId: 'org/project/456' });
+    it('returns true for ado-work-items provider issue items in InProgress state', () => {
+      const item = createWorkItem({ providerId: 'ado-work-items', state: 'InProgress' });
       expect(action.canRun(item)).toBe(true);
     });
 
-    it('returns true for github-my-prs provider items in InProgress state', () => {
+    it('returns true for github-my-prs provider PR items in InProgress state', () => {
       const item = createWorkItem({ providerId: 'github-my-prs', state: 'InProgress' });
       expect(action.canRun(item)).toBe(true);
     });
 
-    it('returns true for github-pr-reviews provider items in InProgress state', () => {
+    it('returns true for github-pr-reviews provider PR items in InProgress state', () => {
       const item = createWorkItem({ providerId: 'github-pr-reviews', state: 'InProgress' });
       expect(action.canRun(item)).toBe(true);
     });
 
-    it('returns true for ado-pr-reviews provider items in InProgress state', () => {
-      const item = createWorkItem({ providerId: 'ado-pr-reviews', state: 'InProgress', externalId: 'org/project/repo/101' });
+    it('returns true for ado-pr-reviews provider PR items in InProgress state', () => {
+      const item = createWorkItem({ providerId: 'ado-pr-reviews', state: 'InProgress' });
       expect(action.canRun(item)).toBe(true);
     });
 
-    it('returns false for non-supported provider items', () => {
-      const item = createWorkItem({ providerId: 'jira', state: 'InProgress' });
+    it('returns true for third-party provider PR items with GitHub URLs', () => {
+      const item = createWorkItem({
+        providerId: 'third-party-prs',
+        itemType: 'pr',
+        externalId: 'owner/repo#321',
+        url: 'https://github.com/owner/repo/pull/321',
+      });
+      expect(action.canRun(item)).toBe(true);
+    });
+
+    it('falls back to issue behavior when itemType is missing and URL is supported', () => {
+      const item = createWorkItem({ itemType: undefined });
+      expect(action.canRun(item)).toBe(true);
+    });
+
+    it('returns false for items without a URL', () => {
+      const item = createWorkItem({ url: undefined });
       expect(action.canRun(item)).toBe(false);
     });
 
-    it('returns false for items without a provider', () => {
-      const item = createWorkItem({ providerId: undefined, state: 'InProgress' });
+    it('returns false for items with unrecognized URL hosts', () => {
+      const item = createWorkItem({
+        providerId: 'third-party-issues',
+        itemType: 'issue',
+        url: 'https://jira.example.com/browse/PROJ-123',
+      });
+      expect(action.canRun(item)).toBe(false);
+    });
+
+    it('returns false for items with unrecognized item types', () => {
+      const item = createWorkItem({ itemType: 'task' });
       expect(action.canRun(item)).toBe(false);
     });
 
@@ -413,6 +480,23 @@ describe('StartWorkAction', () => {
       );
       expect(branchCall).toBeDefined();
       expect(branchCall![1]).toEqual(['branch', 'issue123', 'main']);
+    });
+
+    it('uses issue flow when itemType is issue even for a PR provider id', async () => {
+      const item = createWorkItem({
+        providerId: 'github-my-prs',
+        itemType: 'issue',
+        externalId: 'owner/repo#123',
+        url: 'https://github.com/owner/repo/issues/123',
+      });
+      await action.run(item);
+
+      const branchCall = vi.mocked(execFile).mock.calls.find(
+        (call: any[]) => call[1]?.[0] === 'branch' && call[1]?.[1] !== '--list',
+      );
+      expect(branchCall).toBeDefined();
+      expect(branchCall![1]).toEqual(['branch', 'issue123', 'origin/dev']);
+      expect(authentication.getSession).not.toHaveBeenCalled();
     });
 
     it('shows error when branch already exists', async () => {
@@ -829,6 +913,21 @@ describe('StartWorkAction', () => {
 
       const fetchCalls = vi.mocked(globalThis.fetch).mock.calls;
       expect(fetchCalls[0][0]).toBe('https://api.github.com/repos/owner/repo/pulls/99');
+    });
+
+    it('fetches PR branch via GitHub API for third-party PR items with GitHub URLs', async () => {
+      mockQuickPickWorktree();
+      const item = createWorkItem({
+        providerId: 'third-party-prs',
+        itemType: 'pr',
+        externalId: 'owner/repo#42',
+        url: 'https://github.com/owner/repo/pull/42',
+      });
+      await action.run(item);
+
+      expect(authentication.getSession).toHaveBeenCalledWith('github', ['repo'], { createIfNone: true });
+      const fetchCalls = vi.mocked(globalThis.fetch).mock.calls;
+      expect(fetchCalls[0][0]).toBe('https://api.github.com/repos/owner/repo/pulls/42');
     });
 
     it('does not prompt for base branch for PR items', async () => {
@@ -1303,6 +1402,27 @@ describe('StartWorkAction', () => {
       const item = createWorkItem({
         providerId: 'ado-pr-reviews',
         externalId: 'org/project/repo/101',
+      });
+      await action.run(item);
+
+      expect(authentication.getSession).toHaveBeenCalledWith(
+        'microsoft',
+        ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+        { createIfNone: true },
+      );
+      const fetchCalls = vi.mocked(globalThis.fetch).mock.calls;
+      expect(fetchCalls[0][0]).toBe(
+        'https://dev.azure.com/org/project/_apis/git/repositories/repo/pullrequests/101?api-version=7.1',
+      );
+    });
+
+    it('fetches PR branch via ADO API for third-party PR items with ADO URLs', async () => {
+      mockQuickPickWorktree();
+      const item = createWorkItem({
+        providerId: 'third-party-prs',
+        itemType: 'pr',
+        externalId: 'org/project/repo/101',
+        url: 'https://dev.azure.com/org/project/_git/repo/pullrequest/101',
       });
       await action.run(item);
 

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -243,9 +243,49 @@ describe('StartWorkAction', () => {
       expect(action.canRun(item)).toBe(true);
     });
 
+    it('infers PR behavior from GitHub pull URLs when itemType is missing', () => {
+      const item = createWorkItem({
+        providerId: 'third-party-prs',
+        itemType: undefined,
+        externalId: 'owner/repo#321',
+        url: 'https://github.com/owner/repo/pull/321',
+      });
+      expect(action.canRun(item)).toBe(true);
+    });
+
+    it('infers PR behavior from ADO pull request URLs when itemType is missing', () => {
+      const item = createWorkItem({
+        providerId: 'third-party-prs',
+        itemType: undefined,
+        externalId: 'org/project/repo/101',
+        url: 'https://dev.azure.com/org/project/_git/repo/pullrequest/101',
+      });
+      expect(action.canRun(item)).toBe(true);
+    });
+
     it('falls back to issue behavior when itemType is missing and URL is supported', () => {
       const item = createWorkItem({ itemType: undefined });
       expect(action.canRun(item)).toBe(true);
+    });
+
+    it('returns false when a GitHub URL has an ADO PR externalId format', () => {
+      const item = createWorkItem({
+        providerId: 'third-party-prs',
+        itemType: 'pr',
+        externalId: 'org/project/repo/101',
+        url: 'https://github.com/owner/repo/pull/101',
+      });
+      expect(action.canRun(item)).toBe(false);
+    });
+
+    it('returns false when an ADO PR URL has a GitHub externalId format', () => {
+      const item = createWorkItem({
+        providerId: 'third-party-prs',
+        itemType: 'pr',
+        externalId: 'owner/repo#101',
+        url: 'https://dev.azure.com/org/project/_git/repo/pullrequest/101',
+      });
+      expect(action.canRun(item)).toBe(false);
     });
 
     it('returns false for items without a URL', () => {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -343,7 +343,35 @@ describe('StartWorkAction', () => {
 
       await action.run(item);
 
-      expect(window.showErrorMessage).toHaveBeenCalledWith('DevDocket: Provider returned an unsupported PR branch ref for this work item.');
+      expect(window.showErrorMessage).toHaveBeenCalledWith('DevDocket: Provider returned an unsupported git branch ref for this work item.');
+      expect(window.showInputBox).not.toHaveBeenCalled();
+      expect(execFile).not.toHaveBeenCalled();
+    });
+
+    it('normalizes fully-qualified issue head refs before creating a branch', async () => {
+      const item = createWorkItem({ providerId: 'fake-vendor', externalId: 'ABC-123' });
+      const { action } = createAction(discovered('fake-vendor', 'ABC-123', {
+        kind: 'issue', cloneUrl: 'https://git.example.com/acme/repo.git', ref: 'refs/heads/vendor/ABC-123', repoLabel: 'Vendor Repo',
+      }));
+
+      await action.run(item);
+
+      expect(vi.mocked(execFile).mock.calls[0][1]).toEqual(['branch', '--list', 'vendor/ABC-123']);
+      expect(vi.mocked(execFile).mock.calls[1][1]).toEqual(['branch', 'vendor/ABC-123', 'origin/dev']);
+      expect(vi.mocked(execFile).mock.calls[2][1]).toEqual([
+        'worktree', 'add', path.join('/mock', 'workspace-vendor-ABC-123-ABC-123'), 'vendor/ABC-123',
+      ]);
+    });
+
+    it('rejects unsupported fully-qualified issue refs', async () => {
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', async () => ({
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'refs/tags/v1', repoLabel: 'acme/repo',
+      })));
+
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith('DevDocket: Provider returned an unsupported git branch ref for this work item.');
       expect(window.showInputBox).not.toHaveBeenCalled();
       expect(execFile).not.toHaveBeenCalled();
     });

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -208,6 +208,33 @@ describe('StartWorkAction', () => {
       ]);
     });
 
+    it('reports fetch failures with git error details', async () => {
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'remote' && args[1] === '-v') {
+          cb(null, ORIGIN_REMOTE_V, '');
+          return;
+        }
+        if (args[0] === 'fetch') {
+          cb(new Error('fetch failed'), '', 'Authentication failed');
+          return;
+        }
+        cb(null, '', '');
+      }) as any);
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'pr', cloneUrl: 'https://example.com/acme/repo.git', ref: 'feature/topic', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith(
+        "DevDocket: Could not fetch branch 'feature/topic' from remote 'origin'. Authentication failed",
+      );
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).not.toContainEqual([
+        'worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'origin/feature/topic',
+      ]);
+    });
+
     it('rejects an invalid cloneUrl returned by a lazy resolver', async () => {
       const item = createWorkItem();
       const { action } = createAction(discovered('provider', 'item-1', async () => ({

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { window, workspace } from 'vscode';
 import { StartWorkAction } from '../startWorkAction';
 import * as path from 'path';
+import type { DiscoveredItemCapabilities } from '@devdocket/shared';
 
 vi.mock('child_process', () => {
   const fn = vi.fn((cmd: string, args: string[], optsOrCb: any, cb?: Function) => {
@@ -31,7 +32,7 @@ import * as fs from 'fs';
 
 const ORIGIN_REMOTE_V = 'origin\thttps://example.com/acme/repo.git (fetch)\norigin\thttps://example.com/acme/repo.git (push)\n';
 
-type GitWork = NonNullable<any>;
+type GitWork = NonNullable<DiscoveredItemCapabilities['gitWork']>;
 
 function createWorkItem(overrides: Partial<any> = {}) {
   return {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -1,92 +1,45 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { window, workspace, authentication } from 'vscode';
+import { window, workspace } from 'vscode';
 import { StartWorkAction } from '../startWorkAction';
 import * as path from 'path';
 
-// Mock child_process with custom promisify so util.promisify(execFile) returns { stdout, stderr }
 vi.mock('child_process', () => {
   const fn = vi.fn((cmd: string, args: string[], optsOrCb: any, cb?: Function) => {
     const callback = typeof optsOrCb === 'function' ? optsOrCb : cb;
     callback?.(null, '', '');
   });
   const customSymbol = Symbol.for('nodejs.util.promisify.custom');
-  (fn as any)[customSymbol] = (...promiseArgs: any[]) => {
-    return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
-      const cb = (err: Error | null, stdout: string, stderr: string) => {
-        if (err) {
-          (err as any).stdout = stdout;
-          (err as any).stderr = stderr;
-          reject(err);
-        } else {
-          resolve({ stdout, stderr });
-        }
-      };
-      fn(...promiseArgs, cb);
-    });
-  };
+  (fn as any)[customSymbol] = (...promiseArgs: any[]) => new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+    const cb = (err: Error | null, stdout: string, stderr: string) => {
+      if (err) {
+        (err as any).stdout = stdout;
+        (err as any).stderr = stderr;
+        reject(err);
+      } else {
+        resolve({ stdout, stderr });
+      }
+    };
+    fn(...promiseArgs, cb);
+  });
   return { execFile: fn };
 });
 
-// Mock fs
-vi.mock('fs', () => ({
-  existsSync: vi.fn(() => false),
-}));
+vi.mock('fs', () => ({ existsSync: vi.fn(() => false) }));
 
 import { execFile } from 'child_process';
 import * as fs from 'fs';
 
-function hasOverride(overrides: Partial<any>, key: string): boolean {
-  return Object.prototype.hasOwnProperty.call(overrides, key);
-}
+const ORIGIN_REMOTE_V = 'origin\thttps://example.com/acme/repo.git (fetch)\norigin\thttps://example.com/acme/repo.git (push)\n';
 
-function defaultItemType(providerId: unknown): 'issue' | 'pr' | undefined {
-  if (providerId === 'github-my-prs' || providerId === 'github-pr-reviews' || providerId === 'ado-pr-reviews') {
-    return 'pr';
-  }
-  if (providerId === 'github' || providerId === 'ado-work-items') {
-    return 'issue';
-  }
-  return undefined;
-}
-
-function defaultExternalId(providerId: unknown): string {
-  if (providerId === 'ado-pr-reviews') {
-    return 'org/project/repo/101';
-  }
-  if (providerId === 'ado-work-items') {
-    return 'org/project/456';
-  }
-  return 'owner/repo#123';
-}
-
-function defaultUrl(providerId: unknown, itemType: unknown): string {
-  if (providerId === 'ado-pr-reviews') {
-    return 'https://dev.azure.com/org/project/_git/repo/pullrequest/101';
-  }
-  if (providerId === 'ado-work-items') {
-    return 'https://dev.azure.com/org/project/_workitems/edit/456';
-  }
-  if (itemType === 'pr') {
-    return 'https://github.com/owner/repo/pull/123';
-  }
-  return 'https://github.com/owner/repo/issues/123';
-}
+type GitWork = NonNullable<any>;
 
 function createWorkItem(overrides: Partial<any> = {}) {
-  const providerId = hasOverride(overrides, 'providerId') ? overrides.providerId : 'github';
-  const itemType = hasOverride(overrides, 'itemType') ? overrides.itemType : defaultItemType(providerId);
-  const externalId = hasOverride(overrides, 'externalId') ? overrides.externalId : defaultExternalId(providerId);
-  const url = hasOverride(overrides, 'url') ? overrides.url : defaultUrl(providerId, itemType);
-
   return {
     id: 'wc-test-1',
-    title: '#123: Fix login redirect bug',
-    description: 'Some description',
+    title: 'Test item',
     state: 'InProgress',
-    providerId,
-    externalId,
-    itemType,
-    url,
+    providerId: 'provider',
+    externalId: 'item-1',
     createdAt: Date.now(),
     updatedAt: Date.now(),
     ...overrides,
@@ -103,8 +56,17 @@ function createMockMemento() {
   };
 }
 
-/** Sets up showInputBox to return specific values based on which prompt is shown. */
-function mockInputBox(repoPath: string | undefined, baseBranch: string | undefined) {
+function createAction(items: Record<string, { capabilities?: { gitWork?: GitWork } }> = {}) {
+  const memento = createMockMemento();
+  const action = new StartWorkAction(memento as any, (providerId, externalId) => items[`${providerId}:${externalId}`] as any);
+  return { action, memento };
+}
+
+function discovered(providerId: string, externalId: string, gitWork?: GitWork) {
+  return { [`${providerId}:${externalId}`]: { capabilities: gitWork ? { gitWork } : undefined } };
+}
+
+function mockInputBox(repoPath: string | undefined, baseBranch = 'origin/dev') {
   vi.mocked(window.showInputBox).mockImplementation(async (options: any) => {
     if (options?.prompt?.includes('local path')) {
       return repoPath;
@@ -116,27 +78,17 @@ function mockInputBox(repoPath: string | undefined, baseBranch: string | undefin
   });
 }
 
-/** Sets up showQuickPick to return the worktree option (default for existing tests). */
 function mockQuickPickWorktree() {
   vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Create worktree', value: 'worktree' } as any);
 }
 
-/** Sets up showQuickPick to return the checkout option. */
-function mockQuickPickCheckout() {
-  vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Checkout branch', value: 'checkout' } as any);
-}
-
-/** Default git remote -v output — origin points at the default PR response's repo. */
-const ORIGIN_REMOTE_V = 'origin\thttps://github.com/owner/repo.git (fetch)\norigin\thttps://github.com/owner/repo.git (push)\n';
-
-/** Mocks execFile to fail for local branch existence checks (rev-parse --verify refs/heads/*). */
-function mockNoLocalBranch() {
+function mockNoLocalBranch(remoteOutput = ORIGIN_REMOTE_V) {
   vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
     if (args[0] === 'remote' && args[1] === '-v') {
-      cb(null, ORIGIN_REMOTE_V, '');
+      cb(null, remoteOutput, '');
       return;
     }
-    if (args[0] === 'rev-parse' && args[1] === '--verify' && args[2]?.startsWith('refs/heads/')) {
+    if (args[0] === 'rev-parse' && args[1] === '--verify') {
       cb(new Error('not a valid ref'), '', '');
       return;
     }
@@ -144,605 +96,159 @@ function mockNoLocalBranch() {
   }) as any);
 }
 
-function mockFetchResponse(body: any, status = 200) {
-  const mockResponse = {
-    ok: status >= 200 && status < 300,
-    status,
-    json: vi.fn().mockResolvedValue(body),
-  };
-  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockResponse));
-}
-
-function createGitHubPrResponse(overrides: Partial<any> = {}) {
-  return {
-    head: {
-      ref: 'feature/my-branch',
-      repo: {
-        full_name: 'owner/repo',
-        clone_url: 'https://github.com/owner/repo.git',
-      },
-    },
-    base: {
-      repo: {
-        full_name: 'owner/repo',
-      },
-    },
-    ...overrides,
-  };
-}
-
 describe('StartWorkAction', () => {
-  let action: StartWorkAction;
-  let mockMemento: ReturnType<typeof createMockMemento>;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.unstubAllGlobals();
-    mockMemento = createMockMemento();
-    action = new StartWorkAction(mockMemento as any);
-
-    // Default: showInputBox returns repo path and base branch based on prompt
-    mockInputBox('/mock/workspace', 'origin/dev');
-
-    // Default: select worktree mode (preserves existing test behavior)
+    mockInputBox('/mock/workspace');
     mockQuickPickWorktree();
-
-    // Default: no post-worktree commands configured
     vi.mocked(workspace.getConfiguration).mockReturnValue({
       get: vi.fn((key: string, defaultValue?: any) => defaultValue),
     } as any);
-
-    // Reset execFile mock to succeed with empty output; includes git remote -v
-    vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-      if (args[0] === 'remote' && args[1] === '-v') {
-        cb(null, ORIGIN_REMOTE_V, '');
-        return;
-      }
-      cb(null, '', '');
-    }) as any);
-
-    // Return true for .git paths (repo validation), false otherwise (worktree check)
-    vi.mocked(fs.existsSync).mockImplementation((path: any) => {
-      return path.toString().endsWith('.git');
-    });
+    vi.mocked(fs.existsSync).mockImplementation((p: any) => p.toString().endsWith('.git'));
+    vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => cb(null, '', '')) as any);
   });
 
   describe('canRun', () => {
-    it('returns true for github provider issue items in InProgress state', () => {
-      const item = createWorkItem({ providerId: 'github', state: 'InProgress' });
+    it('returns true when a literal gitWork capability is present', () => {
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
       expect(action.canRun(item)).toBe(true);
     });
 
-    it('returns true for ado-work-items provider issue items in InProgress state', () => {
-      const item = createWorkItem({ providerId: 'ado-work-items', state: 'InProgress' });
+    it('returns true when a lazy gitWork capability is present', () => {
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', async () => ({
+        kind: 'pr', cloneUrl: 'https://example.com/acme/repo.git', ref: 'feature/topic', repoLabel: 'acme/repo',
+      })));
+
       expect(action.canRun(item)).toBe(true);
     });
 
-    it('returns true for github-my-prs provider PR items in InProgress state', () => {
-      const item = createWorkItem({ providerId: 'github-my-prs', state: 'InProgress' });
-      expect(action.canRun(item)).toBe(true);
-    });
+    it('returns false when no capability is present', () => {
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1'));
 
-    it('returns true for github-pr-reviews provider PR items in InProgress state', () => {
-      const item = createWorkItem({ providerId: 'github-pr-reviews', state: 'InProgress' });
-      expect(action.canRun(item)).toBe(true);
-    });
-
-    it('returns true for ado-pr-reviews provider PR items in InProgress state', () => {
-      const item = createWorkItem({ providerId: 'ado-pr-reviews', state: 'InProgress' });
-      expect(action.canRun(item)).toBe(true);
-    });
-
-    it('returns true for third-party provider PR items with GitHub URLs', () => {
-      const item = createWorkItem({
-        providerId: 'third-party-prs',
-        itemType: 'pr',
-        externalId: 'owner/repo#321',
-        url: 'https://github.com/owner/repo/pull/321',
-      });
-      expect(action.canRun(item)).toBe(true);
-    });
-
-    it('infers PR behavior from GitHub pull URLs when itemType is missing', () => {
-      const item = createWorkItem({
-        providerId: 'third-party-prs',
-        itemType: undefined,
-        externalId: 'owner/repo#321',
-        url: 'https://github.com/owner/repo/pull/321',
-      });
-      expect(action.canRun(item)).toBe(true);
-    });
-
-    it('infers PR behavior from ADO pull request URLs when itemType is missing', () => {
-      const item = createWorkItem({
-        providerId: 'third-party-prs',
-        itemType: undefined,
-        externalId: 'org/project/repo/101',
-        url: 'https://dev.azure.com/org/project/_git/repo/pullrequest/101',
-      });
-      expect(action.canRun(item)).toBe(true);
-    });
-
-    it('falls back to issue behavior when itemType is missing and URL is supported', () => {
-      const item = createWorkItem({ itemType: undefined });
-      expect(action.canRun(item)).toBe(true);
-    });
-
-    it('returns false when a GitHub URL has an ADO PR externalId format', () => {
-      const item = createWorkItem({
-        providerId: 'third-party-prs',
-        itemType: 'pr',
-        externalId: 'org/project/repo/101',
-        url: 'https://github.com/owner/repo/pull/101',
-      });
       expect(action.canRun(item)).toBe(false);
     });
 
-    it('returns false when an ADO PR URL has a GitHub externalId format', () => {
-      const item = createWorkItem({
-        providerId: 'third-party-prs',
-        itemType: 'pr',
-        externalId: 'owner/repo#101',
-        url: 'https://dev.azure.com/org/project/_git/repo/pullrequest/101',
-      });
+    it('returns false when the live discovered item is not found', () => {
+      const item = createWorkItem();
+      const { action } = createAction({});
+
       expect(action.canRun(item)).toBe(false);
     });
 
-    it('returns false for items without a URL', () => {
-      const item = createWorkItem({ url: undefined });
+    it('returns false for non-InProgress items', () => {
+      const item = createWorkItem({ state: 'New' });
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
       expect(action.canRun(item)).toBe(false);
-    });
-
-    it('returns false for items with unrecognized URL hosts', () => {
-      const item = createWorkItem({
-        providerId: 'third-party-issues',
-        itemType: 'issue',
-        url: 'https://jira.example.com/browse/PROJ-123',
-      });
-      expect(action.canRun(item)).toBe(false);
-    });
-
-    it('returns false for items with unrecognized item types', () => {
-      const item = createWorkItem({ itemType: 'task' });
-      expect(action.canRun(item)).toBe(false);
-    });
-
-    it('returns false for non-InProgress state items', () => {
-      const newItem = createWorkItem({ state: 'New' });
-      expect(action.canRun(newItem)).toBe(false);
-
-      const done = createWorkItem({ state: 'Done' });
-      expect(action.canRun(done)).toBe(false);
-
-      const paused = createWorkItem({ state: 'Paused' });
-      expect(action.canRun(paused)).toBe(false);
     });
   });
 
-  describe('repo path prompting', () => {
-    it('prompts user for repo path with no default on first use', async () => {
-      const item = createWorkItem();
-      await action.run(item);
+  describe('run', () => {
+    it('creates the provider-suggested branch for an issue', async () => {
+      const item = createWorkItem({ providerId: 'fake-vendor', externalId: 'ABC-123' });
+      const { action, memento } = createAction(discovered('fake-vendor', 'ABC-123', {
+        kind: 'issue', cloneUrl: 'https://git.example.com/acme/repo.git', ref: 'vendor/ABC-123', repoLabel: 'Vendor Repo',
+      }));
 
-      expect(window.showInputBox).toHaveBeenCalledWith({
-        prompt: 'Enter the local path to the git repository for owner/repo',
-        value: '',
-        ignoreFocusOut: true,
-      });
-    });
-
-    it('pre-fills cached path as default on subsequent use', async () => {
-      mockMemento._store.set('repoPath:owner/repo', '/cached/path');
-      mockInputBox('/cached/path', 'origin/dev');
-
-      const item = createWorkItem();
-      await action.run(item);
-
-      expect(window.showInputBox).toHaveBeenCalledWith(
-        expect.objectContaining({ value: '/cached/path' }),
-      );
-    });
-
-    it('caches the selected repo path on success', async () => {
-      const item = createWorkItem();
-      await action.run(item);
-
-      expect(mockMemento.update).toHaveBeenCalledWith('repoPath:owner/repo', '/mock/workspace');
-    });
-
-    it('does not cache when user cancels input box', async () => {
-      mockInputBox(undefined, undefined);
-
-      const item = createWorkItem();
-      await action.run(item);
-
-      expect(mockMemento.update).not.toHaveBeenCalled();
-      expect(execFile).not.toHaveBeenCalled();
-    });
-
-    it('does not cache when user provides empty path', async () => {
-      mockInputBox('   ', undefined);
-
-      const item = createWorkItem();
-      await action.run(item);
-
-      expect(mockMemento.update).not.toHaveBeenCalled();
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: No repository path provided.',
-      );
-    });
-
-    it('does not cache when path is not a git repository', async () => {
-      mockInputBox('/not/a/repo', undefined);
-      vi.mocked(fs.existsSync).mockReturnValue(false);
-
-      const item = createWorkItem();
-      await action.run(item);
-
-      expect(mockMemento.update).not.toHaveBeenCalled();
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: "/not/a/repo" is not a git repository.',
-      );
-    });
-
-    it('isolates cache by repo key — repo A does not prefill for repo B', async () => {
-      mockMemento._store.set('repoPath:owner/repoA', '/path/to/repoA');
-
-      const item = createWorkItem({ externalId: 'owner/repoB#456' });
-      await action.run(item);
-
-      expect(window.showInputBox).toHaveBeenCalledWith(
-        expect.objectContaining({ value: '' }),
-      );
-    });
-
-    it('same repo prefills across different issues', async () => {
-      mockMemento._store.set('repoPath:owner/repo', '/cached/path');
-      mockInputBox('/cached/path', 'origin/dev');
-
-      const item1 = createWorkItem({ externalId: 'owner/repo#100' });
-      await action.run(item1);
-
-      vi.clearAllMocks();
-      mockInputBox('/cached/path', 'origin/dev');
-      mockQuickPickWorktree();
-      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-        cb(null, '', '');
-      }) as any);
-      vi.mocked(fs.existsSync).mockImplementation((p: any) => p.toString().endsWith('.git'));
-
-      const item2 = createWorkItem({ externalId: 'owner/repo#200' });
-      await action.run(item2);
-
-      expect(window.showInputBox).toHaveBeenCalledWith(
-        expect.objectContaining({ value: '/cached/path' }),
-      );
-    });
-  });
-
-  describe('checkout vs worktree prompt', () => {
-    it('shows quick pick with checkout and worktree options for issue items', async () => {
-      const item = createWorkItem();
-      await action.run(item);
-
-      expect(window.showQuickPick).toHaveBeenCalledWith(
-        [
-          { label: 'Checkout branch', value: 'checkout' },
-          { label: 'Create worktree', value: 'worktree' },
-        ],
-        {
-          placeHolder: 'How would you like to work on this?',
-          ignoreFocusOut: true,
-        },
-      );
-    });
-
-    it('aborts when user cancels work mode selection', async () => {
-      vi.mocked(window.showQuickPick).mockResolvedValue(undefined);
-
-      const item = createWorkItem();
-      await action.run(item);
-
-      expect(execFile).not.toHaveBeenCalled();
-    });
-  });
-
-  describe('run (worktree mode)', () => {
-    it('creates branch and worktree with correct names for GitHub items', async () => {
-      const item = createWorkItem({ title: '#123: Fix login redirect bug' });
       await action.run(item);
 
       expect(execFile).toHaveBeenCalledTimes(3);
-
-      // First call: check if branch exists
-      const firstCall = vi.mocked(execFile).mock.calls[0];
-      expect(firstCall[0]).toBe('git');
-      expect(firstCall[1]).toEqual(['branch', '--list', 'issue123']);
-      expect(firstCall[2]).toEqual({ cwd: '/mock/workspace', timeout: 30_000 });
-
-      // Second call: create branch from user-specified base
-      const secondCall = vi.mocked(execFile).mock.calls[1];
-      expect(secondCall[0]).toBe('git');
-      expect(secondCall[1]).toEqual(['branch', 'issue123', 'origin/dev']);
-      expect(secondCall[2]).toEqual({ cwd: '/mock/workspace', timeout: 30_000 });
-
-      // Third call: create worktree
-      const thirdCall = vi.mocked(execFile).mock.calls[2];
-      expect(thirdCall[0]).toBe('git');
-      expect(thirdCall[1]).toEqual([
-        'worktree', 'add',
-        path.join('/mock', 'workspace-issue123'),
-        'issue123',
+      expect(vi.mocked(execFile).mock.calls[0][1]).toEqual(['branch', '--list', 'vendor/ABC-123']);
+      expect(vi.mocked(execFile).mock.calls[1][1]).toEqual(['branch', 'vendor/ABC-123', 'origin/dev']);
+      expect(vi.mocked(execFile).mock.calls[2][1]).toEqual([
+        'worktree', 'add', path.join('/mock', 'workspace-vendor-ABC-123'), 'vendor/ABC-123',
       ]);
-      expect(thirdCall[2]).toEqual({ cwd: '/mock/workspace', timeout: 300_000 });
+      expect(memento.update).toHaveBeenCalledWith('repoPath:Vendor Repo', '/mock/workspace');
     });
 
-    it('creates branch and worktree with correct names for ADO items', async () => {
-      const item = createWorkItem({
-        providerId: 'ado-work-items',
-        externalId: 'org/project/456',
-        title: 'ADO work item 456',
-      });
+    it('uses headCloneUrl when a PR supplies one', async () => {
+      mockNoLocalBranch();
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'pr',
+        cloneUrl: 'https://example.com/acme/repo.git',
+        headCloneUrl: 'https://example.com/contributor/repo.git',
+        ref: 'feature/topic',
+        repoLabel: 'acme/repo',
+      }));
+
       await action.run(item);
 
-      expect(execFile).toHaveBeenCalledTimes(3);
-
-      // First call: check if branch exists
-      const firstCall = vi.mocked(execFile).mock.calls[0];
-      expect(firstCall[0]).toBe('git');
-      expect(firstCall[1]).toEqual(['branch', '--list', 'issue456']);
-      expect(firstCall[2]).toEqual({ cwd: '/mock/workspace', timeout: 30_000 });
-
-      // Second call: create branch
-      const secondCall = vi.mocked(execFile).mock.calls[1];
-      expect(secondCall[0]).toBe('git');
-      expect(secondCall[1]).toEqual(['branch', 'issue456', 'origin/dev']);
-
-      // Third call: create worktree
-      const thirdCall = vi.mocked(execFile).mock.calls[2];
-      expect(thirdCall[0]).toBe('git');
-      expect(thirdCall[1]).toEqual([
-        'worktree', 'add',
-        path.join('/mock', 'workspace-issue456'),
-        'issue456',
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toEqual([
+        ['remote', '-v'],
+        ['remote', 'add', 'devdocket-fork-contributor', 'https://example.com/contributor/repo.git'],
+        ['fetch', 'devdocket-fork-contributor'],
+        ['rev-parse', '--verify', 'refs/heads/feature/topic'],
+        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'devdocket-fork-contributor/feature/topic'],
       ]);
-      expect(thirdCall[2]).toEqual({ cwd: '/mock/workspace', timeout: 300_000 });
     });
 
-    it('uses user-specified base branch for branch creation', async () => {
-      mockInputBox('/mock/workspace', 'main');
-
-      const item = createWorkItem({ title: '#123: Fix bug' });
-      await action.run(item);
-
-      const branchCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'branch' && call[1]?.[1] !== '--list',
-      );
-      expect(branchCall).toBeDefined();
-      expect(branchCall![1]).toEqual(['branch', 'issue123', 'main']);
-    });
-
-    it('uses issue flow when itemType is issue even for a PR provider id', async () => {
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        itemType: 'issue',
-        externalId: 'owner/repo#123',
-        url: 'https://github.com/owner/repo/issues/123',
-      });
-      await action.run(item);
-
-      const branchCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'branch' && call[1]?.[1] !== '--list',
-      );
-      expect(branchCall).toBeDefined();
-      expect(branchCall![1]).toEqual(['branch', 'issue123', 'origin/dev']);
-      expect(authentication.getSession).not.toHaveBeenCalled();
-    });
-
-    it('shows error when branch already exists', async () => {
-      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-        if (args[0] === 'branch' && args[1] === '--list') {
-          cb(null, '  issue123\n', '');
-        } else {
-          cb(null, '', '');
-        }
-      }) as any);
-
+    it('falls back to cloneUrl when a PR has no headCloneUrl', async () => {
+      mockNoLocalBranch();
       const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'pr', cloneUrl: 'https://example.com/acme/repo.git', ref: 'feature/topic', repoLabel: 'acme/repo',
+      }));
+
       await action.run(item);
 
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: Branch "issue123" already exists.',
-      );
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toEqual([
+        ['remote', '-v'],
+        ['fetch', 'origin'],
+        ['rev-parse', '--verify', 'refs/heads/feature/topic'],
+        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'origin/feature/topic'],
+      ]);
     });
 
-    it('shows error when worktree directory already exists', async () => {
-      vi.mocked(fs.existsSync).mockImplementation((p: any) => {
-        const pathStr = p.toString();
-        // .git check passes, worktree dir check also passes (already exists)
-        return pathStr.endsWith('.git') || pathStr.includes('workspace-issue123');
-      });
-
+    it('rejects an invalid cloneUrl returned by a lazy resolver', async () => {
       const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', async () => ({
+        kind: 'issue', cloneUrl: 'not a url', ref: 'issue123', repoLabel: 'acme/repo',
+      })));
+
       await action.run(item);
 
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        expect.stringContaining('already exists'),
-      );
-      // Should not have created any branches (fail-fast before git operations)
+      expect(window.showErrorMessage).toHaveBeenCalledWith('DevDocket: Provider returned an invalid clone URL for this work item.');
+      expect(window.showInputBox).not.toHaveBeenCalled();
       expect(execFile).not.toHaveBeenCalled();
     });
 
-    it('shows error when externalId is missing', async () => {
-      const item = createWorkItem({ externalId: undefined });
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        'Could not determine work item number.',
-      );
-    });
-
-    it('shows error when externalId format is invalid', async () => {
-      const item = createWorkItem({ externalId: 'invalid-format' });
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        'Could not determine work item number.',
-      );
-    });
-
-    it('shows success message after creating worktree', async () => {
+    it('rejects an invalid ref returned by a lazy resolver', async () => {
       const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', async () => ({
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: '-bad', repoLabel: 'acme/repo',
+      })));
+
       await action.run(item);
 
-      expect(window.showInformationMessage).toHaveBeenCalledWith(
-        'DevDocket: Created worktree for issue123',
-      );
+      expect(window.showErrorMessage).toHaveBeenCalledWith('DevDocket: Provider returned an invalid git ref for this work item.');
+      expect(window.showInputBox).not.toHaveBeenCalled();
+      expect(execFile).not.toHaveBeenCalled();
     });
 
-    it('runs post-worktree commands with {path} placeholder', async () => {
-      vi.mocked(workspace.getConfiguration).mockReturnValue({
-        get: vi.fn((key: string, defaultValue?: any) => {
-          if (key === 'commands') {
-            return [
-              { command: 'npm', args: ['install', '--prefix', '{path}'] },
-            ];
-          }
-          return defaultValue;
-        }),
-      } as any);
-
-      const item = createWorkItem();
-      await action.run(item);
-
-      // git commands (3) + 1 post-worktree command
-      expect(execFile).toHaveBeenCalledTimes(4);
-      const postCmd = vi.mocked(execFile).mock.calls[3];
-      expect(postCmd[0]).toBe('npm');
-      const expectedWorktreePath = path.join('/mock', 'workspace-issue123');
-      expect(postCmd[1]).toEqual(['install', '--prefix', expectedWorktreePath]);
-      expect(postCmd[2]).toEqual({ cwd: expectedWorktreePath, timeout: 60_000 });
-    });
-
-    it('shows warning when post-worktree command fails', async () => {
-      vi.mocked(workspace.getConfiguration).mockReturnValue({
-        get: vi.fn((key: string, defaultValue?: any) => {
-          if (key === 'commands') {
-            return [{ command: 'bad-cmd' }];
-          }
-          return defaultValue;
-        }),
-      } as any);
-
-      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], optsOrCb: any, cb?: Function) => {
-        const callback = typeof optsOrCb === 'function' ? optsOrCb : cb;
-        if (cmd === 'bad-cmd') {
-          callback?.(new Error('command not found'), '', '');
-          return;
-        }
-        callback?.(null, '', '');
-      }) as any);
-
-      const item = createWorkItem();
-      await action.run(item);
-
-      expect(window.showWarningMessage).toHaveBeenCalledWith(
-        expect.stringContaining('bad-cmd'),
-      );
-    });
-
-    it('handles git worktree failure and rolls back branch', async () => {
-      let callCount = 0;
+    it('aborts checkout when the working tree is dirty and the user cancels', async () => {
+      vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Checkout branch', value: 'checkout' } as any);
+      vi.mocked(window.showWarningMessage).mockResolvedValue(undefined as any);
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-        callCount++;
-        if (args[0] === 'worktree') {
-          cb(new Error('worktree failed'), '', '');
-          return;
-        }
-        cb(null, '', '');
-      }) as any);
-
-      const item = createWorkItem();
-      await action.run(item);
-
-      // Should have attempted rollback (branch -D)
-      const rollbackCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'branch' && call[1]?.[1] === '-D',
-      );
-      expect(rollbackCall).toBeDefined();
-      expect(rollbackCall![1]).toEqual(['branch', '-D', 'issue123']);
-    });
-
-    it('logs activity with worktreePath and repoPath', async () => {
-      const { commands } = await import('vscode');
-      const item = createWorkItem();
-      await action.run(item);
-
-      const expectedWorktreePath = path.join('/mock', 'workspace-issue123');
-      expect(commands.executeCommand).toHaveBeenCalledWith(
-        'devdocket.addActivity',
-        item.id,
-        'work-started',
-        JSON.stringify({ branchName: 'issue123', worktreePath: expectedWorktreePath, repoPath: '/mock/workspace' }),
-      );
-    });
-  });
-
-  describe('run (checkout mode)', () => {
-    beforeEach(() => {
-      mockQuickPickCheckout();
-    });
-
-    it('checks out new branch with git checkout -b for issue items', async () => {
-      const item = createWorkItem();
-      await action.run(item);
-
-      // git status --porcelain + git checkout -b
-      expect(execFile).toHaveBeenCalledTimes(2);
-
-      const statusCall = vi.mocked(execFile).mock.calls[0];
-      expect(statusCall[1]).toEqual(['status', '--porcelain']);
-
-      const checkoutCall = vi.mocked(execFile).mock.calls[1];
-      expect(checkoutCall[0]).toBe('git');
-      expect(checkoutCall[1]).toEqual(['checkout', '-b', 'issue123', 'origin/dev']);
-      expect(checkoutCall[2]).toEqual({ cwd: '/mock/workspace', timeout: 300_000 });
-    });
-
-    it('shows success message after checkout', async () => {
-      const item = createWorkItem();
-      await action.run(item);
-
-      expect(window.showInformationMessage).toHaveBeenCalledWith(
-        'DevDocket: Checked out branch issue123',
-      );
-    });
-
-    it('logs activity with branchName and repoPath (no worktreePath)', async () => {
-      const { commands } = await import('vscode');
-      const item = createWorkItem();
-      await action.run(item);
-
-      expect(commands.executeCommand).toHaveBeenCalledWith(
-        'devdocket.addActivity',
-        item.id,
-        'work-started',
-        JSON.stringify({ branchName: 'issue123', repoPath: '/mock/workspace' }),
-      );
-    });
-
-    it('prompts confirmation when working tree is dirty', async () => {
-      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-        if (args[0] === 'status' && args[1] === '--porcelain') {
+        if (args[0] === 'status') {
           cb(null, ' M file.ts\n', '');
           return;
         }
         cb(null, '', '');
       }) as any);
-
-      vi.mocked(window.showWarningMessage).mockResolvedValue('Yes' as any);
-
       const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
       await action.run(item);
 
       expect(window.showWarningMessage).toHaveBeenCalledWith(
@@ -750,965 +256,123 @@ describe('StartWorkAction', () => {
         { modal: true },
         'Yes',
       );
-      // Should still proceed
-      const checkoutCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'checkout',
-      );
-      expect(checkoutCall).toBeDefined();
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).not.toContainEqual(['checkout', '-b', 'issue123', 'origin/dev']);
     });
 
-    it('aborts checkout when user declines dirty tree prompt', async () => {
-      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-        if (args[0] === 'status' && args[1] === '--porcelain') {
-          cb(null, ' M file.ts\n', '');
-          return;
-        }
-        cb(null, '', '');
-      }) as any);
-
-      vi.mocked(window.showWarningMessage).mockResolvedValue(undefined as any);
-
-      const item = createWorkItem();
-      await action.run(item);
-
-      const checkoutCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'checkout',
-      );
-      expect(checkoutCall).toBeUndefined();
-    });
-
-    it('does not prompt when working tree is clean', async () => {
-      const item = createWorkItem();
-      await action.run(item);
-
-      expect(window.showWarningMessage).not.toHaveBeenCalledWith(
-        expect.stringContaining('uncommitted changes'),
-        expect.anything(),
-        expect.anything(),
-      );
-    });
-  });
-
-  describe('base branch prompting', () => {
-    it('prompts user for base branch with no default on first use', async () => {
-      const item = createWorkItem();
-      await action.run(item);
-
-      const baseBranchCall = vi.mocked(window.showInputBox).mock.calls.find(
-        (call: any[]) => call[0]?.prompt?.includes('base branch'),
-      );
-      expect(baseBranchCall).toBeDefined();
-      expect(baseBranchCall![0]).toEqual({
-        prompt: 'Enter the base branch for owner/repo',
-        value: '',
-        ignoreFocusOut: true,
-      });
-    });
-
-    it('pre-fills cached branch as default on subsequent use', async () => {
-      mockMemento._store.set('baseBranch:owner/repo', 'origin/main');
-      mockInputBox('/mock/workspace', 'origin/main');
-
-      const item = createWorkItem();
-      await action.run(item);
-
-      const baseBranchCall = vi.mocked(window.showInputBox).mock.calls.find(
-        (call: any[]) => call[0]?.prompt?.includes('base branch'),
-      );
-      expect(baseBranchCall![0]).toEqual(
-        expect.objectContaining({ value: 'origin/main' }),
-      );
-    });
-
-    it('caches the selected base branch on success', async () => {
-      const item = createWorkItem();
-      await action.run(item);
-
-      expect(mockMemento.update).toHaveBeenCalledWith('baseBranch:owner/repo', 'origin/dev');
-    });
-
-    it('does not proceed when user cancels base branch input', async () => {
-      mockInputBox('/mock/workspace', undefined);
-
-      const item = createWorkItem();
-      await action.run(item);
-
-      // Should have cached repo path but not proceeded to git commands
-      expect(mockMemento.update).toHaveBeenCalledTimes(1); // only repoPath
-      expect(execFile).not.toHaveBeenCalled();
-    });
-
-    it('shows error when user provides empty base branch', async () => {
-      mockInputBox('/mock/workspace', '   ');
-
-      const item = createWorkItem();
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: No base branch provided.',
-      );
-    });
-  });
-
-  describe('ADO-specific behavior', () => {
-    it('parses ADO externalId org/project/456 correctly', async () => {
-      const item = createWorkItem({
-        providerId: 'ado-work-items',
-        externalId: 'org/project/456',
-      });
-      await action.run(item);
-
-      // Repo path prompt should use repoKey "org/project"
-      expect(window.showInputBox).toHaveBeenCalledWith(
-        expect.objectContaining({
-          prompt: 'Enter the local path to the git repository for org/project',
-        }),
-      );
-    });
-
-    it('creates branch issue456 for ADO items', async () => {
-      const item = createWorkItem({
-        providerId: 'ado-work-items',
-        externalId: 'org/project/456',
-      });
-      await action.run(item);
-
-      const branchListCall = vi.mocked(execFile).mock.calls[0];
-      expect(branchListCall[1]).toEqual(['branch', '--list', 'issue456']);
-    });
-
-    it('creates worktree dir workspace-issue456 for ADO items', async () => {
-      const item = createWorkItem({
-        providerId: 'ado-work-items',
-        externalId: 'org/project/456',
-      });
-      await action.run(item);
-
-      const worktreeCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'worktree',
-      );
-      expect(worktreeCall).toBeDefined();
-      expect(worktreeCall![1]).toEqual([
-        'worktree', 'add',
-        path.join('/mock', 'workspace-issue456'),
-        'issue456',
-      ]);
-    });
-
-    it('caches repo path per ADO repoKey', async () => {
-      const item = createWorkItem({
-        providerId: 'ado-work-items',
-        externalId: 'org/project/456',
-      });
-      await action.run(item);
-
-      expect(mockMemento.update).toHaveBeenCalledWith('repoPath:org/project', '/mock/workspace');
-    });
-  });
-
-  describe('error scenarios', () => {
-    it('handles generic git failure gracefully', async () => {
-      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-        if (args[0] === 'branch' && args[1] !== '--list') {
-          cb(new Error('git error: permission denied'), '', '');
-          return;
-        }
-        cb(null, '', '');
-      }) as any);
-
-      const item = createWorkItem();
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        expect.stringContaining('Failed to start work'),
-      );
-    });
-  });
-
-  describe('GitHub PR flow', () => {
-    beforeEach(() => {
-      mockFetchResponse(createGitHubPrResponse());
-    });
-
-    it('fetches PR branch via GitHub API for github-my-prs items', async () => {
-      mockQuickPickWorktree();
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      expect(authentication.getSession).toHaveBeenCalledWith('github', ['repo'], { createIfNone: true });
-      const fetchCalls = vi.mocked(globalThis.fetch).mock.calls;
-      expect(fetchCalls[0][0]).toBe('https://api.github.com/repos/owner/repo/pulls/42');
-    });
-
-    it('fetches PR branch via GitHub API for github-pr-reviews items', async () => {
-      mockQuickPickWorktree();
-      const item = createWorkItem({
-        providerId: 'github-pr-reviews',
-        externalId: 'owner/repo#99',
-      });
-      await action.run(item);
-
-      const fetchCalls = vi.mocked(globalThis.fetch).mock.calls;
-      expect(fetchCalls[0][0]).toBe('https://api.github.com/repos/owner/repo/pulls/99');
-    });
-
-    it('fetches PR branch via GitHub API for third-party PR items with GitHub URLs', async () => {
-      mockQuickPickWorktree();
-      const item = createWorkItem({
-        providerId: 'third-party-prs',
-        itemType: 'pr',
-        externalId: 'owner/repo#42',
-        url: 'https://github.com/owner/repo/pull/42',
-      });
-      await action.run(item);
-
-      expect(authentication.getSession).toHaveBeenCalledWith('github', ['repo'], { createIfNone: true });
-      const fetchCalls = vi.mocked(globalThis.fetch).mock.calls;
-      expect(fetchCalls[0][0]).toBe('https://api.github.com/repos/owner/repo/pulls/42');
-    });
-
-    it('does not prompt for base branch for PR items', async () => {
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      const baseBranchCall = vi.mocked(window.showInputBox).mock.calls.find(
-        (call: any[]) => call[0]?.prompt?.includes('base branch'),
-      );
-      expect(baseBranchCall).toBeUndefined();
-    });
-
-    it('fetches from origin for same-repo PRs', async () => {
-      mockQuickPickWorktree();
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      const fetchCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'fetch',
-      );
-      expect(fetchCall).toBeDefined();
-      expect(fetchCall![1]).toEqual(['fetch', 'origin']);
-    });
-
-    it('adds fork remote and full-fetches for fork PRs', async () => {
-      mockFetchResponse(createGitHubPrResponse({
-        head: {
-          ref: 'fix/something',
-          repo: {
-            full_name: 'contributor/repo',
-            clone_url: 'https://github.com/contributor/repo.git',
-          },
-        },
-      }));
-      mockQuickPickWorktree();
-      mockNoLocalBranch();
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      // Should look up remotes
-      const remoteVCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'remote' && call[1]?.[1] === '-v',
-      );
-      expect(remoteVCall).toBeDefined();
-
-      // Should add a fork remote (origin URL doesn't match fork URL)
-      const remoteAddCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'remote' && call[1]?.[1] === 'add',
-      );
-      expect(remoteAddCall).toBeDefined();
-      expect(remoteAddCall![1]).toEqual(['remote', 'add', 'devdocket-fork-contributor', 'https://github.com/contributor/repo.git']);
-
-      // Should do a full fetch (no branch specified)
-      const fetchCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'fetch',
-      );
-      expect(fetchCall).toBeDefined();
-      expect(fetchCall![1]).toEqual(['fetch', 'devdocket-fork-contributor']);
-
-      const worktreeCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'worktree',
-      );
-      expect(worktreeCall).toBeDefined();
-      expect(worktreeCall![1]).toEqual([
-        'worktree', 'add', '-b', 'fix/something',
-        path.join('/mock', 'workspace-pr42'),
-        'devdocket-fork-contributor/fix/something',
-      ]);
-    });
-
-    it('uses existing remote when it matches fork URL', async () => {
-      mockFetchResponse(createGitHubPrResponse({
-        head: {
-          ref: 'fix/something',
-          repo: {
-            full_name: 'contributor/repo',
-            clone_url: 'https://github.com/contributor/repo.git',
-          },
-        },
-      }));
-      mockQuickPickWorktree();
-
-      // git remote -v returns a user remote that matches the fork URL
-      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-        if (args[0] === 'remote' && args[1] === '-v') {
-          cb(null, 'origin\thttps://github.com/owner/repo.git (fetch)\norigin\thttps://github.com/owner/repo.git (push)\nmy-fork\thttps://github.com/contributor/repo.git (fetch)\nmy-fork\thttps://github.com/contributor/repo.git (push)\n', '');
-          return;
-        }
-        cb(null, '', '');
-      }) as any);
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      // Should NOT add a new remote
-      const remoteAddCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'remote' && call[1]?.[1] === 'add',
-      );
-      expect(remoteAddCall).toBeUndefined();
-
-      // Should fetch from the existing remote
-      const fetchCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'fetch',
-      );
-      expect(fetchCall).toBeDefined();
-      expect(fetchCall![1]).toEqual(['fetch', 'my-fork']);
-    });
-
-    it('updates existing devdocket-fork remote with different URL', async () => {
-      mockFetchResponse(createGitHubPrResponse({
-        head: {
-          ref: 'fix/something',
-          repo: {
-            full_name: 'contributor/repo',
-            clone_url: 'https://github.com/contributor/repo.git',
-          },
-        },
-      }));
-      mockQuickPickWorktree();
-
-      // remote add fails (already exists); get-url returns a different URL
+    it('checks out an existing same-repo PR branch directly', async () => {
+      vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Checkout branch', value: 'checkout' } as any);
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         if (args[0] === 'remote' && args[1] === '-v') {
           cb(null, ORIGIN_REMOTE_V, '');
           return;
         }
+        cb(null, '', '');
+      }) as any);
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'pr', cloneUrl: 'https://example.com/acme/repo.git', ref: 'feature/topic', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toEqual([
+        ['remote', '-v'],
+        ['fetch', 'origin'],
+        ['status', '--porcelain'],
+        ['rev-parse', '--verify', 'refs/heads/feature/topic'],
+        ['checkout', 'feature/topic'],
+      ]);
+    });
+
+    it('creates a detached PR worktree when a fork PR branch already exists locally', async () => {
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'remote' && args[1] === '-v') {
+          cb(null, ORIGIN_REMOTE_V, '');
+          return;
+        }
+        cb(null, '', '');
+      }) as any);
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'pr',
+        cloneUrl: 'https://example.com/acme/repo.git',
+        headCloneUrl: 'https://example.com/contributor/repo.git',
+        ref: 'feature/topic',
+        repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
+        'worktree', 'add', '--detach', path.join('/mock', 'workspace-feature-topic'), 'devdocket-fork-contributor/feature/topic',
+      ]);
+    });
+
+    it('updates an existing DevDocket-managed remote with a stale URL', async () => {
+      mockNoLocalBranch('devdocket-fork-contributor\thttps://example.com/old/repo.git (fetch)\n');
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'remote' && args[1] === '-v') {
+          cb(null, 'devdocket-fork-contributor\thttps://example.com/old/repo.git (fetch)\n', '');
+          return;
+        }
         if (args[0] === 'remote' && args[1] === 'add') {
-          cb(new Error('remote devdocket-fork-contributor already exists'), '', '');
+          cb(new Error('remote already exists'), '', '');
           return;
         }
         if (args[0] === 'remote' && args[1] === 'get-url') {
-          cb(null, 'https://github.com/old-contributor/repo.git\n', '');
+          cb(null, 'https://example.com/old/repo.git\n', '');
+          return;
+        }
+        if (args[0] === 'rev-parse') {
+          cb(new Error('not a valid ref'), '', '');
           return;
         }
         cb(null, '', '');
       }) as any);
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      // Should update the URL
-      const setUrlCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'remote' && call[1]?.[1] === 'set-url',
-      );
-      expect(setUrlCall).toBeDefined();
-      expect(setUrlCall![1]).toEqual(['remote', 'set-url', 'devdocket-fork-contributor', 'https://github.com/contributor/repo.git']);
-
-      // Should still fetch
-      const fetchCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'fetch',
-      );
-      expect(fetchCall).toBeDefined();
-      expect(fetchCall![1]).toEqual(['fetch', 'devdocket-fork-contributor']);
-    });
-
-    it('creates detached worktree from tracking ref when local branch exists (fork PR)', async () => {
-      mockFetchResponse(createGitHubPrResponse({
-        head: {
-          ref: 'fix/something',
-          repo: {
-            full_name: 'contributor/repo',
-            clone_url: 'https://github.com/contributor/repo.git',
-          },
-        },
-      }));
-      mockQuickPickWorktree();
-      // Local branch exists — should create detached worktree from tracking ref
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      const worktreeCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'worktree',
-      );
-      expect(worktreeCall).toBeDefined();
-      expect(worktreeCall![1]).toEqual([
-        'worktree', 'add', '--detach',
-        path.join('/mock', 'workspace-pr42'),
-        'devdocket-fork-contributor/fix/something',
-      ]);
-    });
-
-    it('uses checkout -b with tracking ref for fork PRs in checkout mode', async () => {
-      mockFetchResponse(createGitHubPrResponse({
-        head: {
-          ref: 'fix/something',
-          repo: {
-            full_name: 'contributor/repo',
-            clone_url: 'https://github.com/contributor/repo.git',
-          },
-        },
-      }));
-      mockQuickPickCheckout();
-      mockNoLocalBranch();
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      const checkoutCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'checkout',
-      );
-      expect(checkoutCall).toBeDefined();
-      expect(checkoutCall![1]).toEqual(['checkout', '-b', 'fix/something', 'devdocket-fork-contributor/fix/something']);
-    });
-
-    it('uses detached checkout for fork PR when local branch exists', async () => {
-      mockFetchResponse(createGitHubPrResponse({
-        head: {
-          ref: 'fix/something',
-          repo: {
-            full_name: 'contributor/repo',
-            clone_url: 'https://github.com/contributor/repo.git',
-          },
-        },
-      }));
-      mockQuickPickCheckout();
-      // Local branch exists — should use --detach to avoid resetting user's branch
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      const checkoutCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'checkout',
-      );
-      expect(checkoutCall).toBeDefined();
-      expect(checkoutCall![1]).toEqual(['checkout', '--detach', 'devdocket-fork-contributor/fix/something']);
-    });
-
-    it('shows error when fork repository has been deleted', async () => {
-      mockFetchResponse(createGitHubPrResponse({
-        head: {
-          ref: 'fix/something',
-          repo: null,
-        },
-      }));
-      mockQuickPickWorktree();
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: The source repository for PR #42 has been deleted.',
-      );
-    });
-
-    it('creates worktree with pr-prefixed directory name', async () => {
-      mockQuickPickWorktree();
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      const worktreeCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'worktree',
-      );
-      expect(worktreeCall).toBeDefined();
-      expect(worktreeCall![1]).toEqual([
-        'worktree', 'add',
-        path.join('/mock', 'workspace-pr42'),
-        'feature/my-branch',
-      ]);
-    });
-
-    it('checks out PR branch for checkout mode', async () => {
-      mockQuickPickCheckout();
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      const checkoutCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'checkout',
-      );
-      expect(checkoutCall).toBeDefined();
-      expect(checkoutCall![1]).toEqual(['checkout', 'feature/my-branch']);
-    });
-
-    it('creates local branch from origin when no local branch exists (worktree)', async () => {
-      mockQuickPickWorktree();
-      mockNoLocalBranch();
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      const worktreeCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'worktree',
-      );
-      expect(worktreeCall).toBeDefined();
-      expect(worktreeCall![1]).toEqual([
-        'worktree', 'add', '-b', 'feature/my-branch',
-        path.join('/mock', 'workspace-pr42'),
-        'origin/feature/my-branch',
-      ]);
-    });
-
-    it('creates local branch from origin when no local branch exists (checkout)', async () => {
-      mockQuickPickCheckout();
-      mockNoLocalBranch();
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      const checkoutCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'checkout',
-      );
-      expect(checkoutCall).toBeDefined();
-      expect(checkoutCall![1]).toEqual(['checkout', '-b', 'feature/my-branch', '--track', 'origin/feature/my-branch']);
-    });
-
-    it('shows error for 404 PR response', async () => {
-      mockFetchResponse({}, 404);
-      mockQuickPickWorktree();
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#999',
-      });
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: Could not find PR #999',
-      );
-    });
-
-    it('shows error for non-404 API errors', async () => {
-      mockFetchResponse({}, 500);
-      mockQuickPickWorktree();
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: GitHub API error (500)',
-      );
-    });
-
-    it('logs activity with worktreePath for worktree mode', async () => {
-      const { commands } = await import('vscode');
-      mockQuickPickWorktree();
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      const expectedWorktreePath = path.join('/mock', 'workspace-pr42');
-      expect(commands.executeCommand).toHaveBeenCalledWith(
-        'devdocket.addActivity',
-        item.id,
-        'work-started',
-        JSON.stringify({ worktreePath: expectedWorktreePath, repoPath: '/mock/workspace' }),
-      );
-    });
-
-    it('logs activity without worktreePath for checkout mode', async () => {
-      const { commands } = await import('vscode');
-      mockQuickPickCheckout();
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      expect(commands.executeCommand).toHaveBeenCalledWith(
-        'devdocket.addActivity',
-        item.id,
-        'work-started',
-        JSON.stringify({ repoPath: '/mock/workspace' }),
-      );
-    });
-
-    it('prompts for dirty tree before checkout', async () => {
-      mockQuickPickCheckout();
-      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-        if (args[0] === 'status' && args[1] === '--porcelain') {
-          cb(null, ' M dirty.ts\n', '');
-          return;
-        }
-        cb(null, '', '');
-      }) as any);
-      vi.mocked(window.showWarningMessage).mockResolvedValue('Yes' as any);
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      expect(window.showWarningMessage).toHaveBeenCalledWith(
-        'Working tree has uncommitted changes. Checkout anyway?',
-        { modal: true },
-        'Yes',
-      );
-    });
-
-    it('aborts when user cancels work mode selection for PR', async () => {
-      vi.mocked(window.showQuickPick).mockResolvedValue(undefined);
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      // fetch should not have been called (work mode prompt comes before API call)
-      expect(vi.mocked(globalThis.fetch)).not.toHaveBeenCalled();
-      expect(execFile).not.toHaveBeenCalled();
-    });
-
-    it('shows error when worktree dir already exists for PR', async () => {
-      mockQuickPickWorktree();
-      vi.mocked(fs.existsSync).mockImplementation((p: any) => {
-        const pathStr = p.toString();
-        return pathStr.endsWith('.git') || pathStr.includes('workspace-pr42');
-      });
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        expect.stringContaining('already exists'),
-      );
-    });
-  });
-
-  describe('ADO PR flow', () => {
-    beforeEach(() => {
-      mockFetchResponse({ sourceRefName: 'refs/heads/feature/ado-branch' });
-    });
-
-    it('fetches PR branch via ADO API for ado-pr-reviews items', async () => {
-      mockQuickPickWorktree();
-      const item = createWorkItem({
-        providerId: 'ado-pr-reviews',
-        externalId: 'org/project/repo/101',
-      });
-      await action.run(item);
-
-      expect(authentication.getSession).toHaveBeenCalledWith(
-        'microsoft',
-        ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
-        { createIfNone: true },
-      );
-      const fetchCalls = vi.mocked(globalThis.fetch).mock.calls;
-      expect(fetchCalls[0][0]).toBe(
-        'https://dev.azure.com/org/project/_apis/git/repositories/repo/pullrequests/101?api-version=7.1',
-      );
-    });
-
-    it('fetches PR branch via ADO API for third-party PR items with ADO URLs', async () => {
-      mockQuickPickWorktree();
-      const item = createWorkItem({
-        providerId: 'third-party-prs',
-        itemType: 'pr',
-        externalId: 'org/project/repo/101',
-        url: 'https://dev.azure.com/org/project/_git/repo/pullrequest/101',
-      });
-      await action.run(item);
-
-      expect(authentication.getSession).toHaveBeenCalledWith(
-        'microsoft',
-        ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
-        { createIfNone: true },
-      );
-      const fetchCalls = vi.mocked(globalThis.fetch).mock.calls;
-      expect(fetchCalls[0][0]).toBe(
-        'https://dev.azure.com/org/project/_apis/git/repositories/repo/pullrequests/101?api-version=7.1',
-      );
-    });
-
-    it('strips refs/heads/ prefix from sourceRefName', async () => {
-      mockQuickPickWorktree();
-      const item = createWorkItem({
-        providerId: 'ado-pr-reviews',
-        externalId: 'org/project/repo/101',
-      });
-      await action.run(item);
-
-      const fetchCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'fetch',
-      );
-      expect(fetchCall).toBeDefined();
-      expect(fetchCall![1]).toEqual(['fetch', 'origin', 'feature/ado-branch']);
-    });
-
-    it('creates worktree with pr-prefixed directory for ADO PRs', async () => {
-      mockQuickPickWorktree();
-      const item = createWorkItem({
-        providerId: 'ado-pr-reviews',
-        externalId: 'org/project/repo/101',
-      });
-      await action.run(item);
-
-      const worktreeCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'worktree',
-      );
-      expect(worktreeCall).toBeDefined();
-      expect(worktreeCall![1]).toEqual([
-        'worktree', 'add',
-        path.join('/mock', 'workspace-pr101'),
-        'feature/ado-branch',
-      ]);
-    });
-
-    it('checks out ADO PR branch for checkout mode', async () => {
-      mockQuickPickCheckout();
-      const item = createWorkItem({
-        providerId: 'ado-pr-reviews',
-        externalId: 'org/project/repo/101',
-      });
-      await action.run(item);
-
-      const checkoutCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'checkout',
-      );
-      expect(checkoutCall).toBeDefined();
-      expect(checkoutCall![1]).toEqual(['checkout', 'feature/ado-branch']);
-    });
-
-    it('shows error when ADO branch fetch fails', async () => {
-      mockQuickPickWorktree();
-
-      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
-        if (args[0] === 'fetch') {
-          cb(new Error("fatal: couldn't find remote ref feature/ado-branch"), '', '');
-          return;
-        }
-        cb(null, '', '');
-      }) as any);
-
-      const item = createWorkItem({
-        providerId: 'ado-pr-reviews',
-        externalId: 'org/project/repo/101',
-      });
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        "DevDocket: Could not fetch branch 'feature/ado-branch' from origin. The branch may have been deleted.",
-      );
-
-      const worktreeCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'worktree',
-      );
-      expect(worktreeCall).toBeUndefined();
-    });
-
-    it('shows error for 404 ADO PR response', async () => {
-      mockFetchResponse({}, 404);
-      mockQuickPickWorktree();
-
-      const item = createWorkItem({
-        providerId: 'ado-pr-reviews',
-        externalId: 'org/project/repo/999',
-      });
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: Could not find PR #999',
-      );
-    });
-  });
-
-  describe('git ref validation (security)', () => {
-    it('rejects GitHub PR with hyphen-prefixed branch name', async () => {
-      mockFetchResponse(createGitHubPrResponse({
-        head: {
-          ref: '--malicious',
-          repo: {
-            full_name: 'owner/repo',
-            clone_url: 'https://github.com/owner/repo.git',
-          },
-        },
-      }));
-      mockQuickPickWorktree();
-
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        expect.stringContaining('invalid characters'),
-      );
-      // No git checkout/worktree commands should have been made
-      const gitCalls = vi.mocked(execFile).mock.calls.filter(
-        (call: any[]) => call[1]?.[0] === 'checkout' || call[1]?.[0] === 'worktree' || call[1]?.[0] === 'fetch',
-      );
-      expect(gitCalls).toHaveLength(0);
-    });
-
-    it('rejects ADO PR with hyphen-prefixed branch name', async () => {
-      mockFetchResponse({ sourceRefName: 'refs/heads/--malicious' });
-      mockQuickPickWorktree();
-
-      const item = createWorkItem({
-        providerId: 'ado-pr-reviews',
-        externalId: 'org/project/repo/101',
-      });
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        expect.stringContaining('invalid characters'),
-      );
-      // No git checkout/worktree commands should have been made
-      const gitCalls = vi.mocked(execFile).mock.calls.filter(
-        (call: any[]) => call[1]?.[0] === 'checkout' || call[1]?.[0] === 'worktree' || call[1]?.[0] === 'fetch',
-      );
-      expect(gitCalls).toHaveLength(0);
-    });
-
-    it('rejects base branch with hyphen prefix', async () => {
-      mockInputBox('/mock/workspace', '--evil-flag');
-
       const item = createWorkItem();
-      await action.run(item);
-
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: Base branch name contains invalid characters.',
-      );
-      // No branch/checkout git commands should have been made
-      const gitCalls = vi.mocked(execFile).mock.calls.filter(
-        (call: any[]) => call[1]?.[0] === 'branch' || call[1]?.[0] === 'checkout' || call[1]?.[0] === 'worktree',
-      );
-      expect(gitCalls).toHaveLength(0);
-    });
-
-    it('allows valid GitHub PR branch names', async () => {
-      mockFetchResponse(createGitHubPrResponse({
-        head: {
-          ref: 'feature/my-branch',
-          repo: {
-            full_name: 'owner/repo',
-            clone_url: 'https://github.com/owner/repo.git',
-          },
-        },
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'pr',
+        cloneUrl: 'https://example.com/acme/repo.git',
+        headCloneUrl: 'https://example.com/contributor/repo.git',
+        ref: 'feature/topic',
+        repoLabel: 'acme/repo',
       }));
-      mockQuickPickWorktree();
 
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
       await action.run(item);
 
-      // Should NOT show an error about invalid characters
-      expect(window.showErrorMessage).not.toHaveBeenCalledWith(
-        expect.stringContaining('invalid characters'),
-      );
-      // Should have proceeded to git operations
-      const fetchCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'fetch',
-      );
-      expect(fetchCall).toBeDefined();
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
+        'remote', 'set-url', 'devdocket-fork-contributor', 'https://example.com/contributor/repo.git',
+      ]);
     });
 
-    it('allows valid base branch like origin/dev', async () => {
-      mockInputBox('/mock/workspace', 'origin/dev');
-
+    it('runs configured post-worktree commands with the created worktree path', async () => {
+      vi.mocked(workspace.getConfiguration).mockReturnValue({
+        get: vi.fn((key: string, defaultValue?: any) => key === 'commands'
+          ? [{ command: 'npm', args: ['install', '--prefix', '{path}'] }]
+          : defaultValue),
+      } as any);
       const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
       await action.run(item);
 
-      expect(window.showErrorMessage).not.toHaveBeenCalledWith(
-        'DevDocket: Base branch name contains invalid characters.',
-      );
-      // Should have proceeded to git operations
-      const branchCall = vi.mocked(execFile).mock.calls.find(
-        (call: any[]) => call[1]?.[0] === 'branch' && call[1]?.[1] !== '--list',
-      );
-      expect(branchCall).toBeDefined();
+      expect(vi.mocked(execFile).mock.calls.map(call => [call[0], call[1], call[2]])).toContainEqual([
+        'npm', ['install', '--prefix', path.join('/mock', 'workspace-issue123')], { cwd: path.join('/mock', 'workspace-issue123'), timeout: 60_000 },
+      ]);
     });
 
-    it('rejects GitHub PR with invalid clone URL', async () => {
-      mockFetchResponse(createGitHubPrResponse({
-        head: {
-          ref: 'feature/branch',
-          repo: {
-            full_name: 'evil/repo',
-            clone_url: '--upload-pack=malicious',
-          },
-        },
-        base: {
-          repo: {
-            full_name: 'owner/repo',
-          },
-        },
+    it('accepts and routes a third-party provider without host or provider-id knowledge', async () => {
+      const item = createWorkItem({ providerId: 'fake-vendor', externalId: 'work-42' });
+      const { action } = createAction(discovered('fake-vendor', 'work-42', {
+        kind: 'issue', cloneUrl: 'git@git.fake-vendor.example:team/repo.git', ref: 'fake/work-42', repoLabel: 'Fake Vendor Repo',
       }));
-      mockQuickPickWorktree();
 
-      const item = createWorkItem({
-        providerId: 'github-my-prs',
-        externalId: 'owner/repo#42',
-      });
+      expect(action.canRun(item)).toBe(true);
       await action.run(item);
 
-      expect(window.showErrorMessage).toHaveBeenCalledWith(
-        expect.stringContaining('invalid clone URL'),
-      );
-      const gitCalls = vi.mocked(execFile).mock.calls.filter(
-        (call: any[]) => call[1]?.[0] === 'remote' || call[1]?.[0] === 'fetch',
-      );
-      expect(gitCalls).toHaveLength(0);
+      expect(vi.mocked(execFile).mock.calls[1][1]).toEqual(['branch', 'fake/work-42', 'origin/dev']);
     });
   });
 });

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -283,6 +283,19 @@ describe('StartWorkAction', () => {
       expect(execFile).not.toHaveBeenCalled();
     });
 
+    it('rejects git SSH clone URLs with unsafe hosts', async () => {
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', async () => ({
+        kind: 'issue', cloneUrl: 'git@-evil.example:acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      })));
+
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith('DevDocket: Provider returned an invalid clone URL for this work item.');
+      expect(window.showInputBox).not.toHaveBeenCalled();
+      expect(execFile).not.toHaveBeenCalled();
+    });
+
     it('rejects an invalid ref returned by a lazy resolver', async () => {
       const item = createWorkItem();
       const { action } = createAction(discovered('provider', 'item-1', async () => ({

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -309,6 +309,19 @@ describe('StartWorkAction', () => {
       expect(execFile).not.toHaveBeenCalled();
     });
 
+    it('rejects unsupported fully-qualified PR refs', async () => {
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', async () => ({
+        kind: 'pr', cloneUrl: 'https://example.com/acme/repo.git', ref: 'refs/pull/123/head', repoLabel: 'acme/repo',
+      })));
+
+      await action.run(item);
+
+      expect(window.showErrorMessage).toHaveBeenCalledWith('DevDocket: Provider returned an unsupported PR branch ref for this work item.');
+      expect(window.showInputBox).not.toHaveBeenCalled();
+      expect(execFile).not.toHaveBeenCalled();
+    });
+
     it('aborts checkout when the working tree is dirty and the user cancels', async () => {
       vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Checkout branch', value: 'checkout' } as any);
       vi.mocked(window.showWarningMessage).mockResolvedValue(undefined as any);


### PR DESCRIPTION
## Summary

Redesigns Start Git Work around a provider-supplied `capabilities.gitWork` capability on live `DiscoveredItem` data. The action is now provider- and host-agnostic: it looks up the live discovered item through `DevDocketApi.getDiscoveredItem(providerId, externalId)`, resolves `GitWorkInfo`, validates the clone URLs and refs, then runs the existing branch/worktree/checkout flows.

## What changed

- Added shared `GitWorkInfo` and `DiscoveredItemCapabilities` types plus optional `DiscoveredItem.capabilities`.
- Added optional `DevDocketApi.getDiscoveredItem(providerId, externalId)` so actions can read live provider capabilities for accepted work items.
- Refactored `start-git-work` to consume only `GitWorkInfo`:
  - no URL-host detection;
  - no provider-id routing allowlist;
  - no external-id parsing for routing;
  - no direct GitHub or Azure DevOps HTTP calls.
- Updated GitHub providers to attach:
  - literal issue git work info when repo data is already known;
  - lazy PR git work resolvers that fetch current head/base/fork data through the GitHub provider auth/API path.
- Updated ADO providers to attach:
  - lazy PR git work resolvers through the ADO provider auth/API path;
  - literal work-item git work info only when an associated Azure Repos relation identifies the repo.
- Added capability-driven tests, including a synthetic `fake-vendor` provider acceptance test proving third-party providers can trigger Start Git Work without host/provider knowledge in the action.

## Lazy vs. literal capability shape

Providers can attach a literal `GitWorkInfo` when all git data is already known during discovery, such as issue/work-item branch suggestions. Providers can attach a lazy `() => Promise<GitWorkInfo | undefined>` when resolving the data requires an API call at action time, such as PR head refs and fork source repositories. Returning `undefined` means the provider cannot currently resolve the git data.

This keeps host-specific URL/API knowledge inside providers, where auth and source-specific semantics already live.

## API additions

All additions are optional and non-breaking:

- `GitWorkInfo`
- `DiscoveredItemCapabilities`
- `DiscoveredItem.capabilities?`
- `DevDocketApi.getDiscoveredItem?`
- re-exports from `@devdocket/shared` and `packages/core/src/api/types.ts`

No migration notes are required because existing providers and actions continue to compile and run without implementing these optional members.

## Validation

- `npm run build`
- `npm run test`
- `npm run check-boundaries`
- local `superpowers:code-reviewer` review, with follow-up fixes for coverage and ADO work-item repo association

Closes #505
