### PR TITLE
Show provider health status when healthy

### DIFF
--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -102,7 +102,7 @@ The manual Watch URL flow is **idempotent** for already-watched URLs and force-r
 
 DevDocket contributes two right-aligned status bar items (priorities `100000` and `100001`, immediately to the left of the Copilot button). Quick access to the sidebar itself is via the activity-bar container, not the status bar.
 
-- **Provider Health** (priority `100000`) — `⚠ N providers unhealthy`. Hidden when every provider is healthy, so the status bar stays quiet by default; click to open the Provider Health quick pick.
+- **Provider Health** (priority `100000`) — `$(check) DevDocket • N providers` when every provider is healthy, `$(circle-outline) DevDocket • N providers` while provider health is still unknown, and `$(warning) N providers unhealthy` when degraded; click to open the Provider Health quick pick.
 - **Watches** (priority `100001`) — eye icon + run counts (`🔄 N active · ✓ N passed · ✗ N failed`); always visible. Turns amber when at least one watched run has failed and the failure has not yet been acknowledged. Click to open the CI Watches panel.
 
 ## Item Lifecycle

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -102,7 +102,7 @@ The manual Watch URL flow is **idempotent** for already-watched URLs and force-r
 
 DevDocket contributes two right-aligned status bar items (priorities `100000` and `100001`, immediately to the left of the Copilot button). Quick access to the sidebar itself is via the activity-bar container, not the status bar.
 
-- **Provider Health** (priority `100000`) — `$(check) DevDocket • N providers` when every provider is healthy, `$(circle-outline) DevDocket • N providers` while provider health is still unknown, and `$(warning) N providers unhealthy` when degraded; click to open the Provider Health quick pick.
+- **Provider Health** (priority `100000`) — `✓ DevDocket • N providers` when every provider is healthy, `○ DevDocket • N providers` while provider health is still unknown, and `⚠ N providers unhealthy` when degraded; click to open the Provider Health quick pick.
 - **Watches** (priority `100001`) — eye icon + run counts (`🔄 N active · ✓ N passed · ✗ N failed`); always visible. Turns amber when at least one watched run has failed and the failure has not yet been acknowledged. Click to open the CI Watches panel.
 
 ## Item Lifecycle

