### PR TITLE
Add Open-in-DevDocket affordance to CI Watches PR rows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1096,6 +1096,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vscode/codicons": {
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.45.tgz",
+      "integrity": "sha512-1KAZ7XCMagp5Gdrlr4bbbcAqgcIL623iO1wW6rfcSVGAVUQvR0WP7bQx1SbJ11gmV3fdQTSEFIJQ/5C+HuVasw==",
+      "license": "CC-BY-4.0"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -5378,6 +5384,7 @@
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*",
+        "@vscode/codicons": "^0.0.45",
         "marked": "^18.0.2",
         "preact": "^10.29.1",
         "sanitize-html": "^2.17.3",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -481,6 +481,7 @@
   },
   "dependencies": {
     "@devdocket/shared": "*",
+    "@vscode/codicons": "^0.0.45",
     "marked": "^18.0.2",
     "preact": "^10.29.1",
     "sanitize-html": "^2.17.3",

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -397,7 +397,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const api = new DevDocketApiImpl(pr, ar, wr, pwr, wg);
   logger.info(`Store + service init took ${Math.round(performance.now() - initStart)}ms`);
 
-  const watchPanelProvider = new WatchPanelProvider(context.extensionUri, ws);
+  const watchPanelProvider = new WatchPanelProvider(context.extensionUri, ws, wg, pr);
 
   const eventWiringStart = performance.now();
   const eventDisposables = wireEvents(pr, wg, ws, pwr);

--- a/packages/core/src/test/watchPanelProvider.test.ts
+++ b/packages/core/src/test/watchPanelProvider.test.ts
@@ -38,15 +38,21 @@ function createMockWebviewPanel() {
 }
 
 function createMockWorkGraph(items: any[] = []) {
+  const changeEmitter = new vscode.EventEmitter<void>();
   return {
     getAll: vi.fn(() => items),
     getItem: vi.fn((id: string) => items.find(item => item.id === id)),
+    onDidChange: changeEmitter.event,
+    fireDidChange: () => changeEmitter.fire(),
   };
 }
 
 function createMockProviderRegistry(discoveredItems = new Map<string, any[]>()) {
+  const discoveredItemsEmitter = new vscode.EventEmitter<void>();
   return {
     getAllDiscoveredItems: vi.fn(() => discoveredItems),
+    onDidChangeDiscoveredItems: discoveredItemsEmitter.event,
+    fireDidChangeDiscoveredItems: () => discoveredItemsEmitter.fire(),
   };
 }
 
@@ -287,6 +293,39 @@ describe('WatchPanelProvider', () => {
     expect(prWatch).not.toHaveProperty('linkedItemId');
     expect(prWatch).not.toHaveProperty('linkedSourceProviderId');
     expect(prWatch).not.toHaveProperty('linkedSourceExternalId');
+  });
+
+  it('refreshes linked PR targets when work items or discovered items change', () => {
+    const mockPanel = createMockWebviewPanel();
+    vi.mocked(window.createWebviewPanel).mockReturnValue(mockPanel.panel as any);
+    const watcherService = createWatcherService([createPRWatch()]);
+    const workItems: any[] = [];
+    const discoveredItems = new Map<string, any[]>();
+    const workGraph = createMockWorkGraph(workItems);
+    const providerRegistry = createMockProviderRegistry(discoveredItems);
+
+    const provider = new WatchPanelProvider(
+      vscode.Uri.file('C:\\repo') as any,
+      watcherService as any,
+      workGraph as any,
+      providerRegistry as any,
+    );
+    provider.open();
+
+    expect(getUpdateWatchPanelMessage(mockPanel).prWatches[0]).not.toHaveProperty('linkedItemId');
+
+    discoveredItems.set('github-pr-reviews', [{ externalId: 'owner/repo#42', title: 'Review PR', itemType: 'pr' }]);
+    providerRegistry.fireDidChangeDiscoveredItems();
+    expect(getUpdateWatchPanelMessage(mockPanel).prWatches[0]).toEqual(expect.objectContaining({
+      linkedSourceProviderId: 'github-pr-reviews',
+      linkedSourceExternalId: 'owner/repo#42',
+    }));
+
+    workItems.push({ id: 'work-42', providerId: 'github-my-prs', externalId: 'owner/repo#42', itemType: 'pr' });
+    workGraph.fireDidChange();
+    expect(getUpdateWatchPanelMessage(mockPanel).prWatches[0]).toEqual(expect.objectContaining({
+      linkedItemId: 'work-42',
+    }));
   });
 
   it('resolves PR links across PR-emitting provider IDs instead of the watcher provider ID', () => {

--- a/packages/core/src/test/watchPanelProvider.test.ts
+++ b/packages/core/src/test/watchPanelProvider.test.ts
@@ -401,6 +401,38 @@ describe('WatchPanelProvider', () => {
     }));
   });
 
