### PR TITLE
Confirm incoming bulk accept

### DIFF
--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import * as vscode from 'vscode';
 import { WorkItemState, type WorkItem } from '../models/workItem';
 import { MainViewProvider } from '../views/mainViewProvider';
@@ -542,6 +542,79 @@ describe('MainViewProvider', () => {
       },
     );
     expect(workGraph.createItem).not.toHaveBeenCalled();
+  });
+
+  it('confirms before accepting all incoming items', async () => {
+    vi.useFakeTimers();
+    (vscode.window.showInformationMessage as Mock).mockResolvedValueOnce('Accept All');
+    const provider = createProvider(
+      createMockWorkGraph(),
+      createProviderRegistry({
+        github: [
+          { externalId: 'incoming-a', title: 'Incoming A', description: 'A' },
+          { externalId: 'incoming-b', title: 'Incoming B', description: 'B' },
+        ],
+      }),
+      createStateStore(),
+    );
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    await vi.advanceTimersByTimeAsync(50);
+    vi.clearAllMocks();
+
+    mockView.simulateMessage({ type: 'acceptAll' });
+
+    await vi.waitFor(() => {
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'Accept all 2 items into Ready to Start? You can still triage them one by one.',
+        { modal: true },
+        'Accept All',
+      );
+    });
+    await vi.waitFor(() => {
+      expect(vscode.commands.executeCommand).toHaveBeenCalledTimes(2);
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        'devdocket.acceptFromInbox',
+        expect.objectContaining({ providerId: 'github', externalId: 'incoming-a' }),
+      );
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        'devdocket.acceptFromInbox',
+        expect.objectContaining({ providerId: 'github', externalId: 'incoming-b' }),
+      );
+    });
+  });
+
+  it('does not accept incoming items when accept-all confirmation is canceled', async () => {
+    vi.useFakeTimers();
+    (vscode.window.showInformationMessage as Mock).mockResolvedValueOnce(undefined);
+    const provider = createProvider(
+      createMockWorkGraph(),
+      createProviderRegistry({
+        github: [
+          { externalId: 'incoming-a', title: 'Incoming A' },
+          { externalId: 'incoming-b', title: 'Incoming B' },
+        ],
+      }),
+      createStateStore(),
+    );
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    await vi.advanceTimersByTimeAsync(50);
+    vi.clearAllMocks();
+
+    mockView.simulateMessage({ type: 'acceptAll' });
+
+    await vi.waitFor(() => {
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'Accept all 2 items into Ready to Start? You can still triage them one by one.',
+        { modal: true },
+        'Accept All',
+      );
+    });
+    await Promise.resolve();
+    expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
   });
 
   it('routes incoming acceptToFocus messages through the accept-to-focus-from-inbox command', async () => {

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -618,6 +618,58 @@ describe('MainViewProvider', () => {
     });
   });
 
+  it('accepts only incoming items requested by the webview', async () => {
+    vi.useFakeTimers();
+    (vscode.window.showInformationMessage as Mock).mockResolvedValueOnce('Accept All');
+    const provider = createProvider(
+      createMockWorkGraph(),
+      createProviderRegistry({
+        github: [
+          { externalId: 'visible', title: 'Visible incoming' },
+          { externalId: 'hidden', title: 'Hidden incoming' },
+        ],
+        ado: [{ externalId: 'other-visible', title: 'Other visible incoming' }],
+      }),
+      createStateStore(),
+    );
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    await vi.advanceTimersByTimeAsync(50);
+    vi.clearAllMocks();
+
+    mockView.simulateMessage({
+      type: 'acceptAll',
+      items: [
+        { providerId: 'github', externalId: 'visible' },
+        { providerId: 'ado', externalId: 'other-visible' },
+      ],
+    });
+
+    await vi.waitFor(() => {
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'Accept all 2 items into Ready to Start? You can still triage them one by one.',
+        { modal: true },
+        'Accept All',
+      );
+    });
+    await vi.waitFor(() => {
+      expect(vscode.commands.executeCommand).toHaveBeenCalledTimes(2);
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        'devdocket.acceptFromInbox',
+        expect.objectContaining({ providerId: 'github', externalId: 'visible' }),
+      );
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        'devdocket.acceptFromInbox',
+        expect.objectContaining({ providerId: 'ado', externalId: 'other-visible' }),
+      );
+      expect(vscode.commands.executeCommand).not.toHaveBeenCalledWith(
+        'devdocket.acceptFromInbox',
+        expect.objectContaining({ providerId: 'github', externalId: 'hidden' }),
+      );
+    });
+  });
+
   it('does not accept incoming items when accept-all confirmation is canceled', async () => {
     vi.useFakeTimers();
     (vscode.window.showInformationMessage as Mock).mockResolvedValueOnce(undefined);

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -585,6 +585,39 @@ describe('MainViewProvider', () => {
     });
   });
 
