### PR TITLE
Migrate Marketplace publisher to DevDocket

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ See `.github/instructions/storage.instructions.md` for the full storage contract
 
 ### Extension API
 
-The core extension returns `DevDocketApi` from `activate()`. Provider extensions acquire it via `vscode.extensions.getExtension('mthalman.devdocket')`.
+The core extension returns `DevDocketApi` from `activate()`. Provider extensions acquire it via `vscode.extensions.getExtension('DevDocket.devdocket')`.
 
 ```ts
 interface DevDocketApi {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ See `.github/instructions/storage.instructions.md` for the full storage contract
 
 ### Extension API
 
-The core extension returns `DevDocketApi` from `activate()`. Provider extensions acquire it via `vscode.extensions.getExtension('DevDocket.devdocket')`.
+The core extension returns `DevDocketApi` from `activate()`. Provider extensions acquire it via `vscode.extensions.getExtension('devdocket.devdocket')`.
 
 ```ts
 interface DevDocketApi {

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -11,7 +11,7 @@ Your extension must declare a dependency on DevDocket so that VS Code activates 
 ```jsonc
 // package.json
 {
-  "extensionDependencies": ["DevDocket.devdocket"]
+  "extensionDependencies": ["devdocket.devdocket"]
 }
 ```
 
@@ -47,9 +47,9 @@ In your extension's `activate()` function, acquire the `DevDocketApi` from the c
 import * as vscode from 'vscode';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  const coreExtension = vscode.extensions.getExtension('DevDocket.devdocket');
+  const coreExtension = vscode.extensions.getExtension('devdocket.devdocket');
   if (!coreExtension) {
-    vscode.window.showErrorMessage('DevDocket core extension not found. Please install and enable "DevDocket.devdocket".');
+    vscode.window.showErrorMessage('DevDocket core extension not found. Please install and enable "devdocket.devdocket".');
     return;
   }
 
@@ -70,7 +70,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     typeof (api as any).registerAction !== 'function'
   ) {
     console.error('DevDocket API is not in the expected shape', api);
-    vscode.window.showErrorMessage('DevDocket API is unavailable or invalid. Please check that "DevDocket.devdocket" is up to date.');
+    vscode.window.showErrorMessage('DevDocket API is unavailable or invalid. Please check that "devdocket.devdocket" is up to date.');
     return;
   }
 
@@ -529,7 +529,7 @@ class MyTaskProvider implements DevDocketProvider {
 
 // In your activate() function:
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  const coreExtension = vscode.extensions.getExtension('DevDocket.devdocket');
+  const coreExtension = vscode.extensions.getExtension('devdocket.devdocket');
   if (!coreExtension) {
     return;
   }

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -11,7 +11,7 @@ Your extension must declare a dependency on DevDocket so that VS Code activates 
 ```jsonc
 // package.json
 {
-  "extensionDependencies": ["mthalman.devdocket"]
+  "extensionDependencies": ["DevDocket.devdocket"]
 }
 ```
 
@@ -47,9 +47,9 @@ In your extension's `activate()` function, acquire the `DevDocketApi` from the c
 import * as vscode from 'vscode';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  const coreExtension = vscode.extensions.getExtension('mthalman.devdocket');
+  const coreExtension = vscode.extensions.getExtension('DevDocket.devdocket');
   if (!coreExtension) {
-    vscode.window.showErrorMessage('DevDocket core extension not found. Please install and enable "mthalman.devdocket".');
+    vscode.window.showErrorMessage('DevDocket core extension not found. Please install and enable "DevDocket.devdocket".');
     return;
   }
 
@@ -70,7 +70,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     typeof (api as any).registerAction !== 'function'
   ) {
     console.error('DevDocket API is not in the expected shape', api);
-    vscode.window.showErrorMessage('DevDocket API is unavailable or invalid. Please check that "mthalman.devdocket" is up to date.');
+    vscode.window.showErrorMessage('DevDocket API is unavailable or invalid. Please check that "DevDocket.devdocket" is up to date.');
     return;
   }
 
