### PR TITLE
Add undo for dismissing incoming items

### DIFF
--- a/packages/core/src/test/incomingPreviewPanel.test.ts
+++ b/packages/core/src/test/incomingPreviewPanel.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { EventEmitter, window } from 'vscode';
+import { IncomingPreviewPanel } from '../views/incomingPreviewPanel';
+
+type MessageHandler = (message: unknown) => void | Promise<void>;
+type DisposeHandler = () => void;
+
+function createMockWebviewPanel() {
+  let messageHandler: MessageHandler | undefined;
+  let disposeHandler: DisposeHandler | undefined;
+  const panel = {
+    title: '',
+    webview: {
+      html: '',
+      cspSource: 'mock-csp-source',
+      asWebviewUri: vi.fn((uri: { fsPath?: string; path?: string; toString?: () => string }) => ({
+        toString: () => `webview-resource:${uri.fsPath ?? uri.path ?? uri.toString?.() ?? ''}`,
+      })),
+      onDidReceiveMessage: vi.fn((handler: MessageHandler) => {
+        messageHandler = handler;
+        return { dispose: vi.fn(() => { messageHandler = undefined; }) };
+      }),
+      postMessage: vi.fn(async () => true),
+    },
+    onDidDispose: vi.fn((handler: DisposeHandler) => {
+      disposeHandler = handler;
+      return { dispose: vi.fn() };
+    }),
+    dispose: vi.fn(),
+    reveal: vi.fn(),
+  };
+
+  return {
+    panel,
+    simulateMessage: (message: unknown) => messageHandler?.(message) ?? Promise.resolve(),
+    simulateDispose: () => disposeHandler?.(),
+  };
+}
+
+function createMockProviderRegistry(discoveredByProvider: Record<string, any[]>) {
+  const changeEmitter = new EventEmitter<void>();
+  return {
+    getProviderItems: vi.fn((providerId: string) => discoveredByProvider[providerId] ?? []),
+    getAllProviderItems: vi.fn(() => new Map(Object.entries(discoveredByProvider))),
+    getProviderLabel: vi.fn((providerId: string) => providerId === 'github' ? 'GitHub' : providerId),
+    onDidChangeProviderItems: changeEmitter.event,
+  };
+}
+
+function createMockStateStore() {
+  const changeEmitter = new EventEmitter<void>();
+  const states = new Map<string, string>();
+  return {
+    getState: vi.fn((providerId: string, externalId: string) => states.get(`${providerId}::${externalId}`)),
+    setState: vi.fn(async (providerId: string, externalId: string, state: string) => {
+      states.set(`${providerId}::${externalId}`, state);
+      changeEmitter.fire();
+    }),
+    onDidChange: changeEmitter.event,
+  };
+}
+
+function createMockReadStateStore() {
+  return {
+    add: vi.fn(async () => true),
+  };
+}
+
+function createMockWorkGraph() {
+  return {
+    getAll: vi.fn(() => []),
+    getItem: vi.fn(() => undefined),
+    findItemByProvenance: vi.fn(() => undefined),
+    createItem: vi.fn(async (input: { title: string; description?: string }, provenance?: { providerId: string; externalId: string; url?: string; group?: string }) => ({
+      id: 'created-1',
+      title: input.title,
+      description: input.description,
+      providerId: provenance?.providerId,
+      externalId: provenance?.externalId,
+      url: provenance?.url,
+      group: provenance?.group,
+    })),
+  };
+}
+
+function createMockContext() {
+  return {
+    extensionUri: vscode.Uri.file(process.cwd()),
+    subscriptions: [],
+  };
+}
+
+describe('IncomingPreviewPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('offers undo when dismissing a preview item', async () => {
+    const mockPanel = createMockWebviewPanel();
+    vi.mocked(window.createWebviewPanel).mockReturnValue(mockPanel.panel as any);
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValueOnce('Undo' as any);
+    const stateStore = createMockStateStore();
+
+    IncomingPreviewPanel.open(
+      createMockContext() as any,
+      createMockProviderRegistry({
+        github: [{ externalId: 'preview-1', title: 'Preview item', description: 'Details' }],
+      }) as any,
+      stateStore as any,
+      createMockReadStateStore() as any,
+      createMockWorkGraph() as any,
+      'github',
+      'preview-1',
+    );
+
+    await mockPanel.simulateMessage({ type: 'dismissItem' });
+
+    await vi.waitFor(() => {
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'preview-1', 'dismissed');
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Dismissed "Preview item"', 'Undo');
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'preview-1', 'unseen');
+    });
+  });
+});

