### PR TITLE
Inject editor panel dependencies

### DIFF
--- a/.github/instructions/views.instructions.md
+++ b/.github/instructions/views.instructions.md
@@ -44,9 +44,9 @@ Badges shown next to item titles fall into four categories:
 
 Core never infers state badges from `ProviderItem.state` or `reason` strings — providers must declare them explicitly. See `.github/instructions/providers.instructions.md` for the badge conventions.
 
-## PanelManager Lifecycle
+## Panel Lifecycle
 
-`WorkItemEditorPanel` and `IncomingPreviewPanel` use a `PanelManager` instantiated during `activate()` and disposed with the extension context. The static `setPanelManager()` pattern preserves the static API facade while scoping panel cache ownership to the extension lifecycle.
+`WorkItemEditorPanel` receives a `PanelManager` plus its action/state/watch dependencies through its `open(...)` factory. `IncomingPreviewPanel` receives an `IncomingPreviewPanelManager` through its `open(...)` factory. Instantiate both managers during `activate()` and dispose them with the extension context so panel caches are scoped to one activation; do not add mutable static dependency singletons to view modules.
 
 ## Webview Security
 

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -7,8 +7,8 @@ import { ProviderRegistry } from '../services/providerRegistry';
 import { InboxStateStore, type InboxState } from '../storage/inboxStateStore';
 import type { ProviderLabelCache } from '../storage/providerLabelCache';
 import type { ReadStateStore } from '../storage/readStateStore';
-import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
-import { IncomingPreviewPanel } from '../views/incomingPreviewPanel';
+import { WorkItemEditorPanel, type WorkItemEditorPanelDependencies } from '../views/workItemEditorPanel';
+import { IncomingPreviewPanel, type IncomingPreviewPanelManager } from '../views/incomingPreviewPanel';
 import { type InboxItem, type SourceItemNode, type SourcesElement } from './commandItemTypes';
 import { logger } from '../services/logger';
 import type { ResolvedItem } from '../api/types';