@@ -529,7 +529,7 @@ class MyTaskProvider implements DevDocketProvider {
 
 // In your activate() function:
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  const coreExtension = vscode.extensions.getExtension('mthalman.devdocket');
+  const coreExtension = vscode.extensions.getExtension('DevDocket.devdocket');
   if (!coreExtension) {
     return;
   }

--- a/docs/provider-api.md
+++ b/docs/provider-api.md
@@ -44,7 +44,7 @@ Add DevDocket as an extension dependency in your `package.json` so VS Code activ
 ```jsonc
 // package.json
 {
-  "extensionDependencies": ["DevDocket.devdocket"]
+  "extensionDependencies": ["devdocket.devdocket"]
 }
 ```
 
@@ -56,10 +56,10 @@ In your extension's `activate()` function, get the `DevDocketApi` from the core 
 import * as vscode from 'vscode';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  const coreExtension = vscode.extensions.getExtension('DevDocket.devdocket');
+  const coreExtension = vscode.extensions.getExtension('devdocket.devdocket');
   if (!coreExtension) {
     vscode.window.showErrorMessage(
-      'DevDocket core extension not found. Install "DevDocket.devdocket".'
+      'DevDocket core extension not found. Install "devdocket.devdocket".'
     );
     return;
   }
@@ -84,7 +84,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     typeof api.registerAction !== 'function'
   ) {
     vscode.window.showErrorMessage(
-      'DevDocket API is unavailable or invalid. Update "DevDocket.devdocket".'
+      'DevDocket API is unavailable or invalid. Update "devdocket.devdocket".'
     );
     return;
   }

--- a/docs/provider-api.md
+++ b/docs/provider-api.md
@@ -44,7 +44,7 @@ Add DevDocket as an extension dependency in your `package.json` so VS Code activ
 ```jsonc
 // package.json
 {
-  "extensionDependencies": ["mthalman.devdocket"]
+  "extensionDependencies": ["DevDocket.devdocket"]
 }
 ```
 
@@ -56,10 +56,10 @@ In your extension's `activate()` function, get the `DevDocketApi` from the core 
 import * as vscode from 'vscode';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  const coreExtension = vscode.extensions.getExtension('mthalman.devdocket');
+  const coreExtension = vscode.extensions.getExtension('DevDocket.devdocket');
   if (!coreExtension) {
     vscode.window.showErrorMessage(
-      'DevDocket core extension not found. Install "mthalman.devdocket".'
+      'DevDocket core extension not found. Install "DevDocket.devdocket".'
     );
     return;
   }
@@ -84,7 +84,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     typeof api.registerAction !== 'function'
   ) {
     vscode.window.showErrorMessage(
-      'DevDocket API is unavailable or invalid. Update "mthalman.devdocket".'
+      'DevDocket API is unavailable or invalid. Update "DevDocket.devdocket".'
     );
     return;
   }

--- a/packages/ado/package.json
+++ b/packages/ado/package.json
@@ -3,7 +3,7 @@
   "displayName": "DevDocket — Azure DevOps",
   "description": "Azure DevOps provider for DevDocket — discovers assigned work items and PR reviews.",
   "version": "0.1.0",