+  it('uses singular wording when accepting one incoming item', async () => {
+    vi.useFakeTimers();
+    (vscode.window.showInformationMessage as Mock).mockResolvedValueOnce('Accept All');
+    const provider = createProvider(
+      createMockWorkGraph(),
+      createProviderRegistry({
+        github: [{ externalId: 'incoming-one', title: 'Incoming One' }],
+      }),
+      createStateStore(),
+    );
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    await vi.advanceTimersByTimeAsync(50);
+    vi.clearAllMocks();
+
+    mockView.simulateMessage({ type: 'acceptAll' });
+
+    await vi.waitFor(() => {
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        'Accept all 1 item into Ready to Start? You can still triage them one by one.',
+        { modal: true },
+        'Accept All',
+      );
+    });
+    await vi.waitFor(() => {
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        'devdocket.acceptFromInbox',
+        expect.objectContaining({ providerId: 'github', externalId: 'incoming-one' }),
+      );
+    });
+  });
+
   it('does not accept incoming items when accept-all confirmation is canceled', async () => {
     vi.useFakeTimers();
     (vscode.window.showInformationMessage as Mock).mockResolvedValueOnce(undefined);

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -670,6 +670,30 @@ describe('MainViewProvider', () => {
     });
   });
 
+  it('does not accept a different incoming item whose legacy key collides with a requested item', async () => {
+    vi.useFakeTimers();
+    const provider = createProvider(
+      createMockWorkGraph(),
+      createProviderRegistry({
+        'a::b': [{ externalId: 'c', title: 'Collision candidate' }],
+      }),
+      createStateStore(),
+    );
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    await vi.advanceTimersByTimeAsync(50);
+    vi.clearAllMocks();
+
+    await mockView.simulateMessage({
+      type: 'acceptAll',
+      items: [{ providerId: 'a', externalId: 'b::c' }],
+    });
+
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
+    expect(vscode.commands.executeCommand).not.toHaveBeenCalled();
+  });
+
   it('does not accept incoming items when accept-all confirmation is canceled', async () => {
     vi.useFakeTimers();
     (vscode.window.showInformationMessage as Mock).mockResolvedValueOnce(undefined);

--- a/packages/core/src/test/sidebarAcceptAllPayload.test.ts
+++ b/packages/core/src/test/sidebarAcceptAllPayload.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { h, render } from 'preact';
+import { act } from 'preact/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TierData } from '../views/mainTypes';
+
+describe('sidebar Accept All payload', () => {
+  let container: HTMLDivElement | undefined;
+
+  afterEach(() => {
+    if (container) {
+      render(null, container);
+      container.remove();
+      container = undefined;
+    }
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('posts the rendered incoming provider/external ids when Accept All is clicked', async () => {
+    const postMessage = vi.fn();
+    vi.stubGlobal('acquireVsCodeApi', () => ({
+      postMessage,
+      getState: vi.fn(),
+      setState: vi.fn(),
+    }));
+
+    const { App } = await import('../webview/sidebar/App');
+    container = document.createElement('div');
+    document.body.appendChild(container);
+
+    await act(async () => {
+      render(h(App, {}), container!);
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          type: 'updateItems',
+          tiers: [makeIncomingTier()],
+        },
+      }));
+    });
+
+    const acceptAll = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent?.trim() === 'Accept All');
+    expect(acceptAll).toBeInstanceOf(HTMLButtonElement);
+
+    acceptAll!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+    expect(postMessage).toHaveBeenCalledWith({
+      type: 'acceptAll',
+      items: [
+        { providerId: 'github', externalId: 'visible-1' },
+        { providerId: 'ado', externalId: 'visible-2' },
+      ],
+    });
+  });
+});
+
+function makeIncomingTier(): TierData {
+  return {
+    id: 'incoming',
+    name: 'Incoming',
+    icon: '↓',
+    collapsed: false,
+    items: [
+      {
+        id: 'github::visible-1',
+        title: 'Visible GitHub item',
+        badges: [],
+        tierType: 'incoming',
+        providerId: 'github',
+        externalId: 'visible-1',
+      },
+      {
+        id: 'ado::visible-2',
+        title: 'Visible ADO item',
+        badges: [],
+        tierType: 'incoming',
+        providerId: 'ado',
+        externalId: 'visible-2',
+      },
+    ],
+  };
+}

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -17,7 +17,7 @@ export type WebviewMessage =
   | { type: 'showProviderHealth'; providerId: string }
   | { type: 'acceptItem'; providerId: string; externalId: string }
   | { type: 'acceptToFocus'; providerId: string; externalId: string }
