### PR TITLE
Split watcher service responsibilities

### DIFF
--- a/packages/core/src/services/prWatchPool.ts
+++ b/packages/core/src/services/prWatchPool.ts
@@ -303,6 +303,10 @@ export class PRWatchPool implements vscode.Disposable {
       }
 
       await this.runControl.startWatch(runIdentifier, prKey);
+      if (this.prWatches.get(prKey) !== prWatch || prWatch.dismissed) {
+        this.runControl.deleteOwnedWatch(runKey, prKey);
+        return false;
+      }
       if (!prWatch.childRunKeys.includes(runKey)) {
         prWatch.childRunKeys.push(runKey);
         return true;

--- a/packages/core/src/services/prWatchPool.ts
+++ b/packages/core/src/services/prWatchPool.ts
@@ -14,7 +14,6 @@ export interface RunWatchControl {
   startWatch(identifier: RunIdentifier, parentPRKey?: string): Promise<WatchStartResult>;
   getWatchKey(identifier: RunIdentifier): string;
   getWatch(runKey: string): WatchedRun | undefined;
-  getAllWatches(): WatchedRun[];
   entries(): IterableIterator<[string, WatchedRun]>;
   deleteOwnedWatch(runKey: string, parentPRKey: string): void;
   dismissOwnedChildRun(runKey: string, parentPRKey: string, options?: { clearAcknowledgement?: boolean }): boolean;
@@ -450,7 +449,7 @@ export class PRWatchPool implements vscode.Disposable {
     if (prWatch.childRunKeys.length > 0) {
       return true;
     }
-    for (const watch of this.runControl.getAllWatches()) {
+    for (const [, watch] of this.runControl.entries()) {
       if (watch.parentPRKey === prKey) {
         return true;
       }

--- a/packages/core/src/services/prWatchPool.ts
+++ b/packages/core/src/services/prWatchPool.ts
@@ -11,11 +11,7 @@ type WatcherLogger = {
 };
 
 export interface RunWatchControl {
-  startWatch(
-    identifier: RunIdentifier,
-    parentPRKey?: string,
-    options?: { suppressEvents?: boolean; suppressPersist?: boolean },
-  ): Promise<WatchStartResult>;
+  startWatch(identifier: RunIdentifier, parentPRKey?: string): Promise<WatchStartResult>;
   getWatchKey(identifier: RunIdentifier): string;
   getWatch(runKey: string): WatchedRun | undefined;
   getAllWatches(): WatchedRun[];
@@ -313,7 +309,7 @@ export class PRWatchPool implements vscode.Disposable {
         return false;
       }
 
-      await this.runControl.startWatch(runIdentifier, prKey, options);
+      await this.runControl.startWatch(runIdentifier, prKey);
       if (!prWatch.childRunKeys.includes(runKey)) {
         prWatch.childRunKeys.push(runKey);
         return true;

--- a/packages/core/src/services/prWatchPool.ts
+++ b/packages/core/src/services/prWatchPool.ts
@@ -1,0 +1,457 @@
+import * as vscode from 'vscode';
+import type { PRIdentifier, RunIdentifier } from '@devdocket/shared';
+import { PRWatcherRegistry } from './prWatcherRegistry';
+import type { WatchedPR, WatchedRun } from './watcherService';
+import type { WatchStartResult } from './runWatchPool';
+
+type WatcherLogger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+export interface RunWatchControl {
+  startWatch(
+    identifier: RunIdentifier,
+    parentPRKey?: string,
+    options?: { suppressEvents?: boolean; suppressPersist?: boolean },
+  ): Promise<WatchStartResult>;
+  getWatchKey(identifier: RunIdentifier): string;
+  getWatch(runKey: string): WatchedRun | undefined;
+  getAllWatches(): WatchedRun[];
+  entries(): IterableIterator<[string, WatchedRun]>;
+  deleteOwnedWatch(runKey: string, parentPRKey: string): void;
+  dismissOwnedChildRun(runKey: string, parentPRKey: string, options?: { clearAcknowledgement?: boolean }): boolean;
+  resolveRunIdentifier(identifier: RunIdentifier): RunIdentifier;
+}
+
+export interface PRWatchStartResult {
+  watch: WatchedPR;
+  changed: boolean;
+}
+
+export interface PRPollResult {
+  prChanged: boolean;
+  childRunChanged: boolean;
+}
+
+export interface DismissPRWatchResult {
+  dismissed: boolean;
+  childRunChanged: boolean;
+}
+
+/**
+ * Owns PR watch state, PR polling, and child-run linkage.
+ */
+export class PRWatchPool implements vscode.Disposable {
+  private prWatches = new Map<string, WatchedPR>();
+  private consecutiveFailures = new Map<string, number>();
+
+  private readonly _onDidCompletePR = new vscode.EventEmitter<WatchedPR>();
+  readonly onDidCompletePR = this._onDidCompletePR.event;
+
+  constructor(
+    private readonly prWatcherRegistry: PRWatcherRegistry,
+    private readonly runControl: RunWatchControl,
+    private readonly logger: WatcherLogger,
+    private readonly isDisposed: () => boolean,
+    private readonly onPollingNeeded: () => void,
+    private readonly rememberPRWatchKey: (key: string) => void,
+  ) {}
+
+  restore(prs: WatchedPR[]): number {
+    const restored = prs.filter(pr => !pr.dismissed);
+    for (const pr of restored) {
+      this.prWatches.set(this.getPRWatchKey(pr.identifier), pr);
+    }
+    return restored.length;
+  }
+
+  async startPRWatch(identifier: PRIdentifier, options?: { forceRecreate?: boolean }): Promise<PRWatchStartResult> {
+    const key = this.getPRWatchKey(identifier);
+    const existing = this.prWatches.get(key);
+
+    if (options?.forceRecreate && existing) {
+      for (const childKey of existing.childRunKeys) {
+        this.runControl.deleteOwnedWatch(childKey, key);
+      }
+      this.prWatches.delete(key);
+    } else if (existing && !existing.dismissed) {
+      return { watch: existing, changed: false };
+    } else if (existing) {
+      this.prWatches.delete(key);
+    }
+
+    const prWatcher = this.prWatcherRegistry.get(identifier.providerId);
+    if (!prWatcher) {
+      throw new Error(`No PR watcher registered for provider: ${identifier.providerId}`);
+    }
+
+    const snapshot = await prWatcher.getPRRunsSnapshot(identifier);
+    if (snapshot.displayName) {
+      identifier.displayName = snapshot.displayName;
+    }
+    const now = new Date().toISOString();
+
+    const watchedPR: WatchedPR = {
+      identifier,
+      prState: snapshot.prState,
+      childRunKeys: [],
+      watchedAt: now,
+      lastPolledAt: now,
+      dismissed: false,
+    };
+
+    this.prWatches.set(key, watchedPR);
+    this.rememberPRWatchKey(key);
+    this.consecutiveFailures.delete(key);
+    this.logger.info(`Started watching PR: ${identifier.displayName} (${identifier.providerId})`);
+
+    for (const runId of snapshot.runs) {
+      const resolved = this.runControl.resolveRunIdentifier(runId);
+      await this.addChildRun(key, watchedPR, resolved, {
+        suppressEvents: true,
+        suppressPersist: true,
+      });
+    }
+
+    if (snapshot.prState === 'open') {
+      this.onPollingNeeded();
+    }
+
+    return { watch: watchedPR, changed: true };
+  }
+
+  dismissPRWatch(identifier: PRIdentifier): DismissPRWatchResult {
+    const key = this.getPRWatchKey(identifier);
+    const prWatch = this.prWatches.get(key);
+    if (!prWatch) {
+      return { dismissed: false, childRunChanged: false };
+    }
+
+    prWatch.dismissed = true;
+    let childRunChanged = false;
+    for (const childKey of prWatch.childRunKeys) {
+      childRunChanged = this.runControl.dismissOwnedChildRun(childKey, key) || childRunChanged;
+    }
+    this.logger.info(`Dismissed PR watch: ${identifier.displayName}`);
+    return { dismissed: true, childRunChanged };
+  }
+
+  dismissCompletedPRWatches(): number {
+    let dismissedCount = 0;
+    for (const prWatch of this.prWatches.values()) {
+      if ((prWatch.prState === 'merged' || prWatch.prState === 'closed') && !prWatch.dismissed) {
+        const key = this.getPRWatchKey(prWatch.identifier);
+        prWatch.dismissed = true;
+        for (const childKey of prWatch.childRunKeys) {
+          if (this.runControl.dismissOwnedChildRun(childKey, key)) {
+            dismissedCount++;
+          }
+        }
+        dismissedCount++;
+      }
+    }
+    return dismissedCount;
+  }
+
+  countCompletedActiveWatches(): number {
+    let count = 0;
+    const dismissedRunKeys = new Set<string>();
+    const dismissedPRKeys = new Set<string>();
+    const affectedPRKeys = new Set<string>();
+    const runToPRKeys = this.buildActiveChildRunIndex();
+
+    for (const [key, watch] of this.runControl.entries()) {
+      if (!watch.dismissed && watch.status.overallState === 'completed') {
+        dismissedRunKeys.add(key);
+        for (const prKey of this.getPRKeysForRun(key, watch, runToPRKeys)) {
+          affectedPRKeys.add(prKey);
+        }
+        count++;
+      }
+    }
+
+    for (const [prKey, prWatch] of this.prWatches.entries()) {
+      if (!prWatch.dismissed && (prWatch.prState === 'merged' || prWatch.prState === 'closed')) {
+        dismissedPRKeys.add(prKey);
+        count++;
+        for (const childKey of prWatch.childRunKeys) {
+          const childWatch = this.runControl.getWatch(childKey);
+          if (
+            childWatch
+            && !childWatch.dismissed
+            && childWatch.parentPRKey === prKey
+            && !dismissedRunKeys.has(childKey)
+          ) {
+            dismissedRunKeys.add(childKey);
+            count++;
+          }
+        }
+      }
+    }
+
+    for (const prKey of affectedPRKeys) {
+      if (dismissedPRKeys.has(prKey)) continue;
+      const activeChildKeys = this.getActiveChildRunKeys(prKey);
+      if (activeChildKeys.length > 0 && activeChildKeys.every(childKey => dismissedRunKeys.has(childKey))) {
+        count++;
+      }
+    }
+
+    return count;
+  }
+
+  async pollPRWatches(): Promise<PRPollResult> {
+    const activePRs = this.getActivePRWatches().filter(
+      pr => pr.prState === 'open' && !pr.hasWarning,
+    );
+    if (activePRs.length === 0) return { prChanged: false, childRunChanged: false };
+
+    let prChanged = false;
+    let childRunChanged = false;
+
+    for (const prWatch of activePRs) {
+      const key = this.getPRWatchKey(prWatch.identifier);
+      try {
+        const prWatcher = this.prWatcherRegistry.get(prWatch.identifier.providerId);
+        if (!prWatcher) {
+          throw new Error(`PR watcher '${prWatch.identifier.providerId}' is no longer registered`);
+        }
+
+        const snapshot = await prWatcher.getPRRunsSnapshot(prWatch.identifier);
+        if (this.isDisposed()) return { prChanged, childRunChanged };
+        if (this.prWatches.get(key) !== prWatch || prWatch.dismissed) {
+          continue;
+        }
+        prWatch.lastPolledAt = new Date().toISOString();
+
+        if (snapshot.displayName && snapshot.displayName !== prWatch.identifier.displayName) {
+          prWatch.identifier.displayName = snapshot.displayName;
+          prChanged = true;
+        }
+
+        this.consecutiveFailures.delete(key);
+        prWatch.hasWarning = false;
+        prWatch.errorMessage = undefined;
+
+        const currentRunKeys = new Set(prWatch.childRunKeys);
+        const newRunKeys = new Set<string>();
+        for (const runId of snapshot.runs) {
+          const resolved = this.runControl.resolveRunIdentifier(runId);
+          const runKey = this.runControl.getWatchKey(resolved);
+          newRunKeys.add(runKey);
+          if (!currentRunKeys.has(runKey)) {
+            const added = await this.addChildRun(key, prWatch, resolved, {
+              suppressEvents: true,
+              suppressPersist: true,
+            });
+            if (this.isDisposed()) return { prChanged, childRunChanged };
+            if (added) {
+              childRunChanged = true;
+            }
+          }
+        }
+
+        const hadObservedChildren = currentRunKeys.size > 0 || this.hasObservedChildRun(key, prWatch);
+        for (const childKey of currentRunKeys) {
+          if (!newRunKeys.has(childKey)) {
+            if (this.runControl.dismissOwnedChildRun(childKey, key, { clearAcknowledgement: false })) {
+              childRunChanged = true;
+            }
+            prWatch.childRunKeys = prWatch.childRunKeys.filter(k => k !== childKey);
+          }
+        }
+        if (
+          hadObservedChildren
+          && this.getActiveChildRunKeys(key).length === 0
+          && this.dismissChildlessPRWatches([key], { assumeObserved: true }) > 0
+        ) {
+          prChanged = true;
+          continue;
+        }
+
+        if (snapshot.prState !== prWatch.prState) {
+          prWatch.prState = snapshot.prState;
+          prChanged = true;
+          if (snapshot.prState === 'merged' || snapshot.prState === 'closed') {
+            this._onDidCompletePR.fire(prWatch);
+          }
+        }
+      } catch (err) {
+        const failures = (this.consecutiveFailures.get(key) || 0) + 1;
+        this.consecutiveFailures.set(key, failures);
+
+        if (failures >= 3) {
+          prWatch.hasWarning = true;
+          prWatch.errorMessage = err instanceof Error ? err.message : String(err);
+          prChanged = true;
+          this.logger.warn(`3 consecutive failures for PR ${prWatch.identifier.displayName}, marking with warning`);
+        } else {
+          this.logger.warn(`PR poll failed for ${prWatch.identifier.displayName} (attempt ${failures}/3): ${err}`);
+        }
+      }
+    }
+
+    return { prChanged, childRunChanged };
+  }
+
+  async addChildRun(
+    prKey: string,
+    prWatch: WatchedPR,
+    runIdentifier: RunIdentifier,
+    options?: { suppressEvents?: boolean; suppressPersist?: boolean },
+  ): Promise<boolean> {
+    const runKey = this.runControl.getWatchKey(runIdentifier);
+    try {
+      const existing = this.runControl.getWatch(runKey);
+      if (existing && !existing.dismissed) {
+        if (!prWatch.childRunKeys.includes(runKey)) {
+          prWatch.childRunKeys.push(runKey);
+          return true;
+        }
+        return false;
+      }
+
+      await this.runControl.startWatch(runIdentifier, prKey, options);
+      if (!prWatch.childRunKeys.includes(runKey)) {
+        prWatch.childRunKeys.push(runKey);
+        return true;
+      }
+      return false;
+    } catch (err) {
+      this.logger.warn(`Failed to add child run ${runIdentifier.displayName} for PR ${prWatch.identifier.displayName}: ${err}`);
+      return false;
+    }
+  }
+
+  dismissChildlessPRWatchesForRun(runKey: string, watch: WatchedRun): number {
+    return this.dismissChildlessPRWatches(this.getPRKeysForRun(runKey, watch));
+  }
+
+  dismissChildlessPRWatches(prKeys: Iterable<string>, options?: { assumeObserved?: boolean }): number {
+    let dismissedCount = 0;
+    for (const prKey of prKeys) {
+      const prWatch = this.prWatches.get(prKey);
+      if (!prWatch || prWatch.dismissed) continue;
+      if (!options?.assumeObserved && !this.hasObservedChildRun(prKey, prWatch)) continue;
+      if (this.getActiveChildRunKeys(prKey).length > 0) continue;
+
+      prWatch.dismissed = true;
+      dismissedCount++;
+      this.logger.info(`Dismissed childless PR watch: ${prWatch.identifier.displayName}`);
+    }
+    return dismissedCount;
+  }
+
+  getPRKeysForRun(
+    runKey: string,
+    watch: WatchedRun,
+    runToPRKeys = this.buildActiveChildRunIndex(),
+  ): Set<string> {
+    const prKeys = new Set<string>();
+    if (watch.parentPRKey) {
+      prKeys.add(watch.parentPRKey);
+    }
+    for (const prKey of runToPRKeys.get(runKey) ?? []) {
+      prKeys.add(prKey);
+    }
+    return prKeys;
+  }
+
+  getActiveChildRunKeys(prKey: string): string[] {
+    const childRuns = new Set<string>();
+    const prWatch = this.prWatches.get(prKey);
+    for (const childRunKey of prWatch?.childRunKeys ?? []) {
+      const watch = this.runControl.getWatch(childRunKey);
+      if (watch && !watch.dismissed) {
+        childRuns.add(childRunKey);
+      }
+    }
+    for (const [watchKey, watch] of this.runControl.entries()) {
+      if (!watch.dismissed && watch.parentPRKey === prKey) {
+        childRuns.add(watchKey);
+      }
+    }
+    return Array.from(childRuns.values());
+  }
+
+  getChildRuns(prKey: string): WatchedRun[] {
+    const childRuns = new Map<string, WatchedRun>();
+    for (const childRunKey of this.getActiveChildRunKeys(prKey)) {
+      const watch = this.runControl.getWatch(childRunKey);
+      if (watch) {
+        childRuns.set(childRunKey, watch);
+      }
+    }
+    return Array.from(childRuns.values());
+  }
+
+  getActiveLinkedRunKeys(): Set<string> {
+    const prLinkedKeys = new Set<string>();
+    for (const prWatch of this.prWatches.values()) {
+      if (!prWatch.dismissed) {
+        for (const childKey of prWatch.childRunKeys) {
+          prLinkedKeys.add(childKey);
+        }
+      }
+    }
+    return prLinkedKeys;
+  }
+
+  getActivePRWatches(): WatchedPR[] {
+    return Array.from(this.prWatches.values()).filter(pr => !pr.dismissed);
+  }
+
+  getAllPRWatches(): WatchedPR[] {
+    return Array.from(this.prWatches.values());
+  }
+
+  hasPRWatch(key: string): boolean {
+    return this.prWatches.has(key);
+  }
+
+  isPRActive(identifier: PRIdentifier): boolean {
+    const existing = this.prWatches.get(this.getPRWatchKey(identifier));
+    return existing !== undefined && !existing.dismissed;
+  }
+
+  hasPollablePRWatches(): boolean {
+    return this.getActivePRWatches().some(pr => pr.prState === 'open' && !pr.hasWarning);
+  }
+
+  getPRWatchKey(identifier: PRIdentifier): string {
+    return `pr:${identifier.providerId}:${identifier.repo}:${identifier.prId}`;
+  }
+
+  buildActiveChildRunIndex(): Map<string, Set<string>> {
+    const runToPRKeys = new Map<string, Set<string>>();
+    for (const [prKey, prWatch] of this.prWatches.entries()) {
+      if (prWatch.dismissed) continue;
+      for (const childKey of prWatch.childRunKeys) {
+        const prKeys = runToPRKeys.get(childKey) ?? new Set<string>();
+        prKeys.add(prKey);
+        runToPRKeys.set(childKey, prKeys);
+      }
+    }
+    return runToPRKeys;
+  }
+
+  private hasObservedChildRun(prKey: string, prWatch: WatchedPR): boolean {
+    if (prWatch.childRunKeys.length > 0) {
+      return true;
+    }
+    for (const watch of this.runControl.getAllWatches()) {
+      if (watch.parentPRKey === prKey) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  dispose(): void {
+    this._onDidCompletePR.dispose();
+    this.prWatches.clear();
+    this.consecutiveFailures.clear();
+  }
+}

--- a/packages/core/src/services/prWatchPool.ts
+++ b/packages/core/src/services/prWatchPool.ts
@@ -98,6 +98,10 @@ export class PRWatchPool implements vscode.Disposable {
       dismissed: false,
     };
 
+    if (this.isDisposed()) {
+      return { watch: watchedPR, changed: false };
+    }
+
     this.prWatches.set(key, watchedPR);
     this.rememberPRWatchKey(key);
     this.consecutiveFailures.delete(key);
@@ -106,6 +110,18 @@ export class PRWatchPool implements vscode.Disposable {
     for (const runId of snapshot.runs) {
       const resolved = this.runControl.resolveRunIdentifier(runId);
       await this.addChildRun(key, watchedPR, resolved);
+      if (this.isDisposed()) {
+        for (const childKey of watchedPR.childRunKeys) {
+          this.runControl.deleteOwnedWatch(childKey, key);
+        }
+        if (this.prWatches.get(key) === watchedPR) {
+          this.prWatches.delete(key);
+        }
+        return { watch: watchedPR, changed: false };
+      }
+      if (this.prWatches.get(key) !== watchedPR || watchedPR.dismissed) {
+        return { watch: watchedPR, changed: false };
+      }
     }
 
     if (snapshot.prState === 'open') {

--- a/packages/core/src/services/prWatchPool.ts
+++ b/packages/core/src/services/prWatchPool.ts
@@ -105,10 +105,7 @@ export class PRWatchPool implements vscode.Disposable {
 
     for (const runId of snapshot.runs) {
       const resolved = this.runControl.resolveRunIdentifier(runId);
-      await this.addChildRun(key, watchedPR, resolved, {
-        suppressEvents: true,
-        suppressPersist: true,
-      });
+      await this.addChildRun(key, watchedPR, resolved);
     }
 
     if (snapshot.prState === 'open') {
@@ -238,10 +235,7 @@ export class PRWatchPool implements vscode.Disposable {
           const runKey = this.runControl.getWatchKey(resolved);
           newRunKeys.add(runKey);
           if (!currentRunKeys.has(runKey)) {
-            const added = await this.addChildRun(key, prWatch, resolved, {
-              suppressEvents: true,
-              suppressPersist: true,
-            });
+            const added = await this.addChildRun(key, prWatch, resolved);
             if (this.isDisposed()) return { prChanged, childRunChanged };
             if (added) {
               childRunChanged = true;
@@ -292,11 +286,10 @@ export class PRWatchPool implements vscode.Disposable {
     return { prChanged, childRunChanged };
   }
 
-  async addChildRun(
+  private async addChildRun(
     prKey: string,
     prWatch: WatchedPR,
     runIdentifier: RunIdentifier,
-    options?: { suppressEvents?: boolean; suppressPersist?: boolean },
   ): Promise<boolean> {
     const runKey = this.runControl.getWatchKey(runIdentifier);
     try {

--- a/packages/core/src/services/prWatchPool.ts
+++ b/packages/core/src/services/prWatchPool.ts
@@ -84,10 +84,12 @@ export class PRWatchPool implements vscode.Disposable {
       for (const childKey of existing.childRunKeys) {
         this.runControl.deleteOwnedWatch(childKey, key);
       }
+      this.consecutiveFailures.delete(key);
       this.prWatches.delete(key);
     } else if (existing && !existing.dismissed) {
       return { watch: existing, changed: false };
     } else if (existing) {
+      this.consecutiveFailures.delete(key);
       this.prWatches.delete(key);
     }
 
@@ -130,6 +132,7 @@ export class PRWatchPool implements vscode.Disposable {
           this.runControl.deleteOwnedWatch(childKey, key);
         }
         if (this.prWatches.get(key) === watchedPR) {
+          this.consecutiveFailures.delete(key);
           this.prWatches.delete(key);
         }
         return { watch: watchedPR, changed: false };
@@ -154,6 +157,7 @@ export class PRWatchPool implements vscode.Disposable {
     }
 
     prWatch.dismissed = true;
+    this.consecutiveFailures.delete(key);
     let childRunChanged = false;
     for (const childKey of prWatch.childRunKeys) {
       childRunChanged = this.runControl.dismissOwnedChildRun(childKey, key) || childRunChanged;
@@ -168,6 +172,7 @@ export class PRWatchPool implements vscode.Disposable {
       if ((prWatch.prState === 'merged' || prWatch.prState === 'closed') && !prWatch.dismissed) {
         const key = this.getPRWatchKey(prWatch.identifier);
         prWatch.dismissed = true;
+        this.consecutiveFailures.delete(key);
         for (const childKey of prWatch.childRunKeys) {
           if (this.runControl.dismissOwnedChildRun(childKey, key)) {
             dismissedCount++;
@@ -365,6 +370,7 @@ export class PRWatchPool implements vscode.Disposable {
       if (this.getActiveChildRunKeys(prKey).length > 0) continue;
 
       prWatch.dismissed = true;
+      this.consecutiveFailures.delete(prKey);
       dismissedCount++;
       this.logger.info(`Dismissed childless PR watch: ${prWatch.identifier.displayName}`);
     }

--- a/packages/core/src/services/runWatchPool.ts
+++ b/packages/core/src/services/runWatchPool.ts
@@ -115,6 +115,7 @@ export class RunWatchPool implements vscode.Disposable {
     const childWatch = this.watches.get(runKey);
     if (childWatch && childWatch.parentPRKey === parentPRKey) {
       this.watches.delete(runKey);
+      this.consecutiveFailures.delete(runKey);
       this.acknowledgedFailedRunKeys.delete(runKey);
     }
   }

--- a/packages/core/src/services/runWatchPool.ts
+++ b/packages/core/src/services/runWatchPool.ts
@@ -54,11 +54,7 @@ export class RunWatchPool implements vscode.Disposable {
     return restored.length;
   }
 
-  async startWatch(
-    identifier: RunIdentifier,
-    parentPRKey?: string,
-    _options?: { suppressEvents?: boolean; suppressPersist?: boolean },
-  ): Promise<WatchStartResult> {
+  async startWatch(identifier: RunIdentifier, parentPRKey?: string): Promise<WatchStartResult> {
     const key = this.getWatchKey(identifier);
     const existing = this.watches.get(key);
     if (existing && !existing.dismissed) {

--- a/packages/core/src/services/runWatchPool.ts
+++ b/packages/core/src/services/runWatchPool.ts
@@ -1,0 +1,326 @@
+import * as vscode from 'vscode';
+import type { JobStatus, RunIdentifier } from '@devdocket/shared';
+import { WatcherRegistry } from './watcherRegistry';
+import type { WatchedRun } from './watcherService';
+
+type WatcherLogger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+export interface WatchStartResult {
+  watch: WatchedRun;
+  changed: boolean;
+}
+
+export interface DismissWatchResult {
+  dismissed: boolean;
+  dismissedPRCount: number;
+}
+
+export interface DismissCompletedRunsResult {
+  dismissedCount: number;
+  affectedPRKeys: Set<string>;
+}
+
+/**
+ * Owns run watch state, polling, failure acknowledgement, and run events.
+ */
+export class RunWatchPool implements vscode.Disposable {
+  private watches = new Map<string, WatchedRun>();
+  private consecutiveFailures = new Map<string, number>();
+  private acknowledgedFailedRunKeys = new Set<string>();
+
+  private readonly _onDidDetectJobFailure = new vscode.EventEmitter<{ run: WatchedRun; job: JobStatus }>();
+  readonly onDidDetectJobFailure = this._onDidDetectJobFailure.event;
+
+  private readonly _onDidCompleteRun = new vscode.EventEmitter<WatchedRun>();
+  readonly onDidCompleteRun = this._onDidCompleteRun.event;
+
+  constructor(
+    private readonly watcherRegistry: WatcherRegistry,
+    private readonly logger: WatcherLogger,
+    private readonly isDisposed: () => boolean,
+    private readonly onPollingNeeded: () => void,
+    private readonly onRunDismissed: (runKey: string, watch: WatchedRun) => number,
+  ) {}
+
+  restore(watches: WatchedRun[]): number {
+    const restored = watches.filter(w => !w.dismissed);
+    for (const watch of restored) {
+      this.watches.set(this.getWatchKey(watch.identifier), watch);
+    }
+    return restored.length;
+  }
+
+  async startWatch(
+    identifier: RunIdentifier,
+    parentPRKey?: string,
+    _options?: { suppressEvents?: boolean; suppressPersist?: boolean },
+  ): Promise<WatchStartResult> {
+    const key = this.getWatchKey(identifier);
+    const existing = this.watches.get(key);
+    if (existing && !existing.dismissed) {
+      return { watch: existing, changed: false };
+    }
+
+    if (existing) {
+      this.watches.delete(key);
+      this.acknowledgedFailedRunKeys.delete(key);
+    }
+
+    const watcher = this.watcherRegistry.get(identifier.providerId);
+    if (!watcher) {
+      throw new Error(`No watcher registered for provider: ${identifier.providerId}`);
+    }
+
+    const status = await watcher.getRunStatus(identifier);
+    if (status.displayName) {
+      identifier.displayName = status.displayName;
+    }
+    const now = new Date().toISOString();
+
+    const watchedRun: WatchedRun = {
+      identifier,
+      status,
+      watchedAt: now,
+      lastPolledAt: now,
+      dismissed: false,
+      parentPRKey,
+    };
+
+    this.watches.set(key, watchedRun);
+    this.consecutiveFailures.delete(key);
+    this.logger.info(`Started watching: ${identifier.displayName} (${identifier.providerId})`);
+
+    if (watchedRun.status.overallState !== 'completed') {
+      this.onPollingNeeded();
+    }
+
+    return { watch: watchedRun, changed: true };
+  }
+
+  dismissWatch(identifier: RunIdentifier): DismissWatchResult {
+    const key = this.getWatchKey(identifier);
+    const watch = this.watches.get(key);
+    if (!watch) {
+      return { dismissed: false, dismissedPRCount: 0 };
+    }
+
+    watch.dismissed = true;
+    this.acknowledgedFailedRunKeys.delete(key);
+    const dismissedPRCount = this.onRunDismissed(key, watch);
+    this.logger.info(`Dismissed watch: ${identifier.displayName}`);
+    return { dismissed: true, dismissedPRCount };
+  }
+
+  deleteOwnedWatch(runKey: string, parentPRKey: string): void {
+    const childWatch = this.watches.get(runKey);
+    if (childWatch && childWatch.parentPRKey === parentPRKey) {
+      this.watches.delete(runKey);
+      this.acknowledgedFailedRunKeys.delete(runKey);
+    }
+  }
+
+  dismissOwnedChildRun(runKey: string, parentPRKey: string, options?: { clearAcknowledgement?: boolean }): boolean {
+    const childWatch = this.watches.get(runKey);
+    if (childWatch && !childWatch.dismissed && childWatch.parentPRKey === parentPRKey) {
+      childWatch.dismissed = true;
+      if (options?.clearAcknowledgement !== false) {
+        this.acknowledgedFailedRunKeys.delete(runKey);
+      }
+      return true;
+    }
+    return false;
+  }
+
+  dismissCompletedRuns(getPRKeysForRun: (runKey: string, watch: WatchedRun) => Iterable<string>): DismissCompletedRunsResult {
+    let dismissedCount = 0;
+    const affectedPRKeys = new Set<string>();
+
+    for (const [key, watch] of this.watches.entries()) {
+      if (watch.status.overallState === 'completed' && !watch.dismissed) {
+        for (const prKey of getPRKeysForRun(key, watch)) {
+          affectedPRKeys.add(prKey);
+        }
+        watch.dismissed = true;
+        this.acknowledgedFailedRunKeys.delete(key);
+        dismissedCount++;
+      }
+    }
+
+    return { dismissedCount, affectedPRKeys };
+  }
+
+  acknowledgeAllFailures(): number {
+    let added = 0;
+    for (const [key, watch] of this.watches.entries()) {
+      if (!watch.dismissed && RunWatchPool.isFailedRun(watch) && !this.acknowledgedFailedRunKeys.has(key)) {
+        this.acknowledgedFailedRunKeys.add(key);
+        added += 1;
+      }
+    }
+    return added;
+  }
+
+  isFailureAcknowledged(watch: WatchedRun): boolean {
+    return this.acknowledgedFailedRunKeys.has(this.getWatchKey(watch.identifier));
+  }
+
+  getActiveWatches(): WatchedRun[] {
+    return Array.from(this.watches.values()).filter(w => !w.dismissed);
+  }
+
+  getActiveStandaloneWatches(prLinkedKeys: Set<string>): WatchedRun[] {
+    return Array.from(this.watches.values()).filter(
+      w => !w.dismissed && !w.parentPRKey && !prLinkedKeys.has(this.getWatchKey(w.identifier)),
+    );
+  }
+
+  getAllWatches(): WatchedRun[] {
+    return Array.from(this.watches.values());
+  }
+
+  entries(): IterableIterator<[string, WatchedRun]> {
+    return this.watches.entries();
+  }
+
+  getWatch(runKey: string): WatchedRun | undefined {
+    return this.watches.get(runKey);
+  }
+
+  isRunActive(identifier: RunIdentifier): boolean {
+    const existing = this.watches.get(this.getWatchKey(identifier));
+    return existing !== undefined && !existing.dismissed;
+  }
+
+  hasPollableWatches(): boolean {
+    return this.getActiveWatches().some(w => w.status.overallState !== 'completed' && !w.hasWarning);
+  }
+
+  async pollRunWatches(): Promise<boolean> {
+    const pollableWatches = this.getActiveWatches().filter(
+      w => w.status.overallState !== 'completed' && !w.hasWarning,
+    );
+    if (pollableWatches.length === 0) return false;
+
+    let anyChanged = false;
+
+    for (const watch of pollableWatches) {
+      try {
+        const watcher = this.watcherRegistry.get(watch.identifier.providerId);
+        if (!watcher) {
+          throw new Error(`Watcher '${watch.identifier.providerId}' is no longer registered`);
+        }
+
+        const newStatus = await watcher.getRunStatus(watch.identifier);
+        const key = this.getWatchKey(watch.identifier);
+        if (this.isDisposed()) return anyChanged;
+        if (this.watches.get(key) !== watch || watch.dismissed) {
+          continue;
+        }
+        watch.lastPolledAt = new Date().toISOString();
+
+        this.consecutiveFailures.delete(key);
+        watch.hasWarning = false;
+        watch.errorMessage = undefined;
+
+        const oldStatus = watch.status;
+        const statusChanged = oldStatus.overallState !== newStatus.overallState
+          || oldStatus.conclusion !== newStatus.conclusion
+          || oldStatus.jobs.length !== newStatus.jobs.length
+          || newStatus.jobs.some(newJob => {
+            const oldJob = newJob.id
+              ? oldStatus.jobs.find(j => j.id === newJob.id)
+              : oldStatus.jobs.find(j => j.name === newJob.name);
+            return !oldJob || oldJob.state !== newJob.state || oldJob.conclusion !== newJob.conclusion;
+          });
+        watch.status = newStatus;
+        if (newStatus.displayName && newStatus.displayName !== watch.identifier.displayName) {
+          watch.identifier.displayName = newStatus.displayName;
+          anyChanged = true;
+        }
+        if (statusChanged) {
+          anyChanged = true;
+        }
+
+        if (newStatus.overallState !== 'completed') {
+          for (const newJob of newStatus.jobs) {
+            if (newJob.state === 'completed' && newJob.conclusion === 'failure') {
+              const oldJob = newJob.id
+                ? oldStatus.jobs.find(j => j.id === newJob.id)
+                : oldStatus.jobs.find(j => j.name === newJob.name);
+              if (!oldJob || oldJob.state !== 'completed' || oldJob.conclusion !== 'failure') {
+                this._onDidDetectJobFailure.fire({ run: watch, job: newJob });
+              }
+            }
+          }
+        }
+
+        if (oldStatus.overallState !== 'completed' && newStatus.overallState === 'completed') {
+          this._onDidCompleteRun.fire(watch);
+        }
+      } catch (err) {
+        const key = this.getWatchKey(watch.identifier);
+        const failures = (this.consecutiveFailures.get(key) || 0) + 1;
+        this.consecutiveFailures.set(key, failures);
+
+        if (failures >= 3) {
+          watch.hasWarning = true;
+          watch.errorMessage = err instanceof Error ? err.message : String(err);
+          anyChanged = true;
+          this.logger.warn(`3 consecutive failures for ${watch.identifier.displayName}, marking with warning`);
+        } else {
+          this.logger.warn(`Poll failed for ${watch.identifier.displayName} (attempt ${failures}/3): ${err}`);
+        }
+      }
+    }
+
+    return anyChanged;
+  }
+
+  getWatchKey(identifier: RunIdentifier): string {
+    return identifier.repo
+      ? `${identifier.providerId}:${identifier.repo}:${identifier.runId}`
+      : `${identifier.providerId}:${identifier.runId}`;
+  }
+
+  resolveRunIdentifier(identifier: RunIdentifier): RunIdentifier {
+    if (this.watcherRegistry.get(identifier.providerId)) {
+      return identifier;
+    }
+
+    const watcher = this.watcherRegistry.findWatcherForUrl(identifier.url);
+    if (watcher) {
+      try {
+        const parsed = watcher.parseRunUrl(identifier.url);
+        return {
+          ...parsed,
+          displayName: identifier.displayName || parsed.displayName,
+        };
+      } catch (err) {
+        this.logger.warn(`URL matched watcher '${watcher.id}' but parseRunUrl failed for ${identifier.url}: ${err}`);
+      }
+    }
+
+    return identifier;
+  }
+
+  private static isFailedRun(watch: WatchedRun): boolean {
+    if (watch.hasWarning) return true;
+    if (watch.status.overallState !== 'completed') return false;
+    const conclusion = watch.status.conclusion;
+    if (conclusion === undefined || conclusion === 'success') return false;
+    if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral') return false;
+    return true;
+  }
+
+  dispose(): void {
+    this._onDidDetectJobFailure.dispose();
+    this._onDidCompleteRun.dispose();
+    this.watches.clear();
+    this.consecutiveFailures.clear();
+    this.acknowledgedFailedRunKeys.clear();
+  }
+}

--- a/packages/core/src/services/runWatchPool.ts
+++ b/packages/core/src/services/runWatchPool.ts
@@ -121,6 +121,7 @@ export class RunWatchPool implements vscode.Disposable {
     }
 
     watch.dismissed = true;
+    this.consecutiveFailures.delete(key);
     this.acknowledgedFailedRunKeys.delete(key);
     const dismissedPRCount = this.onRunDismissed(key, watch);
     this.logger.info(`Dismissed watch: ${identifier.displayName}`);
@@ -140,6 +141,7 @@ export class RunWatchPool implements vscode.Disposable {
     const childWatch = this.watches.get(runKey);
     if (childWatch && !childWatch.dismissed && childWatch.parentPRKey === parentPRKey) {
       childWatch.dismissed = true;
+      this.consecutiveFailures.delete(runKey);
       if (options?.clearAcknowledgement !== false) {
         this.acknowledgedFailedRunKeys.delete(runKey);
       }
@@ -158,6 +160,7 @@ export class RunWatchPool implements vscode.Disposable {
           affectedPRKeys.add(prKey);
         }
         watch.dismissed = true;
+        this.consecutiveFailures.delete(key);
         this.acknowledgedFailedRunKeys.delete(key);
         dismissedCount++;
       }

--- a/packages/core/src/services/runWatchPool.ts
+++ b/packages/core/src/services/runWatchPool.ts
@@ -86,6 +86,10 @@ export class RunWatchPool implements vscode.Disposable {
       parentPRKey,
     };
 
+    if (this.isDisposed()) {
+      return { watch: watchedRun, changed: false };
+    }
+
     this.watches.set(key, watchedRun);
     this.consecutiveFailures.delete(key);
     this.logger.info(`Started watching: ${identifier.displayName} (${identifier.providerId})`);

--- a/packages/core/src/services/watchPersistence.ts
+++ b/packages/core/src/services/watchPersistence.ts
@@ -13,6 +13,7 @@ type WatcherLogger = {
  */
 export class WatchPersistence {
   private persistedPRWatchKeys: Set<string> | undefined;
+  private readonly pendingPRWatchKeys = new Set<string>();
   private persistFailureNotified = false;
 
   constructor(
@@ -24,23 +25,33 @@ export class WatchPersistence {
     const data = await this.watchStore.loadAll();
     this.persistedPRWatchKeys = new Set([
       ...(this.persistedPRWatchKeys ?? []),
+      ...this.pendingPRWatchKeys,
       ...data.prs.map(getPRWatchKey),
     ]);
+    this.pendingPRWatchKeys.clear();
     return data;
   }
 
   async getPersistedPRWatchKeys(getPRWatchKey: (pr: WatchedPR) => string): Promise<Set<string>> {
     if (!this.persistedPRWatchKeys) {
       const { prs } = await this.watchStore.loadAll();
-      this.persistedPRWatchKeys = new Set(prs.map(getPRWatchKey));
+      this.persistedPRWatchKeys = new Set([
+        ...this.pendingPRWatchKeys,
+        ...prs.map(getPRWatchKey),
+      ]);
+      this.pendingPRWatchKeys.clear();
     }
 
     return this.persistedPRWatchKeys;
   }
 
   rememberPRWatchKey(key: string): void {
-    this.persistedPRWatchKeys ??= new Set<string>();
-    this.persistedPRWatchKeys.add(key);
+    if (this.persistedPRWatchKeys) {
+      this.persistedPRWatchKeys.add(key);
+      return;
+    }
+
+    this.pendingPRWatchKeys.add(key);
   }
 
   saveAll(runs: WatchedRun[], prs: WatchedPR[]): void {
@@ -65,5 +76,6 @@ export class WatchPersistence {
 
   dispose(): void {
     this.persistedPRWatchKeys = undefined;
+    this.pendingPRWatchKeys.clear();
   }
 }

--- a/packages/core/src/services/watchPersistence.ts
+++ b/packages/core/src/services/watchPersistence.ts
@@ -1,0 +1,65 @@
+import * as vscode from 'vscode';
+import { WatchStore } from '../storage/watchStore';
+import type { WatchedPR, WatchedRun } from './watcherService';
+
+type WatcherLogger = {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+/**
+ * Storage adapter for watch state with throttled persistence-failure toasts.
+ */
+export class WatchPersistence {
+  private persistedPRWatchKeys: Set<string> | undefined;
+  private persistFailureNotified = false;
+
+  constructor(
+    private readonly watchStore: WatchStore,
+    private readonly logger: WatcherLogger,
+  ) {}
+
+  async loadAll(getPRWatchKey: (pr: WatchedPR) => string): Promise<{ runs: WatchedRun[]; prs: WatchedPR[] }> {
+    const data = await this.watchStore.loadAll();
+    this.persistedPRWatchKeys = new Set(data.prs.map(getPRWatchKey));
+    return data;
+  }
+
+  async getPersistedPRWatchKeys(getPRWatchKey: (pr: WatchedPR) => string): Promise<Set<string>> {
+    if (!this.persistedPRWatchKeys) {
+      const { prs } = await this.watchStore.loadAll();
+      this.persistedPRWatchKeys = new Set(prs.map(getPRWatchKey));
+    }
+
+    return this.persistedPRWatchKeys;
+  }
+
+  rememberPRWatchKey(key: string): void {
+    this.persistedPRWatchKeys?.add(key);
+  }
+
+  saveAll(runs: WatchedRun[], prs: WatchedPR[]): void {
+    this.watchStore.saveAll(runs, prs).then(
+      () => {
+        if (this.persistFailureNotified) {
+          this.persistFailureNotified = false;
+          this.logger.info('Watch persistence recovered.');
+        }
+      },
+      err => {
+        this.logger.error(`Failed to persist watches: ${err}`);
+        if (!this.persistFailureNotified) {
+          this.persistFailureNotified = true;
+          void vscode.window.showWarningMessage(
+            'DevDocket could not save watch state. Watches may be lost when the window reloads.',
+          );
+        }
+      },
+    );
+  }
+
+  dispose(): void {
+    this.persistedPRWatchKeys = undefined;
+  }
+}

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -146,7 +146,7 @@ export class WatcherService implements vscode.Disposable {
     parentPRKey?: string,
     options?: { suppressEvents?: boolean; suppressPersist?: boolean },
   ): Promise<WatchedRun> {
-    const result = await this.runPool.startWatch(identifier, parentPRKey, options);
+    const result = await this.runPool.startWatch(identifier, parentPRKey);
     if (!result.changed) {
       return result.watch;
     }

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -2,6 +2,9 @@ import * as vscode from 'vscode';
 import type { RunIdentifier, RunStatus, JobStatus, PRIdentifier, PRState } from '@devdocket/shared';
 import { WatcherRegistry } from './watcherRegistry';
 import { PRWatcherRegistry } from './prWatcherRegistry';
+import { RunWatchPool } from './runWatchPool';
+import { PRWatchPool } from './prWatchPool';
+import { WatchPersistence } from './watchPersistence';
 import { WatchStore } from '../storage/watchStore';
 
 /**
@@ -42,8 +45,6 @@ export interface WatchedPR {
  * Polls for status changes, detects job failures, and fires events.
  */
 export class WatcherService implements vscode.Disposable {
-  private watches = new Map<string, WatchedRun>();
-  private prWatches = new Map<string, WatchedPR>();
   private pollTimer: NodeJS.Timeout | undefined;
   private isPollInFlight = false;
   /**
@@ -55,30 +56,18 @@ export class WatcherService implements vscode.Disposable {
    * the in-flight poll resumes).
    */
   private disposed = false;
-  private consecutiveFailures = new Map<string, number>();
-  private persistedPRWatchKeys: Set<string> | undefined;
   private configSubscription: vscode.Disposable | undefined;
-  /**
-   * Set of run-watch keys whose failure the user has already acknowledged
-   * (e.g. by opening the watch panel). Used to suppress the warning color
-   * on the status bar once the user has been alerted to a failure.
-   * In-memory only; resets on extension reload.
-   */
-  private acknowledgedFailedRunKeys = new Set<string>();
-  /**
-   * Tracks whether the most recent persistWatches() attempt failed. Toggled
-   * on/off by {@link persistWatches} so that consecutive failures only show
-   * the user one toast. The next successful save resets this so a future
-   * regression can re-alert the user.
-   */
-  private persistFailureNotified = false;
-  
+  private readonly runPool: RunWatchPool;
+  private readonly prPool: PRWatchPool;
+  private readonly persistence: WatchPersistence;
+  private readonly poolSubscriptions: vscode.Disposable[];
+
   private readonly _onDidChangeWatchedRuns = new vscode.EventEmitter<WatchedRun[]>();
   readonly onDidChangeWatchedRuns = this._onDidChangeWatchedRuns.event;
-  
+
   private readonly _onDidDetectJobFailure = new vscode.EventEmitter<{ run: WatchedRun; job: JobStatus }>();
   readonly onDidDetectJobFailure = this._onDidDetectJobFailure.event;
-  
+
   private readonly _onDidCompleteRun = new vscode.EventEmitter<WatchedRun>();
   readonly onDidCompleteRun = this._onDidCompleteRun.event;
 
@@ -91,9 +80,31 @@ export class WatcherService implements vscode.Disposable {
   constructor(
     private watcherRegistry: WatcherRegistry,
     private prWatcherRegistry: PRWatcherRegistry,
-    private watchStore: WatchStore,
+    watchStore: WatchStore,
     private logger: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void }
   ) {
+    this.persistence = new WatchPersistence(watchStore, logger);
+    this.runPool = new RunWatchPool(
+      watcherRegistry,
+      logger,
+      () => this.disposed,
+      () => this.ensurePollingActive(),
+      (runKey, watch) => this.prPool?.dismissChildlessPRWatchesForRun(runKey, watch) ?? 0,
+    );
+    this.prPool = new PRWatchPool(
+      prWatcherRegistry,
+      this.runPool,
+      logger,
+      () => this.disposed,
+      () => this.ensurePollingActive(),
+      key => this.persistence.rememberPRWatchKey(key),
+    );
+    this.poolSubscriptions = [
+      this.runPool.onDidDetectJobFailure(event => this._onDidDetectJobFailure.fire(event)),
+      this.runPool.onDidCompleteRun(run => this._onDidCompleteRun.fire(run)),
+      this.prPool.onDidCompletePR(pr => this._onDidCompletePR.fire(pr)),
+    ];
+
     this.configSubscription = vscode.workspace.onDidChangeConfiguration(e => {
       if (e.affectsConfiguration('devDocket.watches.pollingIntervalSeconds') && this.pollTimer) {
         this.stopPolling();
@@ -106,36 +117,17 @@ export class WatcherService implements vscode.Disposable {
    * Load persisted watches from disk and resume polling for active ones.
    */
   async loadPersistedWatches(): Promise<void> {
-    const { runs: watches, prs } = await this.watchStore.loadAll();
-    this.persistedPRWatchKeys = new Set(prs.map(pr => this.getPRWatchKey(pr.identifier)));
+    const { runs: watches, prs } = await this.persistence.loadAll(pr => this.getPRWatchKey(pr.identifier));
+    const restored = this.runPool.restore(watches);
+    const restoredPRs = this.prPool.restore(prs);
 
-    // Restore non-dismissed run watches
-    const restored = watches.filter(w => !w.dismissed);
-    for (const watch of restored) {
-      const key = this.getWatchKey(watch.identifier);
-      this.watches.set(key, watch);
-    }
-
-    // Restore non-dismissed PR watches
-    const restoredPRs = prs.filter(pr => !pr.dismissed);
-    for (const pr of restoredPRs) {
-      const key = this.getPRWatchKey(pr.identifier);
-      this.prWatches.set(key, pr);
-    }
-
-    if (restored.length > 0 || restoredPRs.length > 0) {
-      this.logger.info(`Restored ${restored.length} run watch(es) and ${restoredPRs.length} PR watch(es)`);
+    if (restored > 0 || restoredPRs > 0) {
+      this.logger.info(`Restored ${restored} run watch(es) and ${restoredPRs} PR watch(es)`);
       this._onDidChangeWatchedRuns.fire(this.getAllWatches());
-      if (restoredPRs.length > 0) {
+      if (restoredPRs > 0) {
         this._onDidChangePRWatches.fire();
       }
-      // Resume polling for any that are still in progress
-      const hasPollable = restored.some(
-        w => w.status.overallState !== 'completed' && !w.hasWarning
-      ) || restoredPRs.some(
-        pr => pr.prState === 'open' && !pr.hasWarning
-      );
-      if (hasPollable) {
+      if (this.runPool.hasPollableWatches() || this.prPool.hasPollablePRWatches()) {
         this.ensurePollingActive();
       }
     }
@@ -154,62 +146,19 @@ export class WatcherService implements vscode.Disposable {
     parentPRKey?: string,
     options?: { suppressEvents?: boolean; suppressPersist?: boolean },
   ): Promise<WatchedRun> {
-    const key = this.getWatchKey(identifier);
-    const existing = this.watches.get(key);
-    if (existing && !existing.dismissed) {
-      // Already actively watching — return existing watch unchanged. This
-      // makes the "Watch URL" command idempotent so users don't see a hostile
-      // error when they re-add a URL that's already being watched. The PR
-      // re-add path also lands here, where we keep ownership unchanged to
-      // avoid converting a standalone watch into a PR-owned watch.
-      return existing;
-    }
-    // Remove dismissed watch to allow re-watching
-    if (existing) {
-      this.watches.delete(key);
-      // A re-watched run should be able to alert again on the next failure.
-      this.acknowledgedFailedRunKeys.delete(key);
+    const result = await this.runPool.startWatch(identifier, parentPRKey, options);
+    if (!result.changed) {
+      return result.watch;
     }
 
-    const watcher = this.watcherRegistry.get(identifier.providerId);
-    if (!watcher) {
-      throw new Error(`No watcher registered for provider: ${identifier.providerId}`);
-    }
-
-    // Fetch initial status
-    const status = await watcher.getRunStatus(identifier);
-    // Update display name if the watcher returned one
-    if (status.displayName) {
-      identifier.displayName = status.displayName;
-    }
-    const now = new Date().toISOString();
-    
-    const watchedRun: WatchedRun = {
-      identifier,
-      status,
-      watchedAt: now,
-      lastPolledAt: now,
-      dismissed: false,
-      parentPRKey,
-    };
-
-    this.watches.set(key, watchedRun);
-    this.consecutiveFailures.delete(key);
-    this.logger.info(`Started watching: ${identifier.displayName} (${identifier.providerId})`);
-    
     if (!options?.suppressEvents) {
       this._onDidChangeWatchedRuns.fire(this.getAllWatches());
     }
-    
-    // Start polling if the watch is pollable (not already completed)
-    if (watchedRun.status.overallState !== 'completed') {
-      this.ensurePollingActive();
-    }
-    
+
     if (!options?.suppressPersist) {
       this.persistWatches();
     }
-    return watchedRun;
+    return result.watch;
   }
 
   /**
@@ -231,94 +180,24 @@ export class WatcherService implements vscode.Disposable {
     identifier: PRIdentifier,
     options?: { forceRecreate?: boolean },
   ): Promise<WatchedPR> {
-    const key = this.getPRWatchKey(identifier);
-    const existing = this.prWatches.get(key);
-
-    if (options?.forceRecreate && existing) {
-      // Wipe owned child runs so the fresh snapshot starts clean. Children
-      // are 'owned' when their parentPRKey matches this PR's key — a
-      // standalone watch the user added directly that happens to point at
-      // the same run does not have parentPRKey set, so we leave it alone.
-      for (const childKey of existing.childRunKeys) {
-        const childWatch = this.watches.get(childKey);
-        if (childWatch && childWatch.parentPRKey === key) {
-          this.watches.delete(childKey);
-          // Re-watched runs should be able to alert on their next failure.
-          this.acknowledgedFailedRunKeys.delete(childKey);
-        }
-      }
-      this.prWatches.delete(key);
-    } else if (existing && !existing.dismissed) {
-      // Already actively watching — return existing unchanged. Used by the
-      // auto-watch path (which checks isPRWatched first anyway); keeps the
-      // public API forgiving for callers that don't pass forceRecreate.
-      return existing;
-    } else if (existing) {
-      // Previously dismissed — delete and recreate fresh.
-      this.prWatches.delete(key);
-    }
-
-    const prWatcher = this.prWatcherRegistry.get(identifier.providerId);
-    if (!prWatcher) {
-      throw new Error(`No PR watcher registered for provider: ${identifier.providerId}`);
-    }
-
-    // Fetch initial snapshot
-    const snapshot = await prWatcher.getPRRunsSnapshot(identifier);
-    if (snapshot.displayName) {
-      identifier.displayName = snapshot.displayName;
-    }
-    const now = new Date().toISOString();
-
-    const watchedPR: WatchedPR = {
-      identifier,
-      prState: snapshot.prState,
-      childRunKeys: [],
-      watchedAt: now,
-      lastPolledAt: now,
-      dismissed: false,
-    };
-
-    this.prWatches.set(key, watchedPR);
-    this.persistedPRWatchKeys?.add(key);
-    this.consecutiveFailures.delete(key);
-    this.logger.info(`Started watching PR: ${identifier.displayName} (${identifier.providerId})`);
-
-    // Add initial runs as child watches (batched — single event/persist after)
-    for (const runId of snapshot.runs) {
-      const resolved = this.resolveRunIdentifier(runId);
-      await this.addChildRun(key, watchedPR, resolved, {
-        suppressEvents: true,
-        suppressPersist: true,
-      });
+    const result = await this.prPool.startPRWatch(identifier, options);
+    if (!result.changed) {
+      return result.watch;
     }
 
     this._onDidChangePRWatches.fire();
     this._onDidChangeWatchedRuns.fire(this.getAllWatches());
-
-    if (snapshot.prState === 'open') {
-      this.ensurePollingActive();
-    }
-
     this.persistWatches();
-    return watchedPR;
+    return result.watch;
   }
 
   /**
    * Dismiss a watched run (hides it from the tree).
    */
   dismissWatch(identifier: RunIdentifier): void {
-    const key = this.getWatchKey(identifier);
-    const watch = this.watches.get(key);
-    if (watch) {
-      const affectedPRKeys = this.getPRKeysForRun(key, watch);
-      watch.dismissed = true;
-      // Drop the acknowledgement so a re-watch (or recovery + re-failure)
-      // can alert again.
-      this.acknowledgedFailedRunKeys.delete(key);
-      const dismissedPRCount = this.dismissChildlessPRWatches(affectedPRKeys);
-      this.logger.info(`Dismissed watch: ${identifier.displayName}`);
-      if (dismissedPRCount > 0) {
+    const result = this.runPool.dismissWatch(identifier);
+    if (result.dismissed) {
+      if (result.dismissedPRCount > 0) {
         this._onDidChangePRWatches.fire();
       }
       this._onDidChangeWatchedRuns.fire(this.getAllWatches());
@@ -332,20 +211,8 @@ export class WatcherService implements vscode.Disposable {
    * unlinked but not dismissed.
    */
   dismissPRWatch(identifier: PRIdentifier): void {
-    const key = this.getPRWatchKey(identifier);
-    const prWatch = this.prWatches.get(key);
-    if (prWatch) {
-      prWatch.dismissed = true;
-      // Only dismiss child runs actually owned by this PR
-      for (const childKey of prWatch.childRunKeys) {
-        const childWatch = this.watches.get(childKey);
-        if (childWatch && childWatch.parentPRKey === key) {
-          childWatch.dismissed = true;
-          // Drop the acknowledgement so a re-watch can alert again.
-          this.acknowledgedFailedRunKeys.delete(childKey);
-        }
-      }
-      this.logger.info(`Dismissed PR watch: ${identifier.displayName}`);
+    const result = this.prPool.dismissPRWatch(identifier);
+    if (result.dismissed) {
       this._onDidChangePRWatches.fire();
       this._onDidChangeWatchedRuns.fire(this.getAllWatches());
       this.persistWatches();
@@ -358,41 +225,13 @@ export class WatcherService implements vscode.Disposable {
    * @returns The number of watches (runs + PRs + child runs of dismissed PRs) marked dismissed.
    */
   dismissAllCompleted(): number {
-    let dismissedCount = 0;
-    const affectedPRKeys = new Set<string>();
-    const runToPRKeys = this.buildActiveChildRunIndex();
-
-    for (const [key, watch] of this.watches.entries()) {
-      if (watch.status.overallState === 'completed' && !watch.dismissed) {
-        for (const prKey of this.getPRKeysForRun(key, watch, runToPRKeys)) {
-          affectedPRKeys.add(prKey);
-        }
-        watch.dismissed = true;
-        // Drop the ack so a re-watch can alert again. Mirrors dismissWatch.
-        this.acknowledgedFailedRunKeys.delete(key);
-        dismissedCount++;
-      }
-    }
-
-    for (const prWatch of this.prWatches.values()) {
-      if ((prWatch.prState === 'merged' || prWatch.prState === 'closed') && !prWatch.dismissed) {
-        const key = this.getPRWatchKey(prWatch.identifier);
-        prWatch.dismissed = true;
-        // Only dismiss child runs actually owned by this PR
-        for (const childKey of prWatch.childRunKeys) {
-          const childWatch = this.watches.get(childKey);
-          if (childWatch && !childWatch.dismissed && childWatch.parentPRKey === key) {
-            childWatch.dismissed = true;
-            // Drop the ack so a re-watch can alert again.
-            this.acknowledgedFailedRunKeys.delete(childKey);
-            dismissedCount++;
-          }
-        }
-        dismissedCount++;
-      }
-    }
-
-    dismissedCount += this.dismissChildlessPRWatches(affectedPRKeys);
+    const runToPRKeys = this.prPool.buildActiveChildRunIndex();
+    const runResult = this.runPool.dismissCompletedRuns(
+      (runKey, watch) => this.prPool.getPRKeysForRun(runKey, watch, runToPRKeys),
+    );
+    const dismissedPRCount = this.prPool.dismissCompletedPRWatches();
+    const cascadedPRCount = this.prPool.dismissChildlessPRWatches(runResult.affectedPRKeys);
+    const dismissedCount = runResult.dismissedCount + dismissedPRCount + cascadedPRCount;
 
     if (dismissedCount > 0) {
       this.logger.info(`Dismissed ${dismissedCount} completed watch(es)`);
@@ -409,59 +248,14 @@ export class WatcherService implements vscode.Disposable {
    * count before invoking the destructive operation.
    */
   countCompletedActiveWatches(): number {
-    let count = 0;
-    const dismissedRunKeys = new Set<string>();
-    const dismissedPRKeys = new Set<string>();
-    const affectedPRKeys = new Set<string>();
-    const runToPRKeys = this.buildActiveChildRunIndex();
-
-    for (const [key, watch] of this.watches.entries()) {
-      if (!watch.dismissed && watch.status.overallState === 'completed') {
-        dismissedRunKeys.add(key);
-        for (const prKey of this.getPRKeysForRun(key, watch, runToPRKeys)) {
-          affectedPRKeys.add(prKey);
-        }
-        count++;
-      }
-    }
-
-    for (const [prKey, prWatch] of this.prWatches.entries()) {
-      if (!prWatch.dismissed && (prWatch.prState === 'merged' || prWatch.prState === 'closed')) {
-        dismissedPRKeys.add(prKey);
-        count++;
-        for (const childKey of prWatch.childRunKeys) {
-          const childWatch = this.watches.get(childKey);
-          if (
-            childWatch
-            && !childWatch.dismissed
-            && childWatch.parentPRKey === prKey
-            && !dismissedRunKeys.has(childKey)
-          ) {
-            dismissedRunKeys.add(childKey);
-            count++;
-          }
-        }
-      }
-    }
-
-    // Every affected PR was reached from an active completed child run, so the
-    // observed-child guard is already satisfied for this simulated cascade.
-    for (const prKey of affectedPRKeys) {
-      if (dismissedPRKeys.has(prKey)) continue;
-      const activeChildKeys = this.getActiveChildRunKeys(prKey);
-      if (activeChildKeys.length > 0 && activeChildKeys.every(childKey => dismissedRunKeys.has(childKey))) {
-        count++;
-      }
-    }
-
-    return count;
+    return this.prPool.countCompletedActiveWatches();
   }
 
   /**
    * Get all active watches (not dismissed).
    */
   getActiveWatches(): WatchedRun[] {
-    return Array.from(this.watches.values()).filter(w => !w.dismissed);
+    return this.runPool.getActiveWatches();
   }
 
   /**
@@ -479,13 +273,7 @@ export class WatcherService implements vscode.Disposable {
    * acknowledged failure to reappear is via re-watch.
    */
   acknowledgeAllFailures(): void {
-    let added = 0;
-    for (const [key, watch] of this.watches.entries()) {
-      if (!watch.dismissed && WatcherService.isFailedRun(watch) && !this.acknowledgedFailedRunKeys.has(key)) {
-        this.acknowledgedFailedRunKeys.add(key);
-        added += 1;
-      }
-    }
+    const added = this.runPool.acknowledgeAllFailures();
     if (added > 0) {
       this._onDidChangeWatchedRuns.fire(this.getActiveWatches());
     }
@@ -496,28 +284,14 @@ export class WatcherService implements vscode.Disposable {
    * the watch panel while the run was in this failed state).
    */
   isFailureAcknowledged(watch: WatchedRun): boolean {
-    return this.acknowledgedFailedRunKeys.has(this.getWatchKey(watch.identifier));
-  }
-
-  private static isFailedRun(watch: WatchedRun): boolean {
-    // hasWarning means we couldn't poll successfully — surface it as a
-    // 'failure' for ack-tracking purposes so the user can suppress the
-    // status-bar warning. cancelled / skipped / neutral conclusions are
-    // explicit non-results (not failures), matching the canonical
-    // definition in mainViewProvider.ts and the watch panel webview.
-    if (watch.hasWarning) return true;
-    if (watch.status.overallState !== 'completed') return false;
-    const conclusion = watch.status.conclusion;
-    if (conclusion === undefined || conclusion === 'success') return false;
-    if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral') return false;
-    return true;
+    return this.runPool.isFailureAcknowledged(watch);
   }
 
   /**
    * Get all active PR watches (not dismissed).
    */
   getActivePRWatches(): WatchedPR[] {
-    return Array.from(this.prWatches.values()).filter(pr => !pr.dismissed);
+    return this.prPool.getActivePRWatches();
   }
 
   /**
@@ -527,9 +301,7 @@ export class WatcherService implements vscode.Disposable {
    * from "previously watched and dismissed" in user-facing flows.
    */
   isPRActive(identifier: PRIdentifier): boolean {
-    const key = this.getPRWatchKey(identifier);
-    const existing = this.prWatches.get(key);
-    return existing !== undefined && !existing.dismissed;
+    return this.prPool.isPRActive(identifier);
   }
 
   /**
@@ -537,9 +309,7 @@ export class WatcherService implements vscode.Disposable {
    * not dismissed).
    */
   isRunActive(identifier: RunIdentifier): boolean {
-    const key = this.getWatchKey(identifier);
-    const existing = this.watches.get(key);
-    return existing !== undefined && !existing.dismissed;
+    return this.runPool.isRunActive(identifier);
   }
 
   /**
@@ -547,117 +317,25 @@ export class WatcherService implements vscode.Disposable {
    */
   async isPRWatched(identifier: PRIdentifier): Promise<boolean> {
     const key = this.getPRWatchKey(identifier);
-    if (this.prWatches.has(key)) {
+    if (this.prPool.hasPRWatch(key)) {
       return true;
     }
 
-    return (await this.getPersistedPRWatchKeys()).has(key);
+    return (await this.persistence.getPersistedPRWatchKeys(pr => this.getPRWatchKey(pr.identifier))).has(key);
   }
 
   /**
    * Get active standalone watches (not dismissed, no parent PR).
    */
   getActiveStandaloneWatches(): WatchedRun[] {
-    // Collect run keys linked by any active PR
-    const prLinkedKeys = new Set<string>();
-    for (const prWatch of this.prWatches.values()) {
-      if (!prWatch.dismissed) {
-        for (const childKey of prWatch.childRunKeys) {
-          prLinkedKeys.add(childKey);
-        }
-      }
-    }
-    return Array.from(this.watches.values()).filter(
-      w => !w.dismissed && !w.parentPRKey && !prLinkedKeys.has(this.getWatchKey(w.identifier))
-    );
+    return this.runPool.getActiveStandaloneWatches(this.prPool.getActiveLinkedRunKeys());
   }
 
   /**
    * Get active child runs for a PR watch.
    */
   getChildRuns(prKey: string): WatchedRun[] {
-    const childRuns = new Map<string, WatchedRun>();
-    for (const childRunKey of this.getActiveChildRunKeys(prKey)) {
-      const watch = this.watches.get(childRunKey);
-      if (watch) {
-        childRuns.set(childRunKey, watch);
-      }
-    }
-    return Array.from(childRuns.values());
-  }
-
-  private getActiveChildRunKeys(prKey: string): string[] {
-    const childRuns = new Set<string>();
-    // Include runs tracked via childRunKeys (covers linked standalone watches)
-    const prWatch = this.prWatches.get(prKey);
-    for (const childRunKey of prWatch?.childRunKeys ?? []) {
-      const watch = this.watches.get(childRunKey);
-      if (watch && !watch.dismissed) {
-        childRuns.add(childRunKey);
-      }
-    }
-    // Also include any runs explicitly parented by this PR
-    for (const [watchKey, watch] of this.watches.entries()) {
-      if (!watch.dismissed && watch.parentPRKey === prKey) {
-        childRuns.add(watchKey);
-      }
-    }
-    return Array.from(childRuns.values());
-  }
-
-  private getPRKeysForRun(
-    runKey: string,
-    watch: WatchedRun,
-    runToPRKeys = this.buildActiveChildRunIndex(),
-  ): Set<string> {
-    const prKeys = new Set<string>();
-    if (watch.parentPRKey) {
-      prKeys.add(watch.parentPRKey);
-    }
-    for (const prKey of runToPRKeys.get(runKey) ?? []) {
-      prKeys.add(prKey);
-    }
-    return prKeys;
-  }
-
-  private buildActiveChildRunIndex(): Map<string, Set<string>> {
-    const runToPRKeys = new Map<string, Set<string>>();
-    for (const [prKey, prWatch] of this.prWatches.entries()) {
-      if (prWatch.dismissed) continue;
-      for (const childKey of prWatch.childRunKeys) {
-        const prKeys = runToPRKeys.get(childKey) ?? new Set<string>();
-        prKeys.add(prKey);
-        runToPRKeys.set(childKey, prKeys);
-      }
-    }
-    return runToPRKeys;
-  }
-
-  private dismissChildlessPRWatches(prKeys: Iterable<string>, options?: { assumeObserved?: boolean }): number {
-    let dismissedCount = 0;
-    for (const prKey of prKeys) {
-      const prWatch = this.prWatches.get(prKey);
-      if (!prWatch || prWatch.dismissed) continue;
-      if (!options?.assumeObserved && !this.hasObservedChildRun(prKey, prWatch)) continue;
-      if (this.getActiveChildRunKeys(prKey).length > 0) continue;
-
-      prWatch.dismissed = true;
-      dismissedCount++;
-      this.logger.info(`Dismissed childless PR watch: ${prWatch.identifier.displayName}`);
-    }
-    return dismissedCount;
-  }
-
-  private hasObservedChildRun(prKey: string, prWatch: WatchedPR): boolean {
-    if (prWatch.childRunKeys.length > 0) {
-      return true;
-    }
-    for (const watch of this.watches.values()) {
-      if (watch.parentPRKey === prKey) {
-        return true;
-      }
-    }
-    return false;
+    return this.prPool.getChildRuns(prKey);
   }
 
   /**
@@ -674,21 +352,21 @@ export class WatcherService implements vscode.Disposable {
    * Get all watches including dismissed.
    */
   getAllWatches(): WatchedRun[] {
-    return Array.from(this.watches.values());
+    return this.runPool.getAllWatches();
   }
 
   /**
    * Get all PR watches including dismissed.
    */
   getAllPRWatches(): WatchedPR[] {
-    return Array.from(this.prWatches.values());
+    return this.prPool.getAllPRWatches();
   }
 
   /**
    * Get a unique key for a PR watch.
    */
   getPRWatchKey(identifier: PRIdentifier): string {
-    return `pr:${identifier.providerId}:${identifier.repo}:${identifier.prId}`;
+    return this.prPool.getPRWatchKey(identifier);
   }
 
   /**
@@ -707,14 +385,14 @@ export class WatcherService implements vscode.Disposable {
     if (this.pollTimer) {
       return; // Already active
     }
-    
+
     const intervalSeconds = this.getPollingInterval();
     this.pollTimer = setInterval(() => {
       this.pollAllWatches().catch(err => {
         this.logger.error(`Poll error: ${err}`);
       });
     }, intervalSeconds * 1000);
-    
+
     this.logger.info(`Started polling (interval: ${intervalSeconds}s)`);
   }
 
@@ -733,7 +411,6 @@ export class WatcherService implements vscode.Disposable {
    * Poll all active watches for status updates.
    */
   private async pollAllWatches(): Promise<void> {
-    // Concurrency guard: skip if previous poll still in flight
     if (this.isPollInFlight || this.disposed) {
       if (this.isPollInFlight) {
         this.logger.warn('Poll already in flight, skipping tick');
@@ -743,14 +420,10 @@ export class WatcherService implements vscode.Disposable {
 
     this.isPollInFlight = true;
     try {
-      // Phase 1: Poll PR watches first — may add/remove child runs
-      const prResult = await this.pollPRWatches();
-      // Bail if dispose() ran during phase 1 — don't fire events or persist
-      // an empty/partial state that would overwrite the on-disk record.
+      const prResult = await this.prPool.pollPRWatches();
       if (this.disposed) return;
 
-      // Phase 2: Poll run watches (including newly added child runs)
-      const runChanged = await this.pollRunWatches();
+      const runChanged = await this.runPool.pollRunWatches();
       if (this.disposed) return;
 
       if (prResult.prChanged) {
@@ -766,14 +439,7 @@ export class WatcherService implements vscode.Disposable {
         this.persistWatches();
       }
 
-      // Check if anything is still pollable
-      const hasPollableRuns = this.getActiveWatches().some(
-        w => w.status.overallState !== 'completed' && !w.hasWarning
-      );
-      const hasPollablePRs = this.getActivePRWatches().some(
-        pr => pr.prState === 'open' && !pr.hasWarning
-      );
-      if (!hasPollableRuns && !hasPollablePRs) {
+      if (!this.runPool.hasPollableWatches() && !this.prPool.hasPollablePRWatches()) {
         this.stopPolling();
       }
     } finally {
@@ -781,330 +447,24 @@ export class WatcherService implements vscode.Disposable {
     }
   }
 
-  /**
-   * Poll PR watches for state changes and run updates.
-   * @returns Object indicating whether PR metadata or child runs changed
-   */
-  private async pollPRWatches(): Promise<{ prChanged: boolean; childRunChanged: boolean }> {
-    const activePRs = this.getActivePRWatches().filter(
-      pr => pr.prState === 'open' && !pr.hasWarning
-    );
-    if (activePRs.length === 0) return { prChanged: false, childRunChanged: false };
-
-    let prChanged = false;
-    let childRunChanged = false;
-
-    for (const prWatch of activePRs) {
-      const key = this.getPRWatchKey(prWatch.identifier);
-      try {
-        const prWatcher = this.prWatcherRegistry.get(prWatch.identifier.providerId);
-        if (!prWatcher) {
-          throw new Error(`PR watcher '${prWatch.identifier.providerId}' is no longer registered`);
-        }
-
-        const snapshot = await prWatcher.getPRRunsSnapshot(prWatch.identifier);
-        // Bail if the watch was dismissed, replaced (forceRecreate), or the
-        // service was disposed while the snapshot fetch was in flight.
-        // Otherwise we'd mutate stale state, fire onDidCompletePR for an
-        // already-replaced PR, or leak orphan child runs whose parentPRKey
-        // points at a PR no longer in this.prWatches.
-        if (this.disposed) return { prChanged, childRunChanged };
-        if (this.prWatches.get(key) !== prWatch || prWatch.dismissed) {
-          continue;
-        }
-        prWatch.lastPolledAt = new Date().toISOString();
-
-        // Apply updated display name from snapshot
-        if (snapshot.displayName && snapshot.displayName !== prWatch.identifier.displayName) {
-          prWatch.identifier.displayName = snapshot.displayName;
-          prChanged = true;
-        }
-
-        // Reset failure count
-        this.consecutiveFailures.delete(key);
-        prWatch.hasWarning = false;
-        prWatch.errorMessage = undefined;
-
-        // Handle new/removed runs
-        const currentRunKeys = new Set(prWatch.childRunKeys);
-        const newRunKeys = new Set<string>();
-        for (const runId of snapshot.runs) {
-          const resolved = this.resolveRunIdentifier(runId);
-          const runKey = this.getWatchKey(resolved);
-          newRunKeys.add(runKey);
-          if (!currentRunKeys.has(runKey)) {
-            const added = await this.addChildRun(key, prWatch, resolved, {
-              suppressEvents: true,
-              suppressPersist: true,
-            });
-            if (this.disposed) return { prChanged, childRunChanged };
-            if (added) {
-              childRunChanged = true;
-            }
-          }
-        }
-
-        // Remove orphaned child runs (only dismiss runs owned by this PR)
-        const hadObservedChildren = currentRunKeys.size > 0 || this.hasObservedChildRun(key, prWatch);
-        for (const childKey of currentRunKeys) {
-          if (!newRunKeys.has(childKey)) {
-            const childWatch = this.watches.get(childKey);
-            if (childWatch && !childWatch.dismissed && childWatch.parentPRKey === key) {
-              childWatch.dismissed = true;
-              childRunChanged = true;
-            }
-            prWatch.childRunKeys = prWatch.childRunKeys.filter(k => k !== childKey);
-          }
-        }
-        if (
-          hadObservedChildren
-          && this.getActiveChildRunKeys(key).length === 0
-          && this.dismissChildlessPRWatches([key], { assumeObserved: true }) > 0
-        ) {
-          prChanged = true;
-          continue;
-        }
-
-        // Check PR state transitions
-        if (snapshot.prState !== prWatch.prState) {
-          prWatch.prState = snapshot.prState;
-          prChanged = true;
-          if (snapshot.prState === 'merged' || snapshot.prState === 'closed') {
-            this._onDidCompletePR.fire(prWatch);
-          }
-        }
-
-      } catch (err) {
-        const failures = (this.consecutiveFailures.get(key) || 0) + 1;
-        this.consecutiveFailures.set(key, failures);
-
-        if (failures >= 3) {
-          prWatch.hasWarning = true;
-          prWatch.errorMessage = err instanceof Error ? err.message : String(err);
-          prChanged = true;
-          this.logger.warn(`3 consecutive failures for PR ${prWatch.identifier.displayName}, marking with warning`);
-        } else {
-          this.logger.warn(`PR poll failed for ${prWatch.identifier.displayName} (attempt ${failures}/3): ${err}`);
-        }
-      }
-    }
-
-    return { prChanged, childRunChanged };
-  }
-
-  /**
-   * Poll run watches for status updates.
-   */
-  private async pollRunWatches(): Promise<boolean> {
-    const activeWatches = this.getActiveWatches();
-    const pollableWatches = activeWatches.filter(
-      w => w.status.overallState !== 'completed' && !w.hasWarning
-    );
-    if (pollableWatches.length === 0) return false;
-
-    let anyChanged = false;
-
-    for (const watch of pollableWatches) {
-
-      try {
-        const watcher = this.watcherRegistry.get(watch.identifier.providerId);
-        if (!watcher) {
-          throw new Error(`Watcher '${watch.identifier.providerId}' is no longer registered`);
-        }
-
-        const newStatus = await watcher.getRunStatus(watch.identifier);
-        const key = this.getWatchKey(watch.identifier);
-        // Bail if the watch was dismissed, replaced, or the service was
-        // disposed while the status fetch was in flight. Otherwise we'd
-        // mutate a watch the user just hid and potentially fire
-        // onDidCompleteRun for it (popping a "Run completed" toast for
-        // something that's no longer in the panel).
-        if (this.disposed) return anyChanged;
-        if (this.watches.get(key) !== watch || watch.dismissed) {
-          continue;
-        }
-        watch.lastPolledAt = new Date().toISOString();
-
-        // Reset failure count on success
-        this.consecutiveFailures.delete(key);
-        watch.hasWarning = false;
-        watch.errorMessage = undefined;
-
-        // Snapshot old status for comparison, then update immediately
-        // so event subscribers always see current data.
-        const oldStatus = watch.status;
-        const statusChanged = oldStatus.overallState !== newStatus.overallState
-          || oldStatus.conclusion !== newStatus.conclusion
-          || oldStatus.jobs.length !== newStatus.jobs.length
-          || newStatus.jobs.some(newJob => {
-            const oldJob = newJob.id
-              ? oldStatus.jobs.find(j => j.id === newJob.id)
-              : oldStatus.jobs.find(j => j.name === newJob.name);
-            return !oldJob || oldJob.state !== newJob.state || oldJob.conclusion !== newJob.conclusion;
-          });
-        watch.status = newStatus;
-        // Update display name if the watcher returned one
-        if (newStatus.displayName && newStatus.displayName !== watch.identifier.displayName) {
-          watch.identifier.displayName = newStatus.displayName;
-          anyChanged = true;
-        }
-        if (statusChanged) {
-          anyChanged = true;
-        }
-
-        // Detect job failures (while run is still in progress)
-        if (newStatus.overallState !== 'completed') {
-          for (const newJob of newStatus.jobs) {
-            if (newJob.state === 'completed' && newJob.conclusion === 'failure') {
-              const oldJob = newJob.id
-                ? oldStatus.jobs.find(j => j.id === newJob.id)
-                : oldStatus.jobs.find(j => j.name === newJob.name);
-              if (!oldJob || oldJob.state !== 'completed' || oldJob.conclusion !== 'failure') {
-                this._onDidDetectJobFailure.fire({ run: watch, job: newJob });
-              }
-            }
-          }
-        }
-
-        // Check if run just completed
-        if (oldStatus.overallState !== 'completed' && newStatus.overallState === 'completed') {
-          this._onDidCompleteRun.fire(watch);
-        }
-
-      } catch (err) {
-        const key = this.getWatchKey(watch.identifier);
-        const failures = (this.consecutiveFailures.get(key) || 0) + 1;
-        this.consecutiveFailures.set(key, failures);
-        
-        if (failures >= 3) {
-          watch.hasWarning = true;
-          watch.errorMessage = err instanceof Error ? err.message : String(err);
-          anyChanged = true;
-          this.logger.warn(`3 consecutive failures for ${watch.identifier.displayName}, marking with warning`);
-        } else {
-          this.logger.warn(`Poll failed for ${watch.identifier.displayName} (attempt ${failures}/3): ${err}`);
-        }
-      }
-    }
-
-    return anyChanged;
-  }
-
-  /**
-   * Add a child run to a PR watch, starting a new watch for it.
-   * @returns true if the PR's child run list actually changed
-   */
-  private async addChildRun(
-    prKey: string,
-    prWatch: WatchedPR,
-    runIdentifier: RunIdentifier,
-    options?: { suppressEvents?: boolean; suppressPersist?: boolean },
-  ): Promise<boolean> {
-    const runKey = this.getWatchKey(runIdentifier);
-    try {
-      const existing = this.watches.get(runKey);
-      if (existing && !existing.dismissed) {
-        // Preserve ownership of existing watches. Standalone watches remain
-        // standalone even when linked from a PR watch.
-        if (!prWatch.childRunKeys.includes(runKey)) {
-          prWatch.childRunKeys.push(runKey);
-          return true;
-        }
-        return false;
-      }
-
-      await this.startWatch(runIdentifier, prKey, options);
-      if (!prWatch.childRunKeys.includes(runKey)) {
-        prWatch.childRunKeys.push(runKey);
-        return true;
-      }
-      return false;
-    } catch (err) {
-      this.logger.warn(`Failed to add child run ${runIdentifier.displayName} for PR ${prWatch.identifier.displayName}: ${err}`);
-      return false;
-    }
-  }
-
-  /**
-   * Generate a unique key for a watch.
-   */
-  private getWatchKey(identifier: RunIdentifier): string {
-    return identifier.repo
-      ? `${identifier.providerId}:${identifier.repo}:${identifier.runId}`
-      : `${identifier.providerId}:${identifier.runId}`;
-  }
-
-  /**
-   * Resolve a run identifier to one backed by a registered watcher.
-   * If the identifier's providerId matches a registered watcher directly, returns as-is.
-   * Otherwise, tries URL-based matching against all registered run watchers.
-   * Returns the resolved identifier, or the original if no resolution is possible.
-   */
-  private resolveRunIdentifier(identifier: RunIdentifier): RunIdentifier {
-    if (this.watcherRegistry.get(identifier.providerId)) {
-      return identifier;
-    }
-
-    const watcher = this.watcherRegistry.findWatcherForUrl(identifier.url);
-    if (watcher) {
-      try {
-        const parsed = watcher.parseRunUrl(identifier.url);
-        return {
-          ...parsed,
-          displayName: identifier.displayName || parsed.displayName,
-        };
-      } catch (err) {
-        this.logger.warn(`URL matched watcher '${watcher.id}' but parseRunUrl failed for ${identifier.url}: ${err}`);
-      }
-    }
-
-    return identifier;
-  }
-
-  private async getPersistedPRWatchKeys(): Promise<Set<string>> {
-    if (!this.persistedPRWatchKeys) {
-      const { prs } = await this.watchStore.loadAll();
-      this.persistedPRWatchKeys = new Set(prs.map(pr => this.getPRWatchKey(pr.identifier)));
-    }
-
-    return this.persistedPRWatchKeys;
-  }
-
   private persistWatches(): void {
-    this.watchStore.saveAll(this.getAllWatches(), this.getAllPRWatches()).then(
-      () => {
-        if (this.persistFailureNotified) {
-          this.persistFailureNotified = false;
-          this.logger.info('Watch persistence recovered.');
-        }
-      },
-      err => {
-        this.logger.error(`Failed to persist watches: ${err}`);
-        // Throttle: only escalate once per failure streak. The flag clears
-        // on the next successful save so a future regression re-alerts.
-        if (!this.persistFailureNotified) {
-          this.persistFailureNotified = true;
-          void vscode.window.showWarningMessage(
-            'DevDocket could not save watch state. Watches may be lost when the window reloads.',
-          );
-        }
-      },
-    );
+    this.persistence.saveAll(this.getAllWatches(), this.getAllPRWatches());
   }
 
   dispose(): void {
     this.disposed = true;
     this.configSubscription?.dispose();
     this.stopPolling();
+    for (const subscription of this.poolSubscriptions) {
+      subscription.dispose();
+    }
     this._onDidChangeWatchedRuns.dispose();
     this._onDidDetectJobFailure.dispose();
     this._onDidCompleteRun.dispose();
     this._onDidChangePRWatches.dispose();
     this._onDidCompletePR.dispose();
-    this.watches.clear();
-    this.prWatches.clear();
-    this.consecutiveFailures.clear();
-    this.acknowledgedFailedRunKeys.clear();
-    this.persistedPRWatchKeys = undefined;
+    this.runPool.dispose();
+    this.prPool.dispose();
+    this.persistence.dispose();
   }
 }

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -147,7 +147,7 @@ export class WatcherService implements vscode.Disposable {
     options?: { suppressEvents?: boolean; suppressPersist?: boolean },
   ): Promise<WatchedRun> {
     const result = await this.runPool.startWatch(identifier, parentPRKey);
-    if (!result.changed) {
+    if (!result.changed || this.disposed) {
       return result.watch;
     }
 
@@ -181,7 +181,7 @@ export class WatcherService implements vscode.Disposable {
     options?: { forceRecreate?: boolean },
   ): Promise<WatchedPR> {
     const result = await this.prPool.startPRWatch(identifier, options);
-    if (!result.changed) {
+    if (!result.changed || this.disposed) {
       return result.watch;
     }
 
@@ -382,6 +382,9 @@ export class WatcherService implements vscode.Disposable {
    * Start or restart the polling timer.
    */
   private ensurePollingActive(): void {
+    if (this.disposed) {
+      return;
+    }
     if (this.pollTimer) {
       return; // Already active
     }


### PR DESCRIPTION
## Summary

- Extracted run-watch state, polling, completion events, and failure acknowledgement tracking into `packages/core/src/services/runWatchPool.ts`.
- Extracted PR-watch state, PR polling, child-run linkage, and childless-PR cascading dismiss logic into `packages/core/src/services/prWatchPool.ts`.
- Extracted `WatchStore` load/save behavior and throttled persistence warning handling into `packages/core/src/services/watchPersistence.ts`.
- Reduced `WatcherService` to the public orchestrator that owns polling cadence, public event fan-out, persistence calls, and disposal state.

## Public API

The public API of `WatcherService` is unchanged. Its constructor, public methods, exported `WatchedRun` / `WatchedPR` interfaces, and public events (`onDidChangeWatchedRuns`, `onDidDetectJobFailure`, `onDidCompleteRun`, `onDidChangePRWatches`, and `onDidCompletePR`) are preserved.

## Cross-pool cascading dismiss wiring

`RunWatchPool` owns run dismissals and accepts an `onRunDismissed` callback. `WatcherService` wires that callback to `PRWatchPool.dismissChildlessPRWatchesForRun(...)`, so when the last active child run is dismissed the PR pool applies the existing childless-PR rule. PR polling still handles orphaned owned child runs inside `PRWatchPool` and uses the same observed-child guard as before.

## Validation

- `cd packages/core && npm run build`
- `cd packages/core && npm run test` (787 tests passed)
- Local `superpowers:code-reviewer` review: clean

Closes #507