-  "publisher": "mthalman",
+  "publisher": "DevDocket",
   "license": "MIT",
   "engines": {
     "vscode": "^1.92.0"
@@ -12,7 +12,7 @@
     "Other"
   ],
   "extensionDependencies": [
-    "mthalman.devdocket"
+    "DevDocket.devdocket"
   ],
   "activationEvents": [
     "onStartupFinished"

--- a/packages/ado/package.json
+++ b/packages/ado/package.json
@@ -3,7 +3,7 @@
   "displayName": "DevDocket — Azure DevOps",
   "description": "Azure DevOps provider for DevDocket — discovers assigned work items and PR reviews.",
   "version": "0.1.0",
-  "publisher": "DevDocket",
+  "publisher": "devdocket",
   "license": "MIT",
   "engines": {
     "vscode": "^1.92.0"
@@ -12,7 +12,7 @@
     "Other"
   ],
   "extensionDependencies": [
-    "DevDocket.devdocket"
+    "devdocket.devdocket"
   ],
   "activationEvents": [
     "onStartupFinished"

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -17,7 +17,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   const coreExtension = vscode.extensions.getExtension('devdocket.devdocket');
   if (!coreExtension) {
-    logger.error('Core extension not found');
+    logger.error('Core extension devdocket.devdocket not found. Install or enable DevDocket.');
     return;
   }
 

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -15,7 +15,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   log.info('DevDocket ADO activating...');
 
-  const coreExtension = vscode.extensions.getExtension('DevDocket.devdocket');
+  const coreExtension = vscode.extensions.getExtension('devdocket.devdocket');
   if (!coreExtension) {
     logger.error('Core extension not found');
     return;

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -15,7 +15,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   log.info('DevDocket ADO activating...');
 
-  const coreExtension = vscode.extensions.getExtension('mthalman.devdocket');
+  const coreExtension = vscode.extensions.getExtension('DevDocket.devdocket');
   if (!coreExtension) {
     logger.error('Core extension not found');
     return;

--- a/packages/ai-reviewer/package.json
+++ b/packages/ai-reviewer/package.json
@@ -3,7 +3,7 @@
   "displayName": "DevDocket — AI Actions",
   "description": "AI-powered code review and PR walkthrough actions for DevDocket",
   "version": "0.1.0",
-  "publisher": "DevDocket",
+  "publisher": "devdocket",
   "license": "MIT",
   "engines": {
     "vscode": "^1.96.0"
@@ -12,7 +12,7 @@
     "Other"
   ],
   "extensionDependencies": [
-    "DevDocket.devdocket"
+    "devdocket.devdocket"
   ],
   "activationEvents": [
     "onStartupFinished"

--- a/packages/ai-reviewer/package.json
+++ b/packages/ai-reviewer/package.json
@@ -3,7 +3,7 @@
   "displayName": "DevDocket — AI Actions",
   "description": "AI-powered code review and PR walkthrough actions for DevDocket",
   "version": "0.1.0",
-  "publisher": "mthalman",
+  "publisher": "DevDocket",
   "license": "MIT",
   "engines": {
     "vscode": "^1.96.0"
@@ -12,7 +12,7 @@
     "Other"
   ],
   "extensionDependencies": [
-    "mthalman.devdocket"
+    "DevDocket.devdocket"
   ],
   "activationEvents": [
     "onStartupFinished"

--- a/packages/ai-reviewer/src/extension.ts
+++ b/packages/ai-reviewer/src/extension.ts
@@ -12,7 +12,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   log.info('Activating DevDocket AI Reviewer extension');
 
-  const coreExtension = vscode.extensions.getExtension<DevDocketApi>('DevDocket.devdocket');
+  const coreExtension = vscode.extensions.getExtension<DevDocketApi>('devdocket.devdocket');
   if (!coreExtension) {
     const msg = 'DevDocket AI Reviewer: core extension not found. Install the DevDocket extension.';
     log.error(msg);

--- a/packages/ai-reviewer/src/extension.ts
+++ b/packages/ai-reviewer/src/extension.ts
@@ -12,7 +12,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   log.info('Activating DevDocket AI Reviewer extension');
 
-  const coreExtension = vscode.extensions.getExtension<DevDocketApi>('mthalman.devdocket');
+  const coreExtension = vscode.extensions.getExtension<DevDocketApi>('DevDocket.devdocket');
   if (!coreExtension) {
     const msg = 'DevDocket AI Reviewer: core extension not found. Install the DevDocket extension.';
     log.error(msg);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "displayName": "DevDocket",
   "description": "A central hub for managing work across pull requests, issues, investigations, and follow-ups.",
   "version": "0.1.0",
-  "publisher": "DevDocket",
+  "publisher": "devdocket",
   "license": "MIT",
   "engines": {
     "vscode": "^1.92.0"
@@ -49,8 +49,8 @@
               "markdown": "media/walkthroughs/providers.md"
             },
             "completionEvents": [
-              "extensionInstalled:DevDocket.devdocket-github",
-              "extensionInstalled:DevDocket.devdocket-ado"
+              "extensionInstalled:devdocket.devdocket-github",
+              "extensionInstalled:devdocket.devdocket-ado"
             ]
           },
           {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "displayName": "DevDocket",
   "description": "A central hub for managing work across pull requests, issues, investigations, and follow-ups.",
   "version": "0.1.0",
-  "publisher": "mthalman",
+  "publisher": "DevDocket",
   "license": "MIT",
   "engines": {
     "vscode": "^1.92.0"
@@ -49,8 +49,8 @@
               "markdown": "media/walkthroughs/providers.md"
             },
             "completionEvents": [
-              "extensionInstalled:mthalman.devdocket-github",
-              "extensionInstalled:mthalman.devdocket-ado"
+              "extensionInstalled:DevDocket.devdocket-github",
+              "extensionInstalled:DevDocket.devdocket-ado"
             ]
           },
           {

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -763,7 +763,7 @@ export function registerCommands(
       wrapCommand('Failed to open walkthrough', () =>
         vscode.commands.executeCommand(
           'workbench.action.openWalkthrough',
-          'mthalman.devdocket#devdocket.gettingStarted',
+          'DevDocket.devdocket#devdocket.gettingStarted',
           false,
         ),
       )),

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -763,7 +763,7 @@ export function registerCommands(
       wrapCommand('Failed to open walkthrough', () =>
         vscode.commands.executeCommand(
           'workbench.action.openWalkthrough',
-          'DevDocket.devdocket#devdocket.gettingStarted',
+          'devdocket.devdocket#devdocket.gettingStarted',
           false,
         ),
       )),

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -3,7 +3,7 @@
   "displayName": "DevDocket GitHub",
   "description": "GitHub provider for DevDocket — discovers assigned issues, PR reviews, and authored PRs with status tracking.",
   "version": "0.1.0",
-  "publisher": "DevDocket",
+  "publisher": "devdocket",
   "license": "MIT",
   "engines": {
     "vscode": "^1.92.0"
@@ -12,7 +12,7 @@
     "Other"
   ],
   "extensionDependencies": [
-    "DevDocket.devdocket"
+    "devdocket.devdocket"
   ],
   "activationEvents": [
     "onStartupFinished"

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -3,7 +3,7 @@
   "displayName": "DevDocket GitHub",
   "description": "GitHub provider for DevDocket — discovers assigned issues, PR reviews, and authored PRs with status tracking.",
   "version": "0.1.0",
-  "publisher": "mthalman",
+  "publisher": "DevDocket",
   "license": "MIT",
   "engines": {
     "vscode": "^1.92.0"
@@ -12,7 +12,7 @@
     "Other"
   ],
   "extensionDependencies": [
-    "mthalman.devdocket"
+    "DevDocket.devdocket"
   ],
   "activationEvents": [
     "onStartupFinished"

--- a/packages/github/src/extension.ts
+++ b/packages/github/src/extension.ts
@@ -16,7 +16,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   log.info('DevDocket GitHub activating...');
 
   // Acquire the DevDocket API from the core extension
-  const coreExtension = vscode.extensions.getExtension('mthalman.devdocket');
+  const coreExtension = vscode.extensions.getExtension('DevDocket.devdocket');
   if (!coreExtension) {
     logger.error('Core extension not found');
     return;

--- a/packages/github/src/extension.ts
+++ b/packages/github/src/extension.ts
@@ -16,7 +16,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   log.info('DevDocket GitHub activating...');
 
   // Acquire the DevDocket API from the core extension
-  const coreExtension = vscode.extensions.getExtension('DevDocket.devdocket');
+  const coreExtension = vscode.extensions.getExtension('devdocket.devdocket');
   if (!coreExtension) {
     logger.error('Core extension not found');
     return;

--- a/packages/github/src/extension.ts
+++ b/packages/github/src/extension.ts
@@ -18,7 +18,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // Acquire the DevDocket API from the core extension
   const coreExtension = vscode.extensions.getExtension('devdocket.devdocket');
   if (!coreExtension) {
-    logger.error('Core extension not found');
+    logger.error('Core extension devdocket.devdocket not found. Install or enable DevDocket.');
     return;
   }
 

--- a/packages/shared/src/apiTypes.ts
+++ b/packages/shared/src/apiTypes.ts
@@ -135,12 +135,12 @@ export interface DevDocketAction {
  * Public API surface of the DevDocket extension.
  *
  * Obtain this API from the core extension by getting its extension wrapper via
- * `vscode.extensions.getExtension('DevDocket.devdocket')`, then activating it
+ * `vscode.extensions.getExtension('devdocket.devdocket')`, then activating it
  * with `await extension.activate()` (or reading `extension.exports` after activation).
  *
  * @example
  * ```ts
- * const ext = vscode.extensions.getExtension<DevDocketApi>('DevDocket.devdocket');
+ * const ext = vscode.extensions.getExtension<DevDocketApi>('devdocket.devdocket');
  * const api = await ext?.activate();
  * if (api) {
  *   api.registerProvider(myProvider);

--- a/packages/shared/src/apiTypes.ts
+++ b/packages/shared/src/apiTypes.ts
@@ -135,12 +135,12 @@ export interface DevDocketAction {
  * Public API surface of the DevDocket extension.
  *
  * Obtain this API from the core extension by getting its extension wrapper via
- * `vscode.extensions.getExtension('mthalman.devdocket')`, then activating it
+ * `vscode.extensions.getExtension('DevDocket.devdocket')`, then activating it
  * with `await extension.activate()` (or reading `extension.exports` after activation).
  *
  * @example
  * ```ts
- * const ext = vscode.extensions.getExtension<DevDocketApi>('mthalman.devdocket');
+ * const ext = vscode.extensions.getExtension<DevDocketApi>('DevDocket.devdocket');
  * const api = await ext?.activate();
  * if (api) {
  *   api.registerProvider(myProvider);

--- a/packages/start-git-work/package.json
+++ b/packages/start-git-work/package.json
@@ -3,7 +3,7 @@
   "displayName": "DevDocket Start Git Work",
   "description": "Start Git Work action for DevDocket — creates git branches and worktrees for GitHub and Azure DevOps work items.",
   "version": "0.1.0",
-  "publisher": "DevDocket",
+  "publisher": "devdocket",
   "license": "MIT",
   "engines": {
     "vscode": "^1.92.0"
@@ -12,7 +12,7 @@
     "Other"
   ],
   "extensionDependencies": [
-    "DevDocket.devdocket"
+    "devdocket.devdocket"
   ],
   "activationEvents": [
     "onStartupFinished"

--- a/packages/start-git-work/package.json
+++ b/packages/start-git-work/package.json
@@ -3,7 +3,7 @@
   "displayName": "DevDocket Start Git Work",
   "description": "Start Git Work action for DevDocket — creates git branches and worktrees for GitHub and Azure DevOps work items.",
   "version": "0.1.0",
-  "publisher": "mthalman",
+  "publisher": "DevDocket",
   "license": "MIT",
   "engines": {
     "vscode": "^1.92.0"
@@ -12,7 +12,7 @@
     "Other"
   ],
   "extensionDependencies": [
-    "mthalman.devdocket"
+    "DevDocket.devdocket"
   ],
   "activationEvents": [
     "onStartupFinished"

--- a/packages/start-git-work/src/extension.ts
+++ b/packages/start-git-work/src/extension.ts
@@ -13,7 +13,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   const coreExtension = vscode.extensions.getExtension('devdocket.devdocket');
   if (!coreExtension) {
-    logger.error('Core extension not found');
+    logger.error('Core extension devdocket.devdocket not found. Install or enable DevDocket.');
     return;
   }
 

--- a/packages/start-git-work/src/extension.ts
+++ b/packages/start-git-work/src/extension.ts
@@ -11,7 +11,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   log.info('DevDocket Start Git Work activating...');
 
-  const coreExtension = vscode.extensions.getExtension('DevDocket.devdocket');
+  const coreExtension = vscode.extensions.getExtension('devdocket.devdocket');
   if (!coreExtension) {
     logger.error('Core extension not found');
     return;

--- a/packages/start-git-work/src/extension.ts
+++ b/packages/start-git-work/src/extension.ts
@@ -11,7 +11,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   log.info('DevDocket Start Git Work activating...');
 
-  const coreExtension = vscode.extensions.getExtension('mthalman.devdocket');
+  const coreExtension = vscode.extensions.getExtension('DevDocket.devdocket');
   if (!coreExtension) {
     logger.error('Core extension not found');
     return;


### PR DESCRIPTION
## Summary

Migrate DevDocket's VS Code Marketplace publisher references from `mthalman` to `devdocket` across extension package manifests, runtime extension-id lookups, walkthrough metadata, and consumer documentation.

## Changed publisher fields and extension-id references

- Updated `publisher` to `devdocket` in:
  - `packages/core/package.json` (`devdocket`)
  - `packages/github/package.json` (`devdocket-github`)
  - `packages/ado/package.json` (`devdocket-ado`)
  - `packages/start-git-work/package.json` (`devdocket-start-git-work`)
  - `packages/ai-reviewer/package.json` (`devdocket-ai-reviewer`)
- Updated provider/action dependencies and runtime API lookups to `devdocket.devdocket`.
- Updated core walkthrough completion events to `extensionInstalled:devdocket.devdocket-github` and `extensionInstalled:devdocket.devdocket-ado`.
- Updated the open-walkthrough extension identifier to `devdocket.devdocket#devdocket.gettingStarted`.
- Updated consumer examples and JSDoc in `docs/extension-api.md`, `docs/provider-api.md`, `packages/shared/src/apiTypes.ts`, and `AGENTS.md`.
- Left the `.github/workflows/automated-refactoring.yml` `mthalman/superpowers` URL unchanged because it points to an external repository, not a DevDocket VS Code extension ID or publisher reference.

## Required pre-merge actions

These human/external steps must be completed before this can be released:

- Register the `devdocket` publisher on the VS Code Marketplace and Open VSX.
- Grant maintainer account access to the new publisher.
- Decide the marketplace migration path: old-listing deprecation note vs. ownership transfer to preserve the install base.
- Update the `VSCE_PAT` secret in repo settings if a new token is needed.
- Add CHANGELOG entries for the rename release.

Closes #457
