### PR TITLE
Add repository folder picker to Start Git Work

### DIFF
--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -73,6 +73,12 @@ type ResolvedGitWork = GitWorkInfo & { cloneUrl: string; ref: string };
 
 type WorkMode = 'checkout' | 'worktree';
 
+type RepoPathPick = vscode.QuickPickItem & (
+  | { kind: 'repo'; repoPath: string }
+  | { kind: 'paste' }
+  | { kind: 'browse' }
+);
+
 interface PrBranchInfo {
   branchName: string;
   /** Remote tracking ref when branch is on a non-origin remote (e.g. "devdocket-fork-contributor/fix-bug"). */
@@ -794,37 +800,107 @@ export class StartWorkAction implements DevDocketAction {
   }
 
   /**
-   * Prompts the user for a local repo path, pre-filling the last-used path for this repo.
+   * Prompts the user for a local repo path, offering cached and open workspace repositories first.
    * Caches the selection on success. Does not cache on cancel, empty input, or invalid path.
    */
   private async promptForRepoPath(repoKey: string): Promise<string | undefined> {
     const cacheKey = `repoPath:${repoKey}`;
-    const cachedPath = this.globalState.get<string>(cacheKey);
+    const cachedPath = this.globalState.get<string>(cacheKey)?.trim();
+    let validationMessage: string | undefined;
 
-    const selectedPath = await vscode.window.showInputBox({
-      prompt: `Enter the local path to the git repository for ${repoKey}`,
-      value: cachedPath ?? '',
-      ignoreFocusOut: true,
+    while (true) {
+      const selected = await vscode.window.showQuickPick(
+        this.createRepoPathPicks(cachedPath),
+        {
+          placeHolder: validationMessage ?? `Select the local repository for ${repoKey}`,
+          ignoreFocusOut: true,
+        },
+      );
+
+      if (!selected) {
+        return undefined;
+      }
+
+      const selectedPath = await this.resolveRepoPathPick(selected, cachedPath, repoKey);
+      if (selectedPath === undefined) {
+        return undefined;
+      }
+
+      const validationError = this.validateRepoPath(selectedPath);
+      if (validationError) {
+        validationMessage = validationError;
+        continue;
+      }
+
+      await this.globalState.update(cacheKey, selectedPath);
+      return selectedPath;
+    }
+  }
+
+  private createRepoPathPicks(cachedPath: string | undefined): RepoPathPick[] {
+    const picks: RepoPathPick[] = [];
+    const addRepoPath = (repoPath: string, description: string) => {
+      if (picks.some(pick => pick.kind === 'repo' && path.normalize(pick.repoPath) === path.normalize(repoPath))) {
+        return;
+      }
+      picks.push({ label: repoPath, description, kind: 'repo', repoPath });
+    };
+
+    if (cachedPath) {
+      addRepoPath(cachedPath, 'Last used');
+    }
+
+    for (const folder of vscode.workspace.workspaceFolders ?? []) {
+      const folderPath = folder.uri.fsPath;
+      if (fs.existsSync(path.join(folderPath, '.git'))) {
+        addRepoPath(folderPath, 'Open workspace folder');
+      }
+    }
+
+    picks.push({ label: 'Paste path…', description: 'Enter a repository path manually', kind: 'paste' });
+    picks.push({ label: 'Browse…', description: 'Choose a repository folder', kind: 'browse' });
+    return picks;
+  }
+
+  private async resolveRepoPathPick(
+    selected: RepoPathPick,
+    cachedPath: string | undefined,
+    repoKey: string,
+  ): Promise<string | undefined> {
+    if (selected.kind === 'repo') {
+      return selected.repoPath.trim();
+    }
+
+    if (selected.kind === 'paste') {
+      const pastedPath = await vscode.window.showInputBox({
+        prompt: `Enter the local path to the git repository for ${repoKey}`,
+        value: cachedPath ?? '',
+        ignoreFocusOut: true,
+      });
+      return pastedPath?.trim();
+    }
+
+    const selectedFolders = await vscode.window.showOpenDialog({
+      canSelectFolders: true,
+      canSelectFiles: false,
+      canSelectMany: false,
+      openLabel: 'Select Repository Folder',
+      title: `Select local repository for ${repoKey}`,
     });
+    return selectedFolders?.[0]?.fsPath.trim();
+  }
 
-    if (selectedPath === undefined) {
-      return undefined;
+  private validateRepoPath(repoPath: string): string | undefined {
+    if (!repoPath) {
+      return 'Choose a repository folder or paste an absolute path.';
     }
-
-    const trimmedPath = selectedPath.trim();
-    if (!trimmedPath) {
-      void vscode.window.showErrorMessage('DevDocket: No repository path provided.');
-      return undefined;
+    if (!path.isAbsolute(repoPath)) {
+      return `"${repoPath}" is not an absolute path. Choose a repository folder.`;
     }
-
-    const gitPath = path.join(trimmedPath, '.git');
-    if (!fs.existsSync(gitPath)) {
-      void vscode.window.showErrorMessage(`DevDocket: "${trimmedPath}" is not a git repository.`);
-      return undefined;
+    if (!fs.existsSync(path.join(repoPath, '.git'))) {
+      return `"${repoPath}" does not contain a .git directory. Choose a repository folder.`;
     }
-
-    await this.globalState.update(cacheKey, trimmedPath);
-    return trimmedPath;
+    return undefined;
   }
 
   /**

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -898,7 +898,7 @@ export class StartWorkAction implements DevDocketAction {
       return `"${repoPath}" is not an absolute path. Choose a repository folder.`;
     }
     if (!fs.existsSync(path.join(repoPath, '.git'))) {
-      return `"${repoPath}" does not contain a .git directory. Choose a repository folder.`;
+      return `"${repoPath}" does not contain git metadata. Choose a repository folder.`;
     }
     return undefined;
   }

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -857,7 +857,7 @@ export class StartWorkAction implements DevDocketAction {
       }
     }
 
-    picks.push({ label: 'Paste path…', description: 'Enter a repository path manually', pickKind: 'paste' });
+    picks.push({ label: 'Enter path manually…', description: 'Type or paste a repository path', pickKind: 'paste' });
     picks.push({ label: 'Browse…', description: 'Choose a repository folder', pickKind: 'browse' });
     return picks;
   }

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -74,9 +74,9 @@ type ResolvedGitWork = GitWorkInfo & { cloneUrl: string; ref: string };
 type WorkMode = 'checkout' | 'worktree';
 
 type RepoPathPick = vscode.QuickPickItem & (
-  | { kind: 'repo'; repoPath: string }
-  | { kind: 'paste' }
-  | { kind: 'browse' }
+  | { pickKind: 'repo'; repoPath: string }
+  | { pickKind: 'paste' }
+  | { pickKind: 'browse' }
 );
 
 interface PrBranchInfo {
@@ -840,10 +840,10 @@ export class StartWorkAction implements DevDocketAction {
   private createRepoPathPicks(cachedPath: string | undefined): RepoPathPick[] {
     const picks: RepoPathPick[] = [];
     const addRepoPath = (repoPath: string, description: string) => {
-      if (picks.some(pick => pick.kind === 'repo' && this.pathsEqual(pick.repoPath, repoPath))) {
+      if (picks.some(pick => pick.pickKind === 'repo' && this.pathsEqual(pick.repoPath, repoPath))) {
         return;
       }
-      picks.push({ label: repoPath, description, kind: 'repo', repoPath });
+      picks.push({ label: repoPath, description, pickKind: 'repo', repoPath });
     };
 
     if (cachedPath) {
@@ -857,8 +857,8 @@ export class StartWorkAction implements DevDocketAction {
       }
     }
 
-    picks.push({ label: 'Paste path…', description: 'Enter a repository path manually', kind: 'paste' });
-    picks.push({ label: 'Browse…', description: 'Choose a repository folder', kind: 'browse' });
+    picks.push({ label: 'Paste path…', description: 'Enter a repository path manually', pickKind: 'paste' });
+    picks.push({ label: 'Browse…', description: 'Choose a repository folder', pickKind: 'browse' });
     return picks;
   }
 
@@ -867,11 +867,11 @@ export class StartWorkAction implements DevDocketAction {
     cachedPath: string | undefined,
     repoKey: string,
   ): Promise<string | undefined> {
-    if (selected.kind === 'repo') {
+    if (selected.pickKind === 'repo') {
       return selected.repoPath.trim();
     }
 
-    if (selected.kind === 'paste') {
+    if (selected.pickKind === 'paste') {
       const pastedPath = await vscode.window.showInputBox({
         prompt: `Enter the local path to the git repository for ${repoKey}`,
         value: cachedPath ?? '',

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -840,7 +840,7 @@ export class StartWorkAction implements DevDocketAction {
   private createRepoPathPicks(cachedPath: string | undefined): RepoPathPick[] {
     const picks: RepoPathPick[] = [];
     const addRepoPath = (repoPath: string, description: string) => {
-      if (picks.some(pick => pick.kind === 'repo' && path.normalize(pick.repoPath) === path.normalize(repoPath))) {
+      if (picks.some(pick => pick.kind === 'repo' && this.pathsEqual(pick.repoPath, repoPath))) {
         return;
       }
       picks.push({ label: repoPath, description, kind: 'repo', repoPath });

--- a/packages/start-git-work/src/test/__mocks__/vscode.ts
+++ b/packages/start-git-work/src/test/__mocks__/vscode.ts
@@ -50,6 +50,7 @@ const window = {
   showWarningMessage: vi.fn(),
   showErrorMessage: vi.fn(),
   showQuickPick: vi.fn(),
+  showOpenDialog: vi.fn(),
   withProgress: vi.fn(async (_options: any, task: Function) => task({ report: vi.fn() })),
   registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })),
   createWebviewPanel: vi.fn(),

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -79,14 +79,22 @@ function mockInputBox(repoPath: string | undefined, baseBranch = 'origin/dev') {
   });
 }
 
+function isRepoPathPickItems(items: unknown): items is Array<{ kind?: string; repoPath?: string }> {
+  return Array.isArray(items) && items.some(item => ['repo', 'paste', 'browse'].includes((item as { kind?: string }).kind ?? ''));
+}
+
+function isWorkModePickItems(items: unknown): boolean {
+  return Array.isArray(items) && items.some(item => ['checkout', 'worktree'].includes((item as { value?: string }).value ?? ''));
+}
+
 function mockQuickPicks(repoPath = '/mock/workspace', workMode: 'checkout' | 'worktree' = 'worktree') {
-  vi.mocked(window.showQuickPick).mockImplementation(async (items: any, options: any) => {
-    if (options?.placeHolder?.includes('local repository') || options?.placeHolder?.includes('repository folder')) {
-      return items.find((item: any) => item.kind === 'repo' && item.repoPath === repoPath)
-        ?? items.find((item: any) => item.kind === 'repo')
+  vi.mocked(window.showQuickPick).mockImplementation(async (items: any) => {
+    if (isRepoPathPickItems(items)) {
+      return items.find(item => item.kind === 'repo' && item.repoPath === repoPath)
+        ?? items.find(item => item.kind === 'repo')
         ?? undefined;
     }
-    if (options?.placeHolder?.includes('How would')) {
+    if (isWorkModePickItems(items)) {
       return {
         label: workMode === 'worktree' ? 'Create worktree' : 'Checkout branch',
         value: workMode,
@@ -210,11 +218,11 @@ describe('StartWorkAction', () => {
     });
 
     it('uses the selected folder from Browse for the repository path', async () => {
-      vi.mocked(window.showQuickPick).mockImplementation(async (items: any, options: any) => {
-        if (options?.placeHolder?.includes('local repository')) {
-          return items.find((item: any) => item.kind === 'browse');
+      vi.mocked(window.showQuickPick).mockImplementation(async (items: any) => {
+        if (isRepoPathPickItems(items)) {
+          return items.find(item => item.kind === 'browse');
         }
-        if (options?.placeHolder?.includes('How would')) {
+        if (isWorkModePickItems(items)) {
           return { label: 'Create worktree', value: 'worktree' } as any;
         }
         return undefined;
@@ -236,11 +244,11 @@ describe('StartWorkAction', () => {
     });
 
     it('keeps paste path as a legacy fallback', async () => {
-      vi.mocked(window.showQuickPick).mockImplementation(async (items: any, options: any) => {
-        if (options?.placeHolder?.includes('local repository')) {
-          return items.find((item: any) => item.kind === 'paste');
+      vi.mocked(window.showQuickPick).mockImplementation(async (items: any) => {
+        if (isRepoPathPickItems(items)) {
+          return items.find(item => item.kind === 'paste');
         }
-        if (options?.placeHolder?.includes('How would')) {
+        if (isWorkModePickItems(items)) {
           return { label: 'Create worktree', value: 'worktree' } as any;
         }
         return undefined;
@@ -268,14 +276,12 @@ describe('StartWorkAction', () => {
       memento._store.set('repoPath:acme/repo', '/invalid/repo');
       (workspace as any).workspaceFolders = [{ uri: { fsPath: '/valid/repo' } }];
       vi.mocked(fs.existsSync).mockImplementation((p: any) => p.toString().replace(/\\/g, '/').endsWith('/valid/repo/.git'));
-      vi.mocked(window.showQuickPick).mockImplementation(async (items: any, options: any) => {
-        if (options?.placeHolder?.includes('local repository')) {
-          return items.find((item: any) => item.kind === 'repo' && item.repoPath === '/invalid/repo');
+      vi.mocked(window.showQuickPick).mockImplementation(async (items: any) => {
+        if (isRepoPathPickItems(items)) {
+          const repoPick = vi.mocked(window.showQuickPick).mock.calls.length === 1 ? '/invalid/repo' : '/valid/repo';
+          return items.find(item => item.kind === 'repo' && item.repoPath === repoPick);
         }
-        if (options?.placeHolder?.includes('does not contain a .git directory')) {
-          return items.find((item: any) => item.kind === 'repo' && item.repoPath === '/valid/repo');
-        }
-        if (options?.placeHolder?.includes('How would')) {
+        if (isWorkModePickItems(items)) {
           return { label: 'Create worktree', value: 'worktree' } as any;
         }
         return undefined;

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -211,7 +211,7 @@ describe('StartWorkAction', () => {
       expect(repoPickItems.map(item => item.label)).toEqual([
         '/cached/repo',
         '/workspace/repo',
-        'Paste path…',
+        'Enter path manually…',
         'Browse…',
       ]);
       expect(memento.update).toHaveBeenCalledWith('repoPath:acme/repo', '/workspace/repo');
@@ -243,7 +243,7 @@ describe('StartWorkAction', () => {
       expect(memento.update).toHaveBeenCalledWith('repoPath:acme/repo', '/chosen/repo');
     });
 
-    it('keeps paste path as a legacy fallback', async () => {
+    it('keeps manual entry as a legacy fallback', async () => {
       vi.mocked(window.showQuickPick).mockImplementation(async (items: any) => {
         if (isRepoPathPickItems(items)) {
           return items.find(item => item.pickKind === 'paste');

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -79,8 +79,21 @@ function mockInputBox(repoPath: string | undefined, baseBranch = 'origin/dev') {
   });
 }
 
-function mockQuickPickWorktree() {
-  vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Create worktree', value: 'worktree' } as any);
+function mockQuickPicks(repoPath = '/mock/workspace', workMode: 'checkout' | 'worktree' = 'worktree') {
+  vi.mocked(window.showQuickPick).mockImplementation(async (items: any, options: any) => {
+    if (options?.placeHolder?.includes('local repository') || options?.placeHolder?.includes('repository folder')) {
+      return items.find((item: any) => item.kind === 'repo' && item.repoPath === repoPath)
+        ?? items.find((item: any) => item.kind === 'repo')
+        ?? undefined;
+    }
+    if (options?.placeHolder?.includes('How would')) {
+      return {
+        label: workMode === 'worktree' ? 'Create worktree' : 'Checkout branch',
+        value: workMode,
+      } as any;
+    }
+    return undefined;
+  });
 }
 
 function mockNoLocalBranch(remoteOutput = ORIGIN_REMOTE_V) {
@@ -100,8 +113,9 @@ function mockNoLocalBranch(remoteOutput = ORIGIN_REMOTE_V) {
 describe('StartWorkAction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    (workspace as any).workspaceFolders = [{ uri: { fsPath: '/mock/workspace' } }];
     mockInputBox('/mock/workspace');
-    mockQuickPickWorktree();
+    mockQuickPicks();
     vi.mocked(workspace.getConfiguration).mockReturnValue({
       get: vi.fn((key: string, defaultValue?: any) => defaultValue),
     } as any);
@@ -168,6 +182,110 @@ describe('StartWorkAction', () => {
         'worktree', 'add', path.join('/mock', 'workspace-vendor-ABC-123-ABC-123'), 'vendor/ABC-123',
       ]);
       expect(memento.update).toHaveBeenCalledWith('repoPath:Vendor Repo', '/mock/workspace');
+    });
+
+    it('offers cached and git workspace folders before paste and browse choices', async () => {
+      (workspace as any).workspaceFolders = [
+        { uri: { fsPath: '/workspace/repo' } },
+        { uri: { fsPath: '/workspace/not-git' } },
+      ];
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => p.toString().replace(/\\/g, '/').endsWith('/workspace/repo/.git'));
+      mockQuickPicks('/workspace/repo');
+      const item = createWorkItem();
+      const { action, memento } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+      memento._store.set('repoPath:acme/repo', '/cached/repo');
+
+      await action.run(item);
+
+      const repoPickItems = vi.mocked(window.showQuickPick).mock.calls[0]![0] as any[];
+      expect(repoPickItems.map(item => item.label)).toEqual([
+        '/cached/repo',
+        '/workspace/repo',
+        'Paste path…',
+        'Browse…',
+      ]);
+      expect(memento.update).toHaveBeenCalledWith('repoPath:acme/repo', '/workspace/repo');
+    });
+
+    it('uses the selected folder from Browse for the repository path', async () => {
+      vi.mocked(window.showQuickPick).mockImplementation(async (items: any, options: any) => {
+        if (options?.placeHolder?.includes('local repository')) {
+          return items.find((item: any) => item.kind === 'browse');
+        }
+        if (options?.placeHolder?.includes('How would')) {
+          return { label: 'Create worktree', value: 'worktree' } as any;
+        }
+        return undefined;
+      });
+      vi.mocked(window.showOpenDialog).mockResolvedValue([{ fsPath: '/chosen/repo' }] as any);
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => p.toString().replace(/\\/g, '/').endsWith('/chosen/repo/.git'));
+      const item = createWorkItem();
+      const { action, memento } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(window.showOpenDialog).toHaveBeenCalledWith(expect.objectContaining({
+        canSelectFolders: true,
+        canSelectFiles: false,
+      }));
+      expect(memento.update).toHaveBeenCalledWith('repoPath:acme/repo', '/chosen/repo');
+    });
+
+    it('keeps paste path as a legacy fallback', async () => {
+      vi.mocked(window.showQuickPick).mockImplementation(async (items: any, options: any) => {
+        if (options?.placeHolder?.includes('local repository')) {
+          return items.find((item: any) => item.kind === 'paste');
+        }
+        if (options?.placeHolder?.includes('How would')) {
+          return { label: 'Create worktree', value: 'worktree' } as any;
+        }
+        return undefined;
+      });
+      mockInputBox('/pasted/repo');
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => p.toString().replace(/\\/g, '/').endsWith('/pasted/repo/.git'));
+      const item = createWorkItem();
+      const { action, memento } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(window.showInputBox).toHaveBeenCalledWith(expect.objectContaining({
+        prompt: 'Enter the local path to the git repository for acme/repo',
+      }));
+      expect(memento.update).toHaveBeenCalledWith('repoPath:acme/repo', '/pasted/repo');
+    });
+
+    it('re-prompts instead of erroring when the picked path is not a git repository', async () => {
+      const item = createWorkItem();
+      const { action, memento } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+      memento._store.set('repoPath:acme/repo', '/invalid/repo');
+      (workspace as any).workspaceFolders = [{ uri: { fsPath: '/valid/repo' } }];
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => p.toString().replace(/\\/g, '/').endsWith('/valid/repo/.git'));
+      vi.mocked(window.showQuickPick).mockImplementation(async (items: any, options: any) => {
+        if (options?.placeHolder?.includes('local repository')) {
+          return items.find((item: any) => item.kind === 'repo' && item.repoPath === '/invalid/repo');
+        }
+        if (options?.placeHolder?.includes('does not contain a .git directory')) {
+          return items.find((item: any) => item.kind === 'repo' && item.repoPath === '/valid/repo');
+        }
+        if (options?.placeHolder?.includes('How would')) {
+          return { label: 'Create worktree', value: 'worktree' } as any;
+        }
+        return undefined;
+      });
+
+      await action.run(item);
+
+      expect(window.showErrorMessage).not.toHaveBeenCalled();
+      expect(window.showQuickPick).toHaveBeenCalledTimes(3);
+      expect(memento.update).toHaveBeenCalledWith('repoPath:acme/repo', '/valid/repo');
     });
 
     it('uses headCloneUrl when a PR supplies one', async () => {
@@ -390,7 +508,7 @@ describe('StartWorkAction', () => {
     });
 
     it('aborts checkout when the working tree is dirty and the user cancels', async () => {
-      vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Checkout branch', value: 'checkout' } as any);
+      mockQuickPicks('/mock/workspace', 'checkout');
       vi.mocked(window.showWarningMessage).mockResolvedValue(undefined as any);
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         if (args[0] === 'status') {
@@ -415,7 +533,7 @@ describe('StartWorkAction', () => {
     });
 
     it('checks out an existing same-repo PR branch directly', async () => {
-      vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Checkout branch', value: 'checkout' } as any);
+      mockQuickPicks('/mock/workspace', 'checkout');
       vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
         if (args[0] === 'remote' && args[1] === '-v') {
           cb(null, ORIGIN_REMOTE_V, '');
@@ -672,7 +790,7 @@ describe('StartWorkAction', () => {
       });
 
       it('shows error in checkout mode when same-repo PR branch is held by another worktree', async () => {
-        vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Checkout branch', value: 'checkout' } as any);
+        mockQuickPicks('/mock/workspace', 'checkout');
         vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
           if (args[0] === 'remote' && args[1] === '-v') {
             cb(null, ORIGIN_REMOTE_V, '');
@@ -716,7 +834,7 @@ describe('StartWorkAction', () => {
         // If the user is already on the PR branch in the current worktree,
         // `git checkout <branch>` is a no-op success — the pre-check must NOT
         // block by treating the current worktree as a conflict.
-        vi.mocked(window.showQuickPick).mockResolvedValue({ label: 'Checkout branch', value: 'checkout' } as any);
+        mockQuickPicks('/mock/workspace', 'checkout');
         vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
           if (args[0] === 'remote' && args[1] === '-v') {
             cb(null, ORIGIN_REMOTE_V, '');

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -79,8 +79,8 @@ function mockInputBox(repoPath: string | undefined, baseBranch = 'origin/dev') {
   });
 }
 
-function isRepoPathPickItems(items: unknown): items is Array<{ kind?: string; repoPath?: string }> {
-  return Array.isArray(items) && items.some(item => ['repo', 'paste', 'browse'].includes((item as { kind?: string }).kind ?? ''));
+function isRepoPathPickItems(items: unknown): items is Array<{ pickKind?: string; repoPath?: string }> {
+  return Array.isArray(items) && items.some(item => ['repo', 'paste', 'browse'].includes((item as { pickKind?: string }).pickKind ?? ''));
 }
 
 function isWorkModePickItems(items: unknown): boolean {
@@ -90,8 +90,8 @@ function isWorkModePickItems(items: unknown): boolean {
 function mockQuickPicks(repoPath = '/mock/workspace', workMode: 'checkout' | 'worktree' = 'worktree') {
   vi.mocked(window.showQuickPick).mockImplementation(async (items: any) => {
     if (isRepoPathPickItems(items)) {
-      return items.find(item => item.kind === 'repo' && item.repoPath === repoPath)
-        ?? items.find(item => item.kind === 'repo')
+      return items.find(item => item.pickKind === 'repo' && item.repoPath === repoPath)
+        ?? items.find(item => item.pickKind === 'repo')
         ?? undefined;
     }
     if (isWorkModePickItems(items)) {
@@ -220,7 +220,7 @@ describe('StartWorkAction', () => {
     it('uses the selected folder from Browse for the repository path', async () => {
       vi.mocked(window.showQuickPick).mockImplementation(async (items: any) => {
         if (isRepoPathPickItems(items)) {
-          return items.find(item => item.kind === 'browse');
+          return items.find(item => item.pickKind === 'browse');
         }
         if (isWorkModePickItems(items)) {
           return { label: 'Create worktree', value: 'worktree' } as any;
@@ -246,7 +246,7 @@ describe('StartWorkAction', () => {
     it('keeps paste path as a legacy fallback', async () => {
       vi.mocked(window.showQuickPick).mockImplementation(async (items: any) => {
         if (isRepoPathPickItems(items)) {
-          return items.find(item => item.kind === 'paste');
+          return items.find(item => item.pickKind === 'paste');
         }
         if (isWorkModePickItems(items)) {
           return { label: 'Create worktree', value: 'worktree' } as any;
@@ -279,7 +279,7 @@ describe('StartWorkAction', () => {
       vi.mocked(window.showQuickPick).mockImplementation(async (items: any) => {
         if (isRepoPathPickItems(items)) {
           const repoPick = vi.mocked(window.showQuickPick).mock.calls.length === 1 ? '/invalid/repo' : '/valid/repo';
-          return items.find(item => item.kind === 'repo' && item.repoPath === repoPick);
+          return items.find(item => item.pickKind === 'repo' && item.repoPath === repoPick);
         }
         if (isWorkModePickItems(items)) {
           return { label: 'Create worktree', value: 'worktree' } as any;


### PR DESCRIPTION
Summary:
- Replaces the Start Git Work repository path input with cached/workspace quick-pick choices.
- Adds Browse and Paste path options with inline repository validation and re-prompting.
- Covers picker ordering, browse, paste, and invalid-path retry behavior in tests.

Tests:
- npm run build
- npm run test

Closes #540