--- a/packages/core/src/test/itemCard.test.ts
+++ b/packages/core/src/test/itemCard.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { getItemActionClassName } from '../webview/sidebar/components/ItemCard';
+
+describe('ItemCard', () => {
+  it('visually distinguishes only the dismiss action', () => {
+    expect(getItemActionClassName('accept')).toBe('item-action-btn');
+    expect(getItemActionClassName('accept-to-focus')).toBe('item-action-btn');
+    expect(getItemActionClassName('dismiss')).toBe('item-action-btn item-action-btn--dismiss');
+  });
+});

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -544,6 +544,52 @@ describe('MainViewProvider', () => {
     expect(workGraph.createItem).not.toHaveBeenCalled();
   });
 
+  it('offers undo when dismissing incoming sidebar items', async () => {
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValueOnce('Undo' as any);
+    const stateStore = createStateStore();
+    const provider = createProvider(
+      createMockWorkGraph(),
+      createProviderRegistry({
+        github: [{ externalId: 'incoming-dismiss', title: 'Incoming dismiss' }],
+      }),
+      stateStore,
+    );
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+
+    await mockView.simulateMessage({ type: 'dismissItem', providerId: 'github', externalId: 'incoming-dismiss' });
+
+    await vi.waitFor(() => {
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'incoming-dismiss', 'dismissed');
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Dismissed "Incoming dismiss"', 'Undo');
+      expect(stateStore.setState).toHaveBeenCalledWith('github', 'incoming-dismiss', 'unseen');
+    });
+  });
+
+  it('does not undo dismiss when the notification is ignored', async () => {
+    vi.mocked(vscode.window.showInformationMessage).mockResolvedValueOnce(undefined);
+    const stateStore = createStateStore();
+    const provider = createProvider(
+      createMockWorkGraph(),
+      createProviderRegistry({
+        github: [{ externalId: 'incoming-dismiss', title: 'Incoming dismiss' }],
+      }),
+      stateStore,
+    );
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+
+    await mockView.simulateMessage({ type: 'dismissItem', providerId: 'github', externalId: 'incoming-dismiss' });
+
+    await vi.waitFor(() => {
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Dismissed "Incoming dismiss"', 'Undo');
+    });
+    expect(stateStore.setState).toHaveBeenCalledWith('github', 'incoming-dismiss', 'dismissed');
+    expect(stateStore.setState).not.toHaveBeenCalledWith('github', 'incoming-dismiss', 'unseen');
+  });
+
   it('routes incoming acceptToFocus messages through the accept-to-focus-from-inbox command', async () => {
     vi.useFakeTimers();
     const workGraph = createMockWorkGraph();

--- a/packages/core/src/views/dismissUndo.ts
+++ b/packages/core/src/views/dismissUndo.ts
@@ -1,0 +1,33 @@
+import * as vscode from 'vscode';
+import type { InboxStateStore } from '../storage/inboxStateStore';
+import { logger } from '../services/logger';
+
+const UNDO_ACTION = 'Undo';
+
+export function showDismissUndoMessage(
+  stateStore: Pick<InboxStateStore, 'setState'>,
+  providerId: string,
+  externalId: string,
+  title: string,
+): void {
+  void (async () => {
+    let selection: string | undefined;
+    try {
+      selection = await vscode.window.showInformationMessage(`Dismissed "${title}"`, UNDO_ACTION);
+    } catch (err) {
+      logger.error('DevDocket: dismiss undo notification failed', err);
+      return;
+    }
+
+    if (selection !== UNDO_ACTION) {
+      return;
+    }
+
+    try {
+      await stateStore.setState(providerId, externalId, 'unseen');
+    } catch (err) {
+      logger.error('DevDocket: dismiss undo failed', err);
+      void vscode.window.showErrorMessage(`Failed to restore item: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  })();
+}

--- a/packages/core/src/views/incomingPreviewPanel.ts
+++ b/packages/core/src/views/incomingPreviewPanel.ts
@@ -7,6 +7,7 @@ import { WorkGraph } from '../services/workGraph';
 import { InboxStateStore } from '../storage/inboxStateStore';
 import { ReadStateStore } from '../storage/readStateStore';
 import { isSafeUrl } from '../utils/url';
+import { showDismissUndoMessage } from './dismissUndo';
 import { getProviderItemKey, parseProviderItemKey } from './providerItemKey';
 import { getEditorPanelHtml, renderMarkdown } from './editorPanelHtml';
 import type { EditorItemData } from './mainTypes';
@@ -209,13 +210,19 @@ export class IncomingPreviewPanel {
   }
 
   private async dismiss(): Promise<void> {
+    let dismissedTitle = this.externalId;
     try {
+      const providerItem = this.findProviderItem();
+      dismissedTitle = providerItem?.title ?? this.externalId;
       await this.stateStore.setState(this.providerId, this.externalId, 'dismissed');
-      this.dispose();
     } catch (err) {
       logger.error('IncomingPreview: dismiss failed', err);
       void vscode.window.showErrorMessage(`Failed to dismiss item: ${err instanceof Error ? err.message : String(err)}`);
+      return;
     }
+
+    this.dispose();
+    showDismissUndoMessage(this.stateStore, this.providerId, this.externalId, dismissedTitle);
   }
 
   /** If the item has been accepted/dismissed elsewhere, close the preview. */

--- a/packages/core/src/views/incomingPreviewPanel.ts
+++ b/packages/core/src/views/incomingPreviewPanel.ts
@@ -210,7 +210,7 @@ export class IncomingPreviewPanel {
   }
 
   private async dismiss(): Promise<void> {
-    let dismissedTitle = this.externalId;
+    let dismissedTitle: string;
     try {
       const providerItem = this.findProviderItem();
       dismissedTitle = providerItem?.title ?? this.externalId;

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -631,7 +631,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
   }
 
   private async handleDismissItem(providerId: string, externalId: string): Promise<void> {
-    let dismissedTitle = externalId;
+    let dismissedTitle: string;
     try {
       const providerItem = this.providerRegistry.getProviderItems(providerId).find(item => item.externalId === externalId);
       dismissedTitle = providerItem?.title ?? externalId;

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -15,6 +15,7 @@ import { ReadStateStore } from '../storage/readStateStore';
 import { isSafeUrl } from '../utils/url';
 import { buildTierColorCss } from '../webview/shared/colors';
 import { buildProviderBadge, buildProviderBadges, buildTypeBadge } from './badges';
+import { showDismissUndoMessage } from './dismissUndo';
 import { getProviderItemKey, parseProviderItemKey } from './providerItemKey';
 import type {
   BadgeData,
@@ -630,12 +631,18 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
   }
 
   private async handleDismissItem(providerId: string, externalId: string): Promise<void> {
+    let dismissedTitle = externalId;
     try {
+      const providerItem = this.providerRegistry.getProviderItems(providerId).find(item => item.externalId === externalId);
+      dismissedTitle = providerItem?.title ?? externalId;
       await this.stateStore.setState(providerId, externalId, 'dismissed');
     } catch (err) {
       logger.error('DevDocket: dismiss failed', err);
       void vscode.window.showErrorMessage(`Failed to dismiss item: ${err instanceof Error ? err.message : String(err)}`);
+      return;
     }
+
+    showDismissUndoMessage(this.stateStore, providerId, externalId, dismissedTitle);
   }
 
   private async handleTransitionState(itemId: string, targetState: string): Promise<void> {
@@ -1242,6 +1249,10 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       cursor: pointer;
       font-size: 18px;
       line-height: 1;
+    }
+    .item-action-btn--dismiss {
+      color: var(--vscode-errorForeground, var(--vscode-foreground));
+      margin-left: 2px;
     }
     .item-action-btn:hover {
       background: var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.25));

--- a/packages/core/src/webview/sidebar/components/ItemCard.tsx
+++ b/packages/core/src/webview/sidebar/components/ItemCard.tsx
@@ -204,7 +204,7 @@ export function ItemCard({
             <button
               key={action.id}
               type="button"
-              class="item-action-btn"
+              class={getItemActionClassName(action.id)}
               title={action.title}
               aria-label={action.title}
               tabIndex={actionsOpen ? 0 : -1}
@@ -246,6 +246,10 @@ function buildItemAriaLabel(item: ItemCardData): string {
   if (item.hasRelatedItems) parts.push('has related items');
   if (item.isSelected) parts.push('selected');
   return parts.filter((value): value is string => Boolean(value)).join(', ');
+}
+
+export function getItemActionClassName(actionId: string): string {
+  return `item-action-btn ${actionId === 'dismiss' ? 'item-action-btn--dismiss' : ''}`.trim();
 }
 
 function getItemActions(


### PR DESCRIPTION
## Summary
- Add an Undo notification after dismissing Incoming items from the sidebar.
- Add the same Undo path for dismissing from the Incoming preview panel.
- Style the Dismiss action with error foreground color and a small gap.
- Cover sidebar dismiss undo, ignored notifications, preview undo, and dismiss action styling with tests.

## Validation
- npm run build
- npm run test

Closes #539
