### PR TITLE
Improve watch URL command experience

### DIFF
--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -88,7 +88,7 @@ A floating webview that monitors GitHub Actions / Azure DevOps Pipeline runs and
 ### Adding watches
 
 - Inside the panel, click **+ Watch URL** in the header. Paste a supported URL — DevDocket detects whether it is a PR or run, and validates the URL before submission. Examples: `https://github.com/owner/repo/pull/123` and `https://github.com/owner/repo/actions/runs/12345`.
-- From the command palette: **DevDocket: Watch URL…**. The legacy **Watch Pipeline Run** and **Watch Pull Request** command IDs still work as aliases.
+- From the command palette: **DevDocket: Watch URL…**. The legacy command IDs (`devdocket.watchRun` and `devdocket.watchPR`) still work as aliases for extension and keyboard-shortcut users.
 - Supported surfaces include GitHub PR URLs, GitHub Actions run URLs, Azure DevOps PR URLs, and Azure DevOps Pipeline run URLs.
 - GitHub PRs you authored can be auto-watched on discovery — see `devDocket.watches.autoWatchAuthoredPRs`.
 

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -88,7 +88,7 @@ A floating webview that monitors GitHub Actions / Azure DevOps Pipeline runs and
 ### Adding watches
 
 - Inside the panel, click **+ Watch URL** in the header. Paste a supported URL — DevDocket detects whether it is a PR or run, and validates the URL before submission. Examples: `https://github.com/owner/repo/pull/123` and `https://github.com/owner/repo/actions/runs/12345`.
-- From the command palette: **DevDocket: Watch URL…**. The legacy command IDs (`devdocket.watchRun` and `devdocket.watchPR`) still work as aliases for extension and keyboard-shortcut users.
+- From the command palette: **DevDocket: Watch URL…**.
 - Supported surfaces include GitHub PR URLs, GitHub Actions run URLs, Azure DevOps PR URLs, and Azure DevOps Pipeline run URLs.
 - GitHub PRs you authored can be auto-watched on discovery — see `devDocket.watches.autoWatchAuthoredPRs`.
 

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -87,8 +87,9 @@ A floating webview that monitors GitHub Actions / Azure DevOps Pipeline runs and
 
 ### Adding watches
 
-- Inside the panel, click **+ Watch URL** in the header. Paste either a pipeline run URL or a pull request URL — DevDocket detects which kind it is.
-- From the command palette: **DevDocket: Watch Pipeline Run** or **DevDocket: Watch Pull Request**.
+- Inside the panel, click **+ Watch URL** in the header. Paste a supported URL — DevDocket detects whether it is a PR or run, and validates the URL before submission. Examples: `https://github.com/owner/repo/pull/123` and `https://github.com/owner/repo/actions/runs/12345`.
+- From the command palette: **DevDocket: Watch URL…**. The legacy **Watch Pipeline Run** and **Watch Pull Request** command IDs still work as aliases.
+- Supported surfaces include GitHub PR URLs, GitHub Actions run URLs, Azure DevOps PR URLs, and Azure DevOps Pipeline run URLs.
 - GitHub PRs you authored can be auto-watched on discovery — see `devDocket.watches.autoWatchAuthoredPRs`.
 
 The manual Watch URL flow is **idempotent** for already-watched URLs and force-recreates the watch when a PR is in a bad state (e.g. all child runs were dismissed making it invisible).

--- a/packages/core/media/walkthroughs/watches.md
+++ b/packages/core/media/walkthroughs/watches.md
@@ -12,13 +12,18 @@ The panel groups watches into:
 
 ## Add a Watch
 
-From inside the **CI Watches** panel, click **+ Watch URL** in the top-right and paste either a pipeline run URL or a pull request URL. DevDocket figures out which kind it is and starts monitoring.
+From inside the **CI Watches** panel, click **+ Watch URL** in the top-right and paste a supported URL. DevDocket validates the URL as you type, tells you whether it will become a PR watch or run watch, then starts monitoring.
+
+Supported surfaces include:
+
+- GitHub pull requests, for example `https://github.com/owner/repo/pull/123`
+- GitHub Actions runs, for example `https://github.com/owner/repo/actions/runs/12345`
+- Azure DevOps pull requests
+- Azure DevOps Pipeline runs
 
 You can also use the Command Palette:
 
