### PR TITLE
Add actionable provider setup warnings

### DIFF
--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -8,6 +8,17 @@ import { parseAdoProjectsConfig } from './configParser';
 import { validateRefreshInterval, type DevDocketApi } from '@devdocket/shared';
 import { logger, setLogger } from './logger';
 
+const OPEN_SETTINGS = 'Open Settings';
+const ADO_PROJECTS_SETTING = 'devDocketAdo.projects';
+
+function showAdoProjectsSettingsWarning(message: string): void {
+  void vscode.window.showWarningMessage(message, OPEN_SETTINGS).then(action => {
+    if (action === OPEN_SETTINGS) {
+      void vscode.commands.executeCommand('workbench.action.openSettings', ADO_PROJECTS_SETTING);
+    }
+  });
+}
+
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const log = vscode.window.createOutputChannel('DevDocket ADO', { log: true });
   context.subscriptions.push(log);
@@ -61,18 +72,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     if (orgConfigs.length === 0) {
       const hasEntries = projects.some(p => p.trim().length > 0);
       if (hasEntries) {
-        logger.info('All devdocketAdo.projects entries are invalid — entries must be "org" or "org/project"');
+        logger.info('All devDocketAdo.projects entries are invalid — entries must be "org" or "org/project"');
         if (!orgWarningShown) {
-          void vscode.window.showWarningMessage(
-            'DevDocket ADO: All devdocketAdo.projects entries are invalid. Each entry must be "org" or "org/project".',
+          showAdoProjectsSettingsWarning(
+            'DevDocket ADO: All devDocketAdo.projects entries are invalid. Each entry must be "org" or "org/project".',
           );
           orgWarningShown = true;
         }
       } else {
-        logger.info('No organizations configured — set devdocketAdo.projects to enable ADO providers');
+        logger.info('No organizations configured — set devDocketAdo.projects to enable ADO providers');
         if (!orgWarningShown) {
-          void vscode.window.showWarningMessage(
-            'DevDocket ADO: No Azure DevOps organizations configured. Add entries to devdocketAdo.projects (e.g. "myorg" or "myorg/myproject").',
+          showAdoProjectsSettingsWarning(
+            'DevDocket ADO: No Azure DevOps organizations configured. Add entries to devDocketAdo.projects (e.g. "myorg" or "myorg/myproject").',
           );
           orgWarningShown = true;
         }

--- a/packages/ado/src/test/__mocks__/vscode.ts
+++ b/packages/ado/src/test/__mocks__/vscode.ts
@@ -47,7 +47,7 @@ class MockTreeItem {
 const window = {
   showInputBox: vi.fn(),
   showInformationMessage: vi.fn(),
-  showWarningMessage: vi.fn(),
+  showWarningMessage: vi.fn(async () => undefined),
   showErrorMessage: vi.fn(),
   showQuickPick: vi.fn(),
   registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })),

--- a/packages/ado/src/test/extension.test.ts
+++ b/packages/ado/src/test/extension.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
-import { workspace, extensions, window } from 'vscode';
+import { workspace, extensions, window, commands } from 'vscode';
 import { activate, deactivate } from '../extension';
 
 // Stub fetch globally to prevent real network calls from provider.refresh()
@@ -229,6 +229,67 @@ describe('extension activation', () => {
     await activate(mockContext);
 
     expect(mockApi.registerProvider).not.toHaveBeenCalled();
+  });
+
+  it('opens ADO projects settings from the missing-projects warning', async () => {
+    vi.mocked(window.showWarningMessage).mockResolvedValue('Open Settings' as any);
+    vi.mocked(workspace.getConfiguration).mockImplementation((section?: string) => {
+      if (section === 'devDocketAdo') {
+        return {
+          get: vi.fn((key: string, defaultValue?: any) => {
+            if (key === 'organization') return '';
+            if (key === 'projects') return [];
+            if (key === 'refreshIntervalSeconds') return 0;
+            return defaultValue;
+          }),
+        } as any;
+      }
+      return {
+        get: vi.fn((_key: string, defaultValue?: any) => defaultValue),
+      } as any;
+    });
+
+    await activate(mockContext);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('No Azure DevOps organizations configured'),
+      'Open Settings',
+    );
+    expect(commands.executeCommand).toHaveBeenCalledWith(
+      'workbench.action.openSettings',
+      'devDocketAdo.projects',
+    );
+  });
+
+  it('opens ADO projects settings from the invalid-projects warning', async () => {
+    vi.mocked(window.showWarningMessage).mockResolvedValue('Open Settings' as any);
+    vi.mocked(workspace.getConfiguration).mockImplementation((section?: string) => {
+      if (section === 'devDocketAdo') {
+        return {
+          get: vi.fn((key: string, defaultValue?: any) => {
+            if (key === 'projects') return [' / '];
+            if (key === 'refreshIntervalSeconds') return 0;
+            return defaultValue;
+          }),
+        } as any;
+      }
+      return {
+        get: vi.fn((_key: string, defaultValue?: any) => defaultValue),
+      } as any;
+    });
+
+    await activate(mockContext);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(window.showWarningMessage).toHaveBeenCalledWith(
+      expect.stringContaining('entries are invalid'),
+      'Open Settings',
+    );
+    expect(commands.executeCommand).toHaveBeenCalledWith(
+      'workbench.action.openSettings',
+      'devDocketAdo.projects',
+    );
   });
 
   it('creates an output channel', async () => {

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -5,6 +5,9 @@ import { logger } from './logger';
 import { matchesRepoPatterns, parseRepoPatterns, type RepoPattern } from './repoPattern';
 
 const RELATED_ITEMS_BATCH_SIZE = 10;
+const OPEN_SETTINGS = 'Open Settings';
+const SIGN_IN = 'Sign in';
+const GITHUB_SETTINGS_QUERY = '@ext:devdocket.devdocket-github';
 
 /**
  * Base class for GitHub providers that handles the common authentication
@@ -49,7 +52,7 @@ export abstract class BaseGitHubProvider extends BaseProvider {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         logger.error('GitHub authentication failed', err);
-        void vscode.window.showWarningMessage(`DevDocket GitHub: Authentication failed — ${message}`);
+        this.showGitHubAuthenticationWarning(`DevDocket GitHub: Authentication failed — ${message}`);
         return;
       }
 
@@ -210,10 +213,27 @@ export abstract class BaseGitHubProvider extends BaseProvider {
    */
   protected warnOnFetchFailure(message: string, isUserTriggered: boolean): void {
     if (isUserTriggered) {
-      void vscode.window.showWarningMessage(`DevDocket GitHub: ${message}`);
+      this.showGitHubSettingsWarning(`DevDocket GitHub: ${message}`);
     } else {
       logger.warn(message);
     }
+  }
+
+  private showGitHubAuthenticationWarning(message: string): void {
+    void vscode.window.showWarningMessage(message, SIGN_IN).then(action => {
+      if (action === SIGN_IN) {
+        void vscode.authentication.getSession('github', this.getAuthenticationScopes(), { createIfNone: true })
+          .catch(err => logger.error('GitHub sign-in failed', err));
+      }
+    });
+  }
+
+  private showGitHubSettingsWarning(message: string): void {
+    void vscode.window.showWarningMessage(message, OPEN_SETTINGS).then(action => {
+      if (action === OPEN_SETTINGS) {
+        void vscode.commands.executeCommand('workbench.action.openSettings', GITHUB_SETTINGS_QUERY);
+      }
+    });
   }
 
 }

--- a/packages/github/src/test/__mocks__/vscode.ts
+++ b/packages/github/src/test/__mocks__/vscode.ts
@@ -47,7 +47,7 @@ class MockTreeItem {
 const window = {
   showInputBox: vi.fn(),
   showInformationMessage: vi.fn(),
-  showWarningMessage: vi.fn(),
+  showWarningMessage: vi.fn(async () => undefined),
   showErrorMessage: vi.fn(),
   showQuickPick: vi.fn(),
   registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })),

--- a/packages/github/src/test/baseGithubProvider.test.ts
+++ b/packages/github/src/test/baseGithubProvider.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { workspace } from 'vscode';
+import { authentication, commands, window, workspace } from 'vscode';
 import { type ProviderItem } from '@devdocket/shared';
 import { BaseGitHubProvider } from '../baseGithubProvider';
 
@@ -11,6 +11,10 @@ class TestGitHubProvider extends BaseGitHubProvider {
     this.publishProviderItems(items);
   }
 
+  warnForTest(message: string, isUserTriggered: boolean): void {
+    this.warnOnFetchFailure(message, isUserTriggered);
+  }
+
   protected async fetchAndPublish(): Promise<void> {
     this.publishProviderItems([]);
   }
@@ -18,6 +22,9 @@ class TestGitHubProvider extends BaseGitHubProvider {
 
 describe('BaseGitHubProvider repository filtering', () => {
   afterEach(() => {
+    vi.mocked(authentication.getSession).mockReset();
+    vi.mocked(commands.executeCommand).mockReset();
+    vi.mocked(window.showWarningMessage).mockReset();
     vi.mocked(workspace.getConfiguration).mockReset();
   });
 
@@ -47,6 +54,50 @@ describe('BaseGitHubProvider repository filtering', () => {
       'Re-included',
       'No repo identity',
     ]);
+
+    provider.dispose();
+  });
+
+  it('opens GitHub extension settings from user-triggered fetch warnings', async () => {
+    vi.mocked(window.showWarningMessage).mockResolvedValue('Open Settings' as any);
+    const provider = new TestGitHubProvider();
+
+    provider.warnForTest('Failed to fetch assigned issues', true);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(window.showWarningMessage).toHaveBeenCalledWith(
+      'DevDocket GitHub: Failed to fetch assigned issues',
+      'Open Settings',
+    );
+    expect(commands.executeCommand).toHaveBeenCalledWith(
+      'workbench.action.openSettings',
+      '@ext:devdocket.devdocket-github',
+    );
+
+    provider.dispose();
+  });
+
+  it('offers GitHub sign-in when authentication fails', async () => {
+    vi.mocked(window.showWarningMessage).mockResolvedValue('Sign in' as any);
+    vi.mocked(authentication.getSession)
+      .mockRejectedValueOnce(new Error('auth unavailable'))
+      .mockResolvedValueOnce({ accessToken: 'new-token' } as any);
+    const provider = new TestGitHubProvider();
+
+    await provider.refresh();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(window.showWarningMessage).toHaveBeenCalledWith(
+      'DevDocket GitHub: Authentication failed — auth unavailable',
+      'Sign in',
+    );
+    expect(authentication.getSession).toHaveBeenCalledTimes(2);
+    expect(authentication.getSession).toHaveBeenLastCalledWith(
+      'github',
+      ['repo'],
+      { createIfNone: true },
+    );
+    expect(commands.executeCommand).not.toHaveBeenCalledWith('github.signin');
 
     provider.dispose();
   });

--- a/packages/github/src/test/githubPrReviewProvider.error.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.error.test.ts
@@ -127,6 +127,7 @@ describe('GitHubPrReviewProvider — error handling', () => {
 
       expect(window.showWarningMessage).toHaveBeenCalledWith(
         expect.stringContaining('Failed to fetch PR review requests'),
+        'Open Settings',
       );
     });
 
@@ -137,6 +138,7 @@ describe('GitHubPrReviewProvider — error handling', () => {
 
       expect(window.showWarningMessage).toHaveBeenCalledWith(
         expect.stringContaining('Failed to fetch PR review requests'),
+        'Open Settings',
       );
     });
 
@@ -147,6 +149,7 @@ describe('GitHubPrReviewProvider — error handling', () => {
 
       expect(window.showWarningMessage).toHaveBeenCalledWith(
         expect.stringContaining('Failed to fetch PR review requests'),
+        'Open Settings',
       );
     });
 

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -88,6 +88,7 @@ describe('GitHubPrReviewProvider', () => {
 
     expect(window.showWarningMessage).toHaveBeenCalledWith(
       expect.stringContaining('Authentication failed'),
+      'Sign in',
     );
     expect(listener).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
@@ -329,6 +330,7 @@ describe('GitHubPrReviewProvider', () => {
 
     expect(window.showWarningMessage).toHaveBeenCalledWith(
       expect.stringContaining('Failed to fetch PR review requests'),
+      'Open Settings',
     );
   });
 
@@ -577,6 +579,7 @@ describe('GitHubPrReviewProvider', () => {
       expect(listener).toHaveBeenCalledWith([]);
       expect(window.showWarningMessage).toHaveBeenCalledWith(
         expect.stringContaining('Failed to fetch PR review requests'),
+        'Open Settings',
       );
     });
   });

--- a/packages/github/src/test/githubProvider.error.test.ts
+++ b/packages/github/src/test/githubProvider.error.test.ts
@@ -175,6 +175,7 @@ describe('GitHubIssueProvider — error handling', () => {
 
       expect(window.showWarningMessage).toHaveBeenCalledWith(
         expect.stringContaining('Failed to fetch assigned issues'),
+        'Open Settings',
       );
     });
 
@@ -411,6 +412,7 @@ describe('GitHubIssueProvider — error handling', () => {
 
       expect(window.showWarningMessage).toHaveBeenCalledWith(
         expect.stringContaining('Failed to fetch assigned issues'),
+        'Open Settings',
       );
     });
 

--- a/packages/github/src/test/githubProvider.test.ts
+++ b/packages/github/src/test/githubProvider.test.ts
@@ -264,6 +264,7 @@ describe('GitHubIssueProvider', () => {
 
     expect(window.showWarningMessage).toHaveBeenCalledWith(
       expect.stringContaining('Authentication failed'),
+      'Sign in',
     );
     expect(listener).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Add actionable Open Settings buttons to ADO missing/invalid project configuration warnings.
- Add actionable GitHub warning buttons for sign-in and DevDocket GitHub settings.
- Cover the new notification actions in provider tests.

## Validation
- npm run build
- npm run test

Closes #541
