### PR TITLE
Tag sidebar refresh by reason and skip Sources rebuild on readState-only events

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -423,13 +423,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
       mainProvider,
       { webviewOptions: { retainContextWhenHidden: true } },
     ),
-    wg.onDidChange(safeHandler('mc:workGraph', () => mainProvider.scheduleRefresh())),
-    pr.onDidChangeDiscoveredItems(safeHandler('mc:discovered', () => mainProvider.scheduleRefresh())),
-    pr.onDidChangeProviderHealth(safeHandler('mc:health', () => mainProvider.scheduleRefresh())),
-    ss.onDidChange(safeHandler('mc:stateStore', () => mainProvider.scheduleRefresh())),
-    ws.onDidChangeWatchedRuns(safeHandler('mc:watchedRuns', () => mainProvider.scheduleRefresh())),
-    ws.onDidChangePRWatches(safeHandler('mc:watchedPRs', () => mainProvider.scheduleRefresh())),
-    readStateStore.onDidChange(safeHandler('mc:readState', () => mainProvider.scheduleRefresh())),
+    wg.onDidChange(safeHandler('mc:workGraph', () => mainProvider.scheduleRefresh('workGraph'))),
+    pr.onDidChangeDiscoveredItems(safeHandler('mc:discovered', () => mainProvider.scheduleRefresh('discovered'))),
+    pr.onDidChangeProviderHealth(safeHandler('mc:health', () => mainProvider.scheduleRefresh('health'))),
+    ss.onDidChange(safeHandler('mc:stateStore', () => mainProvider.scheduleRefresh('state'))),
+    ws.onDidChangeWatchedRuns(safeHandler('mc:watchedRuns', () => mainProvider.scheduleRefresh('watchedRuns'))),
+    ws.onDidChangePRWatches(safeHandler('mc:watchedPRs', () => mainProvider.scheduleRefresh('watchedPRs'))),
+    readStateStore.onDidChange(safeHandler('mc:readState', () => mainProvider.scheduleRefresh('readState'))),
     pr.onDidRefreshProvider(safeHandler('mc:prune', async (providerId) => {
       if (pr.wasLastRefreshTruncated(providerId)) {
         logger.debug(`Skipping prune for provider ${providerId} because the latest refresh was truncated`);

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -623,6 +623,30 @@ describe('MainViewProvider', () => {
     });
   });
 
+  it('skips sources updates for read-state-only refreshes', async () => {
+    vi.useFakeTimers();
+    const provider = createProvider(
+      createMockWorkGraph(),
+      createProviderRegistry({
+        github: [{ externalId: 'incoming-1', title: 'Incoming item', state: 'open' }],
+      }),
+      createStateStore(),
+    );
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    await vi.advanceTimersByTimeAsync(50);
+    expect(findPostedMessage(mockView, 'updateSources')).toBeDefined();
+
+    mockView.webview.postMessage.mockClear();
+    provider.scheduleRefresh('readState');
+    await vi.advanceTimersByTimeAsync(50);
+
+    const messageTypes = mockView.getMessages().map(message => message?.type);
+    expect(messageTypes).toEqual(['updateItems']);
+    expect(findPostedMessage(mockView, 'updateSources')).toBeUndefined();
+  });
+
   it('debounces refreshes so rapid calls post a single update', async () => {
     vi.useFakeTimers();
     const provider = createProvider(
@@ -633,8 +657,8 @@ describe('MainViewProvider', () => {
     const mockView = createMockWebviewView();
 
     provider.resolveWebviewView(mockView.view, {} as any, {} as any);
-    provider.scheduleRefresh();
-    provider.scheduleRefresh();
+    provider.scheduleRefresh('workGraph');
+    provider.scheduleRefresh('state');
 
     await vi.advanceTimersByTimeAsync(49);
     expect(mockView.webview.postMessage).not.toHaveBeenCalled();

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -26,12 +26,22 @@ import type {
   WebviewMessage,
 } from './mainTypes';
 
+export type RefreshReason =
+  | 'workGraph'
+  | 'discovered'
+  | 'health'
+  | 'state'
+  | 'watchedRuns'
+  | 'watchedPRs'
+  | 'readState';
+
 export class MainViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewId = 'devdocket.main';
   private static readonly REFRESH_DEBOUNCE_MS = 50;
 
   private view?: vscode.WebviewView;
   private refreshTimer?: ReturnType<typeof setTimeout>;
+  private pendingRefreshReasons = new Set<RefreshReason>();
   private disposed = false;
 
   constructor(
@@ -54,6 +64,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       clearTimeout(this.refreshTimer);
       this.refreshTimer = undefined;
     }
+    this.pendingRefreshReasons.clear();
   }
 
   resolveWebviewView(
@@ -73,19 +84,22 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       void this.handleMessage(message);
     });
 
-    this.scheduleRefresh();
+    this.scheduleRefresh('discovered');
   }
 
-  scheduleRefresh(): void {
+  scheduleRefresh(reason: RefreshReason): void {
     if (this.disposed) {
       return;
     }
+    this.pendingRefreshReasons.add(reason);
     if (this.refreshTimer) {
       clearTimeout(this.refreshTimer);
     }
     this.refreshTimer = setTimeout(() => {
+      const reasons = new Set(this.pendingRefreshReasons);
+      this.pendingRefreshReasons.clear();
       this.refreshTimer = undefined;
-      this.refresh();
+      this.refresh(reasons);
     }, MainViewProvider.REFRESH_DEBOUNCE_MS);
   }
 
@@ -97,7 +111,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     void this.view?.webview.postMessage({ type: 'toggleSearch' });
   }
 
-  private refresh(): void {
+  private refresh(reasons: ReadonlySet<RefreshReason>): void {
     if (!this.view) {
       return;
     }
@@ -105,15 +119,28 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     const allDiscoveredItems = this.providerRegistry.getAllDiscoveredItems();
     const relatedItemsIndex = buildRelatedItemsIndex(this.providerRegistry, this.workGraph, allDiscoveredItems);
 
+    // My Work renders unread markers, tier state/order, related-item markers, and CI badges.
     void this.view.webview.postMessage({
       type: 'updateItems',
       tiers: this.buildTierData(allDiscoveredItems, relatedItemsIndex),
     });
-    void this.view.webview.postMessage({
-      type: 'updateSources',
-      providers: this.buildSourcesData(allDiscoveredItems, relatedItemsIndex),
-    });
+    if (this.shouldRefreshSources(reasons)) {
+      void this.view.webview.postMessage({
+        type: 'updateSources',
+        providers: this.buildSourcesData(allDiscoveredItems, relatedItemsIndex),
+      });
+    }
     this.updateBadge();
+  }
+
+  private shouldRefreshSources(reasons: ReadonlySet<RefreshReason>): boolean {
+    // Sources render provider health, discovered-state marks, related-item markers, and CI badges.
+    return reasons.has('discovered')
+      || reasons.has('health')
+      || reasons.has('state')
+      || reasons.has('workGraph')
+      || reasons.has('watchedRuns')
+      || reasons.has('watchedPRs');
   }
 
   /** Update the activity-bar badge with the unread incoming count. */


### PR DESCRIPTION
## Summary

Tags `MainViewProvider.scheduleRefresh()` with a refresh reason and accumulates the union of pending reasons until the debounce fires. The full Sources snapshot is now skipped when only `readState` changed, eliminating an O(items × providers) rebuild + cross-bridge serialization per inbox-card click.

This is a low-risk first cut. Larger optimizations (incremental `itemAdded`/`itemRemoved` patches, Sources virtualization, `buildBadges` memoization) are documented as follow-up work.

## Why

Up to seven event sources (`workGraph`, `discovered`, `health`, `state`, `watchedRuns`, `watchedPRs`, `readState`) all called `scheduleRefresh()` with no source-aware filtering. Every event rebuilt and re-posted both the Tier and Sources snapshots — including for events like `readState` (user clicks a card to mark seen) that don't affect Sources at all. With `MAX_ITEMS_PER_PROVIDER = 10_000` and 4–6 providers, a single inbox click was triggering a ~tens-of-thousands-of-items snapshot rebuild for nothing.

## Fix

- `scheduleRefresh(reason: RefreshReason)` accepts a tagged reason; the union of pending reasons accumulates in a `Set<RefreshReason>` until the 50ms debounce fires.
- `refresh()` decides which slices to rebuild based on the accumulated reasons:
  - `readState` → rebuild Tier only; skip Sources.
  - `discovered` / `health` / `state` / `workGraph` / `watchedRuns` / `watchedPRs` → rebuild both (Sources currently renders related-item markers and CI badges, so these still affect it).
- All seven `scheduleRefresh` call sites in `extension.ts` updated to pass their respective reason.
- Existing user-visible behavior is unchanged — every change is still reflected in the UI; only redundant Sources rebuilds are pruned.

## Out of scope (follow-ups)

- Diff-based incremental webview updates (`itemAdded`, `itemRemoved`, `itemUpdated`).
- Sources virtualization / lazy rendering.
- `buildBadges` per-`(providerId, externalId)` memoization.
- Reducing Sources's dependency on watch state so more reasons can skip Sources rebuild.
- `MAX_ITEMS_PER_PROVIDER` cap reduction.

## Changes

- `packages/core/src/views/mainViewProvider.ts` — tagged scheduler, slice-aware `refresh()`.
- `packages/core/src/extension.ts` — pass reasons at all `scheduleRefresh` call sites.
- `packages/core/src/test/mainViewProvider.test.ts` — assert that a `readState`-only refresh does not post `updateSources`.

## Verification

`cd packages/core && npm run build && npm run test` — passes.

Closes #510
