### PR TITLE
Add GitHub Advanced Security run watcher for CodeQL check runs

### DIFF
--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -1045,6 +1045,10 @@ export class WatcherService implements vscode.Disposable {
       return identifier;
     }
 
+    if (this.isGitHubCheckRunUrl(identifier.url)) {
+      return identifier;
+    }
+
     const watcher = this.watcherRegistry.findWatcherForUrl(identifier.url);
     if (watcher) {
       try {
@@ -1059,6 +1063,17 @@ export class WatcherService implements vscode.Disposable {
     }
 
     return identifier;
+  }
+
+  private isGitHubCheckRunUrl(url: string): boolean {
+    try {
+      const u = new URL(url);
+      return u.protocol === 'https:'
+        && u.hostname === 'github.com'
+        && /^\/[^/]+\/[^/]+\/runs\/\d+\/?$/.test(u.pathname);
+    } catch {
+      return false;
+    }
   }
 
   private async getPersistedPRWatchKeys(): Promise<Set<string>> {

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -1036,16 +1036,15 @@ export class WatcherService implements vscode.Disposable {
 
   /**
    * Resolve a run identifier to one backed by a registered watcher.
-   * If the identifier's providerId matches a registered watcher directly, returns as-is.
-   * Otherwise, tries URL-based matching against all registered run watchers.
-   * Returns the resolved identifier, or the original if no resolution is possible.
+   *
+   * If upstream metadata already classified the run, trust it. Core must not
+   * second-guess provider-owned classifications by inspecting host-specific URLs.
+   *
+   * If the identifier has no provider hint, fall back to URL-based matching for
+   * synthetic identifiers created from a raw URL.
    */
   private resolveRunIdentifier(identifier: RunIdentifier): RunIdentifier {
-    if (this.watcherRegistry.get(identifier.providerId)) {
-      return identifier;
-    }
-
-    if (this.isGitHubCheckRunUrl(identifier.url)) {
+    if (identifier.providerId) {
       return identifier;
     }
 
@@ -1063,17 +1062,6 @@ export class WatcherService implements vscode.Disposable {
     }
 
     return identifier;
-  }
-
-  private isGitHubCheckRunUrl(url: string): boolean {
-    try {
-      const u = new URL(url);
-      return u.protocol === 'https:'
-        && u.hostname === 'github.com'
-        && /^\/[^/]+\/[^/]+\/runs\/\d+\/?$/.test(u.pathname);
-    } catch {
-      return false;
-    }
   }
 
   private async getPersistedPRWatchKeys(): Promise<Set<string>> {

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -538,6 +538,33 @@ describe('WatcherService', () => {
       expect(service.getActiveWatches()[0].parentPRKey).toBeDefined();
     });
 
+    it('adds GitHub Advanced Security child runs when its watcher is registered without warn logs', async () => {
+      const runWatcher = createMockWatcher('github-advanced-security');
+      registry.register(runWatcher);
+
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [{
+          providerId: 'github-advanced-security',
+          runId: '12345',
+          displayName: 'CodeQL',
+          url: 'https://github.com/owner/repo/runs/12345',
+          repo: 'owner/repo',
+        }],
+      }));
+      prRegistry.register(prWatcher);
+
+      const result = await service.startPRWatch(createPRIdentifier());
+      const activeWatches = service.getActiveWatches();
+
+      expect(result.childRunKeys).toHaveLength(1);
+      expect(activeWatches).toHaveLength(1);
+      expect(activeWatches[0].identifier.providerId).toBe('github-advanced-security');
+      expect(activeWatches[0].identifier.runId).toBe('12345');
+      expect(activeWatches[0].identifier.displayName).toBe('CodeQL');
+      expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('Failed to add child run'));
+    });
+
     it('dismisses a PR watch when its last visible child run is dismissed', async () => {
       const runWatcher = createMockWatcher('github-actions');
       registry.register(runWatcher);

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WatcherService, WatchedRun } from '../services/watcherService';
 import { WatcherRegistry } from '../services/watcherRegistry';
@@ -49,7 +52,28 @@ function createMockWatchStore(): WatchStore {
   } as unknown as WatchStore;
 }
 
+function collectTypeScriptFiles(dir: string): string[] {
+  return readdirSync(dir).flatMap(entry => {
+    const path = join(dir, entry);
+    return statSync(path).isDirectory() ? collectTypeScriptFiles(path) : [path];
+  }).filter(path => path.endsWith('.ts'));
+}
+
 describe('WatcherService', () => {
+  it('keeps host-specific run URL routing out of core services', () => {
+    const servicesDir = fileURLToPath(new URL('../services', import.meta.url));
+    const serviceContents = collectTypeScriptFiles(servicesDir)
+      .map(path => readFileSync(path, 'utf8'))
+      .join('\n');
+
+    const slash = String.fromCharCode(47);
+    const backslash = String.fromCharCode(92);
+
+    expect(serviceContents).not.toContain(['github', 'com'].join('.'));
+    expect(serviceContents).not.toContain(`${slash}runs${slash}`);
+    expect(serviceContents).not.toContain(`${backslash}${slash}runs${backslash}${slash}`);
+  });
+
   let service: WatcherService;
   let registry: WatcherRegistry;
   let prRegistry: PRWatcherRegistry;
@@ -538,17 +562,17 @@ describe('WatcherService', () => {
       expect(service.getActiveWatches()[0].parentPRKey).toBeDefined();
     });
 
-    it('adds GitHub Advanced Security child runs when its watcher is registered without warn logs', async () => {
-      const runWatcher = createMockWatcher('github-advanced-security');
+    it('adds child runs when the provider-owned watcher is registered without warn logs', async () => {
+      const runWatcher = createMockWatcher('security-scanner');
       registry.register(runWatcher);
 
       const prWatcher = createMockPRWatcher('test-pr', async () => ({
         prState: 'open',
         runs: [{
-          providerId: 'github-advanced-security',
+          providerId: 'security-scanner',
           runId: '12345',
-          displayName: 'CodeQL',
-          url: 'https://github.com/owner/repo/runs/12345',
+          displayName: 'Security Scan',
+          url: 'https://scanner.example.com/results/12345',
           repo: 'owner/repo',
         }],
       }));
@@ -559,9 +583,9 @@ describe('WatcherService', () => {
 
       expect(result.childRunKeys).toHaveLength(1);
       expect(activeWatches).toHaveLength(1);
-      expect(activeWatches[0].identifier.providerId).toBe('github-advanced-security');
+      expect(activeWatches[0].identifier.providerId).toBe('security-scanner');
       expect(activeWatches[0].identifier.runId).toBe('12345');
-      expect(activeWatches[0].identifier.displayName).toBe('CodeQL');
+      expect(activeWatches[0].identifier.displayName).toBe('Security Scan');
       expect(logger.warn).not.toHaveBeenCalledWith(expect.stringContaining('Failed to add child run'));
     });
 
@@ -813,65 +837,19 @@ describe('WatcherService', () => {
       expect(service.getActivePRWatches()[0].identifier.prId).toBe('42');
     });
 
-    it('resolves run identifiers via URL matching when providerId is unknown', async () => {
-      // Register a run watcher that recognizes URLs
-      const runWatcher = createMockWatcher('ado-pipelines');
-      (runWatcher.canWatch as ReturnType<typeof vi.fn>).mockImplementation(
-        (url: string) => {
-          try {
-            const u = new URL(url);
-            return u.hostname === 'dev.azure.com' && u.pathname.includes('_build/results');
-          } catch { return false; }
-        },
-      );
-      (runWatcher.parseRunUrl as ReturnType<typeof vi.fn>).mockReturnValue({
-        providerId: 'ado-pipelines',
-        runId: '555',
-        displayName: 'Build 555',
-        url: 'https://dev.azure.com/org/project/_build/results?buildId=555',
-        repo: 'org/project',
-      });
+    it('trusts non-empty child run providerIds without URL matching', async () => {
+      const runWatcher = createMockWatcher('url-matched-provider');
+      (runWatcher.canWatch as ReturnType<typeof vi.fn>).mockReturnValue(true);
       registry.register(runWatcher);
-
-      // PR watcher returns a run with an unknown providerId but a recognizable URL
-      const prWatcher = createMockPRWatcher('test-pr', async () => ({
-        prState: 'open',
-        runs: [{
-          providerId: 'azure-pipelines',
-          runId: '10',
-          displayName: 'ADO Pipeline',
-          url: 'https://dev.azure.com/org/project/_build/results?buildId=555',
-          repo: 'owner/repo',
-        }],
-      }));
-      prRegistry.register(prWatcher);
-
-      const result = await service.startPRWatch(createPRIdentifier());
-
-      expect(result.childRunKeys).toHaveLength(1);
-      expect(service.getActiveWatches()).toHaveLength(1);
-      // The resolved identifier should use the watcher's providerId
-      expect(service.getActiveWatches()[0].identifier.providerId).toBe('ado-pipelines');
-      expect(service.getActiveWatches()[0].identifier.runId).toBe('555');
-    });
-
-    it('does not URL-resolve ambiguous GitHub check run URLs for unrelated app slugs', async () => {
-      const runWatcher = createMockWatcher('github-advanced-security');
-      (runWatcher.canWatch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
-        try {
-          const u = new URL(url);
-          return u.hostname === 'github.com' && /^\/[^/]+\/[^/]+\/runs\/\d+\/?$/.test(u.pathname);
-        } catch { return false; }
-      });
-      registry.register(runWatcher);
+      const findWatcherForUrlSpy = vi.spyOn(registry, 'findWatcherForUrl');
 
       const prWatcher = createMockPRWatcher('test-pr', async () => ({
         prState: 'open',
         runs: [{
-          providerId: 'some-ci',
+          providerId: 'authoritative-provider',
           runId: '99',
-          displayName: 'Third-party Check',
-          url: 'https://github.com/owner/repo/runs/99',
+          displayName: 'Provider-owned Check',
+          url: 'https://ci.example.com/checks/99',
           repo: 'owner/repo',
         }],
       }));
@@ -881,12 +859,50 @@ describe('WatcherService', () => {
 
       expect(result.childRunKeys).toHaveLength(0);
       expect(service.getActiveWatches()).toHaveLength(0);
+      expect(findWatcherForUrlSpy).not.toHaveBeenCalled();
+      expect(runWatcher.canWatch).not.toHaveBeenCalled();
       expect(runWatcher.parseRunUrl).not.toHaveBeenCalled();
-      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('No watcher registered for provider: some-ci'));
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('No watcher registered for provider: authoritative-provider'));
     });
 
-    it('skips run identifiers when no watcher matches providerId or URL', async () => {
-      // No run watchers registered — unresolvable run
+    it('resolves run identifiers via URL matching when providerId is empty', async () => {
+      const runWatcher = createMockWatcher('url-matched-provider');
+      (runWatcher.canWatch as ReturnType<typeof vi.fn>).mockImplementation(
+        (url: string) => url.startsWith('https://ci.example.com/builds/'),
+      );
+      (runWatcher.parseRunUrl as ReturnType<typeof vi.fn>).mockReturnValue({
+        providerId: 'url-matched-provider',
+        runId: '555',
+        displayName: 'Build 555',
+        url: 'https://ci.example.com/builds/555',
+        repo: 'org/project',
+      });
+      registry.register(runWatcher);
+      const findWatcherForUrlSpy = vi.spyOn(registry, 'findWatcherForUrl');
+
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [{
+          providerId: '',
+          runId: '10',
+          displayName: 'Raw URL Build',
+          url: 'https://ci.example.com/builds/555',
+          repo: 'owner/repo',
+        }],
+      }));
+      prRegistry.register(prWatcher);
+
+      const result = await service.startPRWatch(createPRIdentifier());
+
+      expect(result.childRunKeys).toHaveLength(1);
+      expect(service.getActiveWatches()).toHaveLength(1);
+      expect(findWatcherForUrlSpy).toHaveBeenCalledWith('https://ci.example.com/builds/555');
+      expect(runWatcher.parseRunUrl).toHaveBeenCalledWith('https://ci.example.com/builds/555');
+      expect(service.getActiveWatches()[0].identifier.providerId).toBe('url-matched-provider');
+      expect(service.getActiveWatches()[0].identifier.runId).toBe('555');
+    });
+
+    it('skips run identifiers when no watcher matches providerId', async () => {
       const prWatcher = createMockPRWatcher('test-pr', async () => ({
         prState: 'open',
         runs: [{

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -1,6 +1,5 @@
-import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WatcherService, WatchedRun } from '../services/watcherService';
 import { WatcherRegistry } from '../services/watcherRegistry';
@@ -52,20 +51,10 @@ function createMockWatchStore(): WatchStore {
   } as unknown as WatchStore;
 }
 
-function collectTypeScriptFiles(dir: string): string[] {
-  return readdirSync(dir).flatMap(entry => {
-    const path = join(dir, entry);
-    return statSync(path).isDirectory() ? collectTypeScriptFiles(path) : [path];
-  }).filter(path => path.endsWith('.ts'));
-}
-
 describe('WatcherService', () => {
-  it('keeps host-specific run URL routing out of core services', () => {
-    const servicesDir = fileURLToPath(new URL('../services', import.meta.url));
-    const serviceContents = collectTypeScriptFiles(servicesDir)
-      .map(path => readFileSync(path, 'utf8'))
-      .join('\n');
-
+  it('keeps host-specific run URL routing out of watcherService', () => {
+    const watcherServicePath = fileURLToPath(new URL('../services/watcherService.ts', import.meta.url));
+    const serviceContents = readFileSync(watcherServicePath, 'utf8');
     const slash = String.fromCharCode(47);
     const backslash = String.fromCharCode(92);
 

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -855,6 +855,36 @@ describe('WatcherService', () => {
       expect(service.getActiveWatches()[0].identifier.runId).toBe('555');
     });
 
+    it('does not URL-resolve ambiguous GitHub check run URLs for unrelated app slugs', async () => {
+      const runWatcher = createMockWatcher('github-advanced-security');
+      (runWatcher.canWatch as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+        try {
+          const u = new URL(url);
+          return u.hostname === 'github.com' && /^\/[^/]+\/[^/]+\/runs\/\d+\/?$/.test(u.pathname);
+        } catch { return false; }
+      });
+      registry.register(runWatcher);
+
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({
+        prState: 'open',
+        runs: [{
+          providerId: 'some-ci',
+          runId: '99',
+          displayName: 'Third-party Check',
+          url: 'https://github.com/owner/repo/runs/99',
+          repo: 'owner/repo',
+        }],
+      }));
+      prRegistry.register(prWatcher);
+
+      const result = await service.startPRWatch(createPRIdentifier());
+
+      expect(result.childRunKeys).toHaveLength(0);
+      expect(service.getActiveWatches()).toHaveLength(0);
+      expect(runWatcher.parseRunUrl).not.toHaveBeenCalled();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('No watcher registered for provider: some-ci'));
+    });
+
     it('skips run identifiers when no watcher matches providerId or URL', async () => {
       // No run watchers registered — unresolvable run
       const prWatcher = createMockPRWatcher('test-pr', async () => ({

--- a/packages/github/src/extension.ts
+++ b/packages/github/src/extension.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { GitHubIssueProvider } from './githubProvider';
 import { GitHubPrReviewProvider } from './githubPrReviewProvider';
 import { GitHubActionsWatcher } from './githubActionsWatcher';
+import { GitHubAdvancedSecurityWatcher } from './githubAdvancedSecurityWatcher';
 import { GitHubPRWatcher } from './githubPRWatcher';
 import { GitHubMyPrsProvider } from './githubMyPrsProvider';
 import { GitHubMentionsProvider } from './githubMentionsProvider';
@@ -53,10 +54,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   mentionsProvider.startPeriodicRefresh(intervalSeconds);
   context.subscriptions.push(api.registerProvider(mentionsProvider), mentionsProvider);
 
-  let watcherRegistered = false;
+  let watcherCount = 0;
   if (typeof api.registerRunWatcher === 'function') {
-    context.subscriptions.push(api.registerRunWatcher(new GitHubActionsWatcher()));
-    watcherRegistered = true;
+    context.subscriptions.push(
+      api.registerRunWatcher(new GitHubActionsWatcher()),
+      api.registerRunWatcher(new GitHubAdvancedSecurityWatcher()),
+    );
+    watcherCount = 2;
   }
 
   let prWatcherRegistered = false;
@@ -66,7 +70,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   }
 
   const parts = ['4 providers'];
-  if (watcherRegistered) { parts.push('1 watcher'); }
+  if (watcherCount > 0) { parts.push(`${watcherCount} watcher${watcherCount === 1 ? '' : 's'}`); }
   if (prWatcherRegistered) { parts.push('1 PR watcher'); }
   logger.info(`DevDocket GitHub activated, registered ${parts.join(' + ')}`);
 }

--- a/packages/github/src/githubAdvancedSecurityWatcher.ts
+++ b/packages/github/src/githubAdvancedSecurityWatcher.ts
@@ -175,14 +175,14 @@ export class GitHubAdvancedSecurityWatcher implements DevDocketRunWatcher {
 
       return await response.json() as T;
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
+      if (err instanceof Error && (err.name === 'AbortError' || err.name === 'TimeoutError')) {
         if (token?.isCancellationRequested) {
           throw createAbortError();
         }
+        if (request?.signal.aborted && request.signal.reason instanceof Error && request.signal.reason.name === 'TimeoutError') {
+          throw new Error(`GitHub API request timed out after ${FETCH_TIMEOUT_MS / 1000}s`);
+        }
         throw err;
-      }
-      if (err instanceof Error && err.name === 'TimeoutError') {
-        throw new Error(`GitHub API request timed out after ${FETCH_TIMEOUT_MS / 1000}s`);
       }
       throw err;
     } finally {

--- a/packages/github/src/githubAdvancedSecurityWatcher.ts
+++ b/packages/github/src/githubAdvancedSecurityWatcher.ts
@@ -1,0 +1,203 @@
+import * as vscode from 'vscode';
+import {
+  combineSignals,
+  createAbortError,
+  type CancellationTokenLike,
+  type DevDocketRunWatcher,
+  type JobStatus,
+  type RunConclusion,
+  type RunIdentifier,
+  type RunState,
+  type RunStatus,
+} from '@devdocket/shared';
+import { logger } from './logger';
+
+interface GitHubCheckRun {
+  id: number;
+  name: string;
+  status: 'queued' | 'in_progress' | 'completed';
+  conclusion: 'success' | 'failure' | 'cancelled' | 'skipped' | 'timed_out' | 'action_required' | 'neutral' | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+}
+
+interface CancellationTokenWithEvent extends CancellationTokenLike {
+  onCancellationRequested?: (listener: () => void) => { dispose(): void };
+}
+
+const CHECK_RUN_URL_RE = /^\/([^/]+)\/([^/]+)\/runs\/(\d+)\/?$/;
+const FETCH_TIMEOUT_MS = 30_000;
+
+export class GitHubAdvancedSecurityWatcher implements DevDocketRunWatcher {
+  readonly id = 'github-advanced-security';
+  readonly label = 'GitHub Advanced Security';
+
+  canWatch(url: string): boolean {
+    try {
+      const u = new URL(url);
+      return u.protocol === 'https:'
+        && u.hostname === 'github.com'
+        && CHECK_RUN_URL_RE.test(u.pathname);
+    } catch {
+      return false;
+    }
+  }
+
+  parseRunUrl(url: string): RunIdentifier {
+    const u = new URL(url);
+    const match = u.pathname.match(CHECK_RUN_URL_RE);
+    if (!match) {
+      throw new Error('Invalid GitHub Advanced Security check run URL');
+    }
+
+    const [, owner, repo, runId] = match;
+
+    return {
+      providerId: this.id,
+      runId,
+      displayName: 'GitHub Advanced Security',
+      url,
+      repo: `${owner}/${repo}`,
+    };
+  }
+
+  async getRunStatus(identifier: RunIdentifier, token?: CancellationTokenLike): Promise<RunStatus> {
+    if (!identifier.repo) {
+      throw new Error('Repository required for GitHub Advanced Security run');
+    }
+
+    const repoParts = identifier.repo.split('/');
+    if (repoParts.length !== 2 || repoParts.some(part => !part)) {
+      throw new Error(`Invalid GitHub repo format: expected "owner/repo" but got "${identifier.repo}"`);
+    }
+
+    const [owner, repo] = repoParts;
+    const encodedOwner = encodeURIComponent(owner);
+    const encodedRepo = encodeURIComponent(repo);
+    const encodedRunId = encodeURIComponent(identifier.runId);
+
+    const checkRun = await this.fetchApi<GitHubCheckRun>(
+      `https://api.github.com/repos/${encodedOwner}/${encodedRepo}/check-runs/${encodedRunId}`,
+      token,
+    );
+
+    const overallState = this.mapState(checkRun.status);
+    const conclusion = checkRun.conclusion ? this.mapConclusion(checkRun.conclusion) : undefined;
+    const job: JobStatus = {
+      id: String(checkRun.id),
+      name: checkRun.name,
+      state: overallState,
+      conclusion,
+      startedAt: checkRun.started_at ?? undefined,
+      completedAt: checkRun.completed_at ?? undefined,
+    };
+
+    return {
+      overallState,
+      conclusion,
+      displayName: checkRun.name,
+      jobs: [job],
+      startedAt: checkRun.started_at ?? undefined,
+      completedAt: overallState === 'completed' ? checkRun.completed_at ?? undefined : undefined,
+    };
+  }
+
+  private mapState(state: 'queued' | 'in_progress' | 'completed'): RunState {
+    return state === 'in_progress' ? 'running' : state;
+  }
+
+  private mapConclusion(conclusion: string): RunConclusion | undefined {
+    switch (conclusion) {
+      case 'success':
+      case 'failure':
+      case 'cancelled':
+      case 'skipped':
+      case 'timed_out':
+      case 'action_required':
+      case 'neutral':
+        return conclusion;
+      default:
+        logger.warn(`Unknown run conclusion '${conclusion}', treating as undefined`);
+        return undefined;
+    }
+  }
+
+  private async fetchApi<T>(url: string, token?: CancellationTokenLike): Promise<T> {
+    const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: false });
+    if (!session) {
+      throw new Error('No GitHub authentication session available. Sign in to GitHub to watch security runs.');
+    }
+
+    const headers: Record<string, string> = {
+      'Accept': 'application/vnd.github+json',
+      'Authorization': `Bearer ${session.accessToken}`,
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'DevDocket-VSCode',
+    };
+
+    let request: { signal: AbortSignal; dispose(): void } | undefined;
+    try {
+      request = this.createRequestSignal(token);
+      const response = await fetch(url, {
+        headers,
+        signal: request.signal,
+      });
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          throw new Error('Run not found or access denied');
+        }
+        if (response.status === 401) {
+          throw new Error('GitHub authentication failed. Please re-authenticate.');
+        }
+        if (response.status === 403) {
+          const rateLimitRemaining = response.headers.get('x-ratelimit-remaining');
+          if (rateLimitRemaining === '0') {
+            throw new Error('GitHub API rate limit exceeded. Please wait and try again.');
+          }
+          throw new Error('GitHub access denied. Check repository permissions.');
+        }
+        throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+      }
+
+      return await response.json() as T;
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        if (token?.isCancellationRequested) {
+          throw createAbortError();
+        }
+        throw err;
+      }
+      if (err instanceof Error && err.name === 'TimeoutError') {
+        throw new Error(`GitHub API request timed out after ${FETCH_TIMEOUT_MS / 1000}s`);
+      }
+      throw err;
+    } finally {
+      request?.dispose();
+    }
+  }
+
+  private createRequestSignal(token?: CancellationTokenLike): { signal: AbortSignal; dispose(): void } {
+    if (token?.isCancellationRequested) {
+      throw createAbortError();
+    }
+
+    const controller = new AbortController();
+    const cancellationToken = token as CancellationTokenWithEvent | undefined;
+    const disposable = cancellationToken?.onCancellationRequested?.(() => controller.abort(createAbortError()));
+    const signal = combineSignals(controller.signal, FETCH_TIMEOUT_MS);
+    let disposed = false;
+    const dispose = () => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      disposable?.dispose();
+      if (!controller.signal.aborted) {
+        controller.abort(createAbortError());
+      }
+    };
+    signal.addEventListener('abort', dispose, { once: true });
+    return { signal, dispose };
+  }
+}

--- a/packages/github/src/githubAdvancedSecurityWatcher.ts
+++ b/packages/github/src/githubAdvancedSecurityWatcher.ts
@@ -16,7 +16,7 @@ interface GitHubCheckRun {
   id: number;
   name: string;
   status: string;
-  conclusion: 'success' | 'failure' | 'cancelled' | 'skipped' | 'timed_out' | 'action_required' | 'neutral' | null;
+  conclusion: 'success' | 'failure' | 'cancelled' | 'skipped' | 'timed_out' | 'action_required' | 'neutral' | 'stale' | null;
   started_at?: string | null;
   completed_at?: string | null;
   app?: {
@@ -137,6 +137,8 @@ export class GitHubAdvancedSecurityWatcher implements DevDocketRunWatcher {
       case 'action_required':
       case 'neutral':
         return conclusion;
+      case 'stale':
+        return 'neutral';
       default:
         logger.warn(`Unknown run conclusion '${conclusion}', treating as undefined`);
         return undefined;

--- a/packages/github/src/githubAdvancedSecurityWatcher.ts
+++ b/packages/github/src/githubAdvancedSecurityWatcher.ts
@@ -15,7 +15,7 @@ import { logger } from './logger';
 interface GitHubCheckRun {
   id: number;
   name: string;
-  status: 'queued' | 'in_progress' | 'completed';
+  status: string;
   conclusion: 'success' | 'failure' | 'cancelled' | 'skipped' | 'timed_out' | 'action_required' | 'neutral' | null;
   started_at?: string | null;
   completed_at?: string | null;
@@ -102,8 +102,21 @@ export class GitHubAdvancedSecurityWatcher implements DevDocketRunWatcher {
     };
   }
 
-  private mapState(state: 'queued' | 'in_progress' | 'completed'): RunState {
-    return state === 'in_progress' ? 'running' : state;
+  private mapState(state: string): RunState {
+    switch (state) {
+      case 'completed':
+        return 'completed';
+      case 'in_progress':
+        return 'running';
+      case 'queued':
+      case 'waiting':
+      case 'requested':
+      case 'pending':
+        return 'queued';
+      default:
+        logger.warn(`Unknown run status '${state}', treating as queued`);
+        return 'queued';
+    }
   }
 
   private mapConclusion(conclusion: string): RunConclusion | undefined {

--- a/packages/github/src/githubAdvancedSecurityWatcher.ts
+++ b/packages/github/src/githubAdvancedSecurityWatcher.ts
@@ -39,7 +39,7 @@ export class GitHubAdvancedSecurityWatcher implements DevDocketRunWatcher {
   canWatch(url: string): boolean {
     try {
       const u = new URL(url);
-      return u.protocol === 'https:'
+      return (u.protocol === 'https:' || u.protocol === 'http:')
         && u.hostname === 'github.com'
         && CHECK_RUN_URL_RE.test(u.pathname);
     } catch {

--- a/packages/github/src/githubAdvancedSecurityWatcher.ts
+++ b/packages/github/src/githubAdvancedSecurityWatcher.ts
@@ -19,6 +19,9 @@ interface GitHubCheckRun {
   conclusion: 'success' | 'failure' | 'cancelled' | 'skipped' | 'timed_out' | 'action_required' | 'neutral' | null;
   started_at?: string | null;
   completed_at?: string | null;
+  app?: {
+    slug?: string | null;
+  } | null;
 }
 
 interface CancellationTokenWithEvent extends CancellationTokenLike {
@@ -27,6 +30,7 @@ interface CancellationTokenWithEvent extends CancellationTokenLike {
 
 const CHECK_RUN_URL_RE = /^\/([^/]+)\/([^/]+)\/runs\/(\d+)\/?$/;
 const FETCH_TIMEOUT_MS = 30_000;
+const GITHUB_ADVANCED_SECURITY_APP_SLUG = 'github-advanced-security';
 
 export class GitHubAdvancedSecurityWatcher implements DevDocketRunWatcher {
   readonly id = 'github-advanced-security';
@@ -80,6 +84,10 @@ export class GitHubAdvancedSecurityWatcher implements DevDocketRunWatcher {
       `https://api.github.com/repos/${encodedOwner}/${encodedRepo}/check-runs/${encodedRunId}`,
       token,
     );
+
+    if (checkRun.app?.slug !== GITHUB_ADVANCED_SECURITY_APP_SLUG) {
+      throw new Error(`Expected GitHub Advanced Security check run but found app '${checkRun.app?.slug ?? 'unknown'}'`);
+    }
 
     const overallState = this.mapState(checkRun.status);
     const conclusion = checkRun.conclusion ? this.mapConclusion(checkRun.conclusion) : undefined;

--- a/packages/github/src/test/extension.test.ts
+++ b/packages/github/src/test/extension.test.ts
@@ -9,7 +9,7 @@ describe('GitHub extension activation', () => {
   let mockApi: any;
   let disposables: any[];
   let providerRegistrationDisposables: any[];
-  let runWatcherDisposable: any;
+  let runWatcherDisposables: any[];
   let prWatcherDisposable: any;
 
   const disposeContextSubscriptions = () => {
@@ -47,7 +47,7 @@ describe('GitHub extension activation', () => {
 
     disposables = [];
     providerRegistrationDisposables = [];
-    runWatcherDisposable = { dispose: vi.fn() };
+    runWatcherDisposables = [];
     prWatcherDisposable = { dispose: vi.fn() };
     mockContext = {
       subscriptions: {
@@ -61,7 +61,11 @@ describe('GitHub extension activation', () => {
         providerRegistrationDisposables.push(registration);
         return registration;
       }),
-      registerRunWatcher: vi.fn(() => runWatcherDisposable),
+      registerRunWatcher: vi.fn((watcher: any) => {
+        const registration = { registrationFor: watcher.id, dispose: vi.fn() };
+        runWatcherDisposables.push(registration);
+        return registration;
+      }),
       registerPRWatcher: vi.fn(() => prWatcherDisposable),
     };
 
@@ -121,7 +125,9 @@ describe('GitHub extension activation', () => {
       'github-my-prs',
       'github-mentions',
     ]);
-    expect(mockApi.registerRunWatcher).toHaveBeenCalledTimes(1);
+    expect(mockApi.registerRunWatcher).toHaveBeenCalledTimes(2);
+    const runWatcherIds = mockApi.registerRunWatcher.mock.calls.map(([watcher]: any[]) => watcher.id);
+    expect(runWatcherIds).toEqual(['github-actions', 'github-advanced-security']);
     expect(mockApi.registerPRWatcher).toHaveBeenCalledTimes(1);
 
     const subscribedProviderIds = disposables
@@ -131,9 +137,11 @@ describe('GitHub extension activation', () => {
     for (const registration of providerRegistrationDisposables) {
       expect(disposables).toContain(registration);
     }
-    expect(disposables).toContain(runWatcherDisposable);
+    for (const registration of runWatcherDisposables) {
+      expect(disposables).toContain(registration);
+    }
     expect(disposables).toContain(prWatcherDisposable);
-    expect(disposables).toHaveLength(11);
+    expect(disposables).toHaveLength(12);
   });
 
   it('lets context subscriptions dispose providers, registrations, and watchers', async () => {
@@ -150,7 +158,9 @@ describe('GitHub extension activation', () => {
     for (const providerDisposeSpy of providerDisposeSpies) {
       expect(providerDisposeSpy).toHaveBeenCalledTimes(1);
     }
-    expect(runWatcherDisposable.dispose).toHaveBeenCalledTimes(1);
+    for (const registration of runWatcherDisposables) {
+      expect(registration.dispose).toHaveBeenCalledTimes(1);
+    }
     expect(prWatcherDisposable.dispose).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/github/src/test/githubAdvancedSecurityWatcher.test.ts
+++ b/packages/github/src/test/githubAdvancedSecurityWatcher.test.ts
@@ -290,6 +290,25 @@ describe('GitHubAdvancedSecurityWatcher', () => {
       }
     });
 
+    it('maps timeout-caused AbortError to the timeout message', async () => {
+      vi.useFakeTimers();
+      try {
+        fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementationOnce((_url, init) => new Promise((_resolve, reject) => {
+          const signal = init?.signal as AbortSignal | undefined;
+          signal?.addEventListener('abort', () => reject(new DOMException('The operation was aborted.', 'AbortError')), { once: true });
+        }));
+
+        const statusPromise = watcher.getRunStatus(makeIdentifier());
+        const expectation = expect(statusPromise).rejects.toThrow('GitHub API request timed out after 30s');
+        await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+        await vi.advanceTimersByTimeAsync(30_000);
+
+        await expectation;
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('aborts an in-flight request when cancellation is requested', async () => {
       let cancellationListener: (() => void) | undefined;
       const dispose = vi.fn();

--- a/packages/github/src/test/githubAdvancedSecurityWatcher.test.ts
+++ b/packages/github/src/test/githubAdvancedSecurityWatcher.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { authentication } from 'vscode';
+import { GitHubAdvancedSecurityWatcher } from '../githubAdvancedSecurityWatcher';
+
+function makeIdentifier(overrides?: Partial<{ runId: string; repo: string }>) {
+  const runId = overrides?.runId ?? '12345';
+  const repo = overrides?.repo ?? 'owner/repo';
+  return {
+    providerId: 'github-advanced-security',
+    runId,
+    displayName: 'GitHub Advanced Security',
+    url: `https://github.com/${repo}/runs/${runId}`,
+    repo,
+  };
+}
+
+function makeResponse(overrides?: Partial<Response>): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: new Headers(),
+    json: async () => ({}),
+    ...overrides,
+  } as Response;
+}
+
+describe('GitHubAdvancedSecurityWatcher', () => {
+  let watcher: GitHubAdvancedSecurityWatcher;
+  let fetchSpy: ReturnType<typeof vi.spyOn> | undefined;
+
+  beforeEach(() => {
+    watcher = new GitHubAdvancedSecurityWatcher();
+    vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'mock-token' } as any);
+  });
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it('has correct id and label', () => {
+    expect(watcher.id).toBe('github-advanced-security');
+    expect(watcher.label).toBe('GitHub Advanced Security');
+  });
+
+  describe('canWatch', () => {
+    it('returns true for canonical GitHub check run URLs', () => {
+      expect(watcher.canWatch('https://github.com/owner/repo/runs/12345')).toBe(true);
+      expect(watcher.canWatch('https://github.com/owner/repo/runs/12345/')).toBe(true);
+    });
+
+    it('returns false for non-GitHub URLs', () => {
+      expect(watcher.canWatch('https://example.com/owner/repo/runs/12345')).toBe(false);
+    });
+
+    it('returns false for malformed GitHub run paths', () => {
+      expect(watcher.canWatch('https://github.com/owner/repo/runs/not-a-number')).toBe(false);
+      expect(watcher.canWatch('https://github.com/owner/runs/12345')).toBe(false);
+      expect(watcher.canWatch('https://github.com/owner/repo/runs/12345/attempts/1')).toBe(false);
+    });
+
+    it('returns false for GitHub Actions run URLs', () => {
+      expect(watcher.canWatch('https://github.com/owner/repo/actions/runs/12345')).toBe(false);
+    });
+
+    it('returns false for ADO URLs', () => {
+      expect(watcher.canWatch('https://dev.azure.com/org/project/_build/results?buildId=12345')).toBe(false);
+    });
+
+    it('returns false for invalid URLs', () => {
+      expect(watcher.canWatch('not-a-url')).toBe(false);
+      expect(watcher.canWatch('')).toBe(false);
+    });
+  });
+
+  describe('parseRunUrl', () => {
+    it('extracts owner, repo, and runId', () => {
+      const result = watcher.parseRunUrl('https://github.com/myorg/myrepo/runs/999');
+
+      expect(result).toEqual({
+        providerId: 'github-advanced-security',
+        runId: '999',
+        displayName: 'GitHub Advanced Security',
+        url: 'https://github.com/myorg/myrepo/runs/999',
+        repo: 'myorg/myrepo',
+      });
+    });
+
+    it('throws for invalid URL format', () => {
+      expect(() => watcher.parseRunUrl('https://github.com/owner/repo/actions/runs/123')).toThrow(
+        'Invalid GitHub Advanced Security check run URL',
+      );
+    });
+  });
+
+  describe('getRunStatus', () => {
+    it('maps GitHub check run response to RunStatus', async () => {
+      const checkRunResponse = {
+        id: 12345,
+        name: 'CodeQL',
+        status: 'completed',
+        conclusion: 'success',
+        started_at: '2026-01-01T00:00:00Z',
+        completed_at: '2026-01-01T00:05:00Z',
+      };
+      let requestSignal: AbortSignal | undefined;
+      fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementationOnce((_url, init) => {
+        requestSignal = init?.signal as AbortSignal | undefined;
+        return Promise.resolve(makeResponse({
+          json: async () => {
+            expect(requestSignal?.aborted).toBe(false);
+            return checkRunResponse;
+          },
+        }));
+      });
+
+      const result = await watcher.getRunStatus(makeIdentifier());
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      expect(fetchSpy.mock.calls[0][0]).toBe('https://api.github.com/repos/owner/repo/check-runs/12345');
+      expect((fetchSpy.mock.calls[0][1]?.headers as Record<string, string>).Authorization).toBe('Bearer mock-token');
+      expect(result).toEqual({
+        overallState: 'completed',
+        conclusion: 'success',
+        displayName: 'CodeQL',
+        jobs: [{
+          id: '12345',
+          name: 'CodeQL',
+          state: 'completed',
+          conclusion: 'success',
+          startedAt: '2026-01-01T00:00:00Z',
+          completedAt: '2026-01-01T00:05:00Z',
+        }],
+        startedAt: '2026-01-01T00:00:00Z',
+        completedAt: '2026-01-01T00:05:00Z',
+      });
+    });
+
+    it('maps in_progress status to running and omits null conclusion', async () => {
+      fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeResponse({
+        json: async () => ({
+          id: 12345,
+          name: 'Secret scanning',
+          status: 'in_progress',
+          conclusion: null,
+          started_at: '2026-01-01T00:00:00Z',
+          completed_at: null,
+        }),
+      }));
+
+      const result = await watcher.getRunStatus(makeIdentifier());
+
+      expect(result.overallState).toBe('running');
+      expect(result.conclusion).toBeUndefined();
+      expect(result.jobs[0].state).toBe('running');
+      expect(result.jobs[0].conclusion).toBeUndefined();
+      expect(result.completedAt).toBeUndefined();
+    });
+
+    it('throws when repo is not set on identifier', async () => {
+      const identifier = makeIdentifier();
+      delete (identifier as Partial<typeof identifier>).repo;
+
+      await expect(watcher.getRunStatus(identifier)).rejects.toThrow('Repository required');
+    });
+
+    it('throws when no GitHub auth session is available', async () => {
+      vi.mocked(authentication.getSession).mockResolvedValueOnce(undefined as any);
+
+      await expect(watcher.getRunStatus(makeIdentifier())).rejects.toThrow('No GitHub authentication session available');
+    });
+
+    it('throws on 404 response', async () => {
+      fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeResponse({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      }));
+
+      await expect(watcher.getRunStatus(makeIdentifier())).rejects.toThrow('Run not found or access denied');
+    });
+
+    it('throws on 401 response', async () => {
+      fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeResponse({
+        ok: false,
+        status: 401,
+        statusText: 'Unauthorized',
+      }));
+
+      await expect(watcher.getRunStatus(makeIdentifier())).rejects.toThrow('GitHub authentication failed');
+    });
+
+    it('throws an auth/permission error on 403 response', async () => {
+      fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeResponse({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+      }));
+
+      await expect(watcher.getRunStatus(makeIdentifier())).rejects.toThrow('GitHub access denied');
+    });
+
+    it('throws a rate limit error on 403 response with exhausted rate limit', async () => {
+      fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeResponse({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: new Headers({ 'x-ratelimit-remaining': '0' }),
+      }));
+
+      await expect(watcher.getRunStatus(makeIdentifier())).rejects.toThrow('GitHub API rate limit exceeded');
+    });
+
+    it('throws on 500 response', async () => {
+      fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeResponse({
+        ok: false,
+        status: 500,
+        statusText: 'Server Error',
+      }));
+
+      await expect(watcher.getRunStatus(makeIdentifier())).rejects.toThrow('GitHub API error: 500 Server Error');
+    });
+
+    it('disposes the cancellation listener after a successful request', async () => {
+      const dispose = vi.fn();
+      const token = {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn(() => ({ dispose })),
+      };
+      fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeResponse({
+        json: async () => ({
+          id: 12345,
+          name: 'CodeQL',
+          status: 'completed',
+          conclusion: 'success',
+          started_at: '2026-01-01T00:00:00Z',
+          completed_at: '2026-01-01T00:05:00Z',
+        }),
+      }));
+
+      await watcher.getRunStatus(makeIdentifier(), token as any);
+
+      expect(dispose).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws AbortError when cancelled before the request starts', async () => {
+      fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+      await expect(watcher.getRunStatus(makeIdentifier(), { isCancellationRequested: true })).rejects.toMatchObject({
+        name: 'AbortError',
+      });
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('throws a timeout error when GitHub does not respond before the request timeout', async () => {
+      vi.useFakeTimers();
+      try {
+        fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementationOnce((_url, init) => new Promise((_resolve, reject) => {
+          const signal = init?.signal as AbortSignal | undefined;
+          signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+        }));
+
+        const statusPromise = watcher.getRunStatus(makeIdentifier());
+        const expectation = expect(statusPromise).rejects.toThrow('GitHub API request timed out after 30s');
+        await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+        await vi.advanceTimersByTimeAsync(30_000);
+
+        await expectation;
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('aborts an in-flight request when cancellation is requested', async () => {
+      let cancellationListener: (() => void) | undefined;
+      const dispose = vi.fn();
+      const token = {
+        isCancellationRequested: false,
+        onCancellationRequested: vi.fn((listener: () => void) => {
+          cancellationListener = listener;
+          return { dispose };
+        }),
+      };
+
+      fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementationOnce((_url, init) => new Promise((_resolve, reject) => {
+        const signal = init?.signal as AbortSignal | undefined;
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true });
+      }));
+
+      const statusPromise = watcher.getRunStatus(makeIdentifier(), token as any);
+      await vi.waitFor(() => expect(token.onCancellationRequested).toHaveBeenCalledTimes(1));
+
+      token.isCancellationRequested = true;
+      cancellationListener?.();
+
+      await expect(statusPromise).rejects.toMatchObject({ name: 'AbortError' });
+      expect(dispose).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/github/src/test/githubAdvancedSecurityWatcher.test.ts
+++ b/packages/github/src/test/githubAdvancedSecurityWatcher.test.ts
@@ -61,6 +61,7 @@ describe('GitHubAdvancedSecurityWatcher', () => {
     it('returns true for canonical GitHub check run URLs', () => {
       expect(watcher.canWatch('https://github.com/owner/repo/runs/12345')).toBe(true);
       expect(watcher.canWatch('https://github.com/owner/repo/runs/12345/')).toBe(true);
+      expect(watcher.canWatch('http://github.com/owner/repo/runs/12345')).toBe(true);
     });
 
     it('returns false for non-GitHub URLs', () => {

--- a/packages/github/src/test/githubAdvancedSecurityWatcher.test.ts
+++ b/packages/github/src/test/githubAdvancedSecurityWatcher.test.ts
@@ -158,6 +158,24 @@ describe('GitHubAdvancedSecurityWatcher', () => {
       expect(result.completedAt).toBeUndefined();
     });
 
+    it('maps waiting check run status to queued', async () => {
+      fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeResponse({
+        json: async () => ({
+          id: 12345,
+          name: 'CodeQL',
+          status: 'waiting',
+          conclusion: null,
+          started_at: null,
+          completed_at: null,
+        }),
+      }));
+
+      const result = await watcher.getRunStatus(makeIdentifier());
+
+      expect(result.overallState).toBe('queued');
+      expect(result.jobs[0].state).toBe('queued');
+    });
+
     it('throws when repo is not set on identifier', async () => {
       const identifier = makeIdentifier();
       delete (identifier as Partial<typeof identifier>).repo;

--- a/packages/github/src/test/githubAdvancedSecurityWatcher.test.ts
+++ b/packages/github/src/test/githubAdvancedSecurityWatcher.test.ts
@@ -162,6 +162,17 @@ describe('GitHubAdvancedSecurityWatcher', () => {
       expect(result.completedAt).toBeUndefined();
     });
 
+    it('maps stale check run conclusion to neutral', async () => {
+      fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeResponse({
+        json: async () => makeCheckRunResponse({ conclusion: 'stale' }),
+      }));
+
+      const result = await watcher.getRunStatus(makeIdentifier());
+
+      expect(result.conclusion).toBe('neutral');
+      expect(result.jobs[0].conclusion).toBe('neutral');
+    });
+
     it('maps waiting check run status to queued', async () => {
       fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeResponse({
         json: async () => makeCheckRunResponse({

--- a/packages/github/src/test/githubAdvancedSecurityWatcher.test.ts
+++ b/packages/github/src/test/githubAdvancedSecurityWatcher.test.ts
@@ -25,6 +25,19 @@ function makeResponse(overrides?: Partial<Response>): Response {
   } as Response;
 }
 
+function makeCheckRunResponse(overrides?: Record<string, unknown>) {
+  return {
+    id: 12345,
+    name: 'CodeQL',
+    status: 'completed',
+    conclusion: 'success',
+    started_at: '2026-01-01T00:00:00Z',
+    completed_at: '2026-01-01T00:05:00Z',
+    app: { slug: 'github-advanced-security' },
+    ...overrides,
+  };
+}
+
 describe('GitHubAdvancedSecurityWatcher', () => {
   let watcher: GitHubAdvancedSecurityWatcher;
   let fetchSpy: ReturnType<typeof vi.spyOn> | undefined;
@@ -96,14 +109,7 @@ describe('GitHubAdvancedSecurityWatcher', () => {
 
   describe('getRunStatus', () => {
     it('maps GitHub check run response to RunStatus', async () => {
-      const checkRunResponse = {
-        id: 12345,
-        name: 'CodeQL',
-        status: 'completed',
-        conclusion: 'success',
-        started_at: '2026-01-01T00:00:00Z',
-        completed_at: '2026-01-01T00:05:00Z',
-      };
+      const checkRunResponse = makeCheckRunResponse();
       let requestSignal: AbortSignal | undefined;
       fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementationOnce((_url, init) => {
         requestSignal = init?.signal as AbortSignal | undefined;
@@ -139,12 +145,10 @@ describe('GitHubAdvancedSecurityWatcher', () => {
 
     it('maps in_progress status to running and omits null conclusion', async () => {
       fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeResponse({
-        json: async () => ({
-          id: 12345,
+        json: async () => makeCheckRunResponse({
           name: 'Secret scanning',
           status: 'in_progress',
           conclusion: null,
-          started_at: '2026-01-01T00:00:00Z',
           completed_at: null,
         }),
       }));
@@ -160,9 +164,7 @@ describe('GitHubAdvancedSecurityWatcher', () => {
 
     it('maps waiting check run status to queued', async () => {
       fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeResponse({
-        json: async () => ({
-          id: 12345,
-          name: 'CodeQL',
+        json: async () => makeCheckRunResponse({
           status: 'waiting',
           conclusion: null,
           started_at: null,
@@ -174,6 +176,16 @@ describe('GitHubAdvancedSecurityWatcher', () => {
 
       expect(result.overallState).toBe('queued');
       expect(result.jobs[0].state).toBe('queued');
+    });
+
+    it('throws when the fetched check run belongs to another app', async () => {
+      fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeResponse({
+        json: async () => makeCheckRunResponse({ app: { slug: 'other-check-provider' } }),
+      }));
+
+      await expect(watcher.getRunStatus(makeIdentifier())).rejects.toThrow(
+        "Expected GitHub Advanced Security check run but found app 'other-check-provider'",
+      );
     });
 
     it('throws when repo is not set on identifier', async () => {
@@ -247,14 +259,7 @@ describe('GitHubAdvancedSecurityWatcher', () => {
         onCancellationRequested: vi.fn(() => ({ dispose })),
       };
       fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(makeResponse({
-        json: async () => ({
-          id: 12345,
-          name: 'CodeQL',
-          status: 'completed',
-          conclusion: 'success',
-          started_at: '2026-01-01T00:00:00Z',
-          completed_at: '2026-01-01T00:05:00Z',
-        }),
+        json: async () => makeCheckRunResponse(),
       }));
 
       await watcher.getRunStatus(makeIdentifier(), token as any);

--- a/packages/github/src/test/githubPRWatcher.test.ts
+++ b/packages/github/src/test/githubPRWatcher.test.ts
@@ -273,6 +273,29 @@ describe('GitHubPRWatcher', () => {
       expect(result.runs[0].runId).toBe('30');
     });
 
+    it('uses github-advanced-security providerId for CodeQL check runs', async () => {
+      mockFetchResponses(
+        { number: 42, title: 'My PR', state: 'open', merged: false, head: { sha: 'abc123' } },
+        {
+          check_runs: [
+            {
+              id: 40,
+              name: 'CodeQL',
+              html_url: 'https://github.com/owner/repo/runs/40',
+              app: { slug: 'github-advanced-security' },
+              check_suite: { id: 603 },
+            },
+          ],
+        },
+      );
+
+      const result = await watcher.getPRRunsSnapshot(makeIdentifier());
+      expect(result.runs).toHaveLength(1);
+      expect(result.runs[0].providerId).toBe('github-advanced-security');
+      expect(result.runs[0].runId).toBe('40');
+      expect(result.runs[0].url).toBe('https://github.com/owner/repo/runs/40');
+    });
+
     it('handles mix of GitHub Actions and external check runs', async () => {
       mockFetchResponses(
         { number: 42, title: 'My PR', state: 'open', merged: false, head: { sha: 'abc123' } },


### PR DESCRIPTION
## Summary

- Add a real `GitHubAdvancedSecurityWatcher` with provider ID `github-advanced-security` for canonical GitHub check-run URLs such as `https://github.com/owner/repo/runs/12345`.
- Poll GitHub Advanced Security/CodeQL checks through the standard GitHub Check Runs API (`GET /repos/{owner}/{repo}/check-runs/{check_run_id}`), mapping status/conclusion into DevDocket run state and exposing a single synthetic job for the check run.
- Register the watcher from the GitHub extension and add regression coverage for PR child runs with `providerId === 'github-advanced-security'` so they are added to the CI Watches tree without warn spam.

## Why this replaces #519

The closed #519 workaround avoided the noisy `[WARN] Failed to add child run` messages by skipping unregistered child runs. This PR fixes the underlying cause instead: CodeQL check runs are now backed by a real watcher that can poll their status, so DevDocket no longer has to silently ignore them.

## Follow-up candidates

While inspecting the existing PR watcher behavior, non-GitHub-Actions checks are routed by `check_run.app.slug` with a fallback provider ID of `check-run`. This PR intentionally only implements the GitHub Advanced Security slug. Other app slugs such as `dependabot`, `secret-scanning`, third-party CI apps, or generic `check-run` could benefit from similar check-run watchers in a follow-up, but are out of scope here.

Closes #503