-  | { type: 'acceptAll' }
+  | { type: 'acceptAll'; items?: Array<{ providerId: string; externalId: string }> }
   | { type: 'dismissItem'; providerId: string; externalId: string }
   | { type: 'transitionState'; itemId: string; targetState: string }
   | { type: 'reorderItems'; itemIds: string[] }

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -591,11 +591,23 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    for (const item of incomingTier.items) {
-      if (!item.providerId || !item.externalId) {
-        continue;
-      }
+    const itemsToAccept = incomingTier.items.filter((item): item is ItemCardData & { providerId: string; externalId: string } => (
+      Boolean(item.providerId) && Boolean(item.externalId)
+    ));
+    if (itemsToAccept.length === 0) {
+      return;
+    }
 
+    const confirm = await vscode.window.showInformationMessage(
+      `Accept all ${itemsToAccept.length} item${itemsToAccept.length === 1 ? '' : 's'} into Ready to Start? You can still triage them one by one.`,
+      { modal: true },
+      'Accept All',
+    );
+    if (confirm !== 'Accept All') {
+      return;
+    }
+
+    for (const item of itemsToAccept) {
       await this.handleAcceptItem(item.providerId, item.externalId);
     }
   }

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -500,7 +500,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
         await this.handleAcceptToFocus(message.providerId, message.externalId);
         break;
       case 'acceptAll':
-        await this.handleAcceptAll();
+        await this.handleAcceptAll(message.items);
         break;
       case 'dismissItem':
         await this.handleDismissItem(message.providerId, message.externalId);
@@ -583,7 +583,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  private async handleAcceptAll(): Promise<void> {
+  private async handleAcceptAll(requestedItems?: ReadonlyArray<{ providerId: string; externalId: string }>): Promise<void> {
     const allProviderItems = this.providerRegistry.getAllProviderItems();
     const relatedItemsIndex = buildRelatedItemsIndex(this.providerRegistry, this.workGraph, allProviderItems);
     const incomingTier = this.buildTierData(allProviderItems, relatedItemsIndex).find(tier => tier.id === 'incoming');
@@ -591,8 +591,13 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
+    const requestedKeys = requestedItems
+      ? new Set(requestedItems.map(item => getProviderItemKey(item.providerId, item.externalId)))
+      : undefined;
     const itemsToAccept = incomingTier.items.filter((item): item is ItemCardData & { providerId: string; externalId: string } => (
-      Boolean(item.providerId) && Boolean(item.externalId)
+      Boolean(item.providerId)
+      && Boolean(item.externalId)
+      && (!requestedKeys || requestedKeys.has(getProviderItemKey(item.providerId, item.externalId)))
     ));
     if (itemsToAccept.length === 0) {
       return;

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -591,13 +591,16 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    const requestedKeys = requestedItems
-      ? new Set(requestedItems.map(item => getProviderItemKey(item.providerId, item.externalId)))
-      : undefined;
+    const requestedByProvider = requestedItems?.reduce((index, item) => {
+      const providerItems = index.get(item.providerId) ?? new Set<string>();
+      providerItems.add(item.externalId);
+      index.set(item.providerId, providerItems);
+      return index;
+    }, new Map<string, Set<string>>());
     const itemsToAccept = incomingTier.items.filter((item): item is ItemCardData & { providerId: string; externalId: string } => (
       Boolean(item.providerId)
       && Boolean(item.externalId)
-      && (!requestedKeys || requestedKeys.has(getProviderItemKey(item.providerId, item.externalId)))
+      && (!requestedByProvider || requestedByProvider.get(item.providerId)?.has(item.externalId) === true)
     ));
     if (itemsToAccept.length === 0) {
       return;

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -324,7 +324,12 @@ export function App() {
                     onCrossTierDrop={tier.id === 'ready-to-start' || tier.id === 'in-progress'
                       ? (itemId) => postMessage({ type: 'crossTierDrop', itemId, targetTier: tier.id })
                       : undefined}
-                    onAcceptAll={tier.id === 'incoming' ? () => postMessage({ type: 'acceptAll' }) : undefined}
+                    onAcceptAll={tier.id === 'incoming' ? () => postMessage({
+                      type: 'acceptAll',
+                      items: tier.items.flatMap(item => (item.providerId && item.externalId)
+                        ? [{ providerId: item.providerId, externalId: item.externalId }]
+                        : []),
+                    }) : undefined}
                     onClearHistory={tier.id === 'done' ? () => postMessage({ type: 'clearHistory' }) : undefined}
                   />
                 ))}


### PR DESCRIPTION
## Summary
- Add a modal confirmation before accepting all visible Incoming items.
- Cover affirmative and canceled confirmation paths with MainViewProvider tests.

## Validation
- npm run build
- npm run test

Closes #538