-[Watch a Pipeline Run](command:devdocket.watchRun)
-
-[Watch a Pull Request](command:devdocket.watchPR)
+[Watch a URL](command:devdocket.watchUrl)
 
 ## Auto-Watching Authored PRs
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -74,6 +74,7 @@
               "markdown": "media/walkthroughs/watches.md"
             },
             "completionEvents": [
+              "onCommand:devdocket.watchUrl",
               "onCommand:devdocket.watchRun",
               "onCommand:devdocket.watchPR",
               "onCommand:devdocket.watchPRFromItem"
@@ -331,6 +332,12 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "devdocket.watchUrl",
+        "title": "DevDocket: Watch URL…",
+        "category": "DevDocket",
+        "icon": "$(add)"
+      },
+      {
         "command": "devdocket.watchRun",
         "title": "DevDocket: Watch Pipeline Run",
         "category": "DevDocket",
@@ -414,6 +421,14 @@
       "commandPalette": [
         {
           "command": "devdocket.addActivity",
+          "when": "false"
+        },
+        {
+          "command": "devdocket.watchRun",
+          "when": "false"
+        },
+        {
+          "command": "devdocket.watchPR",
           "when": "false"
         },
         {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -333,7 +333,7 @@
       },
       {
         "command": "devdocket.watchUrl",
-        "title": "DevDocket: Watch URL…",
+        "title": "Watch URL…",
         "category": "DevDocket",
         "icon": "$(add)"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -75,8 +75,6 @@
             },
             "completionEvents": [
               "onCommand:devdocket.watchUrl",
-              "onCommand:devdocket.watchRun",
-              "onCommand:devdocket.watchPR",
               "onCommand:devdocket.watchPRFromItem"
             ]
           }
@@ -338,18 +336,6 @@
         "icon": "$(add)"
       },
       {
-        "command": "devdocket.watchRun",
-        "title": "DevDocket: Watch Pipeline Run",
-        "category": "DevDocket",
-        "icon": "$(add)"
-      },
-      {
-        "command": "devdocket.watchPR",
-        "title": "DevDocket: Watch Pull Request",
-        "category": "DevDocket",
-        "icon": "$(git-pull-request)"
-      },
-      {
         "command": "devdocket.watchPRFromItem",
         "title": "Watch CI",
         "category": "DevDocket",
@@ -421,14 +407,6 @@
       "commandPalette": [
         {
           "command": "devdocket.addActivity",
-          "when": "false"
-        },
-        {
-          "command": "devdocket.watchRun",
-          "when": "false"
-        },
-        {
-          "command": "devdocket.watchPR",
           "when": "false"
         },
         {

--- a/packages/core/src/commands/watchCommands.ts
+++ b/packages/core/src/commands/watchCommands.ts
@@ -13,7 +13,7 @@ async function handleWatchUrl(
   watcherService: WatcherService,
 ): Promise<void> {
   const url = await vscode.window.showInputBox({
-    prompt: 'Paste a GitHub or Azure DevOps pull request or pipeline run URL',
+    prompt: 'Paste a pull request or pipeline run URL supported by a registered watcher',
     placeHolder: WATCH_URL_PLACEHOLDER,
     validateInput: (value) => formatWatchUrlValidation(classifyWatchUrl(value, watcherRegistry, prWatcherRegistry)),
   });

--- a/packages/core/src/commands/watchCommands.ts
+++ b/packages/core/src/commands/watchCommands.ts
@@ -5,113 +5,64 @@ import { PRWatcherRegistry } from '../services/prWatcherRegistry';
 import type { WatchPanelProvider } from '../views/watchPanelProvider';
 import { isSafeUrl } from '../utils/url';
 import { wrapCommand, handleCommandError } from './commandUtils';
+import { classifyWatchUrl, WATCH_URL_PLACEHOLDER, type WatchUrlClassification } from './watchUrlClassifier';
 
-async function handleWatchRun(watcherRegistry: WatcherRegistry, prWatcherRegistry: PRWatcherRegistry, watcherService: WatcherService): Promise<void> {
+async function handleWatchUrl(
+  watcherRegistry: WatcherRegistry,
+  prWatcherRegistry: PRWatcherRegistry,
+  watcherService: WatcherService,
+): Promise<void> {
   const url = await vscode.window.showInputBox({
-    prompt: 'Enter a pipeline run URL',
-    placeHolder: 'https://github.com/owner/repo/actions/runs/123456789',
-    validateInput: (value) => {
-      const trimmed = value.trim();
-      if (!trimmed) {
-        return 'URL cannot be empty';
-      }
-      if (!isSafeUrl(trimmed)) {
-        return 'Only http(s) URLs are supported.';
-      }
-      const watcher = watcherRegistry.findWatcherForUrl(trimmed);
-      const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmed);
-      if (!watcher && !prWatcher) {
-        return 'Unsupported URL format. No registered watcher recognizes this URL.';
-      }
-      return undefined;
-    },
+    prompt: 'Paste a GitHub or Azure DevOps pull request or pipeline run URL',
+    placeHolder: WATCH_URL_PLACEHOLDER,
+    validateInput: (value) => formatWatchUrlValidation(classifyWatchUrl(value, watcherRegistry, prWatcherRegistry)),
   });
 
-  if (!url) {
+  if (url === undefined) {
     return;
   }
 
-  const trimmedUrl = url.trim();
+  const classification = classifyWatchUrl(url, watcherRegistry, prWatcherRegistry);
+  if (!classification.ok) {
+    void vscode.window.showErrorMessage(`DevDocket: ${classification.message}`);
+    return;
+  }
 
-  // If a PR watcher recognizes the URL, redirect to PR watch flow
-  const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmedUrl);
-  if (prWatcher) {
-    try {
-      const identifier = prWatcher.parsePRUrl(trimmedUrl);
+  try {
+    if (classification.kind === 'pr') {
+      const identifier = classification.watcher.parsePRUrl(classification.url);
       const wasActive = watcherService.isPRActive(identifier);
       const watch = await watcherService.startPRWatch(identifier, { forceRecreate: true });
       const message = wasActive
         ? `Re-watching PR: ${watch.identifier.displayName}`
         : `Now watching PR: ${watch.identifier.displayName}`;
       void vscode.window.showInformationMessage(message);
-    } catch (err: unknown) {
-      handleCommandError('Failed to watch PR', err);
-    }
-    return;
-  }
-
-  try {
-    const watcher = watcherRegistry.findWatcherForUrl(trimmedUrl);
-    if (!watcher) {
-      void vscode.window.showErrorMessage('Unsupported URL format. No registered watcher recognizes this URL.');
       return;
     }
 
-    const identifier = watcher.parseRunUrl(trimmedUrl);
+    const identifier = classification.watcher.parseRunUrl(classification.url);
     const wasActive = watcherService.isRunActive(identifier);
     const watch = await watcherService.startWatch(identifier);
     const message = wasActive
       ? `Already watching: ${watch.identifier.displayName}`
-      : `Now watching: ${watch.identifier.displayName}`;
+      : `Now watching run: ${watch.identifier.displayName}`;
     void vscode.window.showInformationMessage(message);
   } catch (err: unknown) {
-    handleCommandError('Failed to watch pipeline run', err);
+    handleCommandError(
+      classification.kind === 'pr' ? 'Failed to watch PR' : 'Failed to watch pipeline run',
+      err,
+    );
   }
 }
 
-async function handleWatchPR(prWatcherRegistry: PRWatcherRegistry, watcherService: WatcherService): Promise<void> {
-  const url = await vscode.window.showInputBox({
-    prompt: 'Enter a pull request URL',
-    placeHolder: 'https://github.com/owner/repo/pull/42',
-    validateInput: (value) => {
-      const trimmed = value.trim();
-      if (!trimmed) {
-        return 'URL cannot be empty';
-      }
-      if (!isSafeUrl(trimmed)) {
-        return 'Only http(s) URLs are supported.';
-      }
-      const watcher = prWatcherRegistry.findWatcherForUrl(trimmed);
-      if (!watcher) {
-        return 'Unsupported URL format. No registered PR watcher recognizes this URL.';
-      }
-      return undefined;
-    },
-  });
-
-  if (!url) {
-    return;
+function formatWatchUrlValidation(classification: WatchUrlClassification): string | vscode.InputBoxValidationMessage | undefined {
+  if (!classification.ok) {
+    return classification.message === 'URL cannot be empty.' ? undefined : classification.message;
   }
-
-  const trimmedUrl = url.trim();
-
-  try {
-    const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmedUrl);
-    if (!prWatcher) {
-      void vscode.window.showErrorMessage('Unsupported URL format. No registered PR watcher recognizes this URL.');
-      return;
-    }
-
-    const identifier = prWatcher.parsePRUrl(trimmedUrl);
-    const wasActive = watcherService.isPRActive(identifier);
-    const watch = await watcherService.startPRWatch(identifier, { forceRecreate: true });
-    const message = wasActive
-      ? `Re-watching PR: ${watch.identifier.displayName}`
-      : `Now watching PR: ${watch.identifier.displayName}`;
-    void vscode.window.showInformationMessage(message);
-  } catch (err: unknown) {
-    handleCommandError('Failed to watch PR', err);
-  }
+  return {
+    message: classification.validationMessage,
+    severity: vscode.InputBoxValidationSeverity.Info,
+  };
 }
 
 // Normalize argument: context menu passes WatchedRunNode, inline click passes WatchedRun
@@ -287,10 +238,13 @@ export function registerWatchCommands(
   watchPanelProvider: WatchPanelProvider,
 ): void {
   context.subscriptions.push(
+    vscode.commands.registerCommand('devdocket.watchUrl',
+      wrapCommand('Failed to watch URL', () => handleWatchUrl(watcherRegistry, prWatcherRegistry, watcherService))),
+    // Keep the typed commands as back-compat aliases while exposing one unified command in the palette.
     vscode.commands.registerCommand('devdocket.watchRun',
-      wrapCommand('Failed to watch pipeline run', () => handleWatchRun(watcherRegistry, prWatcherRegistry, watcherService))),
+      wrapCommand('Failed to watch URL', () => handleWatchUrl(watcherRegistry, prWatcherRegistry, watcherService))),
     vscode.commands.registerCommand('devdocket.watchPR',
-      wrapCommand('Failed to watch PR', () => handleWatchPR(prWatcherRegistry, watcherService))),
+      wrapCommand('Failed to watch URL', () => handleWatchUrl(watcherRegistry, prWatcherRegistry, watcherService))),
     vscode.commands.registerCommand('devdocket.watchPRFromItem',
       wrapCommand('Failed to watch CI from item', (arg: unknown) => handleWatchPRFromItem(watcherRegistry, prWatcherRegistry, watcherService, arg))),
     vscode.commands.registerCommand('devdocket.dismissWatch',

--- a/packages/core/src/commands/watchCommands.ts
+++ b/packages/core/src/commands/watchCommands.ts
@@ -18,7 +18,7 @@ async function handleWatchUrl(
     validateInput: (value) => formatWatchUrlValidation(classifyWatchUrl(value, watcherRegistry, prWatcherRegistry)),
   });
 
-  if (url === undefined) {
+  if (!url?.trim()) {
     return;
   }
 
@@ -44,7 +44,7 @@ async function handleWatchUrl(
     const wasActive = watcherService.isRunActive(identifier);
     const watch = await watcherService.startWatch(identifier);
     const message = wasActive
-      ? `Already watching: ${watch.identifier.displayName}`
+      ? `Already watching run: ${watch.identifier.displayName}`
       : `Now watching run: ${watch.identifier.displayName}`;
     void vscode.window.showInformationMessage(message);
   } catch (err: unknown) {

--- a/packages/core/src/commands/watchCommands.ts
+++ b/packages/core/src/commands/watchCommands.ts
@@ -240,11 +240,6 @@ export function registerWatchCommands(
   context.subscriptions.push(
     vscode.commands.registerCommand('devdocket.watchUrl',
       wrapCommand('Failed to watch URL', () => handleWatchUrl(watcherRegistry, prWatcherRegistry, watcherService))),
-    // Keep the typed commands as back-compat aliases while exposing one unified command in the palette.
-    vscode.commands.registerCommand('devdocket.watchRun',
-      wrapCommand('Failed to watch URL', () => handleWatchUrl(watcherRegistry, prWatcherRegistry, watcherService))),
-    vscode.commands.registerCommand('devdocket.watchPR',
-      wrapCommand('Failed to watch URL', () => handleWatchUrl(watcherRegistry, prWatcherRegistry, watcherService))),
     vscode.commands.registerCommand('devdocket.watchPRFromItem',
       wrapCommand('Failed to watch CI from item', (arg: unknown) => handleWatchPRFromItem(watcherRegistry, prWatcherRegistry, watcherService, arg))),
     vscode.commands.registerCommand('devdocket.dismissWatch',

--- a/packages/core/src/commands/watchCommands.ts
+++ b/packages/core/src/commands/watchCommands.ts
@@ -57,7 +57,7 @@ async function handleWatchUrl(
 
 function formatWatchUrlValidation(classification: WatchUrlClassification): string | vscode.InputBoxValidationMessage | undefined {
   if (!classification.ok) {
-    return classification.message === 'URL cannot be empty.' ? undefined : classification.message;
+    return classification.reason === 'empty' ? undefined : classification.message;
   }
   return {
     message: classification.validationMessage,
@@ -134,7 +134,7 @@ async function handleWatchPRFromItem(
     const wasActive = watcherService.isRunActive(identifier);
     const watch = await watcherService.startWatch(identifier);
     const message = wasActive
-      ? `Already watching: ${watch.identifier.displayName}`
+      ? `Already watching run: ${watch.identifier.displayName}`
       : `Now watching run: ${watch.identifier.displayName}`;
     void vscode.window.showInformationMessage(message);
     return;

--- a/packages/core/src/commands/watchUrlClassifier.ts
+++ b/packages/core/src/commands/watchUrlClassifier.ts
@@ -28,8 +28,8 @@ export type WatchUrlClassification =
 
 export function classifyWatchUrl(
   value: string,
-  watcherRegistry: Pick<WatcherRegistry, 'findWatcherForUrl'>,
-  prWatcherRegistry: Pick<PRWatcherRegistry, 'findWatcherForUrl'>,
+  watcherRegistry: Pick<WatcherRegistry, 'findWatcherForUrl' | 'getAll'>,
+  prWatcherRegistry: Pick<PRWatcherRegistry, 'findWatcherForUrl' | 'getAll'>,
 ): WatchUrlClassification {
   const trimmed = value.trim();
   if (!trimmed) {
@@ -42,50 +42,44 @@ export function classifyWatchUrl(
 
   const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmed);
   if (prWatcher) {
-    const providerName = providerDisplayName(prWatcher);
     return {
       ok: true,
       kind: 'pr',
       url: trimmed,
       watcher: prWatcher,
-      validationMessage: `This looks like ${indefiniteArticle(providerName)} ${providerName} PR — will be added as a PR watch.`,
+      validationMessage: `Recognized by ${prWatcher.label} — will be added as a PR watch.`,
     };
   }
 
   const runWatcher = watcherRegistry.findWatcherForUrl(trimmed);
   if (runWatcher) {
-    const providerName = providerDisplayName(runWatcher);
     return {
       ok: true,
       kind: 'run',
       url: trimmed,
       watcher: runWatcher,
-      validationMessage: `This looks like ${indefiniteArticle(providerName)} ${providerName} run — will be added as a run watch.`,
+      validationMessage: `Recognized by ${runWatcher.label} — will be added as a run watch.`,
     };
   }
 
   return {
     ok: false,
     reason: 'unsupported',
-    message: 'Unsupported URL. Paste a supported pull request or pipeline run URL (for example, a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL).',
+    message: buildUnsupportedMessage(watcherRegistry, prWatcherRegistry),
   };
 }
 
-function providerDisplayName(watcher: { id: string; label: string }): string {
-  switch (watcher.id) {
-    case 'github-pr':
-      return 'GitHub';
-    case 'github-actions':
-      return 'GitHub Actions';
-    case 'ado-pr':
-      return 'Azure DevOps';
-    case 'ado-pipelines':
-      return 'Azure DevOps Pipeline';
-    default:
-      return watcher.label;
+function buildUnsupportedMessage(
+  watcherRegistry: Pick<WatcherRegistry, 'getAll'>,
+  prWatcherRegistry: Pick<PRWatcherRegistry, 'getAll'>,
+): string {
+  const labels = [
+    ...prWatcherRegistry.getAll().map(w => w.label),
+    ...watcherRegistry.getAll().map(w => w.label),
+  ];
+  if (labels.length === 0) {
+    return 'Unsupported URL. No pull request or pipeline run watchers are currently registered. Install a provider extension that contributes a watcher.';
   }
+  return `Unsupported URL. Paste a URL recognized by one of: ${labels.join(', ')}.`;
 }
 
-function indefiniteArticle(value: string): 'a' | 'an' {
-  return /^[aeiou]/i.test(value) ? 'an' : 'a';
-}

--- a/packages/core/src/commands/watchUrlClassifier.ts
+++ b/packages/core/src/commands/watchUrlClassifier.ts
@@ -22,6 +22,7 @@ export type WatchUrlClassification =
   }
   | {
     ok: false;
+    reason: 'empty' | 'unsafe' | 'unsupported';
     message: string;
   };
 
@@ -32,11 +33,11 @@ export function classifyWatchUrl(
 ): WatchUrlClassification {
   const trimmed = value.trim();
   if (!trimmed) {
-    return { ok: false, message: 'URL cannot be empty.' };
+    return { ok: false, reason: 'empty', message: 'URL cannot be empty.' };
   }
 
   if (!isSafeUrl(trimmed)) {
-    return { ok: false, message: 'Only http(s) URLs are supported.' };
+    return { ok: false, reason: 'unsafe', message: 'Only http(s) URLs are supported.' };
   }
 
   const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmed);
@@ -65,6 +66,7 @@ export function classifyWatchUrl(
 
   return {
     ok: false,
+    reason: 'unsupported',
     message: 'Unsupported URL. Paste a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL.',
   };
 }

--- a/packages/core/src/commands/watchUrlClassifier.ts
+++ b/packages/core/src/commands/watchUrlClassifier.ts
@@ -67,7 +67,7 @@ export function classifyWatchUrl(
   return {
     ok: false,
     reason: 'unsupported',
-    message: 'Unsupported URL. Paste a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL.',
+    message: 'Unsupported URL. Paste a supported pull request or pipeline run URL (for example, a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL).',
   };
 }
 

--- a/packages/core/src/commands/watchUrlClassifier.ts
+++ b/packages/core/src/commands/watchUrlClassifier.ts
@@ -1,0 +1,89 @@
+import type { DevDocketPRWatcher, DevDocketRunWatcher } from '@devdocket/shared';
+import type { PRWatcherRegistry } from '../services/prWatcherRegistry';
+import type { WatcherRegistry } from '../services/watcherRegistry';
+import { isSafeUrl } from '../utils/url';
+
+export const WATCH_URL_PLACEHOLDER = 'https://github.com/owner/repo/pull/123 • https://github.com/owner/repo/actions/runs/12345';
+
+export type WatchUrlClassification =
+  | {
+    ok: true;
+    kind: 'pr';
+    url: string;
+    watcher: DevDocketPRWatcher;
+    validationMessage: string;
+  }
+  | {
+    ok: true;
+    kind: 'run';
+    url: string;
+    watcher: DevDocketRunWatcher;
+    validationMessage: string;
+  }
+  | {
+    ok: false;
+    message: string;
+  };
+
+export function classifyWatchUrl(
+  value: string,
+  watcherRegistry: Pick<WatcherRegistry, 'findWatcherForUrl'>,
+  prWatcherRegistry: Pick<PRWatcherRegistry, 'findWatcherForUrl'>,
+): WatchUrlClassification {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return { ok: false, message: 'URL cannot be empty.' };
+  }
+
+  if (!isSafeUrl(trimmed)) {
+    return { ok: false, message: 'Only http(s) URLs are supported.' };
+  }
+
+  const prWatcher = prWatcherRegistry.findWatcherForUrl(trimmed);
+  if (prWatcher) {
+    const providerName = providerDisplayName(prWatcher);
+    return {
+      ok: true,
+      kind: 'pr',
+      url: trimmed,
+      watcher: prWatcher,
+      validationMessage: `This looks like ${indefiniteArticle(providerName)} ${providerName} PR — will be added as a PR watch.`,
+    };
+  }
+
+  const runWatcher = watcherRegistry.findWatcherForUrl(trimmed);
+  if (runWatcher) {
+    const providerName = providerDisplayName(runWatcher);
+    return {
+      ok: true,
+      kind: 'run',
+      url: trimmed,
+      watcher: runWatcher,
+      validationMessage: `This looks like ${indefiniteArticle(providerName)} ${providerName} run — will be added as a run watch.`,
+    };
+  }
+
+  return {
+    ok: false,
+    message: 'Unsupported URL. Paste a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL.',
+  };
+}
+
+function providerDisplayName(watcher: { id: string; label: string }): string {
+  switch (watcher.id) {
+    case 'github-pr':
+      return 'GitHub';
+    case 'github-actions':
+      return 'GitHub Actions';
+    case 'ado-pr':
+      return 'Azure DevOps';
+    case 'ado-pipelines':
+      return 'Azure DevOps Pipeline';
+    default:
+      return watcher.label;
+  }
+}
+
+function indefiniteArticle(value: string): 'a' | 'an' {
+  return /^[aeiou]/i.test(value) ? 'an' : 'a';
+}

--- a/packages/core/src/commands/watchUrlClassifier.ts
+++ b/packages/core/src/commands/watchUrlClassifier.ts
@@ -3,7 +3,7 @@ import type { PRWatcherRegistry } from '../services/prWatcherRegistry';
 import type { WatcherRegistry } from '../services/watcherRegistry';
 import { isSafeUrl } from '../utils/url';
 
-export const WATCH_URL_PLACEHOLDER = 'https://github.com/owner/repo/pull/123 • https://github.com/owner/repo/actions/runs/12345';
+export const WATCH_URL_PLACEHOLDER = 'Pull request or pipeline run URL';
 
 export type WatchUrlClassification =
   | {

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -59,6 +59,12 @@ const ProgressLocation = {
   Notification: 15,
 };
 
+const InputBoxValidationSeverity = {
+  Info: 1,
+  Warning: 2,
+  Error: 3,
+};
+
 const window = {
   showInputBox: vi.fn(),
   showInformationMessage: vi.fn().mockResolvedValue(undefined),
@@ -257,6 +263,7 @@ export {
   ConfigurationTarget,
   StatusBarAlignment,
   ProgressLocation,
+  InputBoxValidationSeverity,
   window,
   commands,
   env,

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -215,6 +215,9 @@ describe('registerCommands', () => {
       'devdocket.createItemFromUrl',
       'devdocket.clearHistory',
       'devdocket.addActivity',
+      'devdocket.watchUrl',
+      'devdocket.watchRun',
+      'devdocket.watchPR',
       'devdocket.showWatchesQuickPick',
     ];
     for (const cmd of expected) {

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -216,8 +216,6 @@ describe('registerCommands', () => {
       'devdocket.clearHistory',
       'devdocket.addActivity',
       'devdocket.watchUrl',
-      'devdocket.watchRun',
-      'devdocket.watchPR',
       'devdocket.showWatchesQuickPick',
     ];
     for (const cmd of expected) {

--- a/packages/core/src/test/watchCommands.test.ts
+++ b/packages/core/src/test/watchCommands.test.ts
@@ -43,12 +43,12 @@ function registerCommandsWith(options: {
   return { watcherRegistry, prWatcherRegistry, watcherService, context };
 }
 
-function invoke(name: string) {
+function invoke(name: string, ...args: any[]) {
   const handler = commandHandlers.get(name);
   if (!handler) {
     throw new Error(`Command not registered: ${name}`);
   }
-  return handler();
+  return handler(...args);
 }
 
 describe('registerWatchCommands', () => {
@@ -144,6 +144,27 @@ describe('registerWatchCommands', () => {
     expect(watcherService.startWatch).not.toHaveBeenCalled();
     expect(watcherService.startPRWatch).not.toHaveBeenCalled();
     expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+  });
+
+  it('shows run-specific feedback when an item URL run is already watched', async () => {
+    const input = 'https://github.com/owner/repo/actions/runs/12345';
+    const runIdentifier = {
+      providerId: 'github-actions',
+      runId: '12345',
+      displayName: 'CI Build',
+      url: input,
+      repo: 'owner/repo',
+    };
+    const runWatcher = {
+      id: 'github-actions',
+      label: 'GitHub Actions',
+      parseRunUrl: vi.fn(() => runIdentifier),
+    };
+    registerCommandsWith({ input: undefined, runWatcher, runActive: true });
+
+    await invoke('devdocket.watchPRFromItem', { url: input });
+
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Already watching run: CI Build');
   });
 
   it('shows actionable feedback without starting a watch for unsupported URLs', async () => {

--- a/packages/core/src/test/watchCommands.test.ts
+++ b/packages/core/src/test/watchCommands.test.ts
@@ -93,6 +93,27 @@ describe('registerWatchCommands', () => {
     expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Now watching PR: PR #42');
   });
 
+  it('adds PR watches through the legacy watchPR alias using the unified URL classifier', async () => {
+    const input = 'https://github.com/owner/repo/pull/42';
+    const prIdentifier = {
+      providerId: 'github-pr',
+      prId: '42',
+      displayName: 'PR #42',
+      url: input,
+      repo: 'owner/repo',
+    };
+    const prWatcher = {
+      id: 'github-pr',
+      label: 'GitHub Pull Requests',
+      parsePRUrl: vi.fn(() => prIdentifier),
+    };
+    const { watcherService } = registerCommandsWith({ input, prWatcher });
+
+    await invoke('devdocket.watchPR');
+
+    expect(watcherService.startPRWatch).toHaveBeenCalledWith(prIdentifier, { forceRecreate: true });
+  });
+
   it('adds run watches through the legacy watchRun alias using the unified URL classifier', async () => {
     const input = 'https://github.com/owner/repo/actions/runs/12345';
     const runIdentifier = {

--- a/packages/core/src/test/watchCommands.test.ts
+++ b/packages/core/src/test/watchCommands.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import * as vscode from 'vscode';
+import { registerWatchCommands } from '../commands/watchCommands';
+
+let commandHandlers: Map<string, (...args: any[]) => any>;
+
+function registerCommandsWith(options: {
+  input?: string;
+  runWatcher?: any;
+  prWatcher?: any;
+  runActive?: boolean;
+  prActive?: boolean;
+} = {}) {
+  commandHandlers = new Map();
+  (vscode.commands.registerCommand as Mock).mockImplementation((id: string, handler: (...args: any[]) => any) => {
+    commandHandlers.set(id, handler);
+    return { dispose: vi.fn() };
+  });
+  (vscode.window.showInputBox as Mock).mockResolvedValue(options.input);
+
+  const watcherRegistry = {
+    findWatcherForUrl: vi.fn(() => options.runWatcher),
+  };
+  const prWatcherRegistry = {
+    findWatcherForUrl: vi.fn(() => options.prWatcher),
+  };
+  const watcherService = {
+    isRunActive: vi.fn(() => options.runActive ?? false),
+    isPRActive: vi.fn(() => options.prActive ?? false),
+    startWatch: vi.fn(async (identifier) => ({ identifier })),
+    startPRWatch: vi.fn(async (identifier) => ({ identifier })),
+  };
+  const context = { subscriptions: [] };
+
+  registerWatchCommands(
+    context as any,
+    watcherRegistry as any,
+    prWatcherRegistry as any,
+    watcherService as any,
+    { open: vi.fn() } as any,
+  );
+
+  return { watcherRegistry, prWatcherRegistry, watcherService, context };
+}
+
+function invoke(name: string) {
+  const handler = commandHandlers.get(name);
+  if (!handler) {
+    throw new Error(`Command not registered: ${name}`);
+  }
+  return handler();
+}
+
+describe('registerWatchCommands', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers Watch URL plus typed command aliases', () => {
+    registerCommandsWith();
+
+    expect(commandHandlers.has('devdocket.watchUrl')).toBe(true);
+    expect(commandHandlers.has('devdocket.watchRun')).toBe(true);
+    expect(commandHandlers.has('devdocket.watchPR')).toBe(true);
+  });
+
+  it('adds PR watches through the unified Watch URL input with live informational validation', async () => {
+    const input = 'https://github.com/owner/repo/pull/42';
+    const prIdentifier = {
+      providerId: 'github-pr',
+      prId: '42',
+      displayName: 'PR #42',
+      url: input,
+      repo: 'owner/repo',
+    };
+    const prWatcher = {
+      id: 'github-pr',
+      label: 'GitHub Pull Requests',
+      parsePRUrl: vi.fn(() => prIdentifier),
+    };
+    const { watcherService } = registerCommandsWith({ input, prWatcher });
+
+    await invoke('devdocket.watchUrl');
+
+    const inputOptions = (vscode.window.showInputBox as Mock).mock.calls[0][0];
+    expect(inputOptions.placeHolder).toContain('https://github.com/owner/repo/pull/123');
+    expect(inputOptions.placeHolder).toContain('https://github.com/owner/repo/actions/runs/12345');
+    expect(inputOptions.validateInput(input)).toEqual({
+      message: 'This looks like a GitHub PR — will be added as a PR watch.',
+      severity: vscode.InputBoxValidationSeverity.Info,
+    });
+    expect(watcherService.startPRWatch).toHaveBeenCalledWith(prIdentifier, { forceRecreate: true });
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Now watching PR: PR #42');
+  });
+
+  it('adds run watches through the legacy watchRun alias using the unified URL classifier', async () => {
+    const input = 'https://github.com/owner/repo/actions/runs/12345';
+    const runIdentifier = {
+      providerId: 'github-actions',
+      runId: '12345',
+      displayName: 'CI Build',
+      url: input,
+      repo: 'owner/repo',
+    };
+    const runWatcher = {
+      id: 'github-actions',
+      label: 'GitHub Actions',
+      parseRunUrl: vi.fn(() => runIdentifier),
+    };
+    const { watcherService } = registerCommandsWith({ input, runWatcher });
+
+    await invoke('devdocket.watchRun');
+
+    expect(watcherService.startWatch).toHaveBeenCalledWith(runIdentifier);
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Now watching run: CI Build');
+  });
+
+  it('shows actionable feedback without starting a watch for unsupported URLs', async () => {
+    registerCommandsWith({ input: 'https://example.com/nope' });
+
+    await invoke('devdocket.watchUrl');
+
+    const inputOptions = (vscode.window.showInputBox as Mock).mock.calls[0][0];
+    expect(inputOptions.validateInput('')).toBeUndefined();
+    expect(inputOptions.validateInput('https://example.com/nope')).toBe(
+      'Unsupported URL. Paste a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL.',
+    );
+    expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+      'DevDocket: Unsupported URL. Paste a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL.',
+    );
+  });
+});

--- a/packages/core/src/test/watchCommands.test.ts
+++ b/packages/core/src/test/watchCommands.test.ts
@@ -81,8 +81,7 @@ describe('registerWatchCommands', () => {
     await invoke('devdocket.watchUrl');
 
     const inputOptions = (vscode.window.showInputBox as Mock).mock.calls[0][0];
-    expect(inputOptions.placeHolder).toContain('https://github.com/owner/repo/pull/123');
-    expect(inputOptions.placeHolder).toContain('https://github.com/owner/repo/actions/runs/12345');
+    expect(inputOptions.placeHolder).toBe('Pull request or pipeline run URL');
     expect(inputOptions.validateInput(input)).toEqual({
       message: 'This looks like a GitHub PR — will be added as a PR watch.',
       severity: vscode.InputBoxValidationSeverity.Info,

--- a/packages/core/src/test/watchCommands.test.ts
+++ b/packages/core/src/test/watchCommands.test.ts
@@ -115,6 +115,37 @@ describe('registerWatchCommands', () => {
     expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Now watching run: CI Build');
   });
 
+  it('shows run-specific feedback when a run is already watched', async () => {
+    const input = 'https://github.com/owner/repo/actions/runs/12345';
+    const runIdentifier = {
+      providerId: 'github-actions',
+      runId: '12345',
+      displayName: 'CI Build',
+      url: input,
+      repo: 'owner/repo',
+    };
+    const runWatcher = {
+      id: 'github-actions',
+      label: 'GitHub Actions',
+      parseRunUrl: vi.fn(() => runIdentifier),
+    };
+    registerCommandsWith({ input, runWatcher, runActive: true });
+
+    await invoke('devdocket.watchUrl');
+
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Already watching run: CI Build');
+  });
+
+  it('ignores empty submissions without showing an error toast', async () => {
+    const { watcherService } = registerCommandsWith({ input: '   ' });
+
+    await invoke('devdocket.watchUrl');
+
+    expect(watcherService.startWatch).not.toHaveBeenCalled();
+    expect(watcherService.startPRWatch).not.toHaveBeenCalled();
+    expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
+  });
+
   it('shows actionable feedback without starting a watch for unsupported URLs', async () => {
     registerCommandsWith({ input: 'https://example.com/nope' });
 

--- a/packages/core/src/test/watchCommands.test.ts
+++ b/packages/core/src/test/watchCommands.test.ts
@@ -56,12 +56,10 @@ describe('registerWatchCommands', () => {
     vi.clearAllMocks();
   });
 
-  it('registers Watch URL plus typed command aliases', () => {
+  it('registers Watch URL', () => {
     registerCommandsWith();
 
     expect(commandHandlers.has('devdocket.watchUrl')).toBe(true);
-    expect(commandHandlers.has('devdocket.watchRun')).toBe(true);
-    expect(commandHandlers.has('devdocket.watchPR')).toBe(true);
   });
 
   it('adds PR watches through the unified Watch URL input with live informational validation', async () => {
@@ -91,49 +89,6 @@ describe('registerWatchCommands', () => {
     });
     expect(watcherService.startPRWatch).toHaveBeenCalledWith(prIdentifier, { forceRecreate: true });
     expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Now watching PR: PR #42');
-  });
-
-  it('adds PR watches through the legacy watchPR alias using the unified URL classifier', async () => {
-    const input = 'https://github.com/owner/repo/pull/42';
-    const prIdentifier = {
-      providerId: 'github-pr',
-      prId: '42',
-      displayName: 'PR #42',
-      url: input,
-      repo: 'owner/repo',
-    };
-    const prWatcher = {
-      id: 'github-pr',
-      label: 'GitHub Pull Requests',
-      parsePRUrl: vi.fn(() => prIdentifier),
-    };
-    const { watcherService } = registerCommandsWith({ input, prWatcher });
-
-    await invoke('devdocket.watchPR');
-
-    expect(watcherService.startPRWatch).toHaveBeenCalledWith(prIdentifier, { forceRecreate: true });
-  });
-
-  it('adds run watches through the legacy watchRun alias using the unified URL classifier', async () => {
-    const input = 'https://github.com/owner/repo/actions/runs/12345';
-    const runIdentifier = {
-      providerId: 'github-actions',
-      runId: '12345',
-      displayName: 'CI Build',
-      url: input,
-      repo: 'owner/repo',
-    };
-    const runWatcher = {
-      id: 'github-actions',
-      label: 'GitHub Actions',
-      parseRunUrl: vi.fn(() => runIdentifier),
-    };
-    const { watcherService } = registerCommandsWith({ input, runWatcher });
-
-    await invoke('devdocket.watchRun');
-
-    expect(watcherService.startWatch).toHaveBeenCalledWith(runIdentifier);
-    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('Now watching run: CI Build');
   });
 
   it('shows run-specific feedback when a run is already watched', async () => {

--- a/packages/core/src/test/watchCommands.test.ts
+++ b/packages/core/src/test/watchCommands.test.ts
@@ -175,10 +175,10 @@ describe('registerWatchCommands', () => {
     const inputOptions = (vscode.window.showInputBox as Mock).mock.calls[0][0];
     expect(inputOptions.validateInput('')).toBeUndefined();
     expect(inputOptions.validateInput('https://example.com/nope')).toBe(
-      'Unsupported URL. Paste a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL.',
+      'Unsupported URL. Paste a supported pull request or pipeline run URL (for example, a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL).',
     );
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-      'DevDocket: Unsupported URL. Paste a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL.',
+      'DevDocket: Unsupported URL. Paste a supported pull request or pipeline run URL (for example, a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL).',
     );
   });
 });

--- a/packages/core/src/test/watchCommands.test.ts
+++ b/packages/core/src/test/watchCommands.test.ts
@@ -20,9 +20,11 @@ function registerCommandsWith(options: {
 
   const watcherRegistry = {
     findWatcherForUrl: vi.fn(() => options.runWatcher),
+    getAll: vi.fn(() => (options.runWatcher ? [options.runWatcher] : [])),
   };
   const prWatcherRegistry = {
     findWatcherForUrl: vi.fn(() => options.prWatcher),
+    getAll: vi.fn(() => (options.prWatcher ? [options.prWatcher] : [])),
   };
   const watcherService = {
     isRunActive: vi.fn(() => options.runActive ?? false),
@@ -83,7 +85,7 @@ describe('registerWatchCommands', () => {
     const inputOptions = (vscode.window.showInputBox as Mock).mock.calls[0][0];
     expect(inputOptions.placeHolder).toBe('Pull request or pipeline run URL');
     expect(inputOptions.validateInput(input)).toEqual({
-      message: 'This looks like a GitHub PR — will be added as a PR watch.',
+      message: 'Recognized by GitHub Pull Requests — will be added as a PR watch.',
       severity: vscode.InputBoxValidationSeverity.Info,
     });
     expect(watcherService.startPRWatch).toHaveBeenCalledWith(prIdentifier, { forceRecreate: true });
@@ -150,10 +152,10 @@ describe('registerWatchCommands', () => {
     const inputOptions = (vscode.window.showInputBox as Mock).mock.calls[0][0];
     expect(inputOptions.validateInput('')).toBeUndefined();
     expect(inputOptions.validateInput('https://example.com/nope')).toBe(
-      'Unsupported URL. Paste a supported pull request or pipeline run URL (for example, a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL).',
+      'Unsupported URL. No pull request or pipeline run watchers are currently registered. Install a provider extension that contributes a watcher.',
     );
     expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-      'DevDocket: Unsupported URL. Paste a supported pull request or pipeline run URL (for example, a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL).',
+      'DevDocket: Unsupported URL. No pull request or pipeline run watchers are currently registered. Install a provider extension that contributes a watcher.',
     );
   });
 });

--- a/packages/core/src/test/watchPanelProvider.test.ts
+++ b/packages/core/src/test/watchPanelProvider.test.ts
@@ -478,6 +478,7 @@ describe('WatchPanelProvider', () => {
     provider.open();
 
     await mockPanel.simulateMessage({ type: 'dismissCompletedWatches' });
+    await mockPanel.simulateMessage({ type: 'addWatchUrl' });
     await mockPanel.simulateMessage({ type: 'openWatchUrl', url: runIdentifier.url });
     await mockPanel.simulateMessage({ type: 'openWatchUrl', url: 'javascript:alert(1)' });
     await mockPanel.simulateMessage({ type: 'openItem', itemId: 'work-42' });
@@ -493,6 +494,7 @@ describe('WatchPanelProvider', () => {
     // dismissCompletedWatches now routes through the shared command so the
     // confirmation prompt and logging stay in one place.
     expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.dismissAllCompletedWatches');
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.watchUrl');
     expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.editItem', { id: 'work-42' });
     expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.previewIncomingItem', {
       providerId: 'github-pr-reviews',

--- a/packages/core/src/test/watchUrlClassifier.test.ts
+++ b/packages/core/src/test/watchUrlClassifier.test.ts
@@ -95,7 +95,7 @@ describe('classifyWatchUrl', () => {
     expect(classifyWatchUrl('https://example.com/nope', watcherRegistry, prWatcherRegistry)).toEqual({
       ok: false,
       reason: 'unsupported',
-      message: 'Unsupported URL. Paste a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL.',
+      message: 'Unsupported URL. Paste a supported pull request or pipeline run URL (for example, a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL).',
     });
   });
 });

--- a/packages/core/src/test/watchUrlClassifier.test.ts
+++ b/packages/core/src/test/watchUrlClassifier.test.ts
@@ -90,10 +90,11 @@ describe('classifyWatchUrl', () => {
     const watcherRegistry = { findWatcherForUrl: vi.fn(() => undefined) };
     const prWatcherRegistry = { findWatcherForUrl: vi.fn(() => undefined) };
 
-    expect(classifyWatchUrl('   ', watcherRegistry, prWatcherRegistry)).toEqual({ ok: false, message: 'URL cannot be empty.' });
-    expect(classifyWatchUrl('file:///repo', watcherRegistry, prWatcherRegistry)).toEqual({ ok: false, message: 'Only http(s) URLs are supported.' });
+    expect(classifyWatchUrl('   ', watcherRegistry, prWatcherRegistry)).toEqual({ ok: false, reason: 'empty', message: 'URL cannot be empty.' });
+    expect(classifyWatchUrl('file:///repo', watcherRegistry, prWatcherRegistry)).toEqual({ ok: false, reason: 'unsafe', message: 'Only http(s) URLs are supported.' });
     expect(classifyWatchUrl('https://example.com/nope', watcherRegistry, prWatcherRegistry)).toEqual({
       ok: false,
+      reason: 'unsupported',
       message: 'Unsupported URL. Paste a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL.',
     });
   });

--- a/packages/core/src/test/watchUrlClassifier.test.ts
+++ b/packages/core/src/test/watchUrlClassifier.test.ts
@@ -23,9 +23,8 @@ function createPRWatcher(id: string, label: string): DevDocketPRWatcher {
 }
 
 describe('classifyWatchUrl', () => {
-  it('provides GitHub PR and run examples for the shared input placeholder', () => {
-    expect(WATCH_URL_PLACEHOLDER).toContain('https://github.com/owner/repo/pull/123');
-    expect(WATCH_URL_PLACEHOLDER).toContain('https://github.com/owner/repo/actions/runs/12345');
+  it('uses a short hint placeholder describing the accepted URL types', () => {
+    expect(WATCH_URL_PLACEHOLDER).toBe('Pull request or pipeline run URL');
   });
 
   it('classifies pull request URLs before run URLs', () => {

--- a/packages/core/src/test/watchUrlClassifier.test.ts
+++ b/packages/core/src/test/watchUrlClassifier.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { DevDocketPRWatcher, DevDocketRunWatcher } from '@devdocket/shared';
+import { classifyWatchUrl, WATCH_URL_PLACEHOLDER } from '../commands/watchUrlClassifier';
+
+function createRunWatcher(id: string, label: string): DevDocketRunWatcher {
+  return {
+    id,
+    label,
+    canWatch: vi.fn(),
+    parseRunUrl: vi.fn(),
+    getRunStatus: vi.fn(),
+  };
+}
+
+function createPRWatcher(id: string, label: string): DevDocketPRWatcher {
+  return {
+    id,
+    label,
+    canWatch: vi.fn(),
+    parsePRUrl: vi.fn(),
+    getPRRunsSnapshot: vi.fn(),
+  };
+}
+
+describe('classifyWatchUrl', () => {
+  it('provides GitHub PR and run examples for the shared input placeholder', () => {
+    expect(WATCH_URL_PLACEHOLDER).toContain('https://github.com/owner/repo/pull/123');
+    expect(WATCH_URL_PLACEHOLDER).toContain('https://github.com/owner/repo/actions/runs/12345');
+  });
+
+  it('classifies pull request URLs before run URLs', () => {
+    const prWatcher = createPRWatcher('github-pr', 'GitHub Pull Requests');
+    const runWatcher = createRunWatcher('github-actions', 'GitHub Actions');
+    const watcherRegistry = { findWatcherForUrl: vi.fn(() => runWatcher) };
+    const prWatcherRegistry = { findWatcherForUrl: vi.fn(() => prWatcher) };
+
+    const result = classifyWatchUrl(' https://github.com/owner/repo/pull/123 ', watcherRegistry, prWatcherRegistry);
+
+    expect(result).toMatchObject({ ok: true, kind: 'pr', url: 'https://github.com/owner/repo/pull/123', watcher: prWatcher });
+    if (result.ok) {
+      expect(result.validationMessage).toBe('This looks like a GitHub PR — will be added as a PR watch.');
+    }
+    expect(watcherRegistry.findWatcherForUrl).not.toHaveBeenCalled();
+  });
+
+  it('classifies run URLs when no PR watcher recognizes the URL', () => {
+    const runWatcher = createRunWatcher('github-actions', 'GitHub Actions');
+    const watcherRegistry = { findWatcherForUrl: vi.fn(() => runWatcher) };
+    const prWatcherRegistry = { findWatcherForUrl: vi.fn(() => undefined) };
+
+    const result = classifyWatchUrl('https://github.com/owner/repo/actions/runs/12345', watcherRegistry, prWatcherRegistry);
+
+    expect(result).toMatchObject({ ok: true, kind: 'run', watcher: runWatcher });
+    if (result.ok) {
+      expect(result.validationMessage).toBe('This looks like a GitHub Actions run — will be added as a run watch.');
+    }
+  });
+
+  it('uses the watcher label for non-canonical watcher IDs', () => {
+    const runWatcher = createRunWatcher('github-advanced-security', 'GitHub Advanced Security');
+    const result = classifyWatchUrl(
+      'https://github.com/owner/repo/security/code-scanning/123',
+      { findWatcherForUrl: vi.fn(() => runWatcher) },
+      { findWatcherForUrl: vi.fn(() => undefined) },
+    );
+
+    expect(result.ok && result.validationMessage).toBe('This looks like a GitHub Advanced Security run — will be added as a run watch.');
+  });
+
+  it('classifies Azure DevOps PR and pipeline URLs with specific feedback', () => {
+    const adoPRWatcher = createPRWatcher('ado-pr', 'Azure DevOps Pull Requests');
+    const adoRunWatcher = createRunWatcher('ado-pipelines', 'Azure DevOps Pipelines');
+
+    const prResult = classifyWatchUrl(
+      'https://dev.azure.com/org/project/_git/repo/pullrequest/42',
+      { findWatcherForUrl: vi.fn(() => undefined) },
+      { findWatcherForUrl: vi.fn(() => adoPRWatcher) },
+    );
+    const runResult = classifyWatchUrl(
+      'https://dev.azure.com/org/project/_build/results?buildId=123',
+      { findWatcherForUrl: vi.fn(() => adoRunWatcher) },
+      { findWatcherForUrl: vi.fn(() => undefined) },
+    );
+
+    expect(prResult.ok && prResult.validationMessage).toBe('This looks like an Azure DevOps PR — will be added as a PR watch.');
+    expect(runResult.ok && runResult.validationMessage).toBe('This looks like an Azure DevOps Pipeline run — will be added as a run watch.');
+  });
+
+  it('rejects empty, non-http, and unsupported URLs with actionable messages', () => {
+    const watcherRegistry = { findWatcherForUrl: vi.fn(() => undefined) };
+    const prWatcherRegistry = { findWatcherForUrl: vi.fn(() => undefined) };
+
+    expect(classifyWatchUrl('   ', watcherRegistry, prWatcherRegistry)).toEqual({ ok: false, message: 'URL cannot be empty.' });
+    expect(classifyWatchUrl('file:///repo', watcherRegistry, prWatcherRegistry)).toEqual({ ok: false, message: 'Only http(s) URLs are supported.' });
+    expect(classifyWatchUrl('https://example.com/nope', watcherRegistry, prWatcherRegistry)).toEqual({
+      ok: false,
+      message: 'Unsupported URL. Paste a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL.',
+    });
+  });
+});

--- a/packages/core/src/test/watchUrlClassifier.test.ts
+++ b/packages/core/src/test/watchUrlClassifier.test.ts
@@ -30,71 +30,83 @@ describe('classifyWatchUrl', () => {
   it('classifies pull request URLs before run URLs', () => {
     const prWatcher = createPRWatcher('github-pr', 'GitHub Pull Requests');
     const runWatcher = createRunWatcher('github-actions', 'GitHub Actions');
-    const watcherRegistry = { findWatcherForUrl: vi.fn(() => runWatcher) };
-    const prWatcherRegistry = { findWatcherForUrl: vi.fn(() => prWatcher) };
+    const watcherRegistry = { findWatcherForUrl: vi.fn(() => runWatcher), getAll: vi.fn(() => [runWatcher]) };
+    const prWatcherRegistry = { findWatcherForUrl: vi.fn(() => prWatcher), getAll: vi.fn(() => [prWatcher]) };
 
     const result = classifyWatchUrl(' https://github.com/owner/repo/pull/123 ', watcherRegistry, prWatcherRegistry);
 
     expect(result).toMatchObject({ ok: true, kind: 'pr', url: 'https://github.com/owner/repo/pull/123', watcher: prWatcher });
     if (result.ok) {
-      expect(result.validationMessage).toBe('This looks like a GitHub PR — will be added as a PR watch.');
+      expect(result.validationMessage).toBe('Recognized by GitHub Pull Requests — will be added as a PR watch.');
     }
     expect(watcherRegistry.findWatcherForUrl).not.toHaveBeenCalled();
   });
 
   it('classifies run URLs when no PR watcher recognizes the URL', () => {
     const runWatcher = createRunWatcher('github-actions', 'GitHub Actions');
-    const watcherRegistry = { findWatcherForUrl: vi.fn(() => runWatcher) };
-    const prWatcherRegistry = { findWatcherForUrl: vi.fn(() => undefined) };
+    const watcherRegistry = { findWatcherForUrl: vi.fn(() => runWatcher), getAll: vi.fn(() => [runWatcher]) };
+    const prWatcherRegistry = { findWatcherForUrl: vi.fn(() => undefined), getAll: vi.fn(() => []) };
 
     const result = classifyWatchUrl('https://github.com/owner/repo/actions/runs/12345', watcherRegistry, prWatcherRegistry);
 
     expect(result).toMatchObject({ ok: true, kind: 'run', watcher: runWatcher });
     if (result.ok) {
-      expect(result.validationMessage).toBe('This looks like a GitHub Actions run — will be added as a run watch.');
+      expect(result.validationMessage).toBe('Recognized by GitHub Actions — will be added as a run watch.');
     }
   });
 
-  it('uses the watcher label for non-canonical watcher IDs', () => {
+  it('uses the watcher label for any watcher (no hardcoded provider knowledge in core)', () => {
     const runWatcher = createRunWatcher('github-advanced-security', 'GitHub Advanced Security');
     const result = classifyWatchUrl(
       'https://github.com/owner/repo/security/code-scanning/123',
-      { findWatcherForUrl: vi.fn(() => runWatcher) },
-      { findWatcherForUrl: vi.fn(() => undefined) },
+      { findWatcherForUrl: vi.fn(() => runWatcher), getAll: vi.fn(() => [runWatcher]) },
+      { findWatcherForUrl: vi.fn(() => undefined), getAll: vi.fn(() => []) },
     );
 
-    expect(result.ok && result.validationMessage).toBe('This looks like a GitHub Advanced Security run — will be added as a run watch.');
+    expect(result.ok && result.validationMessage).toBe('Recognized by GitHub Advanced Security — will be added as a run watch.');
   });
 
-  it('classifies Azure DevOps PR and pipeline URLs with specific feedback', () => {
+  it('classifies Azure DevOps PR and pipeline URLs using the watcher label', () => {
     const adoPRWatcher = createPRWatcher('ado-pr', 'Azure DevOps Pull Requests');
     const adoRunWatcher = createRunWatcher('ado-pipelines', 'Azure DevOps Pipelines');
 
     const prResult = classifyWatchUrl(
       'https://dev.azure.com/org/project/_git/repo/pullrequest/42',
-      { findWatcherForUrl: vi.fn(() => undefined) },
-      { findWatcherForUrl: vi.fn(() => adoPRWatcher) },
+      { findWatcherForUrl: vi.fn(() => undefined), getAll: vi.fn(() => []) },
+      { findWatcherForUrl: vi.fn(() => adoPRWatcher), getAll: vi.fn(() => [adoPRWatcher]) },
     );
     const runResult = classifyWatchUrl(
       'https://dev.azure.com/org/project/_build/results?buildId=123',
-      { findWatcherForUrl: vi.fn(() => adoRunWatcher) },
-      { findWatcherForUrl: vi.fn(() => undefined) },
+      { findWatcherForUrl: vi.fn(() => adoRunWatcher), getAll: vi.fn(() => [adoRunWatcher]) },
+      { findWatcherForUrl: vi.fn(() => undefined), getAll: vi.fn(() => []) },
     );
 
-    expect(prResult.ok && prResult.validationMessage).toBe('This looks like an Azure DevOps PR — will be added as a PR watch.');
-    expect(runResult.ok && runResult.validationMessage).toBe('This looks like an Azure DevOps Pipeline run — will be added as a run watch.');
+    expect(prResult.ok && prResult.validationMessage).toBe('Recognized by Azure DevOps Pull Requests — will be added as a PR watch.');
+    expect(runResult.ok && runResult.validationMessage).toBe('Recognized by Azure DevOps Pipelines — will be added as a run watch.');
   });
 
   it('rejects empty, non-http, and unsupported URLs with actionable messages', () => {
-    const watcherRegistry = { findWatcherForUrl: vi.fn(() => undefined) };
-    const prWatcherRegistry = { findWatcherForUrl: vi.fn(() => undefined) };
+    const prWatcher = createPRWatcher('github-pr', 'GitHub Pull Requests');
+    const runWatcher = createRunWatcher('github-actions', 'GitHub Actions');
+    const watcherRegistry = { findWatcherForUrl: vi.fn(() => undefined), getAll: vi.fn(() => [runWatcher]) };
+    const prWatcherRegistry = { findWatcherForUrl: vi.fn(() => undefined), getAll: vi.fn(() => [prWatcher]) };
 
     expect(classifyWatchUrl('   ', watcherRegistry, prWatcherRegistry)).toEqual({ ok: false, reason: 'empty', message: 'URL cannot be empty.' });
     expect(classifyWatchUrl('file:///repo', watcherRegistry, prWatcherRegistry)).toEqual({ ok: false, reason: 'unsafe', message: 'Only http(s) URLs are supported.' });
     expect(classifyWatchUrl('https://example.com/nope', watcherRegistry, prWatcherRegistry)).toEqual({
       ok: false,
       reason: 'unsupported',
-      message: 'Unsupported URL. Paste a supported pull request or pipeline run URL (for example, a GitHub PR, GitHub Actions run, Azure DevOps PR, or Azure DevOps pipeline run URL).',
+      message: 'Unsupported URL. Paste a URL recognized by one of: GitHub Pull Requests, GitHub Actions.',
+    });
+  });
+
+  it('reports a helpful message when no watchers are registered', () => {
+    const empty = { findWatcherForUrl: vi.fn(() => undefined), getAll: vi.fn(() => []) };
+    const result = classifyWatchUrl('https://example.com/nope', empty, empty);
+    expect(result).toEqual({
+      ok: false,
+      reason: 'unsupported',
+      message: 'Unsupported URL. No pull request or pipeline run watchers are currently registered. Install a provider extension that contributes a watcher.',
     });
   });
 });

--- a/packages/core/src/views/watchPanelProvider.ts
+++ b/packages/core/src/views/watchPanelProvider.ts
@@ -154,7 +154,7 @@ export class WatchPanelProvider implements vscode.Disposable {
         this.dismissWatchById(message.watchId);
         break;
       case 'addWatchUrl':
-        await vscode.commands.executeCommand('devdocket.watchRun');
+        await vscode.commands.executeCommand('devdocket.watchUrl');
         break;
       case 'watchPanelReady':
         // The webview has mounted and attached its message listener.

--- a/packages/shared/src/apiTypes.ts
+++ b/packages/shared/src/apiTypes.ts
@@ -189,7 +189,7 @@ export interface DevDocketApi {
    * Register a pipeline run watcher.
    *
    * Run watchers provide status polling for CI/CD pipelines (GitHub Actions, ADO Pipelines, etc.).
-   * Once registered, users can watch runs by pasting URLs into the "Watch Pipeline Run" command.
+   * Once registered, users can watch runs by pasting URLs into the "Watch URL" command.
    *
    * @param watcher - The run watcher to register.
    * @returns A {@link Disposable} that unregisters the watcher when disposed.


### PR DESCRIPTION
## Summary
- Add a unified Watch URL command with example placeholder text and live URL classification feedback.
- Keep the legacy watchRun and watchPR command IDs as hidden aliases.
- Document supported watch URL surfaces in the UX guide and Watch CI walkthrough.

## Tests
- npm run build
- npm run test --workspaces -- --reporter=dot

Closes #543
