### PR TITLE
Surface active CI Watch info inline in the work item editor

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -459,7 +459,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   // Scope panel cache to extension lifecycle
   const panelManager = new PanelManager();
   WorkItemEditorPanel.setPanelManager(panelManager);
-  WorkItemEditorPanel.setDependencies(ar, ss);
+  WorkItemEditorPanel.setDependencies(ar, ss, ws);
 
   // panelManager must be first: its dispose() flushes pending saves via
   // WorkGraph, which must still be alive at that point. VS Code disposes

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -521,6 +521,15 @@ export class WatcherService implements vscode.Disposable {
   }
 
   /**
+   * Find an active PR watch by repository and PR ID, ignoring watcher provider.
+   */
+  findPRWatchByExternalId(repo: string, prId: string): WatchedPR | undefined {
+    return Array.from(this.prWatches.values()).find(
+      pr => !pr.dismissed && pr.identifier.repo === repo && pr.identifier.prId === prId,
+    );
+  }
+
+  /**
    * Check whether a PR is currently being actively watched (in memory and
    * not dismissed). In contrast with {@link isPRWatched}, this excludes
    * dismissed entries — useful for distinguishing "already actively watching"

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -469,6 +469,18 @@ describe('WatcherService', () => {
       expect(changeSpy).toHaveBeenCalled();
     });
 
+    it('finds active PR watches by repo and PR id without matching provider id', async () => {
+      const prWatcher = createMockPRWatcher('github-pr-watcher');
+      prRegistry.register(prWatcher);
+      const watch = await service.startPRWatch(createPRIdentifier('github-pr-watcher'));
+
+      expect(service.findPRWatchByExternalId('owner/repo', '42')).toBe(watch);
+      expect(service.findPRWatchByExternalId('owner/repo', '99')).toBeUndefined();
+
+      service.dismissPRWatch(watch.identifier);
+      expect(service.findPRWatchByExternalId('owner/repo', '42')).toBeUndefined();
+    });
+
     it('is idempotent when already watching the same PR (returns existing)', async () => {
       const prWatcher = createMockPRWatcher();
       prRegistry.register(prWatcher);

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -194,7 +194,7 @@ function createMockWatcherService(initialWatch?: any, initialRuns: any[] = []) {
     _setWatch: (nextWatch: any) => { watch = nextWatch; },
     _setRuns: (nextRuns: any[]) => { runs = [...nextRuns]; },
     _firePRWatchesChange: () => prEmitter.fire(),
-    _fireWatchedRunsChange: () => runEmitter.fire(runs),
+    _fireWatchedRunsChange: (changedRuns = runs) => runEmitter.fire(changedRuns),
   };
 }
 
@@ -434,6 +434,39 @@ describe('WorkItemEditorPanel', () => {
         }),
       }),
     }));
+  });
+
+  it('ignores PR watch changes when the current PR watch state is unchanged', () => {
+    const item = makeItem({ providerId: 'github-my-prs', externalId: 'owner/repo#42', itemType: 'pr' });
+    const watcherService = createMockWatcherService(makeWatchedPR(), [makeWatchedRun()]);
+    const { mock } = openPanel(item, createMockWorkGraph(item), createMockProviderRegistry(), createMockActionRegistry(), createMockStateStore(), watcherService);
+    vi.mocked(mock.panel.webview.postMessage).mockClear();
+
+    watcherService._firePRWatchesChange();
+
+    expect(mock.panel.webview.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('ignores watched run changes that do not affect the current PR watch', () => {
+    const item = makeItem({ providerId: 'github-my-prs', externalId: 'owner/repo#42', itemType: 'pr' });
+    const watcherService = createMockWatcherService(makeWatchedPR(), [makeWatchedRun()]);
+    const { mock } = openPanel(item, createMockWorkGraph(item), createMockProviderRegistry(), createMockActionRegistry(), createMockStateStore(), watcherService);
+    vi.mocked(mock.panel.webview.postMessage).mockClear();
+
+    watcherService._fireWatchedRunsChange([
+      makeWatchedRun({
+        identifier: {
+          providerId: 'github-actions',
+          runId: 'run-99',
+          displayName: 'unrelated',
+          repo: 'owner/other-repo',
+          url: 'https://example.com/run/99',
+        },
+        parentPRKey: 'pr:github-pr-watcher:owner/other-repo:99',
+      }),
+    ]);
+
+    expect(mock.panel.webview.postMessage).not.toHaveBeenCalled();
   });
 
   it('opens the CI Watches panel from editor messages', async () => {

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -135,6 +135,87 @@ function createMockStateStore() {
   };
 }
 
+function makeWatchedRun(overrides: Record<string, any> = {}) {
+  const now = new Date().toISOString();
+  return {
+    identifier: {
+      providerId: 'github-actions',
+      runId: 'run-1',
+      displayName: 'build',
+      repo: 'owner/repo',
+      url: 'https://example.com/run/1',
+    },
+    status: {
+      overallState: 'running',
+      conclusion: undefined,
+      jobs: [],
+    },
+    watchedAt: now,
+    lastPolledAt: now,
+    dismissed: false,
+    parentPRKey: 'pr:github-pr-watcher:owner/repo:42',
+    ...overrides,
+  };
+}
+
+function makeWatchedPR(overrides: Record<string, any> = {}) {
+  const now = new Date().toISOString();
+  return {
+    identifier: {
+      providerId: 'github-pr-watcher',
+      prId: '42',
+      displayName: 'PR #42',
+      repo: 'owner/repo',
+      url: 'https://example.com/pull/42',
+    },
+    prState: 'open',
+    childRunKeys: ['github-actions:owner/repo:run-1'],
+    watchedAt: now,
+    lastPolledAt: now,
+    dismissed: false,
+    ...overrides,
+  };
+}
+
+function createMockWatcherService(initialWatch?: any, initialRuns: any[] = []) {
+  const prEmitter = new EventEmitter<void>();
+  const runEmitter = new EventEmitter<any[]>();
+  let watch = initialWatch;
+  let runs = [...initialRuns];
+
+  return {
+    findPRWatchByExternalId: vi.fn((repo: string, prId: string) => (
+      watch && !watch.dismissed && watch.identifier.repo === repo && watch.identifier.prId === prId ? watch : undefined
+    )),
+    getPRWatchKey: vi.fn((identifier: any) => `pr:${identifier.providerId}:${identifier.repo}:${identifier.prId}`),
+    getChildRuns: vi.fn(() => runs.filter(run => !run.dismissed)),
+    onDidChangePRWatches: prEmitter.event,
+    onDidChangeWatchedRuns: runEmitter.event,
+    _setWatch: (nextWatch: any) => { watch = nextWatch; },
+    _setRuns: (nextRuns: any[]) => { runs = [...nextRuns]; },
+    _firePRWatchesChange: () => prEmitter.fire(),
+    _fireWatchedRunsChange: () => runEmitter.fire(runs),
+  };
+}
+
+function getBootstrapItem(html: string) {
+  const match = html.match(/window\.__DEVDOCKET_EDITOR_BOOTSTRAP__ = (.*?);\s*<\/script>/s);
+  if (!match) {
+    throw new Error('Missing editor bootstrap payload');
+  }
+  return JSON.parse(match[1]);
+}
+
+function getLastEditorUpdate(mock: ReturnType<typeof createMockWebviewPanel>) {
+  const messages = vi.mocked(mock.panel.webview.postMessage).mock.calls.map(call => call[0] as any);
+  for (let index = messages.length - 1; index >= 0; index--) {
+    if (messages[index].type === 'updateEditorItem') {
+      return messages[index];
+    }
+  }
+  return undefined;
+}
+
 function createMockContext() {
   return {
     extensionUri: vscode.Uri.file('C:\\repos\\devdocket-mission-control-454\\packages\\core'),
@@ -148,13 +229,14 @@ function openPanel(
   providerRegistry = createMockProviderRegistry(),
   actionRegistry = createMockActionRegistry(),
   stateStore = createMockStateStore(),
+  watcherService?: ReturnType<typeof createMockWatcherService>,
 ) {
   const mock = createMockWebviewPanel();
   const context = createMockContext();
   vi.mocked(window.createWebviewPanel).mockReturnValue(mock.panel as any);
-  WorkItemEditorPanel.setDependencies(actionRegistry as any, stateStore as any);
+  WorkItemEditorPanel.setDependencies(actionRegistry as any, stateStore as any, watcherService as any);
   WorkItemEditorPanel.open(context, workGraph as any, providerRegistry as any, item, item.providerId ? 'GitHub' : undefined);
-  return { mock, context, workGraph, providerRegistry, actionRegistry, stateStore };
+  return { mock, context, workGraph, providerRegistry, actionRegistry, stateStore, watcherService };
 }
 
 describe('WorkItemEditorPanel', () => {
@@ -240,6 +322,127 @@ describe('WorkItemEditorPanel', () => {
         relatedItems: [expect.objectContaining({ targetItemId: 'peer-1', label: 'Closes Peer' })],
       }),
     }));
+  });
+
+  it('includes CI watch data for watched PRs across provider IDs', () => {
+    const item = makeItem({
+      title: 'Watched PR',
+      providerId: 'github-my-prs',
+      externalId: 'owner/repo#42',
+      itemType: 'pr',
+    });
+    const watch = makeWatchedPR();
+    const runs = [
+      makeWatchedRun({ identifier: { ...makeWatchedRun().identifier, runId: 'run-1', displayName: 'build' } }),
+      makeWatchedRun({
+        identifier: { ...makeWatchedRun().identifier, runId: 'run-2', displayName: 'test' },
+        status: { overallState: 'completed', conclusion: 'success', jobs: [] },
+      }),
+      makeWatchedRun({
+        identifier: { ...makeWatchedRun().identifier, runId: 'run-3', displayName: 'deploy' },
+        status: { overallState: 'completed', conclusion: 'failure', jobs: [] },
+      }),
+    ];
+    const watcherService = createMockWatcherService(watch, runs);
+
+    const { mock } = openPanel(item, createMockWorkGraph(item), createMockProviderRegistry(), createMockActionRegistry(), createMockStateStore(), watcherService);
+    const bootstrap = getBootstrapItem(mock.panel.webview.html);
+
+    expect(watcherService.findPRWatchByExternalId).toHaveBeenCalledWith('owner/repo', '42');
+    expect(bootstrap.ciWatch).toEqual({
+      state: 'open',
+      runs: [
+        { name: 'build', state: 'in_progress' },
+        { name: 'test', state: 'completed', conclusion: 'success' },
+        { name: 'deploy', state: 'completed', conclusion: 'failure' },
+      ],
+      totalActive: 1,
+      totalFailing: 1,
+    });
+  });
+
+  it('omits CI watch data when the PR is not watched', () => {
+    const item = makeItem({
+      title: 'Unwatched PR',
+      providerId: 'github-my-prs',
+      externalId: 'owner/repo#42',
+      itemType: 'pr',
+    });
+    const watcherService = createMockWatcherService(undefined, []);
+
+    const { mock } = openPanel(item, createMockWorkGraph(item), createMockProviderRegistry(), createMockActionRegistry(), createMockStateStore(), watcherService);
+    const bootstrap = getBootstrapItem(mock.panel.webview.html);
+
+    expect(bootstrap.ciWatch).toBeUndefined();
+    expect(mock.panel.webview.html).not.toContain('ciWatch');
+  });
+
+  it('removes CI watch data when the PR watch is dismissed while open', () => {
+    const item = makeItem({ providerId: 'github-my-prs', externalId: 'owner/repo#42', itemType: 'pr' });
+    const watch = makeWatchedPR();
+    const watcherService = createMockWatcherService(watch, [makeWatchedRun()]);
+    const { mock } = openPanel(item, createMockWorkGraph(item), createMockProviderRegistry(), createMockActionRegistry(), createMockStateStore(), watcherService);
+
+    watcherService._setWatch({ ...watch, dismissed: true });
+    watcherService._firePRWatchesChange();
+
+    expect(getLastEditorUpdate(mock)).toEqual(expect.objectContaining({
+      type: 'updateEditorItem',
+      item: expect.not.objectContaining({ ciWatch: expect.anything() }),
+    }));
+  });
+
+  it('updates CI watch data when a child run changes state while open', () => {
+    const item = makeItem({ providerId: 'github-my-prs', externalId: 'owner/repo#42', itemType: 'pr' });
+    const watch = makeWatchedPR();
+    const watcherService = createMockWatcherService(watch, [makeWatchedRun()]);
+    const { mock } = openPanel(item, createMockWorkGraph(item), createMockProviderRegistry(), createMockActionRegistry(), createMockStateStore(), watcherService);
+
+    watcherService._setRuns([
+      makeWatchedRun({ status: { overallState: 'completed', conclusion: 'failure', jobs: [] } }),
+    ]);
+    watcherService._fireWatchedRunsChange();
+
+    expect(getLastEditorUpdate(mock)).toEqual(expect.objectContaining({
+      type: 'updateEditorItem',
+      item: expect.objectContaining({
+        ciWatch: expect.objectContaining({
+          runs: [{ name: 'build', state: 'completed', conclusion: 'failure' }],
+          totalActive: 0,
+          totalFailing: 1,
+        }),
+      }),
+    }));
+  });
+
+  it('refreshes CI watch data when the last child run disappears while the PR remains watched', () => {
+    const item = makeItem({ providerId: 'github-my-prs', externalId: 'owner/repo#42', itemType: 'pr' });
+    const watch = makeWatchedPR();
+    const watcherService = createMockWatcherService(watch, [makeWatchedRun()]);
+    const { mock } = openPanel(item, createMockWorkGraph(item), createMockProviderRegistry(), createMockActionRegistry(), createMockStateStore(), watcherService);
+
+    watcherService._setRuns([]);
+    watcherService._fireWatchedRunsChange();
+
+    expect(getLastEditorUpdate(mock)).toEqual(expect.objectContaining({
+      type: 'updateEditorItem',
+      item: expect.objectContaining({
+        ciWatch: expect.objectContaining({
+          runs: [],
+          totalActive: 0,
+          totalFailing: 0,
+        }),
+      }),
+    }));
+  });
+
+  it('opens the CI Watches panel from editor messages', async () => {
+    const item = makeItem();
+    const { mock } = openPanel(item);
+
+    await mock.simulateMessage({ type: 'openWatches' });
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.showWatchesQuickPick');
   });
 
   it('debounces autosave and saves manual fields', async () => {

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -352,9 +352,9 @@ describe('WorkItemEditorPanel', () => {
     expect(bootstrap.ciWatch).toEqual({
       state: 'open',
       runs: [
-        { name: 'build', state: 'in_progress' },
-        { name: 'test', state: 'completed', conclusion: 'success' },
-        { name: 'deploy', state: 'completed', conclusion: 'failure' },
+        { id: 'github-actions:owner/repo:run-1', name: 'build', state: 'in_progress' },
+        { id: 'github-actions:owner/repo:run-2', name: 'test', state: 'completed', conclusion: 'success' },
+        { id: 'github-actions:owner/repo:run-3', name: 'deploy', state: 'completed', conclusion: 'failure' },
       ],
       totalActive: 1,
       totalFailing: 1,
@@ -407,7 +407,7 @@ describe('WorkItemEditorPanel', () => {
       type: 'updateEditorItem',
       item: expect.objectContaining({
         ciWatch: expect.objectContaining({
-          runs: [{ name: 'build', state: 'completed', conclusion: 'failure' }],
+          runs: [{ id: 'github-actions:owner/repo:run-1', name: 'build', state: 'completed', conclusion: 'failure' }],
           totalActive: 0,
           totalFailing: 1,
         }),

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -471,6 +471,70 @@ export function getEditorPanelHtml({ cspSource, scriptUri, initialItem }: Editor
       gap: 10px;
     }
 
+    .ci-watch-heading-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .ci-watch-open-button {
+      min-height: 28px;
+      padding: 0 10px;
+      font-size: 12px;
+    }
+
+    .ci-watch-run-summary {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+    }
+
+    .ci-watch-chip,
+    .ci-watch-more {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      border-radius: 999px;
+      padding: 4px 9px;
+      font-size: 12px;
+      font-weight: 600;
+      border: 1px solid transparent;
+      background: var(--vscode-editorWidget-background, rgba(128, 128, 128, 0.08));
+    }
+
+    .ci-watch-chip--pass {
+      color: var(--vscode-testing-iconPassed, #73c991);
+      border-color: rgba(115, 201, 145, 0.35);
+      background: rgba(115, 201, 145, 0.12);
+    }
+
+    .ci-watch-chip--fail {
+      color: var(--vscode-testing-iconFailed, var(--vscode-errorForeground, #f14c4c));
+      border-color: rgba(241, 76, 76, 0.35);
+      background: rgba(241, 76, 76, 0.12);
+    }
+
+    .ci-watch-chip--running {
+      color: var(--vscode-progressBar-background, var(--vscode-textLink-foreground));
+      border-color: rgba(0, 122, 204, 0.35);
+      background: rgba(0, 122, 204, 0.12);
+    }
+
+    .ci-watch-chip--neutral,
+    .ci-watch-more {
+      color: var(--vscode-descriptionForeground);
+      border-color: var(--vscode-widget-border, rgba(127, 127, 127, 0.3));
+    }
+
+    .ci-watch-empty-runs,
+    .ci-watch-aggregate {
+      color: var(--vscode-descriptionForeground);
+      font-size: 12px;
+    }
+
     .related-item-group-heading {
       color: var(--vscode-descriptionForeground);
       font-size: 12px;

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -71,6 +71,7 @@ export interface BadgeData {
 export interface EditorCIWatchData {
   state: 'open' | 'merged' | 'closed';
   runs: Array<{
+    id: string;
     name: string;
     state: 'queued' | 'in_progress' | 'completed';
     conclusion?: RunConclusion;

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -1,3 +1,4 @@
+import type { RunConclusion } from '@devdocket/shared';
 import type { ResolvedRelatedItem } from './relatedItemTypes';
 
 export type ExtensionMessage =
@@ -24,6 +25,7 @@ export type WebviewMessage =
   | { type: 'openWalkthrough' }
   | { type: 'clearHistory' }
   | { type: 'runAction'; itemId: string }
+  | { type: 'openWatches' }
   | { type: 'openUrl'; url: string }
   | { type: 'openWatchUrl'; url: string }
   | { type: 'dismissCompletedWatches' }
@@ -66,6 +68,18 @@ export interface BadgeData {
   variant: string;
 }
 
+export interface EditorCIWatchData {
+  state: 'open' | 'merged' | 'closed';
+  runs: Array<{
+    name: string;
+    state: 'queued' | 'in_progress' | 'completed';
+    conclusion?: RunConclusion;
+    hasWarning?: boolean;
+  }>;
+  totalActive: number;
+  totalFailing: number;
+}
+
 export interface EditorItemData {
   id: string;
   title: string;
@@ -83,6 +97,7 @@ export interface EditorItemData {
   hasActions: boolean;
   activityLog: Array<{ timestamp: number; type: string; detail?: string }>;
   relatedItems: ResolvedRelatedItem[];
+  ciWatch?: EditorCIWatchData;
   isIncoming?: boolean;
   providerId?: string;
   externalId?: string;

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -19,6 +19,12 @@ interface AutosaveData {
   url?: string;
 }
 
+interface EditorCIWatchContext {
+  watch: WatchedPR;
+  watchKey: string;
+  runs: WatchedRun[];
+}
+
 /**
  * Manages the lifecycle of open WorkItemEditorPanels.
  * Created during extension activation and disposed with the extension context,
@@ -76,6 +82,8 @@ export class WorkItemEditorPanel {
   private lastDisplayedState: WorkItemState | undefined;
   private lastDisplayedGroup: string | undefined;
   private lastManagedState: boolean | undefined;
+  private lastDisplayedCIWatchSignature: string | undefined;
+  private lastDisplayedCIWatchRunKeys = new Set<string>();
 
   /**
    * Replace the active panel manager. Called during `activate()` to scope
@@ -166,7 +174,7 @@ export class WorkItemEditorPanel {
     if (watcherService) {
       this.watcherSubscriptions.push(
         watcherService.onDidChangePRWatches(() => this.refreshForPRWatchChange()),
-        watcherService.onDidChangeWatchedRuns(() => this.refreshForWatchedRunsChange()),
+        watcherService.onDidChangeWatchedRuns(runs => this.refreshForWatchedRunsChange(runs)),
       );
     }
 
@@ -249,14 +257,33 @@ export class WorkItemEditorPanel {
   private refreshForPRWatchChange(): void {
     if (this.disposed) { return; }
     const item = this.workGraph.getItem(this.itemId);
-    if (isPRWorkItem(item)) {
+    if (!isPRWorkItem(item)) { return; }
+
+    if (this.buildCIWatchSignature(item) !== this.lastDisplayedCIWatchSignature) {
       this.update();
     }
   }
 
-  private refreshForWatchedRunsChange(): void {
+  private refreshForWatchedRunsChange(changedRuns: WatchedRun[]): void {
     if (this.disposed) { return; }
-    if (this.findWatchForCurrentItem()) {
+    const item = this.workGraph.getItem(this.itemId);
+    if (!isPRWorkItem(item)) { return; }
+
+    const context = this.getCIWatchContext(item);
+    const currentRunKeys = new Set(context?.runs.map(run => getRunWatchKey(run.identifier)) ?? []);
+    const changedRunTouchesCurrentWatch = changedRuns.some(run => {
+      const runKey = getRunWatchKey(run.identifier);
+      return run.parentPRKey === context?.watchKey
+        || context?.watch.childRunKeys.includes(runKey) === true
+        || this.lastDisplayedCIWatchRunKeys.has(runKey)
+        || currentRunKeys.has(runKey);
+    });
+    const childRunSetChanged = !setsEqual(currentRunKeys, this.lastDisplayedCIWatchRunKeys);
+    if (!changedRunTouchesCurrentWatch && !childRunSetChanged) {
+      return;
+    }
+
+    if (this.buildCIWatchSignature(item, context) !== this.lastDisplayedCIWatchSignature) {
       this.update();
     }
   }
@@ -342,12 +369,15 @@ export class WorkItemEditorPanel {
     const item = this.workGraph.getItem(this.itemId);
     if (!item) {
       this.htmlInitialized = false;
+      this.lastDisplayedCIWatchSignature = undefined;
+      this.lastDisplayedCIWatchRunKeys.clear();
       this.panel.webview.html = '<html><body><p>Item not found.</p></body></html>';
       return;
     }
 
     const relatedItemsIndex = buildRelatedItemsIndex(this.providerRegistry, this.workGraph);
     const editorItem = this.buildEditorItemData(item, relatedItemsIndex);
+    this.rememberDisplayedCIWatchState(item);
     this.lastDisplayedTitle = item.title;
     this.lastDisplayedUrl = item.url;
     this.lastDisplayedDescription = item.description;
@@ -420,49 +450,68 @@ export class WorkItemEditorPanel {
   }
 
   private buildCIWatchData(item: WorkItem): EditorItemData['ciWatch'] {
-    if (!isPRWorkItem(item)) {
+    const context = this.getCIWatchContext(item);
+    if (!context) {
       return undefined;
     }
 
-    const watch = this.findWatchForItem(item);
-    if (!watch) {
-      return undefined;
-    }
-
-    const runs = this.getWatchChildRuns(watch);
     return {
-      state: watch.prState,
-      runs: runs.map(run => ({
+      state: context.watch.prState,
+      runs: context.runs.map(run => ({
         name: run.identifier.displayName,
         state: toEditorRunState(run.status.overallState),
         ...(run.status.conclusion ? { conclusion: run.status.conclusion } : {}),
         ...(run.hasWarning ? { hasWarning: true } : {}),
       })),
-      totalActive: runs.filter(run => run.status.overallState !== 'completed' && !run.dismissed).length,
-      totalFailing: runs.filter(isFailingOrWarningRun).length,
+      totalActive: context.runs.filter(run => run.status.overallState !== 'completed' && !run.dismissed).length,
+      totalFailing: context.runs.filter(isFailingOrWarningRun).length,
     };
   }
 
-  private findWatchForCurrentItem(): WatchedPR | undefined {
-    const item = this.workGraph.getItem(this.itemId);
-    return item ? this.findWatchForItem(item) : undefined;
-  }
+  private getCIWatchContext(item: WorkItem): EditorCIWatchContext | undefined {
+    if (!isPRWorkItem(item)) {
+      return undefined;
+    }
 
-  private findWatchForItem(item: WorkItem): WatchedPR | undefined {
     const watcherService = WorkItemEditorPanel.watcherService;
     const external = item.externalId ? parsePRExternalId(item.externalId) : undefined;
     if (!watcherService || !external) {
       return undefined;
     }
-    return watcherService.findPRWatchByExternalId(external.repo, external.prId);
+
+    const watch = watcherService.findPRWatchByExternalId(external.repo, external.prId);
+    if (!watch) {
+      return undefined;
+    }
+
+    const watchKey = watcherService.getPRWatchKey(watch.identifier);
+    return {
+      watch,
+      watchKey,
+      runs: watcherService.getChildRuns(watchKey),
+    };
   }
 
-  private getWatchChildRuns(watch: WatchedPR): WatchedRun[] {
-    const watcherService = WorkItemEditorPanel.watcherService;
-    if (!watcherService) {
-      return [];
+  private rememberDisplayedCIWatchState(item: WorkItem): void {
+    const context = this.getCIWatchContext(item);
+    this.lastDisplayedCIWatchSignature = this.buildCIWatchSignature(item, context);
+    this.lastDisplayedCIWatchRunKeys = new Set(context?.runs.map(run => getRunWatchKey(run.identifier)) ?? []);
+  }
+
+  private buildCIWatchSignature(item: WorkItem, context = this.getCIWatchContext(item)): string | undefined {
+    if (!context) {
+      return undefined;
     }
-    return watcherService.getChildRuns(watcherService.getPRWatchKey(watch.identifier));
+
+    const runSignatures = context.runs
+      .map(run => [
+        getRunWatchKey(run.identifier),
+        run.status.overallState,
+        run.status.conclusion ?? '',
+        run.hasWarning ? 'warning' : '',
+      ].join(':'))
+      .sort();
+    return [context.watchKey, context.watch.prState, ...runSignatures].join('|');
   }
 
   private getHtml(item: EditorItemData): string {
@@ -592,6 +641,24 @@ function parsePRExternalId(externalId: string): { repo: string; prId: string } |
     repo: externalId.slice(0, separatorIndex),
     prId: externalId.slice(separatorIndex + 1),
   };
+}
+
+function getRunWatchKey(identifier: WatchedRun['identifier']): string {
+  return identifier.repo
+    ? `${identifier.providerId}:${identifier.repo}:${identifier.runId}`
+    : `${identifier.providerId}:${identifier.runId}`;
+}
+
+function setsEqual(left: Set<string>, right: Set<string>): boolean {
+  if (left.size !== right.size) {
+    return false;
+  }
+  for (const value of left) {
+    if (!right.has(value)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function toEditorRunState(state: WatchedRun['status']['overallState']): NonNullable<EditorItemData['ciWatch']>['runs'][number]['state'] {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -5,6 +5,7 @@ import { ActionRegistry } from '../services/actionRegistry';
 import { ProviderRegistry } from '../services/providerRegistry';
 import { buildRelatedItemsIndex, resolveRelatedItemsFor, type RelatedItemsIndex } from '../services/relatedItems';
 import { VALID_TRANSITIONS, WorkGraph } from '../services/workGraph';
+import type { WatcherService, WatchedPR, WatchedRun } from '../services/watcherService';
 import type { DiscoveredStateStore } from '../storage/discoveredStateStore';
 import { isSafeUrl } from '../utils/url';
 import { buildProviderBadge, buildProviderBadges, buildTypeBadge } from './badges';
@@ -49,6 +50,7 @@ export class WorkItemEditorPanel {
   private static panelManager = new PanelManager();
   private static actionRegistry?: ActionRegistry;
   private static stateStore?: DiscoveredStateStore;
+  private static watcherService?: WatcherService;
 
   private readonly panel: vscode.WebviewPanel;
   private readonly workGraph: WorkGraph;
@@ -66,6 +68,7 @@ export class WorkItemEditorPanel {
   private readonly providerRegSub: vscode.Disposable;
   private readonly providerChangeSub: vscode.Disposable;
   private readonly actionRegistrySub?: vscode.Disposable;
+  private readonly watcherSubscriptions: vscode.Disposable[] = [];
   private lastDisplayedTitle: string | undefined;
   private lastDisplayedUrl: string | undefined;
   private lastDisplayedDescription: string | undefined;
@@ -82,9 +85,10 @@ export class WorkItemEditorPanel {
     WorkItemEditorPanel.panelManager = manager;
   }
 
-  static setDependencies(actionRegistry?: ActionRegistry, stateStore?: DiscoveredStateStore): void {
+  static setDependencies(actionRegistry?: ActionRegistry, stateStore?: DiscoveredStateStore, watcherService?: WatcherService): void {
     WorkItemEditorPanel.actionRegistry = actionRegistry;
     WorkItemEditorPanel.stateStore = stateStore;
+    WorkItemEditorPanel.watcherService = watcherService;
   }
 
   static open(
@@ -158,6 +162,14 @@ export class WorkItemEditorPanel {
       this.update();
     });
 
+    const watcherService = WorkItemEditorPanel.watcherService;
+    if (watcherService) {
+      this.watcherSubscriptions.push(
+        watcherService.onDidChangePRWatches(() => this.refreshForPRWatchChange()),
+        watcherService.onDidChangeWatchedRuns(() => this.refreshForWatchedRunsChange()),
+      );
+    }
+
     this.messageSubscription = this.panel.webview.onDidReceiveMessage((msg) => {
       if (msg?.type === 'openItem' && typeof msg.itemId === 'string') {
         void this.handleOpenItem(msg.itemId, msg.providerId, msg.externalId);
@@ -180,6 +192,10 @@ export class WorkItemEditorPanel {
       }
       if (msg?.type === 'runAction' && typeof msg.itemId === 'string') {
         void vscode.commands.executeCommand('devdocket.runAction', { id: msg.itemId });
+        return;
+      }
+      if (msg?.type === 'openWatches') {
+        void vscode.commands.executeCommand('devdocket.showWatchesQuickPick');
         return;
       }
       if (msg?.type === 'acceptItem' && typeof msg.providerId === 'string' && typeof msg.externalId === 'string') {
@@ -221,12 +237,28 @@ export class WorkItemEditorPanel {
         this.providerRegSub.dispose();
         this.providerChangeSub.dispose();
         this.actionRegistrySub?.dispose();
+        this.disposeWatcherSubscriptions();
       }
     });
   }
 
   private isProviderManaged(item: WorkItem): boolean {
     return !!(item.providerId && this.providerRegistry.getProvider(item.providerId));
+  }
+
+  private refreshForPRWatchChange(): void {
+    if (this.disposed) { return; }
+    const item = this.workGraph.getItem(this.itemId);
+    if (isPRWorkItem(item)) {
+      this.update();
+    }
+  }
+
+  private refreshForWatchedRunsChange(): void {
+    if (this.disposed) { return; }
+    if (this.findWatchForCurrentItem()) {
+      this.update();
+    }
   }
 
   /**
@@ -355,6 +387,7 @@ export class WorkItemEditorPanel {
       hasActions: WorkItemEditorPanel.actionRegistry?.hasActionsFor(item) ?? false,
       activityLog: item.activityLog ?? [],
       relatedItems: resolveRelatedItemsFor(item, this.providerRegistry, this.workGraph, relatedItemsIndex),
+      ciWatch: this.buildCIWatchData(item),
       isIncoming: false,
       providerId: item.providerId,
       externalId: item.externalId,
@@ -386,6 +419,52 @@ export class WorkItemEditorPanel {
       .find(discovered => discovered.externalId === item.externalId);
   }
 
+  private buildCIWatchData(item: WorkItem): EditorItemData['ciWatch'] {
+    if (!isPRWorkItem(item)) {
+      return undefined;
+    }
+
+    const watch = this.findWatchForItem(item);
+    if (!watch) {
+      return undefined;
+    }
+
+    const runs = this.getWatchChildRuns(watch);
+    return {
+      state: watch.prState,
+      runs: runs.map(run => ({
+        name: run.identifier.displayName,
+        state: toEditorRunState(run.status.overallState),
+        ...(run.status.conclusion ? { conclusion: run.status.conclusion } : {}),
+        ...(run.hasWarning ? { hasWarning: true } : {}),
+      })),
+      totalActive: runs.filter(run => run.status.overallState !== 'completed' && !run.dismissed).length,
+      totalFailing: runs.filter(isFailingOrWarningRun).length,
+    };
+  }
+
+  private findWatchForCurrentItem(): WatchedPR | undefined {
+    const item = this.workGraph.getItem(this.itemId);
+    return item ? this.findWatchForItem(item) : undefined;
+  }
+
+  private findWatchForItem(item: WorkItem): WatchedPR | undefined {
+    const watcherService = WorkItemEditorPanel.watcherService;
+    const external = item.externalId ? parsePRExternalId(item.externalId) : undefined;
+    if (!watcherService || !external) {
+      return undefined;
+    }
+    return watcherService.findPRWatchByExternalId(external.repo, external.prId);
+  }
+
+  private getWatchChildRuns(watch: WatchedPR): WatchedRun[] {
+    const watcherService = WorkItemEditorPanel.watcherService;
+    if (!watcherService) {
+      return [];
+    }
+    return watcherService.getChildRuns(watcherService.getPRWatchKey(watch.identifier));
+  }
+
   private getHtml(item: EditorItemData): string {
     const scriptUri = this.panel.webview.asWebviewUri(
       vscode.Uri.joinPath(this.extensionUri, 'webview-dist', 'editor.js'),
@@ -412,7 +491,14 @@ export class WorkItemEditorPanel {
       this.providerRegSub.dispose();
       this.providerChangeSub.dispose();
       this.actionRegistrySub?.dispose();
+      this.disposeWatcherSubscriptions();
       this.panel.dispose();
+    }
+  }
+
+  private disposeWatcherSubscriptions(): void {
+    while (this.watcherSubscriptions.length > 0) {
+      this.watcherSubscriptions.pop()?.dispose();
     }
   }
 
@@ -493,10 +579,38 @@ export class WorkItemEditorPanel {
   }
 }
 
+function isPRWorkItem(item: WorkItem | undefined): item is WorkItem & { itemType: 'pr' } {
+  return item?.itemType === 'pr';
+}
+
+function parsePRExternalId(externalId: string): { repo: string; prId: string } | undefined {
+  const separatorIndex = externalId.lastIndexOf('#');
+  if (separatorIndex <= 0 || separatorIndex === externalId.length - 1) {
+    return undefined;
+  }
+  return {
+    repo: externalId.slice(0, separatorIndex),
+    prId: externalId.slice(separatorIndex + 1),
+  };
+}
+
+function toEditorRunState(state: WatchedRun['status']['overallState']): NonNullable<EditorItemData['ciWatch']>['runs'][number]['state'] {
+  return state === 'running' ? 'in_progress' : state;
+}
+
+function isFailingOrWarningRun(run: WatchedRun): boolean {
+  if (run.hasWarning) return true;
+  if (run.status.overallState !== 'completed') return false;
+  const conclusion = run.status.conclusion;
+  if (conclusion === undefined || conclusion === 'success') return false;
+  return conclusion !== 'cancelled' && conclusion !== 'skipped' && conclusion !== 'neutral';
+}
+
 /**
  * Compose the badge list shown in the editor: provider, type, then the
  * provider-supplied badges declared on the {@link DiscoveredItem}. CI badges
- * are not added here — the editor doesn't currently surface CI status inline.
+ * are not added here — the editor surfaces active watch details in its
+ * dedicated CI Watch section instead.
  */
 export function composeEditorBadges(
   providerId?: string,

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -458,6 +458,7 @@ export class WorkItemEditorPanel {
     return {
       state: context.watch.prState,
       runs: context.runs.map(run => ({
+        id: getRunWatchKey(run.identifier),
         name: run.identifier.displayName,
         state: toEditorRunState(run.status.overallState),
         ...(run.status.conclusion ? { conclusion: run.status.conclusion } : {}),

--- a/packages/core/src/webview/editor/EditorApp.tsx
+++ b/packages/core/src/webview/editor/EditorApp.tsx
@@ -4,6 +4,7 @@ import type { EditorItemData, ExtensionMessage } from '../shared/types';
 import { useThemeChangeCounter } from '../shared/theme';
 import { ActivityLog } from './components/ActivityLog';
 import { ActionBar } from './components/ActionBar';
+import { CIWatchSection } from './components/CIWatchSection';
 import { EditableField } from './components/EditableField';
 import { EditorHeader } from './components/EditorHeader';
 import { RelatedItems } from './components/RelatedItems';
@@ -194,6 +195,7 @@ export function EditorApp() {
           externalId: relatedItem.targetExternalId,
         })}
       />
+      <CIWatchSection ciWatch={item.ciWatch} onOpenWatches={() => postMessage({ type: 'openWatches' })} />
       <ActivityLog entries={item.activityLog} />
     </div>
   );

--- a/packages/core/src/webview/editor/components/CIWatchSection.tsx
+++ b/packages/core/src/webview/editor/components/CIWatchSection.tsx
@@ -1,0 +1,96 @@
+import type { EditorCIWatchData } from '../../shared/types';
+
+interface CIWatchSectionProps {
+  ciWatch?: EditorCIWatchData;
+  onOpenWatches: () => void;
+}
+
+const MAX_VISIBLE_RUNS = 5;
+
+export function CIWatchSection({ ciWatch, onOpenWatches }: CIWatchSectionProps) {
+  if (!ciWatch) {
+    return null;
+  }
+
+  const visibleRuns = ciWatch.runs.slice(0, MAX_VISIBLE_RUNS);
+  const hiddenRunCount = ciWatch.runs.length - visibleRuns.length;
+
+  return (
+    <section class="editor-section ci-watch-section" aria-labelledby="editor-ci-watch-heading">
+      <div class="ci-watch-heading-row">
+        <div class="editor-section-heading" id="editor-ci-watch-heading">CI Watch</div>
+        <button
+          type="button"
+          class="editor-button editor-button--secondary ci-watch-open-button"
+          onClick={onOpenWatches}
+        >
+          Open in CI Watches
+        </button>
+      </div>
+      <div class="ci-watch-run-summary" aria-label="Watched runs">
+        {visibleRuns.length > 0 ? visibleRuns.map(run => (
+          <span class={`ci-watch-chip ci-watch-chip--${getRunVariant(run)}`} key={`${run.name}-${run.state}-${run.conclusion ?? ''}`}>
+            <span aria-hidden="true">{getRunIcon(run)}</span>
+            <span>{run.name} ({getRunLabel(run)})</span>
+          </span>
+        )) : <span class="ci-watch-empty-runs">No active child runs</span>}
+        {hiddenRunCount > 0 ? <span class="ci-watch-more">+{hiddenRunCount} more</span> : null}
+      </div>
+      <div class="ci-watch-aggregate">
+        PR state: {ciWatch.state} · {formatCount(ciWatch.totalActive, 'active run')} · {formatCount(ciWatch.totalFailing, 'failing/warning run')}
+      </div>
+    </section>
+  );
+}
+
+type CIRun = EditorCIWatchData['runs'][number];
+
+function getRunIcon(run: CIRun): string {
+  if (run.hasWarning || isFailedRun(run)) {
+    return '⚠';
+  }
+  if (run.state !== 'completed') {
+    return '⏳';
+  }
+  if (run.conclusion === 'success') {
+    return '✓';
+  }
+  return '○';
+}
+
+function getRunVariant(run: CIRun): string {
+  if (run.hasWarning || isFailedRun(run)) {
+    return 'fail';
+  }
+  if (run.state !== 'completed') {
+    return 'running';
+  }
+  if (run.conclusion === 'success') {
+    return 'pass';
+  }
+  return 'neutral';
+}
+
+function getRunLabel(run: CIRun): string {
+  if (run.hasWarning) {
+    return 'warning';
+  }
+  if (run.state === 'queued') {
+    return 'queued';
+  }
+  if (run.state === 'in_progress') {
+    return 'in progress';
+  }
+  return run.conclusion?.replace(/_/g, ' ') ?? 'completed';
+}
+
+function isFailedRun(run: CIRun): boolean {
+  if (run.state !== 'completed') return false;
+  const conclusion = run.conclusion;
+  if (conclusion === undefined || conclusion === 'success') return false;
+  return conclusion !== 'cancelled' && conclusion !== 'skipped' && conclusion !== 'neutral';
+}
+
+function formatCount(count: number, label: string): string {
+  return `${count} ${label}${count === 1 ? '' : 's'}`;
+}

--- a/packages/core/src/webview/editor/components/CIWatchSection.tsx
+++ b/packages/core/src/webview/editor/components/CIWatchSection.tsx
@@ -29,7 +29,7 @@ export function CIWatchSection({ ciWatch, onOpenWatches }: CIWatchSectionProps) 
       </div>
       <div class="ci-watch-run-summary" aria-label="Watched runs">
         {visibleRuns.length > 0 ? visibleRuns.map(run => (
-          <span class={`ci-watch-chip ci-watch-chip--${getRunVariant(run)}`} key={`${run.name}-${run.state}-${run.conclusion ?? ''}`}>
+          <span class={`ci-watch-chip ci-watch-chip--${getRunVariant(run)}`} key={run.id}>
             <span aria-hidden="true">{getRunIcon(run)}</span>
             <span>{run.name} ({getRunLabel(run)})</span>
           </span>

--- a/packages/core/src/webview/shared/types.ts
+++ b/packages/core/src/webview/shared/types.ts
@@ -1,5 +1,6 @@
 export type {
   BadgeData,
+  EditorCIWatchData,
   EditorItemData,
   ExtensionMessage,
   ItemCardData,


### PR DESCRIPTION
## Summary

Adds a **CI Watch** section to the work-item editor that surfaces an active CI Watches snapshot inline whenever the open PR is currently being watched. Closes the loop on the editor side of the bidirectional cross-navigation work (the inverse — opening a watch row in the editor — is tracked separately by #514).

## Why

Until now there was no in-editor surface that told the user "this PR is being watched" or "the latest CI run for this PR is failing." The user had to flip between the editor and the CI Watches panel to see CI status while reading notes / running actions on the PR. For a PR with frequent runs, that's friction.

## UX

A new **CI Watch** section renders between the Related and Activity Log sections, but only when the open PR has a matching active watch. Hidden entirely when there is no watch — no empty placeholder.

```
CI Watch                                          [Open in CI Watches]

⚠ build (failure) · ✓ test (success) · ⏳ deploy (in progress)
PR state: open · 3 active runs · 1 failing
```

- Per-child-run chips/icons (capped at 5; "+N more" overflow).
- Aggregate state line with PR state, active count, failing count.
- "Open in CI Watches" button focuses the CI Watches panel (no scroll-to-row in v1; out of scope per the issue).

## Cross-provider matching

The watched PR's `providerId` is the WATCHER id (`github-pr-watcher`), but the editor's WorkItem `providerId` is the EMITTER id (`github-my-prs`, `github-mentions`, etc.). The new lookup matches on `(repo, prId)` derived from the WorkItem's `externalId` (`${repo}#${prId}`) regardless of `providerId`, mirroring the cross-provider lookup pattern from PR #500's `relatedItems` resolver.

## Live updates

`WorkItemEditorPanel` subscribes to `WatcherService.onDidChangePRWatches` and `onDidChangeWatchedRuns`. When the editor's currently-shown PR is in the changed set, `refreshContent()` is invoked. The disposable is pushed onto the panel's existing disposables array.

## Out of scope

- ADO PR watches (the new lookup helper is provider-agnostic in shape; tests focus on GitHub).
- A "Watch this PR" action in the editor when the PR is not yet watched (already covered by `devdocket.watchPRFromItem` via Run Action).
- Scroll-to-row inside the CI Watches webview.

## Changes

- `packages/core/src/services/watcherService.ts` — new `findPRWatchByExternalId(repo, prId)` lookup helper.
- `packages/core/src/views/workItemEditorPanel.ts` — populate `ciWatch` in `buildEditorItemData`, subscribe to watcher events, handle the `openWatches` postMessage.
- `packages/core/src/views/mainTypes.ts` — `EditorCIWatchData` shape on `EditorItemData`.
- `packages/core/src/webview/shared/types.ts` — re-export of the new editor shape.
- `packages/core/src/webview/editor/components/CIWatchSection.tsx` — new Preact component.
- `packages/core/src/webview/editor/EditorApp.tsx` — render `<CIWatchSection>` between Related and ActivityLog.
- Editor CSS — chip styling.
- `packages/core/src/test/workItemEditorPanel.test.ts` — covers PR-with-watch, PR-without-watch, watch-dismissed-while-editor-open, child-run-state-changed-while-editor-open, and cross-provider match scenarios.

## Verification

`cd packages/core && npm run build && npm run test` — 794 tests across 31 files pass.

Closes #515
