### PR TITLE
Add weekly performance review automation

### DIFF
--- a/.github/prompts/weekly-performance-review.md
+++ b/.github/prompts/weekly-performance-review.md
@@ -1,0 +1,85 @@
+# Weekly Performance Review
+
+You are GitHub Copilot CLI running in programmatic mode from the scheduled Weekly Performance Review workflow for the DevDocket VS Code extension.
+
+## Objective
+
+Act as a senior performance engineer who specializes in developer tools and VS Code extensions. Review DevDocket for code and architecture patterns that can create real user-perceived performance problems. Do not file cosmetic findings or speculative micro-optimizations.
+
+## Required context
+
+1. Use your built-in knowledge of VS Code extension performance expectations and Node.js/TypeScript performance behavior when evaluating the product.
+2. Use your built-in knowledge of the VS Code extension API documentation for platform context; treat <https://code.visualstudio.com/api> as a reference link only.
+3. Inspect the repository enough to understand the extension's activation path, sidebar/webview model, provider/action architecture, storage model, polling/watchers, and GitHub/Azure DevOps integrations.
+
+## Review scope
+
+Focus on performance problems that can plausibly affect real users, not minor polish:
+
+- Memory retention from long-lived caches, webview retention, unbounded Maps/Sets, listener leaks, retained DOM state, or globalState/activity-log growth without retention bounds.
+- Synchronous serialization of independent I/O, such as n awaits in a loop where bounded concurrency would reduce latency without overwhelming providers.
+- Wasteful recomputation across event sources, including full snapshot rebuilds when only a slice changed or missing memoization keyed by stable inputs.
+- Hot-path allocations, quadratic patterns, or repeated expensive transforms inside polling loops, refresh loops, event handlers, and render paths.
+- Render thrash caused by broad upstream change events, full re-renders, or missing diff/patch behavior in the sidebar/webview UI.
+- Storage write amplification, especially re-persisting unchanged data or large snapshots on every event.
+- Network call patterns that ignore 429/Retry-After, fail to dedupe across providers, or repeat equivalent requests during one refresh cycle.
+- Activity log growth patterns that make reads, writes, or serialization increasingly expensive over time.
+
+Skip micro-optimizations, style preferences, theoretical issues without a realistic cost path, and anything that would not move user-perceived performance.
+
+## Finding quality bar
+
+For each candidate finding, be concrete:
+
+- Name the performance pattern observed.
+- Point to specific file and line references whenever possible.
+- Explain the estimated cost shape: CPU, memory, I/O, storage, or latency.
+- Describe the realistic worst-case where it bites, such as cold activation, a user with many providers, a large repo, many work items, long-running usage, or frequent polling.
+- Suggest a direction for improvement. Do not require a complete implementation plan.
+- Explain why this is more than a micro-optimization.
+
+## Deduplication before filing
+
+Before creating an issue for any finding, search existing open and recently closed issues. Use a short, stable title prefix and search both open and closed issues with `gh issue list --search ... --state all --limit 200`.
+
+Use titles with this format:
+
+`[Weekly Perf] <short problem statement>`
+
+For each candidate, run a search similar to:
+
+`gh issue list --search "\"[Weekly Perf] <short problem statement>\" in:title label:weekly-performance-review" --state all --limit 200`
+
+If an existing issue title has the same short prefix or clearly covers the same performance problem, skip filing a duplicate, even if the issue is closed.
+
+## Filing issues
+
+Create zero pull requests. Do not create branches, commits, or PRs. Findings are filed only as GitHub issues.
+
+File one issue per novel finding, with the label `weekly-performance-review`. Cap this run at 8 created issues. If you find more than 8, choose the 8 highest-impact performance problems and skip the rest.
+
+Follow the repository's backtick-safety convention when posting text to GitHub:
+
+1. Use the allowlisted file-write tool to write the full issue body to a temporary body file before calling `gh`; do not build the body with shell heredocs, `echo`, Python, or inline shell strings.
+2. Pass that file with `--body-file`.
+3. Reuse or overwrite the body file as needed; do not require deletion when no cleanup tool is available.
+4. Never pass Markdown containing backticks through `--body`, `--fill`, inline shell arguments, Python strings, or PowerShell strings.
+
+Use a command shape like:
+
+`gh issue create --title "[Weekly Perf] <short problem statement>" --body-file <tmpfile> --label weekly-performance-review`
+
+Each issue body should include:
+
+- `## Problem`
+- `## Current pattern`
+- `## Cost shape`
+- `## Worst-case impact`
+- `## Suggested direction`
+- `## Evidence`
+
+## Summary
+
+At the end, report the count of issues created. Print a final machine-readable line exactly like this, replacing `<count>` with an integer from 0 to 8:
+
+`WEEKLY_PERFORMANCE_REVIEW_ISSUES_CREATED=<count>`

--- a/.github/workflows/weekly-performance-review.yml
+++ b/.github/workflows/weekly-performance-review.yml
@@ -1,0 +1,65 @@
+name: Weekly Performance Review
+
+# Authentication: this workflow runs GitHub Copilot CLI in programmatic mode.
+# Configure the shared COPILOT_CLI_PAT repository secret with a licensed Copilot
+# user's PAT that can make Copilot requests and create issues. Rotate that one
+# secret when the service identity changes; both COPILOT_GITHUB_TOKEN and GH_TOKEN
+# are sourced from it so Copilot CLI and gh authenticate as the same identity.
+on:
+  # Run every Thursday at 10:00 AM UTC (offset from implementation and UX reviews)
+  schedule:
+    - cron: '0 10 * * 4'
+  # Manual trigger for testing
+  workflow_dispatch:
+
+concurrency:
+  group: weekly-performance-review
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  weekly-performance-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install Copilot CLI
+        run: npm install -g @github/copilot
+
+      - name: Run weekly performance review
+        env:
+          # Shared PAT for both Copilot CLI and gh. Rotate COPILOT_CLI_PAT instead
+          # of configuring workflow-specific tokens.
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_PAT }}
+          GH_TOKEN: ${{ secrets.COPILOT_CLI_PAT }}
+        run: |
+          set -o pipefail
+          copilot -p "$(cat .github/prompts/weekly-performance-review.md)" \
+            --model claude-opus-4.7 \
+            --allow-tool='shell(gh issue:*)' \
+            --allow-tool=read \
+            --allow-tool=create \
+            --allow-tool=write \
+            --no-ask-user | tee weekly-performance-review.log
+
+      - name: Summary
+        if: always()
+        run: |
+          count="$(grep -Eo 'WEEKLY_PERFORMANCE_REVIEW_ISSUES_CREATED=[0-8]' weekly-performance-review.log 2>/dev/null | tail -n 1 | cut -d= -f2 || true)"
+          if [ -z "$count" ]; then
+            echo "⚠️ Weekly performance review completed, but no issue-count marker was found." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Weekly performance review issues created: $count" >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
Closes #536

## Summary

- Add the Weekly Performance Review scheduled workflow mirroring the Weekly UX Review scaffolding.
- Add the senior-performance-engineer prompt with performance scope, quality bar, dedupe, filing, and summary marker instructions.
- Created the `weekly-performance-review` GitHub label out-of-band.

## Validation

- `npx --yes js-yaml .github\workflows\weekly-performance-review.yml`
- `npm ci --no-audit --no-fund && npm run test`
- `superpowers:code-reviewer` clean
- Copilot PR review generated no comments
- CI checks passed
- Attempted `gh workflow run weekly-performance-review.yml --ref weekly-perf-review-workflow-536`; GitHub returned 404 because new workflow files are not dispatchable until present on the default branch.