+  it('validates source link fields before previewing incoming items', async () => {
+    const mockPanel = createMockWebviewPanel();
+    vi.mocked(window.createWebviewPanel).mockReturnValue(mockPanel.panel as any);
+
+    const provider = new WatchPanelProvider(
+      vscode.Uri.file('C:\\repo') as any,
+      createWatcherService() as any,
+      createMockWorkGraph(),
+      createMockProviderRegistry(),
+    );
+    provider.open();
+
+    await mockPanel.simulateMessage({
+      type: 'openItem',
+      itemId: 'github-pr-reviews::owner/repo#42',
+      providerId: 42,
+      externalId: {},
+    } as any);
+    await mockPanel.simulateMessage({
+      type: 'openItem',
+      itemId: ['not-a-key'],
+      providerId: 'github-pr-reviews',
+      externalId: 'owner/repo#42',
+    } as any);
+
+    expect(vscode.commands.executeCommand).toHaveBeenCalledTimes(1);
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.previewIncomingItem', {
+      providerId: 'github-pr-reviews',
+      externalId: 'owner/repo#42',
+    });
+  });
+
   it('handles dismiss completed, open URL, and dismiss watch webview commands', async () => {
     const mockPanel = createMockWebviewPanel();
     vi.mocked(window.createWebviewPanel).mockReturnValue(mockPanel.panel as any);

--- a/packages/core/src/test/watchPanelProvider.test.ts
+++ b/packages/core/src/test/watchPanelProvider.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { env, window } from 'vscode';
 import { WatchPanelProvider } from '../views/watchPanelProvider';
@@ -113,6 +115,29 @@ function getUpdateWatchPanelMessage(mockPanel: ReturnType<typeof createMockWebvi
 describe('WatchPanelProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('allows the watch panel webview to load codicons from the resolved package location', () => {
+    const mockPanel = createMockWebviewPanel();
+    vi.mocked(window.createWebviewPanel).mockReturnValue(mockPanel.panel as any);
+    const codiconsCssPath = require.resolve('@vscode/codicons/dist/codicon.css');
+    const codiconsDistDir = path.dirname(codiconsCssPath);
+
+    expect(fs.existsSync(codiconsCssPath)).toBe(true);
+
+    const provider = new WatchPanelProvider(
+      vscode.Uri.file('C:\\repo') as any,
+      createWatcherService() as any,
+      createMockWorkGraph(),
+      createMockProviderRegistry(),
+    );
+    provider.open();
+
+    const options = vi.mocked(window.createWebviewPanel).mock.calls[0][3] as { localResourceRoots?: Array<{ fsPath?: string }> };
+    expect(options.localResourceRoots).toEqual(expect.arrayContaining([
+      expect.objectContaining({ fsPath: codiconsDistDir }),
+    ]));
+    expect(mockPanel.panel.webview.html).toContain(`webview-resource:${codiconsCssPath}`);
   });
 
   it('assembles PR watches with child runs and standalone run watches from the watcher service', () => {

--- a/packages/core/src/test/watchPanelProvider.test.ts
+++ b/packages/core/src/test/watchPanelProvider.test.ts
@@ -37,6 +37,73 @@ function createMockWebviewPanel() {
   };
 }
 
+function createMockWorkGraph(items: any[] = []) {
+  return {
+    getAll: vi.fn(() => items),
+    getItem: vi.fn((id: string) => items.find(item => item.id === id)),
+  };
+}
+
+function createMockProviderRegistry(discoveredItems = new Map<string, any[]>()) {
+  return {
+    getAllDiscoveredItems: vi.fn(() => discoveredItems),
+  };
+}
+
+function createPRWatch(prId = '42', repo = 'owner/repo', providerId = 'github-pr') {
+  return {
+    identifier: {
+      providerId,
+      repo,
+      prId,
+      displayName: `PR #${prId}`,
+      url: providerId === 'ado-pr'
+        ? `https://dev.azure.com/${repo.replace(/\//g, '/_git/')}/pullrequest/${prId}`
+        : `https://github.com/${repo}/pull/${prId}`,
+    },
+    prState: 'open',
+  };
+}
+
+function createChildRun(prId = '42') {
+  return {
+    identifier: {
+      providerId: 'github-actions',
+      repo: 'owner/repo',
+      runId: `100-${prId}`,
+      displayName: 'PR CI',
+      url: `https://github.com/owner/repo/actions/runs/100${prId}`,
+    },
+    status: {
+      overallState: 'completed',
+      conclusion: 'success',
+      jobs: [],
+      startedAt: new Date(Date.now() - 120_000).toISOString(),
+      completedAt: new Date(Date.now() - 30_000).toISOString(),
+    },
+    watchedAt: new Date(Date.now() - 120_000).toISOString(),
+  };
+}
+
+function createWatcherService(prWatches: any[] = []) {
+  return {
+    getActivePRWatches: vi.fn(() => prWatches),
+    getActiveStandaloneWatches: vi.fn(() => []),
+    getPRWatchKey: vi.fn((identifier: { providerId: string; repo: string; prId: string }) => `pr:${identifier.providerId}:${identifier.repo}:${identifier.prId}`),
+    getChildRuns: vi.fn((_prKey: string) => [createChildRun()]),
+    getProviderLabel: vi.fn(() => 'GitHub Actions'),
+    getActiveWatches: vi.fn(() => []),
+    dismissAllCompleted: vi.fn(),
+    acknowledgeAllFailures: vi.fn(),
+    dismissPRWatch: vi.fn(),
+    dismissWatch: vi.fn(),
+  };
+}
+
+function getUpdateWatchPanelMessage(mockPanel: ReturnType<typeof createMockWebviewPanel>) {
+  return vi.mocked(mockPanel.panel.webview.postMessage).mock.calls.at(-1)?.[0] as any;
+}
+
 describe('WatchPanelProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -101,7 +168,12 @@ describe('WatchPanelProvider', () => {
       dismissWatch: vi.fn(),
     };
 
-    const provider = new WatchPanelProvider(vscode.Uri.file('C:\\repo') as any, watcherService as any);
+    const provider = new WatchPanelProvider(
+      vscode.Uri.file('C:\\repo') as any,
+      watcherService as any,
+      createMockWorkGraph(),
+      createMockProviderRegistry(),
+    );
     provider.open();
 
     expect(window.createWebviewPanel).toHaveBeenCalledWith(
@@ -141,6 +213,127 @@ describe('WatchPanelProvider', () => {
     }));
   });
 
+  it('adds linkedItemId when a matching PR work item exists', () => {
+    const mockPanel = createMockWebviewPanel();
+    vi.mocked(window.createWebviewPanel).mockReturnValue(mockPanel.panel as any);
+    const watcherService = createWatcherService([createPRWatch()]);
+    const workGraph = createMockWorkGraph([{
+      id: 'work-42',
+      providerId: 'github-my-prs',
+      externalId: 'owner/repo#42',
+      itemType: 'pr',
+    }]);
+
+    const provider = new WatchPanelProvider(
+      vscode.Uri.file('C:\\repo') as any,
+      watcherService as any,
+      workGraph as any,
+      createMockProviderRegistry(),
+    );
+    provider.open();
+
+    const message = getUpdateWatchPanelMessage(mockPanel);
+    expect(message.prWatches[0]).toEqual(expect.objectContaining({
+      id: 'pr:github-pr:owner/repo:42',
+      linkedItemId: 'work-42',
+    }));
+    expect(message.prWatches[0]).not.toHaveProperty('linkedSourceKey');
+    expect(workGraph.getAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('adds linkedSourceKey when only a matching discovered PR exists', () => {
+    const mockPanel = createMockWebviewPanel();
+    vi.mocked(window.createWebviewPanel).mockReturnValue(mockPanel.panel as any);
+    const watcherService = createWatcherService([createPRWatch()]);
+    const providerRegistry = createMockProviderRegistry(new Map([
+      ['github-pr-reviews', [{ externalId: 'owner/repo#42', title: 'Review PR', itemType: 'pr' }]],
+    ]));
+
+    const provider = new WatchPanelProvider(
+      vscode.Uri.file('C:\\repo') as any,
+      watcherService as any,
+      createMockWorkGraph(),
+      providerRegistry as any,
+    );
+    provider.open();
+
+    const message = getUpdateWatchPanelMessage(mockPanel);
+    expect(message.prWatches[0]).toEqual(expect.objectContaining({
+      id: 'pr:github-pr:owner/repo:42',
+      linkedSourceKey: 'github-pr-reviews::owner/repo#42',
+    }));
+    expect(message.prWatches[0]).not.toHaveProperty('linkedItemId');
+    expect(providerRegistry.getAllDiscoveredItems).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits DevDocket link data when no matching PR item exists', () => {
+    const mockPanel = createMockWebviewPanel();
+    vi.mocked(window.createWebviewPanel).mockReturnValue(mockPanel.panel as any);
+    const watcherService = createWatcherService([createPRWatch()]);
+
+    const provider = new WatchPanelProvider(
+      vscode.Uri.file('C:\\repo') as any,
+      watcherService as any,
+      createMockWorkGraph([{ id: 'issue-42', providerId: 'github', externalId: 'owner/repo#42', itemType: 'issue' }]),
+      createMockProviderRegistry(new Map([
+        ['github', [{ externalId: 'owner/repo#42', title: 'Issue #42', itemType: 'issue' }]],
+      ])),
+    );
+    provider.open();
+
+    const prWatch = getUpdateWatchPanelMessage(mockPanel).prWatches[0];
+    expect(prWatch).not.toHaveProperty('linkedItemId');
+    expect(prWatch).not.toHaveProperty('linkedSourceKey');
+  });
+
+  it('resolves PR links across PR-emitting provider IDs instead of the watcher provider ID', () => {
+    const mockPanel = createMockWebviewPanel();
+    vi.mocked(window.createWebviewPanel).mockReturnValue(mockPanel.panel as any);
+    const watcherService = createWatcherService([createPRWatch()]);
+
+    const provider = new WatchPanelProvider(
+      vscode.Uri.file('C:\\repo') as any,
+      watcherService as any,
+      createMockWorkGraph([{
+        id: 'review-work-42',
+        providerId: 'github-pr-reviews',
+        externalId: 'owner/repo#42',
+        itemType: 'pr',
+      }]),
+      createMockProviderRegistry(),
+    );
+    provider.open();
+
+    expect(getUpdateWatchPanelMessage(mockPanel).prWatches[0]).toEqual(expect.objectContaining({
+      id: 'pr:github-pr:owner/repo:42',
+      linkedItemId: 'review-work-42',
+    }));
+  });
+
+  it('resolves ADO PR watches using the ADO provider externalId format', () => {
+    const mockPanel = createMockWebviewPanel();
+    vi.mocked(window.createWebviewPanel).mockReturnValue(mockPanel.panel as any);
+    const watcherService = createWatcherService([createPRWatch('42', 'org/project/repo', 'ado-pr')]);
+
+    const provider = new WatchPanelProvider(
+      vscode.Uri.file('C:\\repo') as any,
+      watcherService as any,
+      createMockWorkGraph([{
+        id: 'ado-work-42',
+        providerId: 'ado-my-prs',
+        externalId: 'org/project/repo/42',
+        itemType: 'pr',
+      }]),
+      createMockProviderRegistry(),
+    );
+    provider.open();
+
+    expect(getUpdateWatchPanelMessage(mockPanel).prWatches[0]).toEqual(expect.objectContaining({
+      id: 'pr:ado-pr:org/project/repo:42',
+      linkedItemId: 'ado-work-42',
+    }));
+  });
+
   it('handles dismiss completed, open URL, and dismiss watch webview commands', async () => {
     const mockPanel = createMockWebviewPanel();
     vi.mocked(window.createWebviewPanel).mockReturnValue(mockPanel.panel as any);
@@ -175,19 +368,32 @@ describe('WatchPanelProvider', () => {
       dismissPRWatch: vi.fn(),
       dismissWatch: vi.fn(),
     };
+    const workGraph = createMockWorkGraph([{ id: 'work-42' }]);
 
-    const provider = new WatchPanelProvider(vscode.Uri.file('C:\\repo') as any, watcherService as any);
+    const provider = new WatchPanelProvider(
+      vscode.Uri.file('C:\\repo') as any,
+      watcherService as any,
+      workGraph as any,
+      createMockProviderRegistry(),
+    );
     provider.open();
 
     await mockPanel.simulateMessage({ type: 'dismissCompletedWatches' });
     await mockPanel.simulateMessage({ type: 'openWatchUrl', url: runIdentifier.url });
     await mockPanel.simulateMessage({ type: 'openWatchUrl', url: 'javascript:alert(1)' });
+    await mockPanel.simulateMessage({ type: 'openItem', itemId: 'work-42' });
+    await mockPanel.simulateMessage({ type: 'openItem', itemId: 'github-pr-reviews::owner/repo#42' });
     await mockPanel.simulateMessage({ type: 'dismissWatch', watchId: 'pr:github-pr:owner/repo:42' });
     await mockPanel.simulateMessage({ type: 'dismissWatch', watchId: 'run:github-actions:owner/repo:99' });
 
     // dismissCompletedWatches now routes through the shared command so the
     // confirmation prompt and logging stay in one place.
     expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.dismissAllCompletedWatches');
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.editItem', { id: 'work-42' });
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.previewIncomingItem', {
+      providerId: 'github-pr-reviews',
+      externalId: 'owner/repo#42',
+    });
     expect(env.openExternal).toHaveBeenCalledTimes(1);
     expect(env.openExternal).toHaveBeenCalledWith(
       expect.objectContaining({ path: 'https://github.com/owner/repo/actions/runs/99' }),

--- a/packages/core/src/test/watchPanelProvider.test.ts
+++ b/packages/core/src/test/watchPanelProvider.test.ts
@@ -237,11 +237,12 @@ describe('WatchPanelProvider', () => {
       id: 'pr:github-pr:owner/repo:42',
       linkedItemId: 'work-42',
     }));
-    expect(message.prWatches[0]).not.toHaveProperty('linkedSourceKey');
+    expect(message.prWatches[0]).not.toHaveProperty('linkedSourceProviderId');
+    expect(message.prWatches[0]).not.toHaveProperty('linkedSourceExternalId');
     expect(workGraph.getAll).toHaveBeenCalledTimes(1);
   });
 
-  it('adds linkedSourceKey when only a matching discovered PR exists', () => {
+  it('adds linked source provider and external IDs when only a matching discovered PR exists', () => {
     const mockPanel = createMockWebviewPanel();
     vi.mocked(window.createWebviewPanel).mockReturnValue(mockPanel.panel as any);
     const watcherService = createWatcherService([createPRWatch()]);
@@ -260,7 +261,8 @@ describe('WatchPanelProvider', () => {
     const message = getUpdateWatchPanelMessage(mockPanel);
     expect(message.prWatches[0]).toEqual(expect.objectContaining({
       id: 'pr:github-pr:owner/repo:42',
-      linkedSourceKey: 'github-pr-reviews::owner/repo#42',
+      linkedSourceProviderId: 'github-pr-reviews',
+      linkedSourceExternalId: 'owner/repo#42',
     }));
     expect(message.prWatches[0]).not.toHaveProperty('linkedItemId');
     expect(providerRegistry.getAllDiscoveredItems).toHaveBeenCalledTimes(1);
@@ -283,7 +285,8 @@ describe('WatchPanelProvider', () => {
 
     const prWatch = getUpdateWatchPanelMessage(mockPanel).prWatches[0];
     expect(prWatch).not.toHaveProperty('linkedItemId');
-    expect(prWatch).not.toHaveProperty('linkedSourceKey');
+    expect(prWatch).not.toHaveProperty('linkedSourceProviderId');
+    expect(prWatch).not.toHaveProperty('linkedSourceExternalId');
   });
 
   it('resolves PR links across PR-emitting provider IDs instead of the watcher provider ID', () => {
@@ -382,7 +385,12 @@ describe('WatchPanelProvider', () => {
     await mockPanel.simulateMessage({ type: 'openWatchUrl', url: runIdentifier.url });
     await mockPanel.simulateMessage({ type: 'openWatchUrl', url: 'javascript:alert(1)' });
     await mockPanel.simulateMessage({ type: 'openItem', itemId: 'work-42' });
-    await mockPanel.simulateMessage({ type: 'openItem', itemId: 'github-pr-reviews::owner/repo#42' });
+    await mockPanel.simulateMessage({
+      type: 'openItem',
+      itemId: 'github-pr-reviews::owner/repo#42',
+      providerId: 'github-pr-reviews',
+      externalId: 'owner/repo#42',
+    });
     await mockPanel.simulateMessage({ type: 'dismissWatch', watchId: 'pr:github-pr:owner/repo:42' });
     await mockPanel.simulateMessage({ type: 'dismissWatch', watchId: 'run:github-actions:owner/repo:99' });
 

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -116,6 +116,8 @@ export interface PRWatchData {
   repo: string;
   state: 'open' | 'merged' | 'closed';
   url?: string;
+  linkedItemId?: string;
+  linkedSourceKey?: string;
   runs: RunWatchData[];
   hasWarning?: boolean;
   errorMessage?: string;

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -117,7 +117,8 @@ export interface PRWatchData {
   state: 'open' | 'merged' | 'closed';
   url?: string;
   linkedItemId?: string;
-  linkedSourceKey?: string;
+  linkedSourceProviderId?: string;
+  linkedSourceExternalId?: string;
   runs: RunWatchData[];
   hasWarning?: boolean;
   errorMessage?: string;

--- a/packages/core/src/views/watchPanelProvider.ts
+++ b/packages/core/src/views/watchPanelProvider.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import * as crypto from 'node:crypto';
+import * as path from 'node:path';
 import type { DiscoveredItem, PRIdentifier, RunIdentifier, RunState } from '@devdocket/shared';
+import { logger } from '../services/logger';
 import { WatcherService, type WatchedPR, type WatchedRun } from '../services/watcherService';
 import type { WorkItem } from '../models/workItem';
 import type { ProviderRegistry } from '../services/providerRegistry';
@@ -10,12 +12,18 @@ import { buildTierColorCss } from '../webview/shared/colors';
 import { parseDiscoveredItemKey } from './discoveredItemKey';
 import type { PRWatchData, RunWatchData, WebviewMessage } from './mainTypes';
 
+interface CodiconsResources {
+  distDir: string;
+  cssPath: string;
+}
+
 export class WatchPanelProvider implements vscode.Disposable {
   static readonly viewType = 'devdocket.watchPanel';
 
   private panel?: vscode.WebviewPanel;
   private panelDisposables: vscode.Disposable[] = [];
   private readonly refreshDisposables: vscode.Disposable[];
+  private readonly codiconsResources = resolveCodiconsResources();
 
   constructor(
     private readonly extensionUri: vscode.Uri,
@@ -36,16 +44,18 @@ export class WatchPanelProvider implements vscode.Disposable {
       return;
     }
 
+    const localResourceRoots = [vscode.Uri.joinPath(this.extensionUri, 'webview-dist')];
+    if (this.codiconsResources) {
+      localResourceRoots.push(vscode.Uri.file(this.codiconsResources.distDir));
+    }
+
     this.panel = vscode.window.createWebviewPanel(
       WatchPanelProvider.viewType,
       'CI Watches',
       vscode.ViewColumn.Beside,
       {
         enableScripts: true,
-        localResourceRoots: [
-          vscode.Uri.joinPath(this.extensionUri, 'webview-dist'),
-          vscode.Uri.joinPath(this.extensionUri, 'node_modules', '@vscode/codicons', 'dist'),
-        ],
+        localResourceRoots,
       },
     );
 
@@ -258,7 +268,10 @@ export class WatchPanelProvider implements vscode.Disposable {
 
   private getHtml(webview: vscode.Webview): string {
     const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'webview-dist', 'watchPanel.js'));
-    const codiconsUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'node_modules', '@vscode/codicons', 'dist', 'codicon.css'));
+    const codiconsUri = this.codiconsResources
+      ? webview.asWebviewUri(vscode.Uri.file(this.codiconsResources.cssPath))
+      : undefined;
+    const codiconsLink = codiconsUri ? `\n  <link rel="stylesheet" href="${codiconsUri}">` : '';
     const nonce = getNonce();
 
     return `<!DOCTYPE html>
@@ -267,8 +280,7 @@ export class WatchPanelProvider implements vscode.Disposable {
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}' ${webview.cspSource}; font-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
-  <title>CI Watches</title>
-  <link rel="stylesheet" href="${codiconsUri}">
+  <title>CI Watches</title>${codiconsLink}
   <style nonce="${nonce}">
     * { box-sizing: border-box; }
     body {
@@ -655,6 +667,19 @@ function truncate(value: string, maxLength = 140): string {
 
 function toDisplayLabel(value: string): string {
   return value.replace(/_/g, ' ');
+}
+
+function resolveCodiconsResources(): CodiconsResources | undefined {
+  try {
+    const cssPath = require.resolve('@vscode/codicons/dist/codicon.css');
+    return {
+      distDir: path.dirname(cssPath),
+      cssPath,
+    };
+  } catch (error) {
+    logger.warn('Unable to resolve @vscode/codicons; watch panel icons will be unavailable.', error);
+    return undefined;
+  }
 }
 
 function getNonce(): string {

--- a/packages/core/src/views/watchPanelProvider.ts
+++ b/packages/core/src/views/watchPanelProvider.ts
@@ -1,9 +1,13 @@
 import * as vscode from 'vscode';
 import * as crypto from 'node:crypto';
-import type { PRIdentifier, RunConclusion, RunIdentifier, RunState } from '@devdocket/shared';
+import type { DiscoveredItem, PRIdentifier, RunIdentifier, RunState } from '@devdocket/shared';
 import { WatcherService, type WatchedPR, type WatchedRun } from '../services/watcherService';
+import type { WorkItem } from '../models/workItem';
+import type { ProviderRegistry } from '../services/providerRegistry';
+import type { WorkGraph } from '../services/workGraph';
 import { isSafeUrl } from '../utils/url';
 import { buildTierColorCss } from '../webview/shared/colors';
+import { getDiscoveredItemKey, parseDiscoveredItemKey } from './discoveredItemKey';
 import type { PRWatchData, RunWatchData, WebviewMessage } from './mainTypes';
 
 export class WatchPanelProvider implements vscode.Disposable {
@@ -15,6 +19,8 @@ export class WatchPanelProvider implements vscode.Disposable {
   constructor(
     private readonly extensionUri: vscode.Uri,
     private readonly watcherService: WatcherService,
+    private readonly workGraph: WorkGraph,
+    private readonly providerRegistry: ProviderRegistry,
   ) {}
 
   open(): void {
@@ -60,9 +66,10 @@ export class WatchPanelProvider implements vscode.Disposable {
       return;
     }
 
-    const prWatches = this.watcherService
-      .getActivePRWatches()
-      .map(prWatch => this.toPRWatchData(prWatch))
+    const activePRWatches = this.watcherService.getActivePRWatches();
+    const linkedPRTargets = activePRWatches.length > 0 ? this.buildLinkedPRTargetIndex() : new Map<string, LinkedPRTarget>();
+    const prWatches = activePRWatches
+      .map(prWatch => this.toPRWatchData(prWatch, linkedPRTargets))
       .filter(prWatch => prWatch.runs.length > 0)
       .sort((a, b) => comparePRWatches(a, b));
     const runWatches = this.watcherService
@@ -117,6 +124,10 @@ export class WatchPanelProvider implements vscode.Disposable {
         await vscode.env.openExternal(vscode.Uri.parse(safeUrl.href));
         break;
       }
+      case 'openItem': {
+        await this.openItem(message);
+        break;
+      }
       case 'dismissWatch':
         this.dismissWatchById(message.watchId);
         break;
@@ -131,6 +142,21 @@ export class WatchPanelProvider implements vscode.Disposable {
         break;
       default:
         break;
+    }
+  }
+
+  private async openItem(message: Extract<WebviewMessage, { type: 'openItem' }>): Promise<void> {
+    const workItem = this.workGraph.getItem(message.itemId);
+    if (workItem) {
+      await vscode.commands.executeCommand('devdocket.editItem', { id: message.itemId });
+      return;
+    }
+
+    const discoveredKey = parseDiscoveredItemKey(message.itemId);
+    const providerId = message.providerId ?? discoveredKey?.providerId;
+    const externalId = message.externalId ?? discoveredKey?.externalId;
+    if (providerId && externalId) {
+      await vscode.commands.executeCommand('devdocket.previewIncomingItem', { providerId, externalId });
     }
   }
 
@@ -151,14 +177,38 @@ export class WatchPanelProvider implements vscode.Disposable {
     }
   }
 
-  private toPRWatchData(prWatch: WatchedPR): PRWatchData {
+  private buildLinkedPRTargetIndex(): Map<string, LinkedPRTarget> {
+    const linkedTargets = new Map<string, LinkedPRTarget>();
+    for (const item of this.workGraph.getAll()) {
+      if (isPRWorkItem(item)) {
+        linkedTargets.set(item.externalId, { linkedItemId: item.id });
+      }
+    }
+
+    for (const [providerId, items] of this.providerRegistry.getAllDiscoveredItems()) {
+      for (const item of items) {
+        if (!isPRDiscoveredItem(providerId, item) || linkedTargets.has(item.externalId)) {
+          continue;
+        }
+        linkedTargets.set(item.externalId, { linkedSourceKey: getDiscoveredItemKey(providerId, item.externalId) });
+      }
+    }
+
+    return linkedTargets;
+  }
+
+  private toPRWatchData(prWatch: WatchedPR, linkedPRTargets: ReadonlyMap<string, LinkedPRTarget>): PRWatchData {
     const prKey = this.watcherService.getPRWatchKey(prWatch.identifier);
+    const linkedTarget = getPRExternalIds(prWatch.identifier)
+      .map(externalId => linkedPRTargets.get(externalId))
+      .find((target): target is LinkedPRTarget => target !== undefined);
     return {
       id: this.getPRPanelId(prWatch.identifier),
       title: prWatch.identifier.displayName,
       repo: prWatch.identifier.repo,
       state: prWatch.prState,
       url: prWatch.identifier.url,
+      ...(linkedTarget ?? {}),
       runs: this.watcherService
         .getChildRuns(prKey)
         .map(runWatch => this.toRunWatchData(runWatch))
@@ -438,6 +488,35 @@ export class WatchPanelProvider implements vscode.Disposable {
 </body>
 </html>`;
   }
+}
+
+interface LinkedPRTarget {
+  linkedItemId?: string;
+  linkedSourceKey?: string;
+}
+
+const PR_EMITTING_PROVIDER_IDS = new Set([
+  'github-my-prs',
+  'github-pr-reviews',
+  'github-mentions',
+  'ado-my-prs',
+  'ado-pr-reviews',
+]);
+
+function getPRExternalIds(identifier: PRIdentifier): string[] {
+  return [`${identifier.repo}#${identifier.prId}`, `${identifier.repo}/${identifier.prId}`];
+}
+
+function isPRWorkItem(item: WorkItem): item is WorkItem & { providerId: string; externalId: string } {
+  return Boolean(item.providerId && item.externalId && isPRCandidate(item.providerId, item.itemType));
+}
+
+function isPRDiscoveredItem(providerId: string, item: DiscoveredItem): boolean {
+  return isPRCandidate(providerId, item.itemType);
+}
+
+function isPRCandidate(providerId: string, itemType: 'issue' | 'pr' | undefined): boolean {
+  return itemType === 'pr' || (itemType === undefined && PR_EMITTING_PROVIDER_IDS.has(providerId));
 }
 
 function toPanelRunState(state: RunState): RunWatchData['state'] {

--- a/packages/core/src/views/watchPanelProvider.ts
+++ b/packages/core/src/views/watchPanelProvider.ts
@@ -168,15 +168,21 @@ export class WatchPanelProvider implements vscode.Disposable {
   }
 
   private async openItem(message: Extract<WebviewMessage, { type: 'openItem' }>): Promise<void> {
+    if (typeof message.itemId !== 'string') {
+      return;
+    }
+
     const workItem = this.workGraph.getItem(message.itemId);
     if (workItem) {
       await vscode.commands.executeCommand('devdocket.editItem', { id: message.itemId });
       return;
     }
 
-    const discoveredKey = message.providerId && message.externalId ? undefined : parseDiscoveredItemKey(message.itemId);
-    const providerId = message.providerId ?? discoveredKey?.providerId;
-    const externalId = message.externalId ?? discoveredKey?.externalId;
+    const messageProviderId = typeof message.providerId === 'string' ? message.providerId : undefined;
+    const messageExternalId = typeof message.externalId === 'string' ? message.externalId : undefined;
+    const discoveredKey = messageProviderId && messageExternalId ? undefined : parseDiscoveredItemKey(message.itemId);
+    const providerId = messageProviderId ?? discoveredKey?.providerId;
+    const externalId = messageExternalId ?? discoveredKey?.externalId;
     if (providerId && externalId) {
       await vscode.commands.executeCommand('devdocket.previewIncomingItem', { providerId, externalId });
     }

--- a/packages/core/src/views/watchPanelProvider.ts
+++ b/packages/core/src/views/watchPanelProvider.ts
@@ -15,13 +15,19 @@ export class WatchPanelProvider implements vscode.Disposable {
 
   private panel?: vscode.WebviewPanel;
   private panelDisposables: vscode.Disposable[] = [];
+  private readonly refreshDisposables: vscode.Disposable[];
 
   constructor(
     private readonly extensionUri: vscode.Uri,
     private readonly watcherService: WatcherService,
     private readonly workGraph: WorkGraph,
     private readonly providerRegistry: ProviderRegistry,
-  ) {}
+  ) {
+    this.refreshDisposables = [
+      this.workGraph.onDidChange(() => this.refresh()),
+      this.providerRegistry.onDidChangeDiscoveredItems(() => this.refresh()),
+    ];
+  }
 
   open(): void {
     if (this.panel) {
@@ -100,6 +106,9 @@ export class WatchPanelProvider implements vscode.Disposable {
       this.panel.dispose();
     }
     this.clearPanel();
+    for (const disposable of this.refreshDisposables.splice(0)) {
+      disposable.dispose();
+    }
   }
 
   private clearPanel(): void {

--- a/packages/core/src/views/watchPanelProvider.ts
+++ b/packages/core/src/views/watchPanelProvider.ts
@@ -7,7 +7,7 @@ import type { ProviderRegistry } from '../services/providerRegistry';
 import type { WorkGraph } from '../services/workGraph';
 import { isSafeUrl } from '../utils/url';
 import { buildTierColorCss } from '../webview/shared/colors';
-import { getDiscoveredItemKey, parseDiscoveredItemKey } from './discoveredItemKey';
+import { parseDiscoveredItemKey } from './discoveredItemKey';
 import type { PRWatchData, RunWatchData, WebviewMessage } from './mainTypes';
 
 export class WatchPanelProvider implements vscode.Disposable {
@@ -155,7 +155,7 @@ export class WatchPanelProvider implements vscode.Disposable {
       return;
     }
 
-    const discoveredKey = parseDiscoveredItemKey(message.itemId);
+    const discoveredKey = message.providerId && message.externalId ? undefined : parseDiscoveredItemKey(message.itemId);
     const providerId = message.providerId ?? discoveredKey?.providerId;
     const externalId = message.externalId ?? discoveredKey?.externalId;
     if (providerId && externalId) {
@@ -193,7 +193,10 @@ export class WatchPanelProvider implements vscode.Disposable {
         if (!isPRDiscoveredItem(providerId, item) || linkedTargets.has(item.externalId)) {
           continue;
         }
-        linkedTargets.set(item.externalId, { linkedSourceKey: getDiscoveredItemKey(providerId, item.externalId) });
+        linkedTargets.set(item.externalId, {
+          linkedSourceProviderId: providerId,
+          linkedSourceExternalId: item.externalId,
+        });
       }
     }
 
@@ -497,7 +500,8 @@ export class WatchPanelProvider implements vscode.Disposable {
 
 interface LinkedPRTarget {
   linkedItemId?: string;
-  linkedSourceKey?: string;
+  linkedSourceProviderId?: string;
+  linkedSourceExternalId?: string;
 }
 
 const PR_EMITTING_PROVIDER_IDS = new Set([

--- a/packages/core/src/views/watchPanelProvider.ts
+++ b/packages/core/src/views/watchPanelProvider.ts
@@ -36,7 +36,10 @@ export class WatchPanelProvider implements vscode.Disposable {
       vscode.ViewColumn.Beside,
       {
         enableScripts: true,
-        localResourceRoots: [vscode.Uri.joinPath(this.extensionUri, 'webview-dist')],
+        localResourceRoots: [
+          vscode.Uri.joinPath(this.extensionUri, 'webview-dist'),
+          vscode.Uri.joinPath(this.extensionUri, 'node_modules', '@vscode/codicons', 'dist'),
+        ],
       },
     );
 
@@ -243,6 +246,7 @@ export class WatchPanelProvider implements vscode.Disposable {
 
   private getHtml(webview: vscode.Webview): string {
     const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'webview-dist', 'watchPanel.js'));
+    const codiconsUri = webview.asWebviewUri(vscode.Uri.joinPath(this.extensionUri, 'node_modules', '@vscode/codicons', 'dist', 'codicon.css'));
     const nonce = getNonce();
 
     return `<!DOCTYPE html>
@@ -250,8 +254,9 @@ export class WatchPanelProvider implements vscode.Disposable {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}' ${webview.cspSource}; font-src ${webview.cspSource}; script-src 'nonce-${nonce}';">
   <title>CI Watches</title>
+  <link rel="stylesheet" href="${codiconsUri}">
   <style nonce="${nonce}">
     * { box-sizing: border-box; }
     body {

--- a/packages/core/src/webview/watchPanel/WatchApp.tsx
+++ b/packages/core/src/webview/watchPanel/WatchApp.tsx
@@ -102,7 +102,8 @@ export function WatchApp() {
                       url={entry.pr.url}
                       watchId={entry.pr.id}
                       linkedItemId={entry.pr.linkedItemId}
-                      linkedSourceKey={entry.pr.linkedSourceKey}
+                      linkedSourceProviderId={entry.pr.linkedSourceProviderId}
+                      linkedSourceExternalId={entry.pr.linkedSourceExternalId}
                     />
                   );
                 }
@@ -197,7 +198,8 @@ interface WatchCardProps {
   url?: string;
   watchId: string;
   linkedItemId?: string;
-  linkedSourceKey?: string;
+  linkedSourceProviderId?: string;
+  linkedSourceExternalId?: string;
 }
 
 function WatchCard({
@@ -211,7 +213,8 @@ function WatchCard({
   url,
   watchId,
   linkedItemId,
-  linkedSourceKey,
+  linkedSourceProviderId,
+  linkedSourceExternalId,
 }: WatchCardProps) {
   const clickable = Boolean(url);
   const openWatch = () => {
@@ -219,10 +222,20 @@ function WatchCard({
       postMessage({ type: 'openWatchUrl', url });
     }
   };
-  const linkedTargetId = linkedItemId ?? linkedSourceKey;
+  const hasLinkedSource = Boolean(linkedSourceProviderId && linkedSourceExternalId);
+  const hasLinkedTarget = Boolean(linkedItemId || hasLinkedSource);
   const openLinkedItem = () => {
-    if (linkedTargetId) {
-      postMessage({ type: 'openItem', itemId: linkedTargetId });
+    if (linkedItemId) {
+      postMessage({ type: 'openItem', itemId: linkedItemId });
+      return;
+    }
+    if (linkedSourceProviderId && linkedSourceExternalId) {
+      postMessage({
+        type: 'openItem',
+        itemId: `${linkedSourceProviderId}::${linkedSourceExternalId}`,
+        providerId: linkedSourceProviderId,
+        externalId: linkedSourceExternalId,
+      });
     }
   };
   const handleKeyDown = (event: KeyboardEvent) => {
@@ -259,7 +272,7 @@ function WatchCard({
         </div>
       </div>
       <div class="item-actions" role="group" aria-label={`${title} actions`}>
-        {linkedTargetId ? (
+        {hasLinkedTarget ? (
           <button
             type="button"
             class="item-action-btn"

--- a/packages/core/src/webview/watchPanel/WatchApp.tsx
+++ b/packages/core/src/webview/watchPanel/WatchApp.tsx
@@ -271,7 +271,7 @@ function WatchCard({
               openLinkedItem();
             }}
           >
-            ⇱
+            <span class="codicon codicon-go-to-file" aria-hidden="true" />
           </button>
         ) : null}
         <button

--- a/packages/core/src/webview/watchPanel/WatchApp.tsx
+++ b/packages/core/src/webview/watchPanel/WatchApp.tsx
@@ -101,6 +101,8 @@ export function WatchApp() {
                       tierClass={getPRTierClass(entry.pr)}
                       url={entry.pr.url}
                       watchId={entry.pr.id}
+                      linkedItemId={entry.pr.linkedItemId}
+                      linkedSourceKey={entry.pr.linkedSourceKey}
                     />
                   );
                 }
@@ -194,6 +196,8 @@ interface WatchCardProps {
   elapsedTime?: string;
   url?: string;
   watchId: string;
+  linkedItemId?: string;
+  linkedSourceKey?: string;
 }
 
 function WatchCard({
@@ -206,11 +210,19 @@ function WatchCard({
   elapsedTime,
   url,
   watchId,
+  linkedItemId,
+  linkedSourceKey,
 }: WatchCardProps) {
   const clickable = Boolean(url);
   const openWatch = () => {
     if (url) {
       postMessage({ type: 'openWatchUrl', url });
+    }
+  };
+  const linkedTargetId = linkedItemId ?? linkedSourceKey;
+  const openLinkedItem = () => {
+    if (linkedTargetId) {
+      postMessage({ type: 'openItem', itemId: linkedTargetId });
     }
   };
   const handleKeyDown = (event: KeyboardEvent) => {
@@ -247,6 +259,21 @@ function WatchCard({
         </div>
       </div>
       <div class="item-actions" role="group" aria-label={`${title} actions`}>
+        {linkedTargetId ? (
+          <button
+            type="button"
+            class="item-action-btn"
+            title="Open in DevDocket"
+            aria-label="Open in DevDocket"
+            onKeyDown={(event) => event.stopPropagation()}
+            onClick={(event) => {
+              event.stopPropagation();
+              openLinkedItem();
+            }}
+          >
+            ⇱
+          </button>
+        ) : null}
         <button
           type="button"
           class="item-action-btn"


### PR DESCRIPTION
## Summary

Adds a small "Open in DevDocket" affordance on each watched-PR row in the **CI Watches** panel that jumps to the corresponding DevDocket work item or Sources entry for that PR. The primary click target on the row body is unchanged — it still opens the PR's external GitHub URL.

This is the inverse of #515 — together they close the loop in both directions between the editor and the CI Watches panel.

## UX

- A small icon button (codicon `$(go-to-file)`) appears on the right side of each watched-PR row.
- Aria-label: `Open in DevDocket`.
- The button is **omitted entirely** when there is no matching WorkItem AND no matching DiscoveredItem (no dead/disabled state).
- Click → opens the existing DevDocket editor or Sources preview via the existing `openItem` postMessage, which already accepts both work item ids and `${providerId}::${externalId}` Sources keys.

## Cross-provider matching

The watched PR's `providerId` is the WATCHER id (`github-pr-watcher`), but the DevDocket work item's `providerId` is the EMITTER id (`github-my-prs`, `github-pr-reviews`, `github-mentions`, etc.). The lookup matches on the `(repo, prId)` tuple derived from the WorkItem/DiscoveredItem `externalId` (`${repo}#${prId}`) regardless of `providerId` — mirroring PR #500's `relatedItems` cross-provider resolver.

## Performance

The lookup builds a single `Map<externalId, WorkItem | DiscoveredItem>` per panel refresh and looks up each PR row in constant time, avoiding `O(rows × all items)` re-scans.

## Out of scope

- The same affordance on RUN watches (a CI run isn't a tracked work item; the issue lists this as a follow-up).
- Bidirectional linking from the editor side (covered by #515).
- Keyboard equivalent (Alt+Enter / similar).

## Changes

- `packages/core/src/views/watchPanelProvider.ts` — extend `PRWatchData` with `linkedItemId?` / `linkedSourceKey?`; populate via WorkGraph + ProviderRegistry lookup at refresh time.
- `packages/core/src/webview/watchPanel/WatchApp.tsx` — new icon button, hidden when no link exists; wires `openItem` postMessage.
- `packages/core/src/views/mainTypes.ts` — new optional fields on `PRWatchData`.
- `packages/core/src/extension.ts` — wire the watch panel's `openItem` route through the existing handler.
- `packages/core/src/test/watchPanelProvider.test.ts` — covers the four required scenarios: WorkItem found, DiscoveredItem only, neither, cross-provider match.

## Verification

- `npm run build` — passes.
- `npm run test` — 792 tests across 31 files pass.

Closes #514
