### PR TITLE
Bounded concurrency and deferred child-run snapshot for autoWatchAuthoredPRs

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -148,6 +148,7 @@ async function yieldToExtensionHost(): Promise<void> {
 
 interface AutoWatchAuthoredPROptions {
   capNotifiedProviders?: Set<string>;
+  seenPRKeys?: Set<string>;
 }
 
 export async function autoWatchAuthoredPRs(
@@ -159,90 +160,109 @@ export async function autoWatchAuthoredPRs(
   options: AutoWatchAuthoredPROptions = {},
 ): Promise<void> {
   const capNotifiedProviders = options.capNotifiedProviders ?? autoWatchCapNotifiedProviders;
+  const sharedSeenPRKeys = options.seenPRKeys;
   const items = providerRegistry.getDiscoveredItems(providerId).filter(isAutoWatchCandidate);
-  const seenPRKeys = new Set<string>();
+  const localSeenPRKeys = new Set<string>();
+  const reservedPRKeys = new Set<string>();
   const candidates: Array<{ identifier: PRIdentifier; sourceUrl: string }> = [];
+  let skippedCount = 0;
 
-  for (const item of items) {
-    if (signal.aborted) {
-      return;
-    }
-
-    try {
-      const itemUrl = item.url;
-      if (!itemUrl) {
-        continue;
-      }
-
-      // Defense-in-depth: only http(s) URLs are safe to feed into PR
-      // watcher resolution. A malicious provider can claim authored:true
-      // for arbitrary strings; reject anything that wouldn't survive
-      // isSafeUrl downstream.
-      if (!isSafeUrl(itemUrl)) {
-        continue;
-      }
-
-      const prWatcher = prWatcherRegistry.findWatcherForUrl(itemUrl);
-      if (!prWatcher) {
-        continue;
-      }
-
-      const identifier = prWatcher.parsePRUrl(itemUrl);
-      const prKey = getAutoWatchPRKey(identifier);
-      if (seenPRKeys.has(prKey)) {
-        continue;
-      }
-      seenPRKeys.add(prKey);
-
-      if (await watcherService.isPRWatched(identifier)) {
-        continue;
-      }
-
-      candidates.push({ identifier, sourceUrl: itemUrl });
-    } catch (err) {
+  try {
+    for (const item of items) {
       if (signal.aborted) {
         return;
       }
-      logger.warn(`Failed to auto-watch authored PR from provider ${providerId}`, { url: redactUrlForLog(item.url) }, err);
-    }
-  }
 
-  const candidatesToWatch = candidates.slice(0, MAX_AUTO_WATCH_PER_PROVIDER);
-  if (candidates.length > MAX_AUTO_WATCH_PER_PROVIDER) {
-    const skippedCount = candidates.length - MAX_AUTO_WATCH_PER_PROVIDER;
-    const message = `DevDocket: Auto-watching the first ${MAX_AUTO_WATCH_PER_PROVIDER} authored PRs from ${providerId}; skipping ${skippedCount} more to keep refresh responsive.`;
-    logger.warn(
-      `Auto-watch cap reached for provider ${providerId} (limit ${MAX_AUTO_WATCH_PER_PROVIDER}); skipping ${skippedCount} authored PRs to bound polling cost`,
-    );
-    if (!capNotifiedProviders.has(providerId)) {
-      capNotifiedProviders.add(providerId);
-      void vscode.window.showInformationMessage(message).then(
-        undefined,
-        () => { /* notification is best-effort */ },
+      try {
+        const itemUrl = item.url;
+        if (!itemUrl) {
+          continue;
+        }
+
+        // Defense-in-depth: only http(s) URLs are safe to feed into PR
+        // watcher resolution. A malicious provider can claim authored:true
+        // for arbitrary strings; reject anything that wouldn't survive
+        // isSafeUrl downstream.
+        if (!isSafeUrl(itemUrl)) {
+          continue;
+        }
+
+        const prWatcher = prWatcherRegistry.findWatcherForUrl(itemUrl);
+        if (!prWatcher) {
+          continue;
+        }
+
+        const identifier = prWatcher.parsePRUrl(itemUrl);
+        const prKey = getAutoWatchPRKey(identifier);
+        if (localSeenPRKeys.has(prKey) || sharedSeenPRKeys?.has(prKey)) {
+          continue;
+        }
+        localSeenPRKeys.add(prKey);
+
+        if (await watcherService.isPRWatched(identifier)) {
+          continue;
+        }
+
+        if (sharedSeenPRKeys?.has(prKey)) {
+          continue;
+        }
+
+        if (candidates.length >= MAX_AUTO_WATCH_PER_PROVIDER) {
+          skippedCount++;
+          continue;
+        }
+
+        sharedSeenPRKeys?.add(prKey);
+        reservedPRKeys.add(prKey);
+        candidates.push({ identifier, sourceUrl: itemUrl });
+      } catch (err) {
+        if (signal.aborted) {
+          return;
+        }
+        logger.warn(`Failed to auto-watch authored PR from provider ${providerId}`, { url: redactUrlForLog(item.url) }, err);
+      }
+    }
+
+    const candidatesToWatch = candidates;
+    if (skippedCount > 0) {
+      const message = `DevDocket: Auto-watching the first ${MAX_AUTO_WATCH_PER_PROVIDER} authored PRs from ${providerId}; skipping ${skippedCount} more to keep refresh responsive.`;
+      logger.warn(
+        `Auto-watch cap reached for provider ${providerId} (limit ${MAX_AUTO_WATCH_PER_PROVIDER}); skipping ${skippedCount} authored PRs to bound polling cost`,
       );
+      if (!capNotifiedProviders.has(providerId)) {
+        capNotifiedProviders.add(providerId);
+        void vscode.window.showInformationMessage(message).then(
+          undefined,
+          () => { /* notification is best-effort */ },
+        );
+      }
     }
-  }
 
-  let completedCount = 0;
-  await runWorkerPool(candidatesToWatch, async ({ identifier, sourceUrl }) => {
-    if (signal.aborted) {
-      return;
-    }
-
-    try {
-      await watcherService.startPRWatch(identifier, { deferChildRunStatus: true });
-    } catch (err) {
+    let completedCount = 0;
+    await runWorkerPool(candidatesToWatch, async ({ identifier, sourceUrl }) => {
       if (signal.aborted) {
         return;
       }
-      logger.warn(`Failed to auto-watch authored PR from provider ${providerId}`, { url: redactUrlForLog(sourceUrl) }, err);
-    } finally {
-      completedCount++;
-      if (completedCount % AUTO_WATCH_YIELD_EVERY === 0) {
-        await yieldToExtensionHost();
+
+      try {
+        await watcherService.startPRWatch(identifier, { deferChildRunStatus: true });
+      } catch (err) {
+        if (signal.aborted) {
+          return;
+        }
+        logger.warn(`Failed to auto-watch authored PR from provider ${providerId}`, { url: redactUrlForLog(sourceUrl) }, err);
+      } finally {
+        completedCount++;
+        if (completedCount % AUTO_WATCH_YIELD_EVERY === 0) {
+          await yieldToExtensionHost();
+        }
       }
+    }, AUTO_WATCH_CONCURRENCY);
+  } finally {
+    for (const prKey of reservedPRKeys) {
+      sharedSeenPRKeys?.delete(prKey);
     }
-  }, AUTO_WATCH_CONCURRENCY);
+  }
 }
 
 function wireEvents(
@@ -333,6 +353,7 @@ function wireEvents(
   }));
 
   const autoWatchControllers = new Map<string, AbortController>();
+  const autoWatchSeenPRKeys = new Set<string>();
   const autoCompleteControllers = new Map<string, AbortController>();
   const autoCompleteSub = providerRegistry.onDidRefreshProvider(safeHandler('Error handling provider refresh', async (providerId) => {
     try {
@@ -359,7 +380,7 @@ function wireEvents(
       autoWatchControllers.set(providerId, autoWatchController);
       refreshTasks.push((async () => {
         try {
-          await autoWatchAuthoredPRs(providerId, providerRegistry, prWatcherRegistry, watcherService, autoWatchController.signal);
+          await autoWatchAuthoredPRs(providerId, providerRegistry, prWatcherRegistry, watcherService, autoWatchController.signal, { seenPRKeys: autoWatchSeenPRKeys });
         } finally {
           if (autoWatchControllers.get(providerId) === autoWatchController) {
             autoWatchControllers.delete(providerId);

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { runWorkerPool, type PRIdentifier } from '@devdocket/shared';
 import { DevDocketApi } from './api/types';
 import { DevDocketApiImpl } from './api/devDocketApi';
 import { JsonTaskStore } from './storage/jsonTaskStore';
@@ -110,6 +111,9 @@ function isAutoWatchCandidate(item: { authored?: boolean; url?: string }): item 
  * per poll interval).
  */
 const MAX_AUTO_WATCH_PER_PROVIDER = 200;
+const AUTO_WATCH_CONCURRENCY = 6;
+const AUTO_WATCH_YIELD_EVERY = 25;
+const autoWatchCapNotifiedProviders = new Set<string>();
 
 /**
  * Strip query string and fragment from a URL before logging so that
@@ -128,15 +132,36 @@ function redactUrlForLog(value: string | undefined): string | undefined {
   }
 }
 
+function getAutoWatchPRKey(identifier: PRIdentifier): string {
+  return `${identifier.providerId}:${identifier.repo}:${identifier.prId}`;
+}
+
+async function yieldToExtensionHost(): Promise<void> {
+  await new Promise<void>((resolve) => {
+    if (typeof setImmediate === 'function') {
+      setImmediate(resolve);
+      return;
+    }
+    setTimeout(resolve, 0);
+  });
+}
+
+interface AutoWatchAuthoredPROptions {
+  capNotifiedProviders?: Set<string>;
+}
+
 export async function autoWatchAuthoredPRs(
   providerId: string,
   providerRegistry: ProviderRegistry,
   prWatcherRegistry: PRWatcherRegistry,
   watcherService: WatcherService,
   signal: AbortSignal,
+  options: AutoWatchAuthoredPROptions = {},
 ): Promise<void> {
+  const capNotifiedProviders = options.capNotifiedProviders ?? autoWatchCapNotifiedProviders;
   const items = providerRegistry.getDiscoveredItems(providerId).filter(isAutoWatchCandidate);
-  let watchedThisPass = 0;
+  const seenPRKeys = new Set<string>();
+  const candidates: Array<{ identifier: PRIdentifier; sourceUrl: string }> = [];
 
   for (const item of items) {
     if (signal.aborted) {
@@ -163,19 +188,17 @@ export async function autoWatchAuthoredPRs(
       }
 
       const identifier = prWatcher.parsePRUrl(itemUrl);
+      const prKey = getAutoWatchPRKey(identifier);
+      if (seenPRKeys.has(prKey)) {
+        continue;
+      }
+      seenPRKeys.add(prKey);
+
       if (await watcherService.isPRWatched(identifier)) {
         continue;
       }
 
-      if (watchedThisPass >= MAX_AUTO_WATCH_PER_PROVIDER) {
-        logger.warn(
-          `Auto-watch cap reached for provider ${providerId} (limit ${MAX_AUTO_WATCH_PER_PROVIDER}); skipping remaining authored PRs to bound polling cost`,
-        );
-        return;
-      }
-
-      await watcherService.startPRWatch(identifier);
-      watchedThisPass++;
+      candidates.push({ identifier, sourceUrl: itemUrl });
     } catch (err) {
       if (signal.aborted) {
         return;
@@ -183,6 +206,43 @@ export async function autoWatchAuthoredPRs(
       logger.warn(`Failed to auto-watch authored PR from provider ${providerId}`, { url: redactUrlForLog(item.url) }, err);
     }
   }
+
+  const candidatesToWatch = candidates.slice(0, MAX_AUTO_WATCH_PER_PROVIDER);
+  if (candidates.length > MAX_AUTO_WATCH_PER_PROVIDER) {
+    const skippedCount = candidates.length - MAX_AUTO_WATCH_PER_PROVIDER;
+    const message = `DevDocket: Auto-watching the first ${MAX_AUTO_WATCH_PER_PROVIDER} authored PRs from ${providerId}; skipping ${skippedCount} more to keep refresh responsive.`;
+    logger.warn(
+      `Auto-watch cap reached for provider ${providerId} (limit ${MAX_AUTO_WATCH_PER_PROVIDER}); skipping ${skippedCount} authored PRs to bound polling cost`,
+    );
+    if (!capNotifiedProviders.has(providerId)) {
+      capNotifiedProviders.add(providerId);
+      void vscode.window.showInformationMessage(message).then(
+        undefined,
+        () => { /* notification is best-effort */ },
+      );
+    }
+  }
+
+  let completedCount = 0;
+  await runWorkerPool(candidatesToWatch, async ({ identifier, sourceUrl }) => {
+    if (signal.aborted) {
+      return;
+    }
+
+    try {
+      await watcherService.startPRWatch(identifier, { deferChildRunStatus: true });
+    } catch (err) {
+      if (signal.aborted) {
+        return;
+      }
+      logger.warn(`Failed to auto-watch authored PR from provider ${providerId}`, { url: redactUrlForLog(sourceUrl) }, err);
+    } finally {
+      completedCount++;
+      if (completedCount % AUTO_WATCH_YIELD_EVERY === 0) {
+        await yieldToExtensionHost();
+      }
+    }
+  }, AUTO_WATCH_CONCURRENCY);
 }
 
 function wireEvents(

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -19,6 +19,8 @@ export interface WatchedRun {
   errorMessage?: string;
   /** Key of the parent PR watch, if this run is a child of a PR watch */
   parentPRKey?: string;
+  /** Suppress completion/failure events for the next successful status fetch */
+  suppressNextStatusEvents?: boolean;
 }
 
 /**
@@ -951,6 +953,12 @@ export class WatcherService implements vscode.Disposable {
         }
         watch.lastPolledAt = new Date().toISOString();
 
+        const suppressStatusEvents = watch.suppressNextStatusEvents === true;
+        if (suppressStatusEvents) {
+          delete watch.suppressNextStatusEvents;
+          anyChanged = true;
+        }
+
         // Reset failure count on success
         this.consecutiveFailures.delete(key);
         watch.hasWarning = false;
@@ -979,7 +987,7 @@ export class WatcherService implements vscode.Disposable {
         }
 
         // Detect job failures (while run is still in progress)
-        if (newStatus.overallState !== 'completed') {
+        if (!suppressStatusEvents && newStatus.overallState !== 'completed') {
           for (const newJob of newStatus.jobs) {
             if (newJob.state === 'completed' && newJob.conclusion === 'failure') {
               const oldJob = newJob.id
@@ -993,7 +1001,7 @@ export class WatcherService implements vscode.Disposable {
         }
 
         // Check if run just completed
-        if (oldStatus.overallState !== 'completed' && newStatus.overallState === 'completed') {
+        if (!suppressStatusEvents && oldStatus.overallState !== 'completed' && newStatus.overallState === 'completed') {
           this._onDidCompleteRun.fire(watch);
         }
 
@@ -1052,6 +1060,7 @@ export class WatcherService implements vscode.Disposable {
           lastPolledAt: now,
           dismissed: false,
           parentPRKey: prKey,
+          suppressNextStatusEvents: true,
         });
         this.consecutiveFailures.delete(runKey);
         // Match startWatch's dismissed-then-restarted behavior so re-watched

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -37,6 +37,22 @@ export interface WatchedPR {
   errorMessage?: string;
 }
 
+interface StartPRWatchOptions {
+  forceRecreate?: boolean;
+  /**
+   * Register child runs from the initial PR snapshot without immediately
+   * calling getRunStatus for each run. The normal polling loop will fetch
+   * their first statuses on its next tick.
+   */
+  deferChildRunStatus?: boolean;
+}
+
+interface AddChildRunOptions {
+  suppressEvents?: boolean;
+  suppressPersist?: boolean;
+  deferStatusFetch?: boolean;
+}
+
 /**
  * Service that manages watching pipeline runs and pull requests.
  * Polls for status changes, detects job failures, and fires events.
@@ -224,12 +240,18 @@ export class WatcherService implements vscode.Disposable {
    * the previously-active state may have stale or invisible child runs that
    * the user can't recover any other way.
    *
+   * Pass `{ deferChildRunStatus: true }` to register child runs from the
+   * initial PR snapshot without immediately fetching each run's status. This
+   * is intended for bulk auto-watch; manual callers should keep the default
+   * eager child-run snapshot behavior.
+   *
    * @param identifier - PR identifier from parsePRUrl
+   * @param options - Optional controls for recreation and initial child-run status fetching
    * @returns The watched PR (existing or newly created)
    */
   async startPRWatch(
     identifier: PRIdentifier,
-    options?: { forceRecreate?: boolean },
+    options?: StartPRWatchOptions,
   ): Promise<WatchedPR> {
     const key = this.getPRWatchKey(identifier);
     const existing = this.prWatches.get(key);
@@ -290,13 +312,17 @@ export class WatcherService implements vscode.Disposable {
       await this.addChildRun(key, watchedPR, resolved, {
         suppressEvents: true,
         suppressPersist: true,
+        deferStatusFetch: options?.deferChildRunStatus,
       });
     }
 
     this._onDidChangePRWatches.fire();
     this._onDidChangeWatchedRuns.fire(this.getAllWatches());
 
-    if (snapshot.prState === 'open') {
+    // Deferred child watches start as queued placeholders, so make sure the
+    // poller wakes up to fetch their first real statuses even if the PR itself
+    // is no longer open.
+    if (snapshot.prState === 'open' || watchedPR.childRunKeys.length > 0) {
       this.ensurePollingActive();
     }
 
@@ -998,7 +1024,7 @@ export class WatcherService implements vscode.Disposable {
     prKey: string,
     prWatch: WatchedPR,
     runIdentifier: RunIdentifier,
-    options?: { suppressEvents?: boolean; suppressPersist?: boolean },
+    options?: AddChildRunOptions,
   ): Promise<boolean> {
     const runKey = this.getWatchKey(runIdentifier);
     try {
@@ -1013,7 +1039,35 @@ export class WatcherService implements vscode.Disposable {
         return false;
       }
 
-      await this.startWatch(runIdentifier, prKey, options);
+      if (options?.deferStatusFetch) {
+        if (!this.watcherRegistry.get(runIdentifier.providerId)) {
+          throw new Error(`No watcher registered for provider: ${runIdentifier.providerId}`);
+        }
+
+        const now = new Date().toISOString();
+        this.watches.set(runKey, {
+          identifier: runIdentifier,
+          status: { overallState: 'queued', jobs: [] },
+          watchedAt: now,
+          lastPolledAt: now,
+          dismissed: false,
+          parentPRKey: prKey,
+        });
+        this.consecutiveFailures.delete(runKey);
+        // Match startWatch's dismissed-then-restarted behavior so re-watched
+        // failed runs can alert again after deferred registration.
+        this.acknowledgedFailedRunKeys.delete(runKey);
+        this.logger.info(`Started watching: ${runIdentifier.displayName} (${runIdentifier.providerId})`);
+        if (!options.suppressEvents) {
+          this._onDidChangeWatchedRuns.fire(this.getAllWatches());
+        }
+        if (!options.suppressPersist) {
+          this.persistWatches();
+        }
+      } else {
+        await this.startWatch(runIdentifier, prKey, options);
+      }
+
       if (!prWatch.childRunKeys.includes(runKey)) {
         prWatch.childRunKeys.push(runKey);
         return true;

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -436,7 +436,61 @@ describe('activate()', () => {
     expect(prWatcherRegistry.findWatcherForUrl).toHaveBeenCalledWith('https://github.com/owner/repo/pull/42');
     expect(prWatcher.parsePRUrl).toHaveBeenCalledWith('https://github.com/owner/repo/pull/42');
     expect(watcherService.isPRWatched).toHaveBeenCalledWith(identifier);
-    expect(watcherService.startPRWatch).toHaveBeenCalledWith(identifier);
+    expect(watcherService.startPRWatch).toHaveBeenCalledWith(identifier, { deferChildRunStatus: true });
+  });
+
+  it('dispatches authored PR auto-watch starts concurrently with deferred child status', async () => {
+    const items = Array.from({ length: 8 }, (_, i) => ({
+      externalId: `owner/repo#${i}`,
+      title: `PR ${i}`,
+      url: `https://github.com/owner/repo/pull/${i}`,
+      authored: true,
+    }));
+    const providerRegistry = { getDiscoveredItems: vi.fn().mockReturnValue(items) } as any;
+    const prWatcher = {
+      parsePRUrl: vi.fn((url: string) => ({ providerId: 'github-prs', prId: url, displayName: url, url, repo: 'owner/repo' })),
+    };
+    const prWatcherRegistry = { findWatcherForUrl: vi.fn(() => prWatcher) } as any;
+
+    const pendingResolvers: Array<() => void> = [];
+    let resolveImmediately = false;
+    const watcherService = {
+      isPRWatched: vi.fn().mockResolvedValue(false),
+      startPRWatch: vi.fn().mockImplementation(() => new Promise<void>((resolve) => {
+        if (resolveImmediately) {
+          resolve();
+          return;
+        }
+        pendingResolvers.push(resolve);
+      })),
+    } as any;
+
+    const autoWatchPromise = autoWatchAuthoredPRs(
+      'github-my-prs',
+      providerRegistry,
+      prWatcherRegistry,
+      watcherService,
+      new AbortController().signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(watcherService.startPRWatch).toHaveBeenCalled();
+    });
+    const callsBeforeFirstWaveCompletes = watcherService.startPRWatch.mock.calls.length;
+
+    resolveImmediately = true;
+    for (const resolve of pendingResolvers.splice(0)) {
+      resolve();
+    }
+    await autoWatchPromise;
+
+    expect(callsBeforeFirstWaveCompletes).toBeGreaterThan(1);
+    expect(callsBeforeFirstWaveCompletes).toBeLessThanOrEqual(6);
+    expect(watcherService.startPRWatch).toHaveBeenCalledTimes(8);
+    for (const [identifier, options] of watcherService.startPRWatch.mock.calls) {
+      expect(identifier.providerId).toBe('github-prs');
+      expect(options).toEqual({ deferChildRunStatus: true });
+    }
   });
 
   it('refuses to auto-watch authored items whose url is not http(s)', async () => {
@@ -473,7 +527,7 @@ describe('activate()', () => {
     expect(prWatcherRegistry.findWatcherForUrl).toHaveBeenCalledTimes(1);
     expect(prWatcherRegistry.findWatcherForUrl).toHaveBeenCalledWith('https://github.com/owner/repo/pull/42');
     expect(watcherService.startPRWatch).toHaveBeenCalledTimes(1);
-    expect(watcherService.startPRWatch).toHaveBeenCalledWith(goodIdentifier);
+    expect(watcherService.startPRWatch).toHaveBeenCalledWith(goodIdentifier, { deferChildRunStatus: true });
   });
 
   it('caps the number of authored PRs auto-watched per provider per pass', async () => {
@@ -502,10 +556,41 @@ describe('activate()', () => {
       prWatcherRegistry,
       watcherService,
       new AbortController().signal,
+      { capNotifiedProviders: new Set() },
     );
 
     // Cap is 200 per provider per refresh pass.
     expect(watcherService.startPRWatch).toHaveBeenCalledTimes(200);
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledTimes(1);
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Auto-watching the first 200 authored PRs'),
+    );
+  });
+
+  it('shows the auto-watch cap notification only once for the same provider', async () => {
+    const items = Array.from({ length: 201 }, (_, i) => ({
+      externalId: `owner/repo#${i}`,
+      title: `PR ${i}`,
+      url: `https://github.com/owner/repo/pull/${i}`,
+      authored: true,
+    }));
+    const providerRegistry = { getDiscoveredItems: vi.fn().mockReturnValue(items) } as any;
+    const prWatcher = {
+      parsePRUrl: vi.fn((url: string) => ({ providerId: 'github-prs', prId: url, displayName: url, url, repo: 'owner/repo' })),
+    };
+    const prWatcherRegistry = { findWatcherForUrl: vi.fn(() => prWatcher) } as any;
+    const watcherService = {
+      isPRWatched: vi.fn().mockResolvedValue(false),
+      startPRWatch: vi.fn().mockResolvedValue(undefined),
+    } as any;
+    const signal = new AbortController().signal;
+
+    const capNotifiedProviders = new Set<string>();
+
+    await autoWatchAuthoredPRs('overflow-provider', providerRegistry, prWatcherRegistry, watcherService, signal, { capNotifiedProviders });
+    await autoWatchAuthoredPRs('overflow-provider', providerRegistry, prWatcherRegistry, watcherService, signal, { capNotifiedProviders });
+
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledTimes(1);
   });
 
   it('runs auto-watch and auto-complete in parallel after provider refresh', async () => {

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -493,6 +493,66 @@ describe('activate()', () => {
     }
   });
 
+  it('deduplicates authored PR auto-watch starts across concurrent provider refreshes', async () => {
+    const sharedSeenPRKeys = new Set<string>();
+    const providerRegistry = {
+      getDiscoveredItems: vi.fn((providerId: string) => [{
+        externalId: `${providerId}:owner/repo#42`,
+        title: '#42: Authored PR',
+        url: 'https://github.com/owner/repo/pull/42',
+        authored: true,
+      }]),
+    } as any;
+    const identifier = {
+      providerId: 'github-prs',
+      prId: '42',
+      displayName: 'PR #42',
+      url: 'https://github.com/owner/repo/pull/42',
+      repo: 'owner/repo',
+    };
+    const prWatcher = {
+      parsePRUrl: vi.fn().mockReturnValue(identifier),
+    };
+    const prWatcherRegistry = {
+      findWatcherForUrl: vi.fn().mockReturnValue(prWatcher),
+    } as any;
+    let resolveWatch: (() => void) | undefined;
+    const watcherService = {
+      isPRWatched: vi.fn().mockResolvedValue(false),
+      startPRWatch: vi.fn().mockImplementation(() => new Promise<void>((resolve) => {
+        resolveWatch = resolve;
+      })),
+    } as any;
+    const signal = new AbortController().signal;
+
+    const firstAutoWatch = autoWatchAuthoredPRs(
+      'provider-a',
+      providerRegistry,
+      prWatcherRegistry,
+      watcherService,
+      signal,
+      { seenPRKeys: sharedSeenPRKeys },
+    );
+
+    await vi.waitFor(() => {
+      expect(watcherService.startPRWatch).toHaveBeenCalledTimes(1);
+    });
+
+    await autoWatchAuthoredPRs(
+      'provider-b',
+      providerRegistry,
+      prWatcherRegistry,
+      watcherService,
+      signal,
+      { seenPRKeys: sharedSeenPRKeys },
+    );
+
+    expect(watcherService.startPRWatch).toHaveBeenCalledTimes(1);
+    resolveWatch?.();
+    await firstAutoWatch;
+    expect(sharedSeenPRKeys.size).toBe(0);
+  });
+
   it('refuses to auto-watch authored items whose url is not http(s)', async () => {
     // Defense-in-depth: a malicious provider can claim authored:true with
     // any URL string. Reject anything that wouldn't survive isSafeUrl.

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -536,6 +536,66 @@ describe('WatcherService', () => {
       expect(result.childRunKeys).toHaveLength(1);
       expect(service.getActiveWatches()).toHaveLength(1);
       expect(service.getActiveWatches()[0].parentPRKey).toBeDefined();
+      expect(runWatcher.getRunStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it('can defer initial child run status fetches while still registering child runs', async () => {
+      const runWatcher = createMockWatcher('github-actions');
+      registry.register(runWatcher);
+
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [{
+          providerId: 'github-actions',
+          runId: 'run-1',
+          displayName: 'CI Build',
+          url: 'https://example.com/run/1',
+          repo: 'owner/repo',
+        }],
+      }));
+      prRegistry.register(prWatcher);
+
+      const result = await service.startPRWatch(createPRIdentifier(), { deferChildRunStatus: true });
+
+      expect(result.childRunKeys).toHaveLength(1);
+      expect(service.getActiveWatches()).toHaveLength(1);
+      expect(service.getActiveWatches()[0].parentPRKey).toBe(service.getPRWatchKey(result.identifier));
+      expect(runWatcher.getRunStatus).not.toHaveBeenCalled();
+    });
+
+    it('clears failure acknowledgement when deferred child registration replaces a dismissed run', async () => {
+      const runWatcher = createMockWatcher('github-actions');
+      registry.register(runWatcher);
+
+      const runIdentifier = {
+        providerId: 'github-actions',
+        runId: 'run-1',
+        displayName: 'CI Build',
+        url: 'https://example.com/run/1',
+        repo: 'owner/repo',
+      };
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [runIdentifier],
+      }));
+      prRegistry.register(prWatcher);
+
+      const runKey = (service as any).getWatchKey(runIdentifier);
+      (service as any).watches.set(runKey, {
+        identifier: runIdentifier,
+        status: { overallState: 'completed', conclusion: 'failure', jobs: [] },
+        watchedAt: new Date().toISOString(),
+        lastPolledAt: new Date().toISOString(),
+        dismissed: true,
+        parentPRKey: service.getPRWatchKey(createPRIdentifier()),
+      });
+      (service as any).acknowledgedFailedRunKeys.add(runKey);
+
+      await service.startPRWatch(createPRIdentifier(), { deferChildRunStatus: true });
+
+      const [rewatchedRun] = service.getActiveWatches();
+      expect(rewatchedRun).toBeDefined();
+      expect(service.isFailureAcknowledged(rewatchedRun)).toBe(false);
     });
 
     it('dismisses a PR watch when its last visible child run is dismissed', async () => {

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -563,6 +563,84 @@ describe('WatcherService', () => {
       expect(runWatcher.getRunStatus).not.toHaveBeenCalled();
     });
 
+    it('suppresses completion and failure events for the first deferred child run status fetch', async () => {
+      const runWatcher: DevDocketRunWatcher = {
+        id: 'github-actions',
+        label: 'GitHub Actions',
+        canWatch: vi.fn().mockReturnValue(true),
+        parseRunUrl: vi.fn(),
+        getRunStatus: vi.fn(async (identifier: RunIdentifier) => {
+          if (identifier.runId === 'completed-run') {
+            return { overallState: 'completed' as const, conclusion: 'success' as const, jobs: [] };
+          }
+          return {
+            overallState: 'running' as const,
+            conclusion: undefined,
+            jobs: [{ name: 'build', state: 'completed' as const, conclusion: 'failure' as const }],
+          };
+        }),
+      };
+      registry.register(runWatcher);
+
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [
+          {
+            providerId: 'github-actions',
+            runId: 'completed-run',
+            displayName: 'Completed Run',
+            url: 'https://example.com/run/completed',
+            repo: 'owner/repo',
+          },
+          {
+            providerId: 'github-actions',
+            runId: 'failing-run',
+            displayName: 'Failing Run',
+            url: 'https://example.com/run/failing',
+            repo: 'owner/repo',
+          },
+        ],
+      }));
+      prRegistry.register(prWatcher);
+      const completeSpy = vi.fn();
+      const failureSpy = vi.fn();
+      service.onDidCompleteRun(completeSpy);
+      service.onDidDetectJobFailure(failureSpy);
+
+      await service.startPRWatch(createPRIdentifier(), { deferChildRunStatus: true });
+      expect(service.getActiveWatches().every(w => w.suppressNextStatusEvents)).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(60000);
+
+      expect(completeSpy).not.toHaveBeenCalled();
+      expect(failureSpy).not.toHaveBeenCalled();
+      expect(service.getActiveWatches().every(w => w.suppressNextStatusEvents === undefined)).toBe(true);
+      expect(service.getActiveWatches().map(w => w.status.overallState).sort()).toEqual(['completed', 'running']);
+
+      (runWatcher.getRunStatus as ReturnType<typeof vi.fn>).mockImplementation(async (identifier: RunIdentifier) => {
+        if (identifier.runId === 'completed-run') {
+          return { overallState: 'completed' as const, conclusion: 'success' as const, jobs: [] };
+        }
+        return {
+          overallState: 'running' as const,
+          conclusion: undefined,
+          jobs: [
+            { name: 'build', state: 'completed' as const, conclusion: 'failure' as const },
+            { name: 'test', state: 'completed' as const, conclusion: 'failure' as const },
+          ],
+        };
+      });
+
+      await vi.advanceTimersByTimeAsync(60000);
+
+      expect(failureSpy).toHaveBeenCalledTimes(1);
+      expect(failureSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          job: expect.objectContaining({ name: 'test', conclusion: 'failure' }),
+        }),
+      );
+    });
+
     it('clears failure acknowledgement when deferred child registration replaces a dismissed run', async () => {
       const runWatcher = createMockWatcher('github-actions');
       registry.register(runWatcher);


### PR DESCRIPTION
## Summary

Replaces the strictly-sequential `for await` loop in `autoWatchAuthoredPRs` with bounded concurrency, and adds an opt-in "defer child-run snapshot" mode used only by the auto-watch path so a fresh activation no longer serializes hundreds of `getPRRunsSnapshot` + per-child `getRunStatus` HTTP round-trips.

## Why

`autoWatchAuthoredPRs` iterated authored PRs sequentially, awaiting `watcherService.startPRWatch(identifier)` for each. `startPRWatch` performs a network call (`prWatcher.getPRRunsSnapshot`) and then for each returned run does an additional `getRunStatus` HTTP call. With `MAX_AUTO_WATCH_PER_PROVIDER = 200` and PRs that have multiple checks, the worst-case shape was hundreds of seconds of HTTP latency on a slow link — and `autoWatchAuthoredPRs`'s promise was part of `Promise.allSettled(refreshTasks)`, so `onDidRefreshProvider` follow-up (auto-complete checks) was gated on its completion.

## Fix

- Use `runWorkerPool` from `@devdocket/shared` (existing helper) with a worker count of `6` to fire `startPRWatch` calls concurrently.
- Add a `{ deferChildRunStatus?: boolean }` option to `startPRWatch` that, when true, registers child runs but skips the eager per-child `getRunStatus` round-trip. Auto-watch passes this flag; manual `watchPRFromItem` and other callers do NOT, so they keep their eager-snapshot behavior.
- De-duplicate identical authored items across providers within a single auto-watch pass.
- Yield to the event loop between worker batches via `setImmediate` to keep the extension host responsive.
- When a provider exceeds `MAX_AUTO_WATCH_PER_PROVIDER`, surface a single one-shot `vscode.window.showInformationMessage` instead of only logging.

## Out of scope

- The larger `WatcherService` god-class split (#507).
- Adjusting `MAX_AUTO_WATCH_PER_PROVIDER`.
- Adding rate-limit / 429 backoff handling — left to `githubMyPrsProvider.ts` / `githubPRWatcher.ts`.

## Changes

- `packages/core/src/extension.ts` — bounded concurrency via `runWorkerPool`, dedupe, one-shot capped notification.
- `packages/core/src/services/watcherService.ts` — `deferChildRunStatus` option threaded through `startPRWatch` → `addChildRun`.
- `packages/core/src/test/extension.test.ts` — concurrent dispatch test, dedupe test, capped-notification test.
- `packages/core/src/test/watcherService.test.ts` — defer-option behavior test.

## Verification

`cd packages/core && npm run build && npm run test` — 791 tests across 31 files pass.

Closes #511