@@ -294,6 +294,7 @@ async function handleCreateItem(
   workGraph: WorkGraph,
   providerRegistry: ProviderRegistry,
   labelCache: ProviderLabelCache,
+  editorPanelDependencies: WorkItemEditorPanelDependencies,
 ): Promise<void> {
   const title = await vscode.window.showInputBox({
     prompt: 'Work item title',
@@ -307,7 +308,7 @@ async function handleCreateItem(
   logger.info(`Creating new work item: ${title.trim()}`);
   const createdItem = await workGraph.createItem({ title: title.trim() });
   const providerLabel = createdItem.providerId ? labelCache.get(createdItem.providerId) : undefined;
-  void WorkItemEditorPanel.open(context, workGraph, providerRegistry, createdItem, providerLabel);
+  void WorkItemEditorPanel.open(context, workGraph, providerRegistry, createdItem, editorPanelDependencies, providerLabel);
   void vscode.window.showInformationMessage(`DevDocket: Created "${title.trim()}"`);
 }
 
@@ -316,6 +317,7 @@ async function handleCreateItemFromUrl(
   workGraph: WorkGraph,
   providerRegistry: ProviderRegistry,
   labelCache: ProviderLabelCache,
+  editorPanelDependencies: WorkItemEditorPanelDependencies,
 ): Promise<void> {
   const url = await vscode.window.showInputBox({
     prompt: 'Enter a URL to create a work item from',
@@ -353,7 +355,7 @@ async function handleCreateItemFromUrl(
   const existing = workGraph.findItemByProvenance(details.providerId, details.externalId);
   if (existing) {
     const providerLabel = existing.providerId ? labelCache.get(existing.providerId) : undefined;
-    WorkItemEditorPanel.open(context, workGraph, providerRegistry, existing, providerLabel);
+    WorkItemEditorPanel.open(context, workGraph, providerRegistry, existing, editorPanelDependencies, providerLabel);
     void vscode.window.showInformationMessage('DevDocket: Item already exists for this source item');
     return;
   }
@@ -365,7 +367,7 @@ async function handleCreateItemFromUrl(
   );
 
   const providerLabel = createdItem.providerId ? labelCache.get(createdItem.providerId) : undefined;
-  WorkItemEditorPanel.open(context, workGraph, providerRegistry, createdItem, providerLabel);
+  WorkItemEditorPanel.open(context, workGraph, providerRegistry, createdItem, editorPanelDependencies, providerLabel);
   void vscode.window.showInformationMessage(`DevDocket: Created "${details.title}"`);
 }
 
@@ -416,13 +418,14 @@ function handleEditItem(
   workGraph: WorkGraph,
   providerRegistry: ProviderRegistry,
   labelCache: ProviderLabelCache,
+  editorPanelDependencies: WorkItemEditorPanelDependencies,
   item?: { id?: string },
 ): void {
   if (!item?.id) { return; }
   const workItem = workGraph.getItem(item.id);
   if (workItem) {
     const providerLabel = workItem.providerId ? labelCache.get(workItem.providerId) : undefined;
-    WorkItemEditorPanel.open(context, workGraph, providerRegistry, workItem, providerLabel);
+    WorkItemEditorPanel.open(context, workGraph, providerRegistry, workItem, editorPanelDependencies, providerLabel);
   }
 }
 
@@ -750,6 +753,8 @@ export function registerCommands(
   prWatcherRegistry: PRWatcherRegistry,
   watcherService: WatcherService,
   watchPanelProvider: WatchPanelProvider,
+  editorPanelDependencies: WorkItemEditorPanelDependencies,
+  incomingPreviewPanelManager: IncomingPreviewPanelManager,
   toggleMainSearch: () => void,
 ): void {
   context.subscriptions.push(
@@ -766,9 +771,9 @@ export function registerCommands(
         ),
       )),
     vscode.commands.registerCommand('devdocket.createItem',
-      wrapCommand('Failed to create item', () => handleCreateItem(context, workGraph, providerRegistry, labelCache))),
+      wrapCommand('Failed to create item', () => handleCreateItem(context, workGraph, providerRegistry, labelCache, editorPanelDependencies))),
     vscode.commands.registerCommand('devdocket.createItemFromUrl',
-      wrapCommand('Failed to create item from URL', () => handleCreateItemFromUrl(context, workGraph, providerRegistry, labelCache))),
+      wrapCommand('Failed to create item from URL', () => handleCreateItemFromUrl(context, workGraph, providerRegistry, labelCache, editorPanelDependencies))),
     vscode.commands.registerCommand('devdocket.previewIncomingItem',
       wrapCommand('Failed to preview incoming item', (arg: unknown) => {
         if (!arg || typeof arg !== 'object') {
@@ -778,7 +783,7 @@ export function registerCommands(
         if (typeof providerId !== 'string' || typeof externalId !== 'string') {
           throw new Error('previewIncomingItem requires string providerId and externalId');
         }
-        IncomingPreviewPanel.open(context, providerRegistry, stateStore, readStateStore, workGraph, providerId, externalId);
+        IncomingPreviewPanel.open(context, incomingPreviewPanelManager, providerRegistry, stateStore, readStateStore, workGraph, providerId, externalId);
       })),
     vscode.commands.registerCommand('devdocket.acceptToFocus',
       wrapCommand('Failed to move item to In Progress', (item, selectedItems) => handleAcceptToFocus(workGraph, item, selectedItems))),
@@ -795,7 +800,7 @@ export function registerCommands(
     vscode.commands.registerCommand('devdocket.clearHistory',
       wrapCommand('Failed to clear history', () => handleClearHistory(workGraph))),
     vscode.commands.registerCommand('devdocket.editItem',
-      wrapCommand('Failed to open editor', (item) => handleEditItem(context, workGraph, providerRegistry, labelCache, item))),
+      wrapCommand('Failed to open editor', (item) => handleEditItem(context, workGraph, providerRegistry, labelCache, editorPanelDependencies, item))),
     vscode.commands.registerCommand('devdocket.openInBrowser',
       wrapCommand('Failed to open in browser', (item) => handleOpenInBrowser(workGraph, item))),
     vscode.commands.registerCommand('devdocket.copyUrl',

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -18,7 +18,8 @@ import { WatchStore } from './storage/watchStore';
 import { WatchesStatusBar } from './views/watchesStatusBar';
 import { ProviderHealthStatusBar } from './views/providerHealthStatusBar';
 import { WatchPanelProvider } from './views/watchPanelProvider';
-import { WorkItemEditorPanel, PanelManager } from './views/workItemEditorPanel';
+import { PanelManager, type WorkItemEditorPanelDependencies } from './views/workItemEditorPanel';
+import { IncomingPreviewPanelManager } from './views/incomingPreviewPanel';
 import { MainViewProvider } from './views/mainViewProvider';
 import { registerCommands } from './commands/commands';
 import { isSafeUrl } from './utils/url';
@@ -539,17 +540,23 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     logger.error('Failed to load persisted watches', err);
   }
 
-  // Scope panel cache to extension lifecycle
+  // Scope panel caches to extension lifecycle.
   const panelManager = new PanelManager();
-  WorkItemEditorPanel.setPanelManager(panelManager);
-  WorkItemEditorPanel.setDependencies(ar, ss, ws);
+  const incomingPreviewPanelManager = new IncomingPreviewPanelManager();
+  const editorPanelDependencies: WorkItemEditorPanelDependencies = {
+    panelManager,
+    actionRegistry: ar,
+    stateStore: ss,
+    watcherService: ws,
+  };
 
-  // panelManager must be first: its dispose() flushes pending saves via
+  // Panel managers must be first: editor disposal flushes pending saves via
   // WorkGraph, which must still be alive at that point. VS Code disposes
-  // subscriptions in array order, so placing it first ensures it runs
+  // subscriptions in array order, so placing them first ensures they run
   // before WorkGraph is disposed.
   context.subscriptions.push(
     panelManager,
+    incomingPreviewPanelManager,
     ...eventDisposables,
     mainProvider,
     watchPanelProvider,
@@ -566,7 +573,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   );
 
   const commandRegStart = performance.now();
-  registerCommands(context, wg, ar, ss, readStateStore, pr, labelCache, wr, pwr, ws, watchPanelProvider, () => mainProvider.toggleSearch());
+  registerCommands(context, wg, ar, ss, readStateStore, pr, labelCache, wr, pwr, ws, watchPanelProvider, editorPanelDependencies, incomingPreviewPanelManager, () => mainProvider.toggleSearch());
   logger.info(`Command registration took ${Math.round(performance.now() - commandRegStart)}ms`);
 
   logger.info(`DevDocket activated in ${Math.round(performance.now() - activationStart)}ms`);

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -12,7 +12,8 @@ import type { WatcherRegistry } from '../services/watcherRegistry';
 import type { PRWatcherRegistry } from '../services/prWatcherRegistry';
 import type { WatcherService } from '../services/watcherService';
 import type { InboxItem, InboxProviderNode, InboxGroupNode, SourceItemNode, SourceProviderNode, SourceGroupNode } from '../commands/commandItemTypes';
-import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
+import { PanelManager, WorkItemEditorPanel, type WorkItemEditorPanelDependencies } from '../views/workItemEditorPanel';
+import { IncomingPreviewPanelManager } from '../views/incomingPreviewPanel';
 import { logger } from '../services/logger';
 
 vi.mock('../services/logger', () => ({
@@ -133,6 +134,8 @@ describe('registerCommands', () => {
   let providerRegistry: ReturnType<typeof createMockProviderRegistry>;
   let labelCache: ReturnType<typeof createMockLabelCache>;
   let watchPanelProvider: { open: Mock };
+  let editorPanelDependencies: WorkItemEditorPanelDependencies;
+  let incomingPreviewPanelManager: IncomingPreviewPanelManager;
   let ctx: vscode.ExtensionContext;
 
   beforeEach(() => {
@@ -156,6 +159,12 @@ describe('registerCommands', () => {
     providerRegistry = createMockProviderRegistry();
     labelCache = createMockLabelCache();
     watchPanelProvider = { open: vi.fn() };
+    editorPanelDependencies = {
+      panelManager: new PanelManager(),
+      actionRegistry: actionRegistry as any,
+      stateStore: stateStore as any,
+    };
+    incomingPreviewPanelManager = new IncomingPreviewPanelManager();
     ctx = createMockContext();
 
     registerCommands(
@@ -170,6 +179,8 @@ describe('registerCommands', () => {
       {} as PRWatcherRegistry,
       {} as WatcherService,
       watchPanelProvider as any,
+      editorPanelDependencies,
+      incomingPreviewPanelManager,
       vi.fn(),
     );
   });
@@ -264,6 +275,7 @@ describe('registerCommands', () => {
         workGraph,
         providerRegistry,
         createdItem,
+        editorPanelDependencies,
         undefined,
       );
       expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
@@ -332,7 +344,7 @@ describe('registerCommands', () => {
 
       expect(workGraph.createItem).not.toHaveBeenCalled();
       expect(WorkItemEditorPanel.open).toHaveBeenCalledWith(
-        expect.anything(), expect.anything(), expect.anything(), existing, undefined,
+        expect.anything(), expect.anything(), expect.anything(), existing, editorPanelDependencies, undefined,
       );
       expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
         'DevDocket: Item already exists for this source item',
@@ -411,7 +423,7 @@ describe('registerCommands', () => {
       invoke('devdocket.editItem', { id: item.id });
 
       expect(workGraph.getItem).toHaveBeenCalledWith(item.id);
-      expect(WorkItemEditorPanel.open).toHaveBeenCalledWith(ctx, workGraph, providerRegistry, item, undefined);
+      expect(WorkItemEditorPanel.open).toHaveBeenCalledWith(ctx, workGraph, providerRegistry, item, editorPanelDependencies, undefined);
     });
 
     it('passes provider label when item has providerId', () => {
@@ -422,7 +434,7 @@ describe('registerCommands', () => {
       invoke('devdocket.editItem', { id: item.id });
 
       expect(labelCache.get).toHaveBeenCalledWith('github');
-      expect(WorkItemEditorPanel.open).toHaveBeenCalledWith(ctx, workGraph, providerRegistry, item, 'GitHub Issues');
+      expect(WorkItemEditorPanel.open).toHaveBeenCalledWith(ctx, workGraph, providerRegistry, item, editorPanelDependencies, 'GitHub Issues');
     });
 
     it('does not open editor when item is not found', () => {

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { EventEmitter, ViewColumn, window } from 'vscode';
-import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
+import { PanelManager, WorkItemEditorPanel, type WorkItemEditorPanelDependencies } from '../views/workItemEditorPanel';
 import { WorkItem, WorkItemState } from '../models/workItem';
 
 function makeItem(overrides: Partial<WorkItem> = {}): WorkItem {
@@ -226,6 +226,20 @@ function createMockContext() {
   } as unknown as vscode.ExtensionContext;
 }
 
+function createEditorDependencies(
+  actionRegistry = createMockActionRegistry(),
+  stateStore = createMockStateStore(),
+  watcherService?: ReturnType<typeof createMockWatcherService>,
+  panelManager = new PanelManager(),
+): WorkItemEditorPanelDependencies {
+  return {
+    panelManager,
+    actionRegistry: actionRegistry as any,
+    stateStore: stateStore as any,
+    watcherService: watcherService as any,
+  };
+}
+
 function openPanel(
   item: WorkItem,
   workGraph = createMockWorkGraph(item),
@@ -233,21 +247,27 @@ function openPanel(
   actionRegistry = createMockActionRegistry(),
   stateStore = createMockStateStore(),
   watcherService?: ReturnType<typeof createMockWatcherService>,
+  panelManager = new PanelManager(),
 ) {
   const mock = createMockWebviewPanel();
   const context = createMockContext();
+  const dependencies = createEditorDependencies(actionRegistry, stateStore, watcherService, panelManager);
   vi.mocked(window.createWebviewPanel).mockReturnValue(mock.panel as any);
-  WorkItemEditorPanel.setDependencies(actionRegistry as any, stateStore as any, watcherService as any);
-  WorkItemEditorPanel.open(context, workGraph as any, providerRegistry as any, item, item.providerId ? 'GitHub' : undefined);
-  return { mock, context, workGraph, providerRegistry, actionRegistry, stateStore, watcherService };
+  WorkItemEditorPanel.open(context, workGraph as any, providerRegistry as any, item, dependencies, item.providerId ? 'GitHub' : undefined);
+  return { mock, context, workGraph, providerRegistry, actionRegistry, stateStore, watcherService, panelManager, dependencies };
 }
 
 describe('WorkItemEditorPanel', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    WorkItemEditorPanel.clearPanelCache();
-    WorkItemEditorPanel.setDependencies(undefined, undefined);
     vi.useRealTimers();
+  });
+
+  it('does not expose mutable static dependency state', () => {
+    const keys = Reflect.ownKeys(WorkItemEditorPanel);
+    for (const key of ['panelManager', 'actionRegistry', 'stateStore', 'watcherService', 'setPanelManager', 'setDependencies']) {
+      expect(keys).not.toContain(key);
+    }
   });
 
   it('creates a webview panel with the editor bundle shell', () => {
@@ -646,12 +666,40 @@ describe('WorkItemEditorPanel', () => {
     const mock = createMockWebviewPanel();
     const context = createMockContext();
     vi.mocked(window.createWebviewPanel).mockReturnValue(mock.panel as any);
-    WorkItemEditorPanel.setDependencies(createMockActionRegistry() as any, createMockStateStore() as any);
+    const dependencies = createEditorDependencies(undefined, undefined, undefined, new PanelManager());
 
-    WorkItemEditorPanel.open(context, createMockWorkGraph(item) as any, createMockProviderRegistry() as any, item);
-    WorkItemEditorPanel.open(context, createMockWorkGraph(item) as any, createMockProviderRegistry() as any, item);
+    WorkItemEditorPanel.open(context, createMockWorkGraph(item) as any, createMockProviderRegistry() as any, item, dependencies);
+    WorkItemEditorPanel.open(context, createMockWorkGraph(item) as any, createMockProviderRegistry() as any, item, dependencies);
 
     expect(window.createWebviewPanel).toHaveBeenCalledTimes(1);
     expect(mock.panel.reveal).toHaveBeenCalledTimes(1);
+  });
+
+  it('scopes panel reuse to the injected panel manager', () => {
+    const item = makeItem({ id: 'reuse-activation-1', title: 'Reusable per activation' });
+    const firstMock = createMockWebviewPanel();
+    const secondMock = createMockWebviewPanel();
+    vi.mocked(window.createWebviewPanel)
+      .mockReturnValueOnce(firstMock.panel as any)
+      .mockReturnValueOnce(secondMock.panel as any);
+
+    WorkItemEditorPanel.open(
+      createMockContext(),
+      createMockWorkGraph(item) as any,
+      createMockProviderRegistry() as any,
+      item,
+      createEditorDependencies(undefined, undefined, undefined, new PanelManager()),
+    );
+    WorkItemEditorPanel.open(
+      createMockContext(),
+      createMockWorkGraph(item) as any,
+      createMockProviderRegistry() as any,
+      item,
+      createEditorDependencies(undefined, undefined, undefined, new PanelManager()),
+    );
+
+    expect(window.createWebviewPanel).toHaveBeenCalledTimes(2);
+    expect(firstMock.panel.reveal).not.toHaveBeenCalled();
+    expect(secondMock.panel.reveal).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/views/incomingPreviewPanel.ts
+++ b/packages/core/src/views/incomingPreviewPanel.ts
@@ -13,6 +13,31 @@ import type { EditorItemData } from './mainTypes';
 import { composeEditorBadges } from './workItemEditorPanel';
 
 /**
+ * Manages the lifecycle of open IncomingPreviewPanels.
+ * Created during extension activation and disposed with the extension context,
+ * preventing stale preview references across extension reloads.
+ */
+export class IncomingPreviewPanelManager {
+  /** @internal Used by IncomingPreviewPanel — not part of public API. */
+  readonly openPanels = new Map<string, IncomingPreviewPanel>();
+  private disposed = false;
+
+  clearPanelCache(): void {
+    const panels = Array.from(this.openPanels.values());
+    for (const preview of panels) {
+      preview.dispose();
+    }
+    this.openPanels.clear();
+  }
+
+  dispose(): void {
+    if (this.disposed) { return; }
+    this.disposed = true;
+    this.clearPanelCache();
+  }
+}
+
+/**
  * Read-only "preview" editor panel for an incoming/discovered item that does
  * not yet have a backing WorkItem.
  *
@@ -25,13 +50,13 @@ import { composeEditorBadges } from './workItemEditorPanel';
  */
 export class IncomingPreviewPanel {
   private static readonly viewType = 'devdocket.previewItem';
-  private static readonly openPanels = new Map<string, IncomingPreviewPanel>();
 
   private readonly panel: vscode.WebviewPanel;
   private readonly providerRegistry: ProviderRegistry;
   private readonly stateStore: InboxStateStore;
   private readonly readStateStore: ReadStateStore;
   private readonly workGraph: WorkGraph;
+  private readonly panelManager: IncomingPreviewPanelManager;
   private readonly providerId: string;
   private readonly externalId: string;
   private readonly extensionUri: vscode.Uri;
@@ -41,6 +66,7 @@ export class IncomingPreviewPanel {
 
   static open(
     context: vscode.ExtensionContext,
+    panelManager: IncomingPreviewPanelManager,
     providerRegistry: ProviderRegistry,
     stateStore: InboxStateStore,
     readStateStore: ReadStateStore,
@@ -49,7 +75,7 @@ export class IncomingPreviewPanel {
     externalId: string,
   ): void {
     const key = IncomingPreviewPanel.cacheKey(providerId, externalId);
-    const existing = IncomingPreviewPanel.openPanels.get(key);
+    const existing = panelManager.openPanels.get(key);
     if (existing) {
       existing.update();
       existing.panel.reveal();
@@ -75,8 +101,8 @@ export class IncomingPreviewPanel {
       },
     );
 
-    const preview = new IncomingPreviewPanel(panel, providerRegistry, stateStore, readStateStore, workGraph, providerId, externalId, context.extensionUri);
-    IncomingPreviewPanel.openPanels.set(key, preview);
+    const preview = new IncomingPreviewPanel(panel, providerRegistry, stateStore, readStateStore, workGraph, panelManager, providerId, externalId, context.extensionUri);
+    panelManager.openPanels.set(key, preview);
     // Panel cleanup is wired in the constructor via panel.onDidDispose →
     // this.dispose(). Pushing onto context.subscriptions would leak a
     // closure per open (panels self-dispose long before the extension does).
@@ -88,6 +114,7 @@ export class IncomingPreviewPanel {
     stateStore: InboxStateStore,
     readStateStore: ReadStateStore,
     workGraph: WorkGraph,
+    panelManager: IncomingPreviewPanelManager,
     providerId: string,
     externalId: string,
     extensionUri: vscode.Uri,
@@ -97,6 +124,7 @@ export class IncomingPreviewPanel {
     this.stateStore = stateStore;
     this.readStateStore = readStateStore;
     this.workGraph = workGraph;
+    this.panelManager = panelManager;
     this.providerId = providerId;
     this.externalId = externalId;
     this.extensionUri = extensionUri;
@@ -309,7 +337,7 @@ export class IncomingPreviewPanel {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
-    IncomingPreviewPanel.openPanels.delete(IncomingPreviewPanel.cacheKey(this.providerId, this.externalId));
+    this.panelManager.openPanels.delete(IncomingPreviewPanel.cacheKey(this.providerId, this.externalId));
     for (const sub of this.subscriptions) {
       try { sub.dispose(); } catch { /* ignore */ }
     }

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -132,7 +132,6 @@ export class WorkItemEditorPanel {
       providerLabel,
     );
     manager.openPanels.set(item.id, editor);
-    context.subscriptions.push({ dispose: () => editor.dispose() });
   }
 
   private constructor(

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -51,18 +51,24 @@ export class PanelManager {
   }
 }
 
+export interface WorkItemEditorPanelDependencies {
+  panelManager: PanelManager;
+  actionRegistry: ActionRegistry;
+  stateStore: InboxStateStore;
+  watcherService?: WatcherService;
+}
+
 export class WorkItemEditorPanel {
   private static readonly viewType = 'devdocket.editItem';
-  private static panelManager = new PanelManager();
-  private static actionRegistry?: ActionRegistry;
-  private static stateStore?: InboxStateStore;
-  private static watcherService?: WatcherService;
 
   private readonly panel: vscode.WebviewPanel;
   private readonly workGraph: WorkGraph;
   private readonly providerRegistry: ProviderRegistry;
   private readonly itemId: string;
   private readonly panelManager: PanelManager;
+  private readonly actionRegistry: ActionRegistry;
+  private readonly stateStore: InboxStateStore;
+  private readonly watcherService?: WatcherService;
   private readonly extensionUri: vscode.Uri;
   private disposed = false;
   private htmlInitialized = false;
@@ -73,7 +79,7 @@ export class WorkItemEditorPanel {
   private readonly workGraphSub: vscode.Disposable;
   private readonly providerRegSub: vscode.Disposable;
   private readonly providerChangeSub: vscode.Disposable;
-  private readonly actionRegistrySub?: vscode.Disposable;
+  private readonly actionRegistrySub: vscode.Disposable;
   private readonly watcherSubscriptions: vscode.Disposable[] = [];
   private lastDisplayedTitle: string | undefined;
   private lastDisplayedUrl: string | undefined;
@@ -85,28 +91,15 @@ export class WorkItemEditorPanel {
   private lastDisplayedCIWatchSignature: string | undefined;
   private lastDisplayedCIWatchRunKeys = new Set<string>();
 
-  /**
-   * Replace the active panel manager. Called during `activate()` to scope
-   * the panel cache to the extension lifecycle.
-   */
-  static setPanelManager(manager: PanelManager): void {
-    WorkItemEditorPanel.panelManager = manager;
-  }
-
-  static setDependencies(actionRegistry?: ActionRegistry, stateStore?: InboxStateStore, watcherService?: WatcherService): void {
-    WorkItemEditorPanel.actionRegistry = actionRegistry;
-    WorkItemEditorPanel.stateStore = stateStore;
-    WorkItemEditorPanel.watcherService = watcherService;
-  }
-
   static open(
     context: vscode.ExtensionContext,
     workGraph: WorkGraph,
     providerRegistry: ProviderRegistry,
     item: WorkItem,
+    dependencies: WorkItemEditorPanelDependencies,
     providerLabel?: string,
   ): void {
-    const manager = WorkItemEditorPanel.panelManager;
+    const manager = dependencies.panelManager;
     const existing = manager.openPanels.get(item.id);
     if (existing) {
       existing.providerLabel = providerLabel;
@@ -126,14 +119,20 @@ export class WorkItemEditorPanel {
       },
     );
 
-    const editor = new WorkItemEditorPanel(panel, workGraph, providerRegistry, item.id, manager, context.extensionUri, providerLabel);
+    const editor = new WorkItemEditorPanel(
+      panel,
+      workGraph,
+      providerRegistry,
+      item.id,
+      manager,
+      dependencies.actionRegistry,
+      dependencies.stateStore,
+      dependencies.watcherService,
+      context.extensionUri,
+      providerLabel,
+    );
     manager.openPanels.set(item.id, editor);
     context.subscriptions.push({ dispose: () => editor.dispose() });
-  }
-
-  /** @internal Exposed for testing only. */
-  static clearPanelCache(): void {
-    WorkItemEditorPanel.panelManager.clearPanelCache();
   }
 
   private constructor(
@@ -142,6 +141,9 @@ export class WorkItemEditorPanel {
     providerRegistry: ProviderRegistry,
     itemId: string,
     panelManager: PanelManager,
+    actionRegistry: ActionRegistry,
+    stateStore: InboxStateStore,
+    watcherService: WatcherService | undefined,
     extensionUri: vscode.Uri,
     private providerLabel?: string,
   ) {
@@ -150,6 +152,9 @@ export class WorkItemEditorPanel {
     this.providerRegistry = providerRegistry;
     this.itemId = itemId;
     this.panelManager = panelManager;
+    this.actionRegistry = actionRegistry;
+    this.stateStore = stateStore;
+    this.watcherService = watcherService;
     this.extensionUri = extensionUri;
 
     this.update();
@@ -166,15 +171,15 @@ export class WorkItemEditorPanel {
       this.update();
     });
 
-    this.actionRegistrySub = WorkItemEditorPanel.actionRegistry?.onDidChangeRegistrations(() => {
+    this.actionRegistrySub = this.actionRegistry.onDidChangeRegistrations(() => {
       this.update();
     });
 
-    const watcherService = WorkItemEditorPanel.watcherService;
-    if (watcherService) {
+    const activeWatcherService = this.watcherService;
+    if (activeWatcherService) {
       this.watcherSubscriptions.push(
-        watcherService.onDidChangePRWatches(() => this.refreshForPRWatchChange()),
-        watcherService.onDidChangeWatchedRuns(runs => this.refreshForWatchedRunsChange(runs)),
+        activeWatcherService.onDidChangePRWatches(() => this.refreshForPRWatchChange()),
+        activeWatcherService.onDidChangeWatchedRuns(runs => this.refreshForWatchedRunsChange(runs)),
       );
     }
 
@@ -244,7 +249,7 @@ export class WorkItemEditorPanel {
         this.workGraphSub.dispose();
         this.providerRegSub.dispose();
         this.providerChangeSub.dispose();
-        this.actionRegistrySub?.dispose();
+        this.actionRegistrySub.dispose();
         this.disposeWatcherSubscriptions();
       }
     });
@@ -414,7 +419,7 @@ export class WorkItemEditorPanel {
       badges: composeEditorBadges(item.providerId, providerItem, providerLabel),
       isProviderManaged: this.isProviderManaged(item),
       validTransitions: Array.from(VALID_TRANSITIONS.get(item.state) ?? []),
-      hasActions: WorkItemEditorPanel.actionRegistry?.hasActionsFor(item) ?? false,
+      hasActions: this.actionRegistry.hasActionsFor(item),
       activityLog: item.activityLog ?? [],
       relatedItems: resolveRelatedItemsFor(item, this.providerRegistry, this.workGraph, relatedItemsIndex),
       ciWatch: this.buildCIWatchData(item),
@@ -472,7 +477,7 @@ export class WorkItemEditorPanel {
       return undefined;
     }
 
-    const watcherService = WorkItemEditorPanel.watcherService;
+    const watcherService = this.watcherService;
     const external = item.externalId ? parsePRExternalId(item.externalId) : undefined;
     if (!watcherService || !external) {
       return undefined;
@@ -538,7 +543,7 @@ export class WorkItemEditorPanel {
       this.workGraphSub.dispose();
       this.providerRegSub.dispose();
       this.providerChangeSub.dispose();
-      this.actionRegistrySub?.dispose();
+      this.actionRegistrySub.dispose();
       this.disposeWatcherSubscriptions();
       this.panel.dispose();
     }
@@ -579,11 +584,6 @@ export class WorkItemEditorPanel {
   }
 
   private async handleAcceptItem(providerId: string, externalId: string): Promise<void> {
-    const stateStore = WorkItemEditorPanel.stateStore;
-    if (!stateStore) {
-      return;
-    }
-
     try {
       const existing = this.workGraph.findItemByProvenance(providerId, externalId);
       if (!existing) {
@@ -605,7 +605,7 @@ export class WorkItemEditorPanel {
           },
         );
       }
-      await stateStore.setState(providerId, externalId, 'accepted');
+      await this.stateStore.setState(providerId, externalId, 'accepted');
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       void vscode.window.showErrorMessage(`Failed to accept item: ${message}`);
@@ -613,13 +613,8 @@ export class WorkItemEditorPanel {
   }
 
   private async handleDismissItem(providerId: string, externalId: string): Promise<void> {
-    const stateStore = WorkItemEditorPanel.stateStore;
-    if (!stateStore) {
-      return;
-    }
-
     try {
-      await stateStore.setState(providerId, externalId, 'dismissed');
+      await this.stateStore.setState(providerId, externalId, 'dismissed');
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       void vscode.window.showErrorMessage(`Failed to dismiss item: ${message}`);


### PR DESCRIPTION
Closes #535

## Summary
- Replaced WorkItemEditorPanel static dependency setters with activation-scoped dependency injection.
- Added an activation-scoped IncomingPreviewPanelManager for preview panel reuse.
- Updated view lifecycle guidance and regression tests for static dependency state.

## Tests
- npm run build
- npm run test

## Migration Notes
No public API surface changed. The refactor is internal to the core extension views, commands, and activation wiring.
