### PR TITLE
Filter merged GitHub PRs from Incoming providers

### DIFF
--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -62,16 +62,22 @@ export async function filterMergedGitHubPrs(
         if (signal?.aborted) {
           throw createAbortError();
         }
-        const response = await fetch(item.pull_request!.url, {
-          headers: getGitHubAuthHeaders(token),
-          signal: combineSignals(signal, 30_000),
-        });
-        if (!response.ok) {
-          logger.debug(`Failed to fetch PR merge details for ${item.html_url}: ${response.status}`);
+        try {
+          const response = await fetch(item.pull_request!.url, {
+            headers: getGitHubAuthHeaders(token),
+            signal: combineSignals(signal, 30_000),
+          });
+          if (!response.ok) {
+            logger.debug(`Failed to fetch PR merge details for ${item.html_url}: ${response.status}`);
+            return { htmlUrl: item.html_url, merged: false };
+          }
+          const detail = await response.json() as GitHubPrMergeFields;
+          return { htmlUrl: item.html_url, merged: isMergedGitHubPr(detail) };
+        } catch (error) {
+          if (error instanceof Error && error.name === 'AbortError' && signal?.aborted) { throw error; }
+          logger.debug(`Failed to fetch PR merge details for ${item.html_url}: ${String(error)}`);
           return { htmlUrl: item.html_url, merged: false };
         }
-        const detail = await response.json() as GitHubPrMergeFields;
-        return { htmlUrl: item.html_url, merged: isMergedGitHubPr(detail) };
       },
       3,
     );

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { isValidGitHubRepo, createAbortError, runWorkerPoolSettled, type ProviderBadge } from '@devdocket/shared';
+import { isValidGitHubRepo, combineSignals, createAbortError, runWorkerPoolSettled, type ProviderBadge } from '@devdocket/shared';
 import { logger } from './logger';
 
 export interface GitHubIssue {
@@ -12,7 +12,7 @@ export interface GitHubIssue {
   comments_url?: string;
   comments?: number;
   updated_at?: string;
-  pull_request?: { url: string; merged_at?: string | null };
+  pull_request?: { url: string };
   merged_at?: string | null;
   merged?: boolean;
 }
@@ -21,14 +21,73 @@ export interface GitHubSearchResponse {
   items: GitHubIssue[];
 }
 
-export function isMergedGitHubPr(item: GitHubIssue): boolean {
-  if (item.pull_request?.merged_at) {
-    return true;
-  }
+export interface GitHubPrMergeFields {
+  state?: string;
+  merged_at?: string | null;
+  merged?: boolean;
+}
+
+export function isMergedGitHubPr(item: GitHubPrMergeFields): boolean {
   if (item.merged_at) {
     return true;
   }
   return item.state?.toLowerCase() === 'closed' && item.merged === true;
+}
+
+export async function filterMergedGitHubPrs(
+  token: string,
+  items: GitHubIssue[],
+  signal?: AbortSignal,
+): Promise<GitHubIssue[]> {
+  const mergedUrls = new Set<string>();
+  const detailCandidates: GitHubIssue[] = [];
+
+  for (const item of items) {
+    if (!item.pull_request) {
+      continue;
+    }
+    if (isMergedGitHubPr(item)) {
+      mergedUrls.add(item.html_url);
+      continue;
+    }
+    if (item.state?.toLowerCase() === 'closed' && item.pull_request.url) {
+      detailCandidates.push(item);
+    }
+  }
+
+  if (detailCandidates.length > 0) {
+    const results = await runWorkerPoolSettled(
+      detailCandidates,
+      async (item) => {
+        if (signal?.aborted) {
+          throw createAbortError();
+        }
+        const response = await fetch(item.pull_request!.url, {
+          headers: getGitHubAuthHeaders(token),
+          signal: combineSignals(signal, 30_000),
+        });
+        if (!response.ok) {
+          logger.debug(`Failed to fetch PR merge details for ${item.html_url}: ${response.status}`);
+          return { htmlUrl: item.html_url, merged: false };
+        }
+        const detail = await response.json() as GitHubPrMergeFields;
+        return { htmlUrl: item.html_url, merged: isMergedGitHubPr(detail) };
+      },
+      3,
+    );
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        logger.debug(`Failed to inspect PR merge details: ${String(result.reason)}`);
+        continue;
+      }
+      if (result.value.merged) {
+        mergedUrls.add(result.value.htmlUrl);
+      }
+    }
+  }
+
+  return items.filter(item => !mergedUrls.has(item.html_url));
 }
 
 /**

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -12,11 +12,23 @@ export interface GitHubIssue {
   comments_url?: string;
   comments?: number;
   updated_at?: string;
-  pull_request?: { url: string };
+  pull_request?: { url: string; merged_at?: string | null };
+  merged_at?: string | null;
+  merged?: boolean;
 }
 
 export interface GitHubSearchResponse {
   items: GitHubIssue[];
+}
+
+export function isMergedGitHubPr(item: GitHubIssue): boolean {
+  if (item.pull_request?.merged_at) {
+    return true;
+  }
+  if (item.merged_at) {
+    return true;
+  }
+  return item.state?.toLowerCase() === 'closed' && item.merged === true;
 }
 
 /**

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -5,7 +5,7 @@ import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
 import { matchesRepoPatterns } from './repoPattern';
-import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, isMergedGitHubPr, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
+import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, filterMergedGitHubPrs, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
 
 const MENTIONS_ACTIVATED_KEY = 'mentionsActivatedAt';
 const COMMENT_FETCH_CONCURRENCY = 3;
@@ -73,12 +73,11 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     const patterns = this.getConfiguredPatterns();
     const { results, failures } = await this.fetchAllMentions(accessToken, activatedAt, signal);
 
-    const itemsWithRepo = results
-      .filter(issue => !isMergedGitHubPr(issue))
-      .map((issue) => ({
-        issue,
-        repoName: parseRepoFromUrls(issue.html_url, issue.repository_url),
-      }));
+    const activeResults = await filterMergedGitHubPrs(accessToken, results, signal);
+    const itemsWithRepo = activeResults.map((issue) => ({
+      issue,
+      repoName: parseRepoFromUrls(issue.html_url, issue.repository_url),
+    }));
 
     const filtered = patterns.length > 0
       ? itemsWithRepo.filter(({ repoName }) => matchesRepoPatterns(repoName, patterns))

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -5,7 +5,7 @@ import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
 import { matchesRepoPatterns } from './repoPattern';
-import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
+import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, isMergedGitHubPr, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
 
 const MENTIONS_ACTIVATED_KEY = 'mentionsActivatedAt';
 const COMMENT_FETCH_CONCURRENCY = 3;
@@ -73,10 +73,12 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     const patterns = this.getConfiguredPatterns();
     const { results, failures } = await this.fetchAllMentions(accessToken, activatedAt, signal);
 
-    const itemsWithRepo = results.map((issue) => ({
-      issue,
-      repoName: parseRepoFromUrls(issue.html_url, issue.repository_url),
-    }));
+    const itemsWithRepo = results
+      .filter(issue => !isMergedGitHubPr(issue))
+      .map((issue) => ({
+        issue,
+        repoName: parseRepoFromUrls(issue.html_url, issue.repository_url),
+      }));
 
     const filtered = patterns.length > 0
       ? itemsWithRepo.filter(({ repoName }) => matchesRepoPatterns(repoName, patterns))

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -2,7 +2,7 @@ import { DiscoveredItem, ProviderBadge, combineSignals, createAbortError, runWor
 import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
-import { getGitHubAuthHeaders, isMergedGitHubPr, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
+import { getGitHubAuthHeaders, filterMergedGitHubPrs, type GitHubIssue, type GitHubPrMergeFields, type GitHubSearchResponse } from './githubApiHelpers';
 import { matchesRepoPatterns } from './repoPattern';
 
 /** Map a PR status string from {@link GitHubMyPrsProvider.determinePrStatus} to its UI badge. */
