### PR TITLE
Add per-package extension publish workflows

### DIFF
--- a/.github/workflows/_publish-vscode-extension.yml
+++ b/.github/workflows/_publish-vscode-extension.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Package extension
         working-directory: ${{ env.PACKAGE_DIR }}
-        run: npx --yes @vscode/vsce package --allow-missing-repository --out "$VSIX_PATH"
+        run: npx --yes @vscode/vsce package --no-dependencies --allow-missing-repository --out "$VSIX_PATH"
 
       - name: Publish extension
         working-directory: ${{ env.PACKAGE_DIR }}

--- a/.github/workflows/_publish-vscode-extension.yml
+++ b/.github/workflows/_publish-vscode-extension.yml
@@ -1,0 +1,113 @@
+name: Publish VS Code Extension
+
+on:
+  workflow_call:
+    inputs:
+      package-directory:
+        required: true
+        type: string
+      package-title:
+        required: true
+        type: string
+      tag-prefix:
+        required: true
+        type: string
+    secrets:
+      VSCE_PAT:
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      PACKAGE_DIR: ${{ inputs.package-directory }}
+      PACKAGE_TITLE: ${{ inputs.package-title }}
+      TAG_PREFIX: ${{ inputs.tag-prefix }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build shared
+        run: npm run build -w @devdocket/shared
+
+      - name: Build extension
+        run: npm run build -w "$PACKAGE_DIR"
+
+      - name: Test extension
+        run: npm run test -w "$PACKAGE_DIR"
+
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#${TAG_PREFIX}}"
+          PACKAGE_NAME=$(node -p "require('./${PACKAGE_DIR}/package.json').name")
+          PKG_VERSION=$(node -p "require('./${PACKAGE_DIR}/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
+          echo "VSIX_PATH=$PACKAGE_NAME-$TAG_VERSION.vsix" >> "$GITHUB_ENV"
+
+      - name: Validate marketplace token
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "The VSCE_PAT repository secret is required to publish to the VS Code Marketplace."
+            exit 1
+          fi
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Package extension
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npx --yes @vscode/vsce package --allow-missing-repository --out "$VSIX_PATH"
+
+      - name: Publish extension
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npx --yes @vscode/vsce publish --packagePath "$VSIX_PATH"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Generate release notes
+        run: |
+          generate_fallback_notes() {
+            PREV_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1 || true)
+            if [ -n "$PREV_TAG" ]; then
+              RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
+            else
+              RANGE="$GITHUB_REF_NAME"
+            fi
+
+            NOTES=$(git log "$RANGE" --pretty=format:"* %s (%h)" -- "$PACKAGE_DIR/")
+            if [ -z "$NOTES" ]; then
+              NOTES="* No changes to $PACKAGE_DIR in this release"
+            fi
+            printf '%s\n' "$NOTES" > release-notes.md
+          }
+
+          CHANGELOG_PATH="$PACKAGE_DIR/CHANGELOG.md"
+          if [ -f scripts/extract-changelog.mjs ] && [ -f "$CHANGELOG_PATH" ]; then
+            error_log=release-notes-error.log
+            if ! node scripts/extract-changelog.mjs "$CHANGELOG_PATH" > release-notes.md 2>"$error_log"; then
+              echo "Failed to extract changelog entry; falling back to scoped git log:" >&2
+              cat "$error_log" >&2
+              generate_fallback_notes
+            fi
+            rm -f "$error_log"
+          else
+            generate_fallback_notes
+          fi
+
+      - name: Create GitHub Release
+        run: gh release create "$GITHUB_REF_NAME" --title "$PACKAGE_TITLE $TAG_VERSION" --notes-file release-notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/_publish-vscode-extension.yml
+++ b/.github/workflows/_publish-vscode-extension.yml
@@ -12,17 +12,20 @@ on:
       tag-prefix:
         required: true
         type: string
-    secrets:
-      VSCE_PAT:
-        required: true
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: marketplace-publish
+    permissions:
+      contents: write
+      id-token: write
     env:
       PACKAGE_DIR: ${{ inputs.package-directory }}
       PACKAGE_TITLE: ${{ inputs.package-title }}
       TAG_PREFIX: ${{ inputs.tag-prefix }}
+      AZURE_CLIENT_ID: ${{ vars.AZURE_PUBLISH_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ vars.AZURE_PUBLISH_TENANT_ID }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,14 +61,19 @@ jobs:
           echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
           echo "VSIX_PATH=$PACKAGE_NAME-$TAG_VERSION.vsix" >> "$GITHUB_ENV"
 
-      - name: Validate marketplace token
+      - name: Validate Entra ID configuration
         run: |
-          if [ -z "$VSCE_PAT" ]; then
-            echo "The VSCE_PAT repository secret is required to publish to the VS Code Marketplace."
+          if [ -z "$AZURE_CLIENT_ID" ] || [ -z "$AZURE_TENANT_ID" ]; then
+            echo "Repository variables AZURE_PUBLISH_CLIENT_ID and AZURE_PUBLISH_TENANT_ID are required to publish to the VS Code Marketplace via OIDC."
             exit 1
           fi
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Authenticate to Azure (Entra ID via OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_PUBLISH_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_PUBLISH_TENANT_ID }}
+          allow-no-subscriptions: true
 
       - name: Package extension
         working-directory: ${{ env.PACKAGE_DIR }}
@@ -73,9 +81,7 @@ jobs:
 
       - name: Publish extension
         working-directory: ${{ env.PACKAGE_DIR }}
-        run: npx --yes @vscode/vsce publish --packagePath "$VSIX_PATH"
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: npx --yes @vscode/vsce publish --azure-credential --packagePath "$VSIX_PATH"
 
       - name: Generate release notes
         run: |

--- a/.github/workflows/publish-ado.yml
+++ b/.github/workflows/publish-ado.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 concurrency:
   group: publish-${{ github.workflow }}
@@ -19,5 +20,3 @@ jobs:
       package-directory: packages/ado
       package-title: DevDocket Azure DevOps
       tag-prefix: ado-v
-    secrets:
-      VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/publish-ado.yml
+++ b/.github/workflows/publish-ado.yml
@@ -1,0 +1,104 @@
+name: Publish DevDocket Azure DevOps
+
+on:
+  push:
+    tags:
+      - "ado-v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  PACKAGE_DIR: packages/ado
+  PACKAGE_TITLE: DevDocket Azure DevOps
+  TAG_PREFIX: ado-v
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build workspace
+        run: npm run build
+
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#${TAG_PREFIX}}"
+          PACKAGE_NAME=$(node -p "require('./${PACKAGE_DIR}/package.json').name")
+          PKG_VERSION=$(node -p "require('./${PACKAGE_DIR}/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
+          echo "VSIX_PATH=$PACKAGE_NAME-$TAG_VERSION.vsix" >> "$GITHUB_ENV"
+
+      - name: Validate marketplace token
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "The VSCE_PAT repository secret is required to publish to the VS Code Marketplace."
+            exit 1
+          fi
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Package extension
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npx --yes @vscode/vsce package --allow-missing-repository --out "$VSIX_PATH"
+
+      - name: Publish extension
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npx --yes @vscode/vsce publish --packagePath "$VSIX_PATH"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Generate release notes
+        run: |
+          generate_fallback_notes() {
+            PREV_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
+            if [ -n "$PREV_TAG" ]; then
+              RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
+            else
+              RANGE="$GITHUB_REF_NAME"
+            fi
+
+            NOTES=$(git log "$RANGE" --pretty=format:"* %s (%h)" -- "$PACKAGE_DIR/")
+            if [ -z "$NOTES" ]; then
+              NOTES="* No changes to $PACKAGE_DIR in this release"
+            fi
+            printf '%s\n' "$NOTES" > release-notes.md
+          }
+
+          CHANGELOG_PATH="$PACKAGE_DIR/CHANGELOG.md"
+          if [ -f scripts/extract-changelog.mjs ] && [ -f "$CHANGELOG_PATH" ]; then
+            error_log=release-notes-error.log
+            if ! node scripts/extract-changelog.mjs "$CHANGELOG_PATH" > release-notes.md 2>"$error_log"; then
+              echo "Failed to extract changelog entry; falling back to scoped git log:" >&2
+              cat "$error_log" >&2
+              generate_fallback_notes
+            fi
+            rm -f "$error_log"
+          else
+            generate_fallback_notes
+          fi
+
+      - name: Create GitHub Release
+        run: gh release create "$GITHUB_REF_NAME" --title "$PACKAGE_TITLE $TAG_VERSION" --notes-file release-notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-ado.yml
+++ b/.github/workflows/publish-ado.yml
@@ -12,93 +12,12 @@ concurrency:
   group: publish-${{ github.workflow }}
   cancel-in-progress: false
 
-env:
-  PACKAGE_DIR: packages/ado
-  PACKAGE_TITLE: DevDocket Azure DevOps
-  TAG_PREFIX: ado-v
-
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build workspace
-        run: npm run build
-
-      - name: Verify tag version matches package.json
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#${TAG_PREFIX}}"
-          PACKAGE_NAME=$(node -p "require('./${PACKAGE_DIR}/package.json').name")
-          PKG_VERSION=$(node -p "require('./${PACKAGE_DIR}/package.json').version")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-            exit 1
-          fi
-          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
-          echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
-          echo "VSIX_PATH=$PACKAGE_NAME-$TAG_VERSION.vsix" >> "$GITHUB_ENV"
-
-      - name: Validate marketplace token
-        run: |
-          if [ -z "$VSCE_PAT" ]; then
-            echo "The VSCE_PAT repository secret is required to publish to the VS Code Marketplace."
-            exit 1
-          fi
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-
-      - name: Package extension
-        working-directory: ${{ env.PACKAGE_DIR }}
-        run: npx --yes @vscode/vsce package --allow-missing-repository --out "$VSIX_PATH"
-
-      - name: Publish extension
-        working-directory: ${{ env.PACKAGE_DIR }}
-        run: npx --yes @vscode/vsce publish --packagePath "$VSIX_PATH"
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-
-      - name: Generate release notes
-        run: |
-          generate_fallback_notes() {
-            PREV_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
-            if [ -n "$PREV_TAG" ]; then
-              RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
-            else
-              RANGE="$GITHUB_REF_NAME"
-            fi
-
-            NOTES=$(git log "$RANGE" --pretty=format:"* %s (%h)" -- "$PACKAGE_DIR/")
-            if [ -z "$NOTES" ]; then
-              NOTES="* No changes to $PACKAGE_DIR in this release"
-            fi
-            printf '%s\n' "$NOTES" > release-notes.md
-          }
-
-          CHANGELOG_PATH="$PACKAGE_DIR/CHANGELOG.md"
-          if [ -f scripts/extract-changelog.mjs ] && [ -f "$CHANGELOG_PATH" ]; then
-            error_log=release-notes-error.log
-            if ! node scripts/extract-changelog.mjs "$CHANGELOG_PATH" > release-notes.md 2>"$error_log"; then
-              echo "Failed to extract changelog entry; falling back to scoped git log:" >&2
-              cat "$error_log" >&2
-              generate_fallback_notes
-            fi
-            rm -f "$error_log"
-          else
-            generate_fallback_notes
-          fi
-
-      - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" --title "$PACKAGE_TITLE $TAG_VERSION" --notes-file release-notes.md
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/_publish-vscode-extension.yml
+    with:
+      package-directory: packages/ado
+      package-title: DevDocket Azure DevOps
+      tag-prefix: ado-v
+    secrets:
+      VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/publish-ai-reviewer.yml
+++ b/.github/workflows/publish-ai-reviewer.yml
@@ -12,93 +12,12 @@ concurrency:
   group: publish-${{ github.workflow }}
   cancel-in-progress: false
 
-env:
-  PACKAGE_DIR: packages/ai-reviewer
-  PACKAGE_TITLE: DevDocket AI Reviewer
-  TAG_PREFIX: ai-reviewer-v
-
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build workspace
-        run: npm run build
-
-      - name: Verify tag version matches package.json
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#${TAG_PREFIX}}"
-          PACKAGE_NAME=$(node -p "require('./${PACKAGE_DIR}/package.json').name")
-          PKG_VERSION=$(node -p "require('./${PACKAGE_DIR}/package.json').version")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-            exit 1
-          fi
-          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
-          echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
-          echo "VSIX_PATH=$PACKAGE_NAME-$TAG_VERSION.vsix" >> "$GITHUB_ENV"
-
-      - name: Validate marketplace token
-        run: |
-          if [ -z "$VSCE_PAT" ]; then
-            echo "The VSCE_PAT repository secret is required to publish to the VS Code Marketplace."
-            exit 1
-          fi
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-
-      - name: Package extension
-        working-directory: ${{ env.PACKAGE_DIR }}
-        run: npx --yes @vscode/vsce package --allow-missing-repository --out "$VSIX_PATH"
-
-      - name: Publish extension
-        working-directory: ${{ env.PACKAGE_DIR }}
-        run: npx --yes @vscode/vsce publish --packagePath "$VSIX_PATH"
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-
-      - name: Generate release notes
-        run: |
-          generate_fallback_notes() {
-            PREV_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
-            if [ -n "$PREV_TAG" ]; then
-              RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
-            else
-              RANGE="$GITHUB_REF_NAME"
-            fi
-
-            NOTES=$(git log "$RANGE" --pretty=format:"* %s (%h)" -- "$PACKAGE_DIR/")
-            if [ -z "$NOTES" ]; then
-              NOTES="* No changes to $PACKAGE_DIR in this release"
-            fi
-            printf '%s\n' "$NOTES" > release-notes.md
-          }
-
-          CHANGELOG_PATH="$PACKAGE_DIR/CHANGELOG.md"
-          if [ -f scripts/extract-changelog.mjs ] && [ -f "$CHANGELOG_PATH" ]; then
-            error_log=release-notes-error.log
-            if ! node scripts/extract-changelog.mjs "$CHANGELOG_PATH" > release-notes.md 2>"$error_log"; then
-              echo "Failed to extract changelog entry; falling back to scoped git log:" >&2
-              cat "$error_log" >&2
-              generate_fallback_notes
-            fi
-            rm -f "$error_log"
-          else
-            generate_fallback_notes
-          fi
-
-      - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" --title "$PACKAGE_TITLE $TAG_VERSION" --notes-file release-notes.md
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/_publish-vscode-extension.yml
+    with:
+      package-directory: packages/ai-reviewer
+      package-title: DevDocket AI Reviewer
+      tag-prefix: ai-reviewer-v
+    secrets:
+      VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/publish-ai-reviewer.yml
+++ b/.github/workflows/publish-ai-reviewer.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 concurrency:
   group: publish-${{ github.workflow }}
@@ -19,5 +20,3 @@ jobs:
       package-directory: packages/ai-reviewer
       package-title: DevDocket AI Reviewer
       tag-prefix: ai-reviewer-v
-    secrets:
-      VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/publish-ai-reviewer.yml
+++ b/.github/workflows/publish-ai-reviewer.yml
@@ -1,0 +1,104 @@
+name: Publish DevDocket AI Reviewer
+
+on:
+  push:
+    tags:
+      - "ai-reviewer-v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  PACKAGE_DIR: packages/ai-reviewer
+  PACKAGE_TITLE: DevDocket AI Reviewer
+  TAG_PREFIX: ai-reviewer-v
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build workspace
+        run: npm run build
+
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#${TAG_PREFIX}}"
+          PACKAGE_NAME=$(node -p "require('./${PACKAGE_DIR}/package.json').name")
+          PKG_VERSION=$(node -p "require('./${PACKAGE_DIR}/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
+          echo "VSIX_PATH=$PACKAGE_NAME-$TAG_VERSION.vsix" >> "$GITHUB_ENV"
+
+      - name: Validate marketplace token
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "The VSCE_PAT repository secret is required to publish to the VS Code Marketplace."
+            exit 1
+          fi
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Package extension
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npx --yes @vscode/vsce package --allow-missing-repository --out "$VSIX_PATH"
+
+      - name: Publish extension
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npx --yes @vscode/vsce publish --packagePath "$VSIX_PATH"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Generate release notes
+        run: |
+          generate_fallback_notes() {
+            PREV_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
+            if [ -n "$PREV_TAG" ]; then
+              RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
+            else
+              RANGE="$GITHUB_REF_NAME"
+            fi
+
+            NOTES=$(git log "$RANGE" --pretty=format:"* %s (%h)" -- "$PACKAGE_DIR/")
+            if [ -z "$NOTES" ]; then
+              NOTES="* No changes to $PACKAGE_DIR in this release"
+            fi
+            printf '%s\n' "$NOTES" > release-notes.md
+          }
+
+          CHANGELOG_PATH="$PACKAGE_DIR/CHANGELOG.md"
+          if [ -f scripts/extract-changelog.mjs ] && [ -f "$CHANGELOG_PATH" ]; then
+            error_log=release-notes-error.log
+            if ! node scripts/extract-changelog.mjs "$CHANGELOG_PATH" > release-notes.md 2>"$error_log"; then
+              echo "Failed to extract changelog entry; falling back to scoped git log:" >&2
+              cat "$error_log" >&2
+              generate_fallback_notes
+            fi
+            rm -f "$error_log"
+          else
+            generate_fallback_notes
+          fi
+
+      - name: Create GitHub Release
+        run: gh release create "$GITHUB_REF_NAME" --title "$PACKAGE_TITLE $TAG_VERSION" --notes-file release-notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -1,0 +1,104 @@
+name: Publish DevDocket Core
+
+on:
+  push:
+    tags:
+      - "core-v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  PACKAGE_DIR: packages/core
+  PACKAGE_TITLE: DevDocket Core
+  TAG_PREFIX: core-v
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build workspace
+        run: npm run build
+
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#${TAG_PREFIX}}"
+          PACKAGE_NAME=$(node -p "require('./${PACKAGE_DIR}/package.json').name")
+          PKG_VERSION=$(node -p "require('./${PACKAGE_DIR}/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
+          echo "VSIX_PATH=$PACKAGE_NAME-$TAG_VERSION.vsix" >> "$GITHUB_ENV"
+
+      - name: Validate marketplace token
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "The VSCE_PAT repository secret is required to publish to the VS Code Marketplace."
+            exit 1
+          fi
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Package extension
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npx --yes @vscode/vsce package --allow-missing-repository --out "$VSIX_PATH"
+
+      - name: Publish extension
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npx --yes @vscode/vsce publish --packagePath "$VSIX_PATH"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Generate release notes
+        run: |
+          generate_fallback_notes() {
+            PREV_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
+            if [ -n "$PREV_TAG" ]; then
+              RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
+            else
+              RANGE="$GITHUB_REF_NAME"
+            fi
+
+            NOTES=$(git log "$RANGE" --pretty=format:"* %s (%h)" -- "$PACKAGE_DIR/")
+            if [ -z "$NOTES" ]; then
+              NOTES="* No changes to $PACKAGE_DIR in this release"
+            fi
+            printf '%s\n' "$NOTES" > release-notes.md
+          }
+
+          CHANGELOG_PATH="$PACKAGE_DIR/CHANGELOG.md"
+          if [ -f scripts/extract-changelog.mjs ] && [ -f "$CHANGELOG_PATH" ]; then
+            error_log=release-notes-error.log
+            if ! node scripts/extract-changelog.mjs "$CHANGELOG_PATH" > release-notes.md 2>"$error_log"; then
+              echo "Failed to extract changelog entry; falling back to scoped git log:" >&2
+              cat "$error_log" >&2
+              generate_fallback_notes
+            fi
+            rm -f "$error_log"
+          else
+            generate_fallback_notes
+          fi
+
+      - name: Create GitHub Release
+        run: gh release create "$GITHUB_REF_NAME" --title "$PACKAGE_TITLE $TAG_VERSION" --notes-file release-notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 concurrency:
   group: publish-${{ github.workflow }}
@@ -19,5 +20,3 @@ jobs:
       package-directory: packages/core
       package-title: DevDocket Core
       tag-prefix: core-v
-    secrets:
-      VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -12,93 +12,12 @@ concurrency:
   group: publish-${{ github.workflow }}
   cancel-in-progress: false
 
-env:
-  PACKAGE_DIR: packages/core
-  PACKAGE_TITLE: DevDocket Core
-  TAG_PREFIX: core-v
-
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build workspace
-        run: npm run build
-
-      - name: Verify tag version matches package.json
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#${TAG_PREFIX}}"
-          PACKAGE_NAME=$(node -p "require('./${PACKAGE_DIR}/package.json').name")
-          PKG_VERSION=$(node -p "require('./${PACKAGE_DIR}/package.json').version")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-            exit 1
-          fi
-          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
-          echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
-          echo "VSIX_PATH=$PACKAGE_NAME-$TAG_VERSION.vsix" >> "$GITHUB_ENV"
-
-      - name: Validate marketplace token
-        run: |
-          if [ -z "$VSCE_PAT" ]; then
-            echo "The VSCE_PAT repository secret is required to publish to the VS Code Marketplace."
-            exit 1
-          fi
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-
-      - name: Package extension
-        working-directory: ${{ env.PACKAGE_DIR }}
-        run: npx --yes @vscode/vsce package --allow-missing-repository --out "$VSIX_PATH"
-
-      - name: Publish extension
-        working-directory: ${{ env.PACKAGE_DIR }}
-        run: npx --yes @vscode/vsce publish --packagePath "$VSIX_PATH"
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-
-      - name: Generate release notes
-        run: |
-          generate_fallback_notes() {
-            PREV_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
-            if [ -n "$PREV_TAG" ]; then
-              RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
-            else
-              RANGE="$GITHUB_REF_NAME"
-            fi
-
-            NOTES=$(git log "$RANGE" --pretty=format:"* %s (%h)" -- "$PACKAGE_DIR/")
-            if [ -z "$NOTES" ]; then
-              NOTES="* No changes to $PACKAGE_DIR in this release"
-            fi
-            printf '%s\n' "$NOTES" > release-notes.md
-          }
-
-          CHANGELOG_PATH="$PACKAGE_DIR/CHANGELOG.md"
-          if [ -f scripts/extract-changelog.mjs ] && [ -f "$CHANGELOG_PATH" ]; then
-            error_log=release-notes-error.log
-            if ! node scripts/extract-changelog.mjs "$CHANGELOG_PATH" > release-notes.md 2>"$error_log"; then
-              echo "Failed to extract changelog entry; falling back to scoped git log:" >&2
-              cat "$error_log" >&2
-              generate_fallback_notes
-            fi
-            rm -f "$error_log"
-          else
-            generate_fallback_notes
-          fi
-
-      - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" --title "$PACKAGE_TITLE $TAG_VERSION" --notes-file release-notes.md
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/_publish-vscode-extension.yml
+    with:
+      package-directory: packages/core
+      package-title: DevDocket Core
+      tag-prefix: core-v
+    secrets:
+      VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -1,0 +1,104 @@
+name: Publish DevDocket GitHub
+
+on:
+  push:
+    tags:
+      - "github-v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  PACKAGE_DIR: packages/github
+  PACKAGE_TITLE: DevDocket GitHub
+  TAG_PREFIX: github-v
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build workspace
+        run: npm run build
+
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#${TAG_PREFIX}}"
+          PACKAGE_NAME=$(node -p "require('./${PACKAGE_DIR}/package.json').name")
+          PKG_VERSION=$(node -p "require('./${PACKAGE_DIR}/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
+          echo "VSIX_PATH=$PACKAGE_NAME-$TAG_VERSION.vsix" >> "$GITHUB_ENV"
+
+      - name: Validate marketplace token
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "The VSCE_PAT repository secret is required to publish to the VS Code Marketplace."
+            exit 1
+          fi
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Package extension
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npx --yes @vscode/vsce package --allow-missing-repository --out "$VSIX_PATH"
+
+      - name: Publish extension
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npx --yes @vscode/vsce publish --packagePath "$VSIX_PATH"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Generate release notes
+        run: |
+          generate_fallback_notes() {
+            PREV_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
+            if [ -n "$PREV_TAG" ]; then
+              RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
+            else
+              RANGE="$GITHUB_REF_NAME"
+            fi
+
+            NOTES=$(git log "$RANGE" --pretty=format:"* %s (%h)" -- "$PACKAGE_DIR/")
+            if [ -z "$NOTES" ]; then
+              NOTES="* No changes to $PACKAGE_DIR in this release"
+            fi
+            printf '%s\n' "$NOTES" > release-notes.md
+          }
+
+          CHANGELOG_PATH="$PACKAGE_DIR/CHANGELOG.md"
+          if [ -f scripts/extract-changelog.mjs ] && [ -f "$CHANGELOG_PATH" ]; then
+            error_log=release-notes-error.log
+            if ! node scripts/extract-changelog.mjs "$CHANGELOG_PATH" > release-notes.md 2>"$error_log"; then
+              echo "Failed to extract changelog entry; falling back to scoped git log:" >&2
+              cat "$error_log" >&2
+              generate_fallback_notes
+            fi
+            rm -f "$error_log"
+          else
+            generate_fallback_notes
+          fi
+
+      - name: Create GitHub Release
+        run: gh release create "$GITHUB_REF_NAME" --title "$PACKAGE_TITLE $TAG_VERSION" --notes-file release-notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 concurrency:
   group: publish-${{ github.workflow }}
@@ -19,5 +20,3 @@ jobs:
       package-directory: packages/github
       package-title: DevDocket GitHub
       tag-prefix: github-v
-    secrets:
-      VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/publish-github.yml
+++ b/.github/workflows/publish-github.yml
@@ -12,93 +12,12 @@ concurrency:
   group: publish-${{ github.workflow }}
   cancel-in-progress: false
 
-env:
-  PACKAGE_DIR: packages/github
-  PACKAGE_TITLE: DevDocket GitHub
-  TAG_PREFIX: github-v
-
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build workspace
-        run: npm run build
-
-      - name: Verify tag version matches package.json
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#${TAG_PREFIX}}"
-          PACKAGE_NAME=$(node -p "require('./${PACKAGE_DIR}/package.json').name")
-          PKG_VERSION=$(node -p "require('./${PACKAGE_DIR}/package.json').version")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-            exit 1
-          fi
-          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
-          echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
-          echo "VSIX_PATH=$PACKAGE_NAME-$TAG_VERSION.vsix" >> "$GITHUB_ENV"
-
-      - name: Validate marketplace token
-        run: |
-          if [ -z "$VSCE_PAT" ]; then
-            echo "The VSCE_PAT repository secret is required to publish to the VS Code Marketplace."
-            exit 1
-          fi
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-
-      - name: Package extension
-        working-directory: ${{ env.PACKAGE_DIR }}
-        run: npx --yes @vscode/vsce package --allow-missing-repository --out "$VSIX_PATH"
-
-      - name: Publish extension
-        working-directory: ${{ env.PACKAGE_DIR }}
-        run: npx --yes @vscode/vsce publish --packagePath "$VSIX_PATH"
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-
-      - name: Generate release notes
-        run: |
-          generate_fallback_notes() {
-            PREV_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
-            if [ -n "$PREV_TAG" ]; then
-              RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
-            else
-              RANGE="$GITHUB_REF_NAME"
-            fi
-
-            NOTES=$(git log "$RANGE" --pretty=format:"* %s (%h)" -- "$PACKAGE_DIR/")
-            if [ -z "$NOTES" ]; then
-              NOTES="* No changes to $PACKAGE_DIR in this release"
-            fi
-            printf '%s\n' "$NOTES" > release-notes.md
-          }
-
-          CHANGELOG_PATH="$PACKAGE_DIR/CHANGELOG.md"
-          if [ -f scripts/extract-changelog.mjs ] && [ -f "$CHANGELOG_PATH" ]; then
-            error_log=release-notes-error.log
-            if ! node scripts/extract-changelog.mjs "$CHANGELOG_PATH" > release-notes.md 2>"$error_log"; then
-              echo "Failed to extract changelog entry; falling back to scoped git log:" >&2
-              cat "$error_log" >&2
-              generate_fallback_notes
-            fi
-            rm -f "$error_log"
-          else
-            generate_fallback_notes
-          fi
-
-      - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" --title "$PACKAGE_TITLE $TAG_VERSION" --notes-file release-notes.md
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/_publish-vscode-extension.yml
+    with:
+      package-directory: packages/github
+      package-title: DevDocket GitHub
+      tag-prefix: github-v
+    secrets:
+      VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/publish-start-git-work.yml
+++ b/.github/workflows/publish-start-git-work.yml
@@ -1,0 +1,104 @@
+name: Publish DevDocket Start Git Work
+
+on:
+  push:
+    tags:
+      - "start-git-work-v*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: publish-${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  PACKAGE_DIR: packages/start-git-work
+  PACKAGE_TITLE: DevDocket Start Git Work
+  TAG_PREFIX: start-git-work-v
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build workspace
+        run: npm run build
+
+      - name: Verify tag version matches package.json
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#${TAG_PREFIX}}"
+          PACKAGE_NAME=$(node -p "require('./${PACKAGE_DIR}/package.json').name")
+          PKG_VERSION=$(node -p "require('./${PACKAGE_DIR}/package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
+          echo "VSIX_PATH=$PACKAGE_NAME-$TAG_VERSION.vsix" >> "$GITHUB_ENV"
+
+      - name: Validate marketplace token
+        run: |
+          if [ -z "$VSCE_PAT" ]; then
+            echo "The VSCE_PAT repository secret is required to publish to the VS Code Marketplace."
+            exit 1
+          fi
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Package extension
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npx --yes @vscode/vsce package --allow-missing-repository --out "$VSIX_PATH"
+
+      - name: Publish extension
+        working-directory: ${{ env.PACKAGE_DIR }}
+        run: npx --yes @vscode/vsce publish --packagePath "$VSIX_PATH"
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+
+      - name: Generate release notes
+        run: |
+          generate_fallback_notes() {
+            PREV_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
+            if [ -n "$PREV_TAG" ]; then
+              RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
+            else
+              RANGE="$GITHUB_REF_NAME"
+            fi
+
+            NOTES=$(git log "$RANGE" --pretty=format:"* %s (%h)" -- "$PACKAGE_DIR/")
+            if [ -z "$NOTES" ]; then
+              NOTES="* No changes to $PACKAGE_DIR in this release"
+            fi
+            printf '%s\n' "$NOTES" > release-notes.md
+          }
+
+          CHANGELOG_PATH="$PACKAGE_DIR/CHANGELOG.md"
+          if [ -f scripts/extract-changelog.mjs ] && [ -f "$CHANGELOG_PATH" ]; then
+            error_log=release-notes-error.log
+            if ! node scripts/extract-changelog.mjs "$CHANGELOG_PATH" > release-notes.md 2>"$error_log"; then
+              echo "Failed to extract changelog entry; falling back to scoped git log:" >&2
+              cat "$error_log" >&2
+              generate_fallback_notes
+            fi
+            rm -f "$error_log"
+          else
+            generate_fallback_notes
+          fi
+
+      - name: Create GitHub Release
+        run: gh release create "$GITHUB_REF_NAME" --title "$PACKAGE_TITLE $TAG_VERSION" --notes-file release-notes.md
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-start-git-work.yml
+++ b/.github/workflows/publish-start-git-work.yml
@@ -12,93 +12,12 @@ concurrency:
   group: publish-${{ github.workflow }}
   cancel-in-progress: false
 
-env:
-  PACKAGE_DIR: packages/start-git-work
-  PACKAGE_TITLE: DevDocket Start Git Work
-  TAG_PREFIX: start-git-work-v
-
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Build workspace
-        run: npm run build
-
-      - name: Verify tag version matches package.json
-        run: |
-          TAG_VERSION="${GITHUB_REF_NAME#${TAG_PREFIX}}"
-          PACKAGE_NAME=$(node -p "require('./${PACKAGE_DIR}/package.json').name")
-          PKG_VERSION=$(node -p "require('./${PACKAGE_DIR}/package.json').version")
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
-            echo "Tag version ($TAG_VERSION) does not match package.json version ($PKG_VERSION)"
-            exit 1
-          fi
-          echo "TAG_VERSION=$TAG_VERSION" >> "$GITHUB_ENV"
-          echo "PACKAGE_NAME=$PACKAGE_NAME" >> "$GITHUB_ENV"
-          echo "VSIX_PATH=$PACKAGE_NAME-$TAG_VERSION.vsix" >> "$GITHUB_ENV"
-
-      - name: Validate marketplace token
-        run: |
-          if [ -z "$VSCE_PAT" ]; then
-            echo "The VSCE_PAT repository secret is required to publish to the VS Code Marketplace."
-            exit 1
-          fi
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-
-      - name: Package extension
-        working-directory: ${{ env.PACKAGE_DIR }}
-        run: npx --yes @vscode/vsce package --allow-missing-repository --out "$VSIX_PATH"
-
-      - name: Publish extension
-        working-directory: ${{ env.PACKAGE_DIR }}
-        run: npx --yes @vscode/vsce publish --packagePath "$VSIX_PATH"
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-
-      - name: Generate release notes
-        run: |
-          generate_fallback_notes() {
-            PREV_TAG=$(git tag -l "${TAG_PREFIX}*" --sort=-v:refname | grep -vFx "${GITHUB_REF_NAME}" | head -n1)
-            if [ -n "$PREV_TAG" ]; then
-              RANGE="${PREV_TAG}..${GITHUB_REF_NAME}"
-            else
-              RANGE="$GITHUB_REF_NAME"
-            fi
-
-            NOTES=$(git log "$RANGE" --pretty=format:"* %s (%h)" -- "$PACKAGE_DIR/")
-            if [ -z "$NOTES" ]; then
-              NOTES="* No changes to $PACKAGE_DIR in this release"
-            fi
-            printf '%s\n' "$NOTES" > release-notes.md
-          }
-
-          CHANGELOG_PATH="$PACKAGE_DIR/CHANGELOG.md"
-          if [ -f scripts/extract-changelog.mjs ] && [ -f "$CHANGELOG_PATH" ]; then
-            error_log=release-notes-error.log
-            if ! node scripts/extract-changelog.mjs "$CHANGELOG_PATH" > release-notes.md 2>"$error_log"; then
-              echo "Failed to extract changelog entry; falling back to scoped git log:" >&2
-              cat "$error_log" >&2
-              generate_fallback_notes
-            fi
-            rm -f "$error_log"
-          else
-            generate_fallback_notes
-          fi
-
-      - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" --title "$PACKAGE_TITLE $TAG_VERSION" --notes-file release-notes.md
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/_publish-vscode-extension.yml
+    with:
+      package-directory: packages/start-git-work
+      package-title: DevDocket Start Git Work
+      tag-prefix: start-git-work-v
+    secrets:
+      VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/publish-start-git-work.yml
+++ b/.github/workflows/publish-start-git-work.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 concurrency:
   group: publish-${{ github.workflow }}
@@ -19,5 +20,3 @@ jobs:
       package-directory: packages/start-git-work
       package-title: DevDocket Start Git Work
       tag-prefix: start-git-work-v
-    secrets:
-      VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/packages/ado/.vscodeignore
+++ b/packages/ado/.vscodeignore
@@ -6,4 +6,7 @@ node_modules/**
 tsconfig.json
 vitest.config.ts
 eslint.config.mjs
-**/*.map
+dist/*.map
+webview-dist/*.map
+!dist/extension.js
+!webview-dist/*.js

--- a/packages/ai-reviewer/.vscodeignore
+++ b/packages/ai-reviewer/.vscodeignore
@@ -6,4 +6,7 @@ node_modules/**
 tsconfig.json
 vitest.config.ts
 eslint.config.mjs
-**/*.map
+dist/*.map
+webview-dist/*.map
+!dist/extension.js
+!webview-dist/*.js

--- a/packages/core/.vscodeignore
+++ b/packages/core/.vscodeignore
@@ -6,4 +6,7 @@ node_modules/**
 tsconfig.json
 vitest.config.ts
 eslint.config.mjs
-**/*.map
+dist/*.map
+webview-dist/*.map
+!dist/extension.js
+!webview-dist/*.js

--- a/packages/github/.vscodeignore
+++ b/packages/github/.vscodeignore
@@ -6,4 +6,7 @@ node_modules/**
 tsconfig.json
 vitest.config.ts
 eslint.config.mjs
-**/*.map
+dist/*.map
+webview-dist/*.map
+!dist/extension.js
+!webview-dist/*.js

--- a/packages/start-git-work/.vscodeignore
+++ b/packages/start-git-work/.vscodeignore
@@ -6,4 +6,7 @@ node_modules/**
 tsconfig.json
 vitest.config.ts
 eslint.config.mjs
-**/*.map
+dist/*.map
+webview-dist/*.map
+!dist/extension.js
+!webview-dist/*.js


### PR DESCRIPTION
## Summary

- Add one tag-triggered VS Code Marketplace publish workflow for each publishable extension package: core, GitHub, Azure DevOps, Start Git Work, and AI Reviewer.
- Route those package-specific workflows through a reusable publish workflow that builds shared, builds/tests the target extension workspace, packages/publishes with `@vscode/vsce`, and creates a GitHub Release.
- Authenticate to the VS Code Marketplace via **Microsoft Entra ID + GitHub Actions OIDC** (no long-lived PAT). This aligns with [Microsoft's global PAT deprecation](https://aka.ms/GlobalPATDeprecation) (global PATs decommissioned Dec 1, 2026).
- Generate package-scoped release notes from Changesets changelogs when PR #452's extraction script is available, with a scoped git-log fallback that works before PR #452 lands.
- Ensure VSIX packaging includes built extension outputs while avoiding monorepo workspace dependency traversal.

## Validation

- `npm run build`
- `npm run test`
- Workflow YAML parsed with Python/PyYAML
- `npx --yes prettier --check .github\workflows\_publish-vscode-extension.yml .github\workflows\publish-ado.yml .github\workflows\publish-ai-reviewer.yml .github\workflows\publish-core.yml .github\workflows\publish-github.yml .github\workflows\publish-start-git-work.yml`
- `npx --yes @vscode/vsce ls --no-dependencies` from `packages/core` and `packages/github` to confirm built outputs are included and maps are excluded
- `superpowers:code-reviewer` review clean
- Copilot PR review comments addressed

## Notes for maintainers

This builds on PR #452's Changesets tag conventions and workflow filename detection. It can merge independently because the reusable workflow falls back to scoped git-log release notes when `scripts/extract-changelog.mjs` is not present, but it may need a merge from `dev` after PR #452 lands to pick up the final Changesets workflow/scripts.

### Required one-time Entra ID / Marketplace setup

Tag-triggered publishing requires Microsoft Entra ID federated credentials and a Marketplace publisher membership. Complete these steps **before** pushing the first release tag:

1. **Register an Entra ID application** in your tenant (Azure Portal → Microsoft Entra ID → App registrations → New registration). Single-tenant is fine.
2. **Add a federated credential** to the app (Certificates & secrets → Federated credentials → Add):
   - Issuer: `https://token.actions.githubusercontent.com`
   - Subject: `repo:devdocket/devdocket:environment:marketplace-publish`
   - Audience: `api://AzureADTokenExchange`
3. **Add the app's service principal as a member of the `devdocket` Marketplace publisher** at <https://marketplace.visualstudio.com/manage/publishers/devdocket> with the **Contributor** role (or higher). The portal accepts the SP by its Entra object ID.
4. **Create the GitHub Environment `marketplace-publish`** in repo Settings → Environments. Recommended protections:
   - Required reviewers: at least one maintainer
   - Deployment branch and tag rules: restrict to selected tag patterns (`shared-v*`, `core-v*`, `github-v*`, `ado-v*`, `start-git-work-v*`, `ai-reviewer-v*`)
5. **Set repository variables** (Settings → Secrets and variables → Actions → Variables):
   - `AZURE_PUBLISH_CLIENT_ID` — the Entra app's Application (client) ID
   - `AZURE_PUBLISH_TENANT_ID` — the Entra tenant ID

No long-lived secrets are stored. The previous `VSCE_PAT` repository secret can be removed once any in-flight PAT-based runs have completed.

Closes #409