--- a/packages/core/src/test/providerHealthStatusBar.test.ts
+++ b/packages/core/src/test/providerHealthStatusBar.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { EventEmitter, ThemeColor, window } from 'vscode';
+import { ProviderHealthStatusBar } from '../views/providerHealthStatusBar';
+
+function createProviderRegistry(
+  providers: Array<{ id: string; label: string }>,
+  healthByProvider: Record<string, { status: 'healthy' | 'unhealthy' | 'unknown'; lastRefreshTime?: Date; lastError?: string }>,
+) {
+  const healthEmitter = new EventEmitter<void>();
+  const registerEmitter = new EventEmitter<void>();
+  const itemsEmitter = new EventEmitter<void>();
+
+  return {
+    getProviders: vi.fn(() => providers),
+    getProviderHealth: vi.fn((providerId: string) => healthByProvider[providerId] ?? { status: 'unknown' }),
+    onDidChangeProviderHealth: healthEmitter.event,
+    onDidRegisterProvider: registerEmitter.event,
+    onDidChangeProviderItems: itemsEmitter.event,
+    setHealth(providerId: string, health: { status: 'healthy' | 'unhealthy' | 'unknown'; lastRefreshTime?: Date; lastError?: string }) {
+      healthByProvider[providerId] = health;
+      healthEmitter.fire();
+    },
+    fireProviderItemsChanged() {
+      itemsEmitter.fire();
+    },
+  };
+}
+
+describe('ProviderHealthStatusBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hides when no providers are registered', () => {
+    const providerRegistry = createProviderRegistry([], {});
+
+    new ProviderHealthStatusBar(providerRegistry as any);
+
+    const statusBarItem = (window.createStatusBarItem as ReturnType<typeof vi.fn>).mock.results[0].value;
+    expect(statusBarItem.hide).toHaveBeenCalled();
+    expect(statusBarItem.show).not.toHaveBeenCalled();
+  });
+
+  it('shows a low-key healthy summary when every provider is healthy', () => {
+    const providerRegistry = createProviderRegistry(
+      [
+        { id: 'github', label: 'GitHub' },
+        { id: 'ado', label: 'Azure DevOps' },
+      ],
+      {
+        github: { status: 'healthy', lastRefreshTime: new Date('2024-01-02T03:04:05Z') },
+        ado: { status: 'healthy' },
+      },
+    );
+
+    new ProviderHealthStatusBar(providerRegistry as any);
+
+    const statusBarItem = (window.createStatusBarItem as ReturnType<typeof vi.fn>).mock.results[0].value;
+    expect(statusBarItem.text).toBe('$(check) DevDocket • 2 providers');
+    expect(statusBarItem.command).toBe('devdocket.showProviderHealthQuickPick');
+    expect(statusBarItem.tooltip).toContain('GitHub: healthy');
+    expect(statusBarItem.tooltip).toContain('Azure DevOps: healthy (not refreshed yet)');
+    expect(statusBarItem.backgroundColor).toBeUndefined();
+    expect(statusBarItem.color).toBeUndefined();
+    expect(statusBarItem.show).toHaveBeenCalled();
+    expect(statusBarItem.hide).not.toHaveBeenCalled();
+  });
+
+  it('switches between warning and healthy text as provider health changes', () => {
+    const providerRegistry = createProviderRegistry(
+      [{ id: 'github', label: 'GitHub' }],
+      { github: { status: 'unhealthy', lastError: 'Token expired\nRefresh failed' } },
+    );
+
+    new ProviderHealthStatusBar(providerRegistry as any);
+
+    const statusBarItem = (vscode.window.createStatusBarItem as ReturnType<typeof vi.fn>).mock.results[0].value;
+    expect(statusBarItem.text).toBe('$(warning) 1 provider unhealthy');
+    expect(statusBarItem.tooltip).toContain('GitHub: unhealthy — Token expired Refresh failed');
+    expect(statusBarItem.backgroundColor).toEqual(new ThemeColor('statusBarItem.warningBackground'));
+    expect(statusBarItem.color).toEqual(new ThemeColor('statusBarItem.warningForeground'));
+
+    providerRegistry.setHealth('github', { status: 'healthy', lastRefreshTime: new Date('2024-01-02T03:04:05Z') });
+
+    expect(statusBarItem.text).toBe('$(check) DevDocket • 1 provider');
+    expect(statusBarItem.backgroundColor).toBeUndefined();
+    expect(statusBarItem.color).toBeUndefined();
+    expect(statusBarItem.show).toHaveBeenCalledTimes(2);
+  });
+
+  it('shows a neutral summary while registered provider health is unknown', () => {
+    const providerRegistry = createProviderRegistry(
+      [{ id: 'github', label: 'GitHub' }],
+      { github: { status: 'unknown' } },
+    );
+
+    new ProviderHealthStatusBar(providerRegistry as any);
+
+    const statusBarItem = (window.createStatusBarItem as ReturnType<typeof vi.fn>).mock.results[0].value;
+    expect(statusBarItem.text).toBe('$(circle-outline) DevDocket • 1 provider');
+    expect(statusBarItem.tooltip).toContain('GitHub: unknown (not refreshed yet)');
+    expect(statusBarItem.backgroundColor).toBeUndefined();
+    expect(statusBarItem.color).toBeUndefined();
+    expect(statusBarItem.show).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/views/providerHealthStatusBar.ts
+++ b/packages/core/src/views/providerHealthStatusBar.ts
@@ -12,8 +12,12 @@ function sanitizeError(error: string, maxLength = 100): string {
   return trimmed.length > maxLength ? trimmed.substring(0, maxLength) + '…' : trimmed;
 }
 
+function formatProviderCount(count: number): string {
+  return `${count} provider${count === 1 ? '' : 's'}`;
+}
+
 /**
- * Status bar item that shows a warning when any provider is unhealthy.
+ * Status bar item that shows provider health at a glance.
  * Click to open quick-pick with provider health details.
  */
 export class ProviderHealthStatusBar implements vscode.Disposable {
@@ -57,17 +61,35 @@ export class ProviderHealthStatusBar implements vscode.Disposable {
       return health.status === 'unhealthy';
     });
 
-    if (unhealthyProviders.length === 0) {
-      this.statusBarItem.hide();
+    const count = unhealthyProviders.length;
+    if (count > 0) {
+      this.statusBarItem.text = `$(warning) ${formatProviderCount(count)} unhealthy`;
+      this.statusBarItem.tooltip = this.buildTooltip(providers);
+      this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
+      this.statusBarItem.color = new vscode.ThemeColor('statusBarItem.warningForeground');
+      this.statusBarItem.show();
       return;
     }
 
-    const count = unhealthyProviders.length;
-    this.statusBarItem.text = `$(warning) ${count} provider${count === 1 ? '' : 's'} unhealthy`;
-    this.statusBarItem.tooltip = 'Click to view provider health details';
-    this.statusBarItem.backgroundColor = new vscode.ThemeColor('statusBarItem.warningBackground');
-    this.statusBarItem.color = new vscode.ThemeColor('statusBarItem.warningForeground');
+    const hasUnknownProviders = providers.some(p => this.providerRegistry.getProviderHealth(p.id).status === 'unknown');
+    this.statusBarItem.text = `${hasUnknownProviders ? '$(circle-outline)' : '$(check)'} DevDocket • ${formatProviderCount(providers.length)}`;
+    this.statusBarItem.tooltip = this.buildTooltip(providers);
+    this.statusBarItem.backgroundColor = undefined;
+    this.statusBarItem.color = undefined;
     this.statusBarItem.show();
+  }
+
+  private buildTooltip(providers: ReturnType<ProviderRegistry['getProviders']>): string {
+    const providerLines = providers.map(provider => {
+      const health = this.providerRegistry.getProviderHealth(provider.id);
+      const lastRefresh = health.lastRefreshTime
+        ? `last refreshed ${health.lastRefreshTime.toLocaleString()}`
+        : 'not refreshed yet';
+      const error = health.lastError ? ` — ${sanitizeError(health.lastError)}` : '';
+      return `${provider.label}: ${health.status}${error} (${lastRefresh})`;
+    });
+
+    return ['Click to view provider health details', '', ...providerLines].join('\n');
   }
 
   dispose(): void {


### PR DESCRIPTION
## Summary

- Keep the Provider Health status bar item visible whenever providers are registered.
- Show `$(check) DevDocket • N providers` when all providers are healthy, a neutral unknown state before health is known, and the existing warning state when degraded.
- Add provider health status bar tests and update the UX guide.

## Validation

- `npm run build`
- `npm run test`
- `superpowers:code-reviewer` review clean

Closes #545