@@ -18,7 +18,7 @@ function statusToBadge(status: string): ProviderBadge | undefined {
   }
 }
 
-export interface PrDetail {
+export interface PrDetail extends GitHubPrMergeFields {
   draft?: boolean;
   head?: { sha?: string };
   mergeable_state?: string;
@@ -79,8 +79,10 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
       logger.error('Failed to fetch assigned PRs', err);
     }
 
-    const authoredPrs = authoredResult.prs.filter(pr => !isMergedGitHubPr(pr));
-    const assignedPrs = assignedResult.prs.filter(pr => !isMergedGitHubPr(pr));
+    const [authoredPrs, assignedPrs] = await Promise.all([
+      filterMergedGitHubPrs(accessToken, authoredResult.prs, signal),
+      filterMergedGitHubPrs(accessToken, assignedResult.prs, signal),
+    ]);
 
     // Filter out self-authored PRs from assigned results to avoid duplicates
     const authoredUrls = new Set(authoredPrs.map(pr => pr.html_url));

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -2,7 +2,7 @@ import { DiscoveredItem, ProviderBadge, combineSignals, createAbortError, runWor
 import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
-import { getGitHubAuthHeaders, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
+import { getGitHubAuthHeaders, isMergedGitHubPr, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
 import { matchesRepoPatterns } from './repoPattern';
 
 /** Map a PR status string from {@link GitHubMyPrsProvider.determinePrStatus} to its UI badge. */
@@ -79,12 +79,15 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
       logger.error('Failed to fetch assigned PRs', err);
     }
 
+    const authoredPrs = authoredResult.prs.filter(pr => !isMergedGitHubPr(pr));
+    const assignedPrs = assignedResult.prs.filter(pr => !isMergedGitHubPr(pr));
+
     // Filter out self-authored PRs from assigned results to avoid duplicates
-    const authoredUrls = new Set(authoredResult.prs.map(pr => pr.html_url));
-    const uniqueAssignedPrs = assignedResult.prs.filter(pr => !authoredUrls.has(pr.html_url));
+    const authoredUrls = new Set(authoredPrs.map(pr => pr.html_url));
+    const uniqueAssignedPrs = assignedPrs.filter(pr => !authoredUrls.has(pr.html_url));
 
     // Parse repo name once per PR
-    const allPrsList = [...authoredResult.prs, ...uniqueAssignedPrs];
+    const allPrsList = [...authoredPrs, ...uniqueAssignedPrs];
     const repoNameMap = new Map(allPrsList.map(pr =>
       [pr.html_url, parseRepoFromUrls(pr.html_url, pr.repository_url)]
     ));
@@ -92,8 +95,8 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
     // Post-filter when patterns are configured
     const repoFilter = (pr: GitHubIssue) => matchesRepoPatterns(repoNameMap.get(pr.html_url)!, patterns);
     const filteredAuthored = patterns.length > 0
-      ? authoredResult.prs.filter(repoFilter)
-      : authoredResult.prs;
+      ? authoredPrs.filter(repoFilter)
+      : authoredPrs;
     const filteredAssigned = patterns.length > 0
       ? uniqueAssignedPrs.filter(repoFilter)
       : uniqueAssignedPrs;

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -3,7 +3,7 @@ import { DiscoveredItem, combineSignals, createAbortError, runWorkerPool, safeDe
 import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
-import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
+import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, isMergedGitHubPr, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
 import { matchesRepoPatterns } from './repoPattern';
 
 interface TimelineEvent {
@@ -30,16 +30,17 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
     const patterns = this.getConfiguredPatterns();
 
     const { prs, failed } = await this.fetchAllPrReviews(accessToken, signal);
+    const activePrs = prs.filter(pr => !isMergedGitHubPr(pr));
 
     // Parse repo name once per PR
-    const repoNameMap = new Map(prs.map(pr =>
+    const repoNameMap = new Map(activePrs.map(pr =>
       [pr.html_url, parseRepoFromUrls(pr.html_url, pr.repository_url)]
     ));
 
     // Post-filter when patterns are configured
     const filteredPrs = patterns.length > 0
-      ? prs.filter(pr => matchesRepoPatterns(repoNameMap.get(pr.html_url)!, patterns))
-      : prs;
+      ? activePrs.filter(pr => matchesRepoPatterns(repoNameMap.get(pr.html_url)!, patterns))
+      : activePrs;
 
     logger.info(`Discovered ${filteredPrs.length} PR review requests`);
 

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -3,7 +3,7 @@ import { DiscoveredItem, combineSignals, createAbortError, runWorkerPool, safeDe
 import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
-import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, isMergedGitHubPr, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
+import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, filterMergedGitHubPrs, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
 import { matchesRepoPatterns } from './repoPattern';
 
 interface TimelineEvent {
@@ -30,7 +30,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
     const patterns = this.getConfiguredPatterns();
 
     const { prs, failed } = await this.fetchAllPrReviews(accessToken, signal);
-    const activePrs = prs.filter(pr => !isMergedGitHubPr(pr));
+    const activePrs = await filterMergedGitHubPrs(accessToken, prs, signal);
 
     // Parse repo name once per PR
     const repoNameMap = new Map(activePrs.map(pr =>

--- a/packages/github/src/test/githubApiHelpers.test.ts
+++ b/packages/github/src/test/githubApiHelpers.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { isMergedGitHubPr, type GitHubIssue } from '../githubApiHelpers';
+
+function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
+  return {
+    number: 1,
+    title: 'Test item',
+    state: 'open',
+    html_url: 'https://github.com/owner/repo/issues/1',
+    repository_url: 'https://api.github.com/repos/owner/repo',
+    ...overrides,
+  };
+}
+
+describe('isMergedGitHubPr', () => {
+  it('detects merged PR search results from pull_request.merged_at', () => {
+    const item = createIssue({
+      html_url: 'https://github.com/owner/repo/pull/1',
+      pull_request: {
+        url: 'https://api.github.com/repos/owner/repo/pulls/1',
+        merged_at: '2025-01-01T00:00:00Z',
+      },
+    });
+
+    expect(isMergedGitHubPr(item)).toBe(true);
+  });
+
+  it('detects merged REST PR objects from merged_at', () => {
+    const item = createIssue({
+      html_url: 'https://github.com/owner/repo/pull/1',
+      merged_at: '2025-01-01T00:00:00Z',
+    });
+
+    expect(isMergedGitHubPr(item)).toBe(true);
+  });
+
+  it('detects merged REST PR objects from closed state and merged flag', () => {
+    const item = createIssue({
+      html_url: 'https://github.com/owner/repo/pull/1',
+      state: 'closed',
+      merged: true,
+    });
+
+    expect(isMergedGitHubPr(item)).toBe(true);
+  });
+
+  it('does not treat open PRs as merged', () => {
+    const item = createIssue({
+      html_url: 'https://github.com/owner/repo/pull/1',
+      pull_request: {
+        url: 'https://api.github.com/repos/owner/repo/pulls/1',
+        merged_at: null,
+      },
+      merged_at: null,
+      merged: false,
+    });
+
+    expect(isMergedGitHubPr(item)).toBe(false);
+  });
+
+  it('does not treat closed non-merged PRs as merged', () => {
+    const item = createIssue({
+      html_url: 'https://github.com/owner/repo/pull/1',
+      state: 'closed',
+      pull_request: {
+        url: 'https://api.github.com/repos/owner/repo/pulls/1',
+        merged_at: null,
+      },
+      merged: false,
+    });
+
+    expect(isMergedGitHubPr(item)).toBe(false);
+  });
+
+  it('does not treat closed issues as merged', () => {
+    const item = createIssue({ state: 'closed' });
+
+    expect(isMergedGitHubPr(item)).toBe(false);
+  });
+});

--- a/packages/github/src/test/githubApiHelpers.test.ts
+++ b/packages/github/src/test/githubApiHelpers.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest';
-import { isMergedGitHubPr, type GitHubIssue } from '../githubApiHelpers';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { filterMergedGitHubPrs, isMergedGitHubPr, type GitHubIssue } from '../githubApiHelpers';
 
 function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
   return {
@@ -12,19 +12,20 @@ function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
   };
 }
 
-describe('isMergedGitHubPr', () => {
-  it('detects merged PR search results from pull_request.merged_at', () => {
-    const item = createIssue({
-      html_url: 'https://github.com/owner/repo/pull/1',
-      pull_request: {
-        url: 'https://api.github.com/repos/owner/repo/pulls/1',
-        merged_at: '2025-01-01T00:00:00Z',
-      },
-    });
-
-    expect(isMergedGitHubPr(item)).toBe(true);
+function createPr(number: number, state: string): GitHubIssue {
+  return createIssue({
+    number,
+    state,
+    html_url: `https://github.com/owner/repo/pull/${number}`,
+    pull_request: { url: `https://api.github.com/repos/owner/repo/pulls/${number}` },
   });
+}
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('isMergedGitHubPr', () => {
   it('detects merged REST PR objects from merged_at', () => {
     const item = createIssue({
       html_url: 'https://github.com/owner/repo/pull/1',
@@ -47,10 +48,6 @@ describe('isMergedGitHubPr', () => {
   it('does not treat open PRs as merged', () => {
     const item = createIssue({
       html_url: 'https://github.com/owner/repo/pull/1',
-      pull_request: {
-        url: 'https://api.github.com/repos/owner/repo/pulls/1',
-        merged_at: null,
-      },
       merged_at: null,
       merged: false,
     });
@@ -62,10 +59,6 @@ describe('isMergedGitHubPr', () => {
     const item = createIssue({
       html_url: 'https://github.com/owner/repo/pull/1',
       state: 'closed',
-      pull_request: {
-        url: 'https://api.github.com/repos/owner/repo/pulls/1',
-        merged_at: null,
-      },
       merged: false,
     });
 
@@ -76,5 +69,33 @@ describe('isMergedGitHubPr', () => {
     const item = createIssue({ state: 'closed' });
 
     expect(isMergedGitHubPr(item)).toBe(false);
+  });
+});
+
+describe('filterMergedGitHubPrs', () => {
+  it('fetches PR details for closed PR search results before filtering merged PRs', async () => {
+    const openPr = createPr(1, 'open');
+    const mergedPr = createPr(2, 'closed');
+    const closedUnmergedPr = createPr(3, 'closed');
+    const closedIssue = createIssue({ number: 4, state: 'closed' });
+    const mockFetch = vi.fn(async (url: string) => {
+      if (url.endsWith('/pulls/2')) {
+        return { ok: true, json: async () => ({ state: 'closed', merged: true, merged_at: '2025-01-01T00:00:00Z' }) };
+      }
+      if (url.endsWith('/pulls/3')) {
+        return { ok: true, json: async () => ({ state: 'closed', merged: false, merged_at: null }) };
+      }
+      return { ok: false, status: 404, statusText: 'Not Found' };
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const activePrs = await filterMergedGitHubPrs('test-token', [openPr, mergedPr, closedUnmergedPr, closedIssue]);
+
+    expect(activePrs).toEqual([openPr, closedUnmergedPr, closedIssue]);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch.mock.calls.map(call => call[0])).toEqual([
+      'https://api.github.com/repos/owner/repo/pulls/2',
+      'https://api.github.com/repos/owner/repo/pulls/3',
+    ]);
   });
 });

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -154,23 +154,30 @@ describe('GitHubMentionsProvider', () => {
     }));
   });
 
-  it('excludes merged PRs from mentioned search results before publishing', async () => {
+  it('excludes merged PRs by fetching details for closed mentioned search results before publishing', async () => {
     const mergedPr = {
       ...createMockPr(20, 'Already merged', 'org/repo'),
       state: 'closed',
-      pull_request: { url: 'https://api.github.com/repos/org/repo/pulls/20', merged_at: '2025-01-01T00:00:00Z' },
     };
     const closedIssue = { ...createMockIssue(30, 'Closed issue', 'org/repo'), state: 'closed' };
 
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        items: [
-          createMockPr(10, 'Open PR', 'org/repo'),
-          mergedPr,
-          closedIssue,
-        ],
-      }),
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('search/issues')) {
+        return {
+          ok: true,
+          json: async () => ({
+            items: [
+              createMockPr(10, 'Open PR', 'org/repo'),
+              mergedPr,
+              closedIssue,
+            ],
+          }),
+        };
+      }
+      if (url.endsWith('/pulls/20')) {
+        return { ok: true, json: async () => ({ state: 'closed', merged: true, merged_at: '2025-01-01T00:00:00Z' }) };
+      }
+      return { ok: false, status: 404, statusText: 'Not Found' };
     });
 
     const listener = vi.fn();

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -154,6 +154,34 @@ describe('GitHubMentionsProvider', () => {
     }));
   });
 
+  it('excludes merged PRs from mentioned search results before publishing', async () => {
+    const mergedPr = {
+      ...createMockPr(20, 'Already merged', 'org/repo'),
+      state: 'closed',
+      pull_request: { url: 'https://api.github.com/repos/org/repo/pulls/20', merged_at: '2025-01-01T00:00:00Z' },
+    };
+    const closedIssue = { ...createMockIssue(30, 'Closed issue', 'org/repo'), state: 'closed' };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        items: [
+          createMockPr(10, 'Open PR', 'org/repo'),
+          mergedPr,
+          closedIssue,
+        ],
+      }),
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items.map((item: any) => item.externalId)).toEqual(['org/repo#10', 'org/repo#30']);
+    expect(items.map((item: any) => item.externalId)).not.toContain('org/repo#20');
+  });
+
   it('fetches and attaches related items for mentioned PRs only', async () => {
     const relatedItems = [{ externalId: 'other/repo#99', itemType: 'issue' as const, relation: 'closes' as const }];
     vi.spyOn(provider as any, 'fetchRelatedItemsForPRs').mockResolvedValue(new Map([

--- a/packages/github/src/test/githubMyPrsProvider.test.ts
+++ b/packages/github/src/test/githubMyPrsProvider.test.ts
@@ -88,6 +88,49 @@ describe('GitHubMyPrsProvider', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
+  it('excludes merged PRs from authored and assigned search results', async () => {
+    const openPr = createMockPr(1, 'Open PR');
+    const mergedAuthoredPr = {
+      ...createMockPr(2, 'Merged authored PR'),
+      state: 'closed',
+      pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/2', merged_at: '2025-01-01T00:00:00Z' },
+    };
+    const mergedAssignedPr = {
+      ...createMockPr(3, 'Merged assigned PR', 'other/repo'),
+      state: 'closed',
+      pull_request: { url: 'https://api.github.com/repos/other/repo/pulls/3', merged_at: '2025-01-02T00:00:00Z' },
+    };
+
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('search/issues') && url.includes('author:@me')) {
+        return mockSearchResponse([openPr, mergedAuthoredPr]);
+      }
+      if (url.includes('search/issues') && url.includes('assignee:@me')) {
+        return mockSearchResponse([mergedAssignedPr]);
+      }
+      if (url.endsWith('/pulls/1')) {
+        return mockPrDetailResponse({ draft: false });
+      }
+      if (url.endsWith('/pulls/1/reviews')) {
+        return mockReviewsResponse([]);
+      }
+      return mockFailedResponse(404);
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items).toHaveLength(1);
+    expect(items[0].externalId).toBe('owner/repo#1');
+    expect(items.map((item: any) => item.externalId)).not.toContain('owner/repo#2');
+    expect(items.map((item: any) => item.externalId)).not.toContain('other/repo#3');
+    expect((provider as any).fetchRelatedItemsForPRs).toHaveBeenCalledWith([
+      { externalId: 'owner/repo#1', repoOwner: 'owner', repoName: 'repo', number: 1 },
+    ], 'test-token', expect.any(AbortSignal));
+  });
+
   it('discovers open authored PRs with status', async () => {
     const pr1 = createMockPr(1, 'Fix bug');
     const pr2 = createMockPr(2, 'Add feature');

--- a/packages/github/src/test/githubMyPrsProvider.test.ts
+++ b/packages/github/src/test/githubMyPrsProvider.test.ts
@@ -88,17 +88,15 @@ describe('GitHubMyPrsProvider', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('excludes merged PRs from authored and assigned search results', async () => {
+  it('excludes merged PRs by fetching details for closed authored and assigned search results', async () => {
     const openPr = createMockPr(1, 'Open PR');
     const mergedAuthoredPr = {
       ...createMockPr(2, 'Merged authored PR'),
       state: 'closed',
-      pull_request: { url: 'https://api.github.com/repos/owner/repo/pulls/2', merged_at: '2025-01-01T00:00:00Z' },
     };
     const mergedAssignedPr = {
       ...createMockPr(3, 'Merged assigned PR', 'other/repo'),
       state: 'closed',
-      pull_request: { url: 'https://api.github.com/repos/other/repo/pulls/3', merged_at: '2025-01-02T00:00:00Z' },
     };
 
     mockFetch.mockImplementation(async (url: string) => {
@@ -113,6 +111,12 @@ describe('GitHubMyPrsProvider', () => {
       }
       if (url.endsWith('/pulls/1/reviews')) {
         return mockReviewsResponse([]);
+      }
+      if (url.endsWith('/pulls/2')) {
+        return mockPrDetailResponse({ state: 'closed', merged: true, merged_at: '2025-01-01T00:00:00Z' });
+      }
+      if (url.endsWith('/pulls/3')) {
+        return mockPrDetailResponse({ state: 'closed', merged: true, merged_at: '2025-01-02T00:00:00Z' });
       }
       return mockFailedResponse(404);
     });

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -160,22 +160,31 @@ describe('GitHubPrReviewProvider', () => {
     );
   });
 
-  it('excludes merged PRs from search results before publishing', async () => {
+  it('excludes merged PRs by fetching details for closed search results before publishing', async () => {
     const openPr = { ...createMockPr(42, 'Add feature', 'org/myrepo'), state: 'open' };
     const mergedPr = {
       ...createMockPrWithApi(43, 'Already merged', 'org/myrepo'),
       state: 'closed',
-      pull_request: { url: 'https://api.github.com/repos/org/myrepo/pulls/43', merged_at: '2025-01-01T00:00:00Z' },
     };
     const closedUnmergedPr = {
       ...createMockPrWithApi(44, 'Closed without merge', 'org/myrepo'),
       state: 'closed',
-      merged: false,
     };
 
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ items: [openPr, mergedPr, closedUnmergedPr] }),
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('search/issues')) {
+        return {
+          ok: true,
+          json: async () => ({ items: [openPr, mergedPr, closedUnmergedPr] }),
+        };
+      }
+      if (url.endsWith('/pulls/43')) {
+        return { ok: true, json: async () => ({ state: 'closed', merged: true, merged_at: '2025-01-01T00:00:00Z' }) };
+      }
+      if (url.endsWith('/pulls/44')) {
+        return { ok: true, json: async () => ({ state: 'closed', merged: false, merged_at: null }) };
+      }
+      return { ok: false, status: 404, statusText: 'Not Found' };
     });
 
     const listener = vi.fn();

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -161,7 +161,7 @@ describe('GitHubPrReviewProvider', () => {
   });
 
   it('excludes merged PRs by fetching details for closed search results before publishing', async () => {
-    const openPr = { ...createMockPr(42, 'Add feature', 'org/myrepo'), state: 'open' };
+    const openPr = { ...createMockPrWithApi(42, 'Add feature', 'org/myrepo'), state: 'open' };
     const mergedPr = {
       ...createMockPrWithApi(43, 'Already merged', 'org/myrepo'),
       state: 'closed',

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -160,6 +160,33 @@ describe('GitHubPrReviewProvider', () => {
     );
   });
 
+  it('excludes merged PRs from search results before publishing', async () => {
+    const openPr = { ...createMockPr(42, 'Add feature', 'org/myrepo'), state: 'open' };
+    const mergedPr = {
+      ...createMockPrWithApi(43, 'Already merged', 'org/myrepo'),
+      state: 'closed',
+      pull_request: { url: 'https://api.github.com/repos/org/myrepo/pulls/43', merged_at: '2025-01-01T00:00:00Z' },
+    };
+    const closedUnmergedPr = {
+      ...createMockPrWithApi(44, 'Closed without merge', 'org/myrepo'),
+      state: 'closed',
+      merged: false,
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [openPr, mergedPr, closedUnmergedPr] }),
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    const items = listener.mock.calls[0][0];
+    expect(items.map((item: any) => item.externalId)).toEqual(['org/myrepo#42', 'org/myrepo#44']);
+    expect(items.map((item: any) => item.externalId)).not.toContain('org/myrepo#43');
+  });
+
   it('fires onDidDiscoverItems with correctly mapped DiscoveredItems', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,


### PR DESCRIPTION
## Summary

Drops merged GitHub PRs from the items emitted by the three GitHub PR-surfacing providers, so a merged PR no longer lingers in the **Incoming** tier indefinitely.

## Why

`autoComplete.ts` only operates on items already in the WorkGraph (`New | InProgress | Paused`). Items in the **Incoming** tier haven't been accepted yet — they're still raw `DiscoveredItem`s. The auto-completion path therefore can't help here; the fix has to be provider-side.

Of the three affected providers:
- `GitHubMyPrsProvider` — authored PRs query may include merged ones depending on filters.
- `GitHubPrReviewProvider` — `review-requested:@me` keeps surfacing merged PRs for some time after they merge.
- `GitHubMentionsProvider` — @mentions never expire when a PR merges, so a merged PR you were mentioned in could stay in Incoming indefinitely.

## Fix

Each provider now filters out merged PRs at emit time. Detection is shape-aware:
- **Search-shaped responses** (issues search): `result.pull_request?.merged_at` truthy.
- **REST-shaped PR objects**: `pr.merged_at` truthy, or `pr.state === 'closed' && pr.merged === true`.
- **Closed but not merged** items are preserved (different signal — closed-as-not-planned, etc.).
- A small shared helper in `githubApiHelpers.ts` keeps the detection consistent across providers.

## Out of scope

- Auto-toast notification when a PR merges from Incoming.
- ADO providers (file separately if the same symptom exists there).
- Dropping all closed items (not just merged PRs).

## Changes

- `packages/github/src/githubApiHelpers.ts` — shared `isMergedPr(...)` helper.
- `packages/github/src/githubMyPrsProvider.ts` — filter at assembly.
- `packages/github/src/githubPrReviewProvider.ts` — filter at assembly.
- `packages/github/src/githubMentionsProvider.ts` — filter at assembly.
- `packages/github/src/test/` — per-provider tests asserting merged PRs are excluded; open and closed-not-merged items are still emitted.

## Verification

`cd packages/github && npm run build && npm run test` — 380 tests across 19 files pass.

Closes #513
