### PR TITLE
Make WatcherService persisted-load merge-safe and awaited at activate

### DIFF
--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -451,10 +451,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     ws.onDidChangePRWatches(safeHandler('watch-panel:prs', () => watchPanelProvider.refresh())),
   );
 
-  // Load persisted watches after the watch services are ready.
-  ws.loadPersistedWatches().catch(err => {
+  // Load persisted watches after watch-service subscriptions are ready but before
+  // commands and the public API can start new watches.
+  try {
+    await ws.loadPersistedWatches();
+  } catch (err) {
     logger.error('Failed to load persisted watches', err);
-  });
+  }
 
   // Scope panel cache to extension lifecycle
   const panelManager = new PanelManager();

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -57,6 +57,7 @@ export class WatcherService implements vscode.Disposable {
   private disposed = false;
   private consecutiveFailures = new Map<string, number>();
   private persistedPRWatchKeys: Set<string> | undefined;
+  private loadPersistedWatchesPromise: Promise<void> | undefined;
   private configSubscription: vscode.Disposable | undefined;
   /**
    * Set of run-watch keys whose failure the user has already acknowledged
@@ -104,23 +105,52 @@ export class WatcherService implements vscode.Disposable {
 
   /**
    * Load persisted watches from disk and resume polling for active ones.
+   * Concurrent callers join the same load, and restored entries never replace
+   * watches that were started in memory while the load was in flight.
    */
   async loadPersistedWatches(): Promise<void> {
-    const { runs: watches, prs } = await this.watchStore.loadAll();
-    this.persistedPRWatchKeys = new Set(prs.map(pr => this.getPRWatchKey(pr.identifier)));
-
-    // Restore non-dismissed run watches
-    const restored = watches.filter(w => !w.dismissed);
-    for (const watch of restored) {
-      const key = this.getWatchKey(watch.identifier);
-      this.watches.set(key, watch);
+    if (!this.loadPersistedWatchesPromise) {
+      this.loadPersistedWatchesPromise = this.restorePersistedWatches().catch(err => {
+        this.loadPersistedWatchesPromise = undefined;
+        throw err;
+      });
     }
 
-    // Restore non-dismissed PR watches
-    const restoredPRs = prs.filter(pr => !pr.dismissed);
-    for (const pr of restoredPRs) {
+    return this.loadPersistedWatchesPromise;
+  }
+
+  private async restorePersistedWatches(): Promise<void> {
+    const { runs: watches, prs } = await this.watchStore.loadAll();
+    const hadLiveWatches = this.watches.size > 0 || this.prWatches.size > 0;
+    const loadedPRWatchKeys = prs.map(pr => this.getPRWatchKey(pr.identifier));
+    this.persistedPRWatchKeys = new Set([
+      ...(this.persistedPRWatchKeys ?? []),
+      ...this.prWatches.keys(),
+      ...loadedPRWatchKeys,
+    ]);
+
+    // Restore non-dismissed run watches without clobbering watches that were
+    // started in memory before the load completed.
+    const restored: WatchedRun[] = [];
+    for (const watch of watches.filter(w => !w.dismissed)) {
+      const key = this.getWatchKey(watch.identifier);
+      if (this.watches.has(key)) {
+        continue;
+      }
+      this.watches.set(key, watch);
+      restored.push(watch);
+    }
+
+    // Restore non-dismissed PR watches without clobbering watches that were
+    // started in memory before the load completed.
+    const restoredPRs: WatchedPR[] = [];
+    for (const pr of prs.filter(pr => !pr.dismissed)) {
       const key = this.getPRWatchKey(pr.identifier);
+      if (this.prWatches.has(key)) {
+        continue;
+      }
       this.prWatches.set(key, pr);
+      restoredPRs.push(pr);
     }
 
     if (restored.length > 0 || restoredPRs.length > 0) {
@@ -138,6 +168,10 @@ export class WatcherService implements vscode.Disposable {
       if (hasPollable) {
         this.ensurePollingActive();
       }
+    }
+
+    if (hadLiveWatches && (restored.length > 0 || restoredPRs.length > 0)) {
+      this.persistWatches();
     }
   }
 
@@ -1062,6 +1096,15 @@ export class WatcherService implements vscode.Disposable {
   }
 
   private async getPersistedPRWatchKeys(): Promise<Set<string>> {
+    if (this.loadPersistedWatchesPromise) {
+      try {
+        await this.loadPersistedWatchesPromise;
+      } catch {
+        // Fall through to the lazy load below so isPRWatched remains resilient
+        // when the activation-time restore fails.
+      }
+    }
+
     if (!this.persistedPRWatchKeys) {
       const { prs } = await this.watchStore.loadAll();
       this.persistedPRWatchKeys = new Set(prs.map(pr => this.getPRWatchKey(pr.identifier)));

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -368,6 +368,34 @@ describe('WatcherService', () => {
       expect(service.getActiveWatches()).toHaveLength(1);
       expect(service.getActiveWatches()[0].identifier.runId).toBe('run-1');
     });
+
+    it('does not clobber a run watch started while persisted watches load', async () => {
+      const identifier = { ...createIdentifier(), displayName: 'Live Run' };
+      const persistedWatch: WatchedRun = {
+        identifier: { ...identifier, displayName: 'Persisted Run' },
+        status: { overallState: 'completed', conclusion: 'success', jobs: [] },
+        watchedAt: new Date().toISOString(),
+        lastPolledAt: new Date().toISOString(),
+        dismissed: false,
+      };
+      (watchStore.loadAll as ReturnType<typeof vi.fn>).mockImplementation(() => new Promise(resolve => {
+        setTimeout(() => resolve({ runs: [persistedWatch], prs: [] }), 100);
+      }));
+      const watcher = createMockWatcher('test');
+      registry.register(watcher);
+
+      const loadPromise = service.loadPersistedWatches();
+      await vi.advanceTimersByTimeAsync(50);
+
+      const started = await service.startWatch(identifier);
+      await vi.advanceTimersByTimeAsync(50);
+      await loadPromise;
+
+      const active = service.getActiveWatches();
+      expect(active).toHaveLength(1);
+      expect(active[0]).toBe(started);
+      expect(active[0].identifier.displayName).toBe('Live Run');
+    });
   });
 
   describe('PR watching', () => {
@@ -784,6 +812,58 @@ describe('WatcherService', () => {
 
       expect(service.getActivePRWatches()).toHaveLength(1);
       expect(service.getActivePRWatches()[0].identifier.prId).toBe('42');
+    });
+
+    it('does not clobber a PR watch started while persisted watches load', async () => {
+      const identifier = createPRIdentifier();
+      const persistedPR = {
+        identifier: { ...identifier, displayName: 'Persisted PR #42' },
+        prState: 'closed' as const,
+        childRunKeys: [],
+        watchedAt: new Date().toISOString(),
+        lastPolledAt: new Date().toISOString(),
+        dismissed: false,
+      };
+      const otherPersistedPR = {
+        identifier: { ...createPRIdentifier(), prId: '99', displayName: 'Persisted PR #99' },
+        prState: 'open' as const,
+        childRunKeys: [],
+        watchedAt: new Date().toISOString(),
+        lastPolledAt: new Date().toISOString(),
+        dismissed: false,
+      };
+      (watchStore.loadAll as ReturnType<typeof vi.fn>).mockImplementation(() => new Promise(resolve => {
+        setTimeout(() => resolve({ runs: [], prs: [persistedPR, otherPersistedPR] }), 100);
+      }));
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        displayName: 'Live PR #42',
+        runs: [],
+      }));
+      prRegistry.register(prWatcher);
+
+      const loadPromise = service.loadPersistedWatches();
+      await vi.advanceTimersByTimeAsync(50);
+
+      const started = await service.startPRWatch(identifier);
+      expect(started.identifier.displayName).toBe('Live PR #42');
+
+      await vi.advanceTimersByTimeAsync(50);
+      await loadPromise;
+
+      const active = service.getActivePRWatches();
+      expect(active).toHaveLength(2);
+      expect(active.find(pr => pr.identifier.prId === '42')).toBe(started);
+      expect(active.find(pr => pr.identifier.prId === '42')?.identifier.displayName).toBe('Live PR #42');
+      expect(active.find(pr => pr.identifier.prId === '42')?.prState).toBe('open');
+      expect(active.find(pr => pr.identifier.prId === '99')?.identifier.displayName).toBe('Persisted PR #99');
+      expect(watchStore.saveAll).toHaveBeenLastCalledWith(
+        [],
+        expect.arrayContaining([
+          expect.objectContaining({ identifier: expect.objectContaining({ prId: '42', displayName: 'Live PR #42' }) }),
+          expect.objectContaining({ identifier: expect.objectContaining({ prId: '99', displayName: 'Persisted PR #99' }) }),
+        ]),
+      );
     });
 
     it('resolves run identifiers via URL matching when providerId is unknown', async () => {


### PR DESCRIPTION
## Summary

Closes the race in which `WatcherService.loadPersistedWatches()` could silently overwrite a freshly-created in-memory watch (created by `autoWatchAuthoredPRs` or a manual user action) with a stale snapshot from globalState during extension activation.

## Why

`activate()` in `packages/core/src/extension.ts` previously fired `ws.loadPersistedWatches()` without `await`-ing it. The public `DevDocketApi` was returned to provider extensions before the load completed. A provider that called `api.registerPRWatcher(...)` and triggered `autoWatchAuthoredPRs` (which immediately calls `startPRWatch`) before the persisted load completed could race the loader. The loader unconditionally `prWatches.set(key, watch)`, overwriting any in-memory watch already created. Worse, `persistWatches()` would then save the loaded snapshot back to disk as if it had always been that snapshot — silent data loss.

## Fix (belt-and-suspenders)

1. **Await load before returning the API.** `activate()` now awaits `ws.loadPersistedWatches()` before registering commands and returning the API. Cost is one bounded globalState read.
2. **Make the loader merge-safe.** `loadPersistedWatches()` now skips restoring entries whose key already exists in `this.watches` / `this.prWatches`. Even if a future change introduces another async hop, the loader can never clobber a live in-memory watch.
3. **In-flight load promise.** Internal callers see a single in-flight load promise so concurrent invocations join the same operation rather than racing.
4. **Re-persist merged state.** When the merged outcome differs from disk (e.g., a new live watch was added during load), the merged state is persisted back so disk matches reality.

## Out of scope

- Public `loaded` Promise on `WatcherService` — kept internal as no external caller currently needs it.
- Refactor of `WatcherService` itself (#507).

## Changes

- `packages/core/src/extension.ts` — await `loadPersistedWatches()` before returning the API.
- `packages/core/src/services/watcherService.ts` — merge-safe loader, in-flight load promise, persisted-key merging, re-persistence on merge.
- `packages/core/src/test/watcherService.test.ts` — regression test simulating slow `WatchStore.loadAll()` (~100ms) with a `startPRWatch` call interleaved; asserts the new live watch survives load completion.

## Verification

`cd packages/core && npm run build && npm run test` — passes.

Closes #509
