### PR TITLE
Improve provider refresh progress

### DIFF
--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -87,7 +87,6 @@ export class AdoWorkItemProvider extends BaseProvider {
     try {
       logger.info('Fetching assigned ADO work items...');
       if (token?.isCancellationRequested) {
-        this._onDidDiscoverItems.fire([]);
         return;
       }
 
@@ -95,7 +94,10 @@ export class AdoWorkItemProvider extends BaseProvider {
         createIfNone: true,
       }).catch(() => null);
 
-      if (!session || token?.isCancellationRequested) {
+      if (token?.isCancellationRequested) {
+        return;
+      }
+      if (!session) {
         this._onDidDiscoverItems.fire([]);
         return;
       }

--- a/packages/ado/src/baseAdoPrProvider.ts
+++ b/packages/ado/src/baseAdoPrProvider.ts
@@ -82,7 +82,6 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
     try {
       logger.info(`Fetching ADO ${this.logLabel}...`);
       if (token?.isCancellationRequested) {
-        this._onDidDiscoverItems.fire([]);
         return;
       }
 
@@ -90,7 +89,10 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
         createIfNone: true,
       }).catch(() => null);
 
-      if (!session || token?.isCancellationRequested) {
+      if (token?.isCancellationRequested) {
+        return;
+      }
+      if (!session) {
         this._onDidDiscoverItems.fire([]);
         return;
       }

--- a/packages/ado/src/test/adoMyPrsProvider.test.ts
+++ b/packages/ado/src/test/adoMyPrsProvider.test.ts
@@ -98,14 +98,14 @@ describe('AdoMyPrsProvider', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('fires empty items when cancellation is requested before auth', async () => {
+  it('does not clear items when cancellation is requested before auth', async () => {
     const token = { isCancellationRequested: true } as any;
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
     await provider.refresh(token);
 
-    expect(listener).toHaveBeenCalledWith([]);
+    expect(listener).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 

--- a/packages/ado/src/test/adoPrReviewProvider.cancellation.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.cancellation.test.ts
@@ -107,6 +107,45 @@ describe('AdoPrReviewProvider — cancellation (AbortSignal wiring)', () => {
     });
   });
 
+  // ── Pre-cancelled token ────────────────────────────────────────────
+
+  describe('already-cancelled token', () => {
+    it('returns immediately without clearing items', async () => {
+      const token = {
+        isCancellationRequested: true,
+        onCancellationRequested: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+      };
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+
+      await provider.refresh(token as any);
+
+      expect(authentication.getSession).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('does not clear items when cancelled during authentication', async () => {
+      const { token, cancel } = createMockCancellationToken();
+      vi.mocked(authentication.getSession).mockImplementation(async () => {
+        cancel();
+        return {
+          accessToken: 'test-token',
+          id: 'session-1',
+          scopes: ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+          account: { id: '1', label: 'testuser' },
+        } as any;
+      });
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+
+      await provider.refresh(token);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
   // ── Mid-fetch cancellation ─────────────────────────────────────────
 
   describe('mid-fetch cancellation', () => {

--- a/packages/ado/src/test/adoPrReviewProvider.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.test.ts
@@ -85,19 +85,18 @@ describe('AdoPrReviewProvider', () => {
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('fires empty items when cancellation is requested before auth', async () => {
+  it('does not clear items when cancellation is requested before auth', async () => {
     const token = { isCancellationRequested: true } as any;
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
     await provider.refresh(token);
 
-    expect(listener).toHaveBeenCalledTimes(1);
-    expect(listener).toHaveBeenCalledWith([]);
+    expect(listener).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('fires empty items when cancellation is requested after auth', async () => {
+  it('does not clear items when cancellation is requested after auth', async () => {
     const token = { isCancellationRequested: false } as any;
     vi.mocked(authentication.getSession).mockImplementation(async () => {
       token.isCancellationRequested = true;
@@ -113,8 +112,7 @@ describe('AdoPrReviewProvider', () => {
     provider.onDidDiscoverItems(listener);
     await provider.refresh(token);
 
-    expect(listener).toHaveBeenCalledTimes(1);
-    expect(listener).toHaveBeenCalledWith([]);
+    expect(listener).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 

--- a/packages/ado/src/test/adoWorkItemProvider.cancellation.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.cancellation.test.ts
@@ -141,6 +141,45 @@ describe('AdoWorkItemProvider — cancellation (AbortSignal wiring)', () => {
     });
   });
 
+  // ── Pre-cancelled token ────────────────────────────────────────────
+
+  describe('already-cancelled token', () => {
+    it('returns immediately without clearing items', async () => {
+      const token = {
+        isCancellationRequested: true,
+        onCancellationRequested: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+      };
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+
+      await provider.refresh(token as any);
+
+      expect(authentication.getSession).not.toHaveBeenCalled();
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it('does not clear items when cancelled during authentication', async () => {
+      const { token, cancel } = createMockCancellationToken();
+      vi.mocked(authentication.getSession).mockImplementation(async () => {
+        cancel();
+        return {
+          accessToken: 'test-token',
+          id: 'session-1',
+          scopes: ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+          account: { id: '1', label: 'testuser' },
+        } as any;
+      });
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+
+      await provider.refresh(token);
+
+      expect(mockFetch).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
   // ── Mid-fetch cancellation ─────────────────────────────────────────
 
   describe('mid-fetch cancellation', () => {

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -273,19 +273,18 @@ describe('AdoWorkItemProvider', () => {
     expect(window.showWarningMessage).not.toHaveBeenCalled();
   });
 
-  it('fires empty items when cancellation is requested before auth', async () => {
+  it('does not clear items when cancellation is requested before auth', async () => {
     const token = { isCancellationRequested: true } as any;
 
     const listener = vi.fn();
     provider.onDidDiscoverItems(listener);
     await provider.refresh(token);
 
-    expect(listener).toHaveBeenCalledTimes(1);
-    expect(listener).toHaveBeenCalledWith([]);
+    expect(listener).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it('fires empty items when cancellation is requested after auth', async () => {
+  it('does not clear items when cancellation is requested after auth', async () => {
     const token = { isCancellationRequested: false } as any;
     vi.mocked(authentication.getSession).mockImplementation(async () => {
       token.isCancellationRequested = true;
@@ -301,8 +300,7 @@ describe('AdoWorkItemProvider', () => {
     provider.onDidDiscoverItems(listener);
     await provider.refresh(token);
 
-    expect(listener).toHaveBeenCalledTimes(1);
-    expect(listener).toHaveBeenCalledWith([]);
+    expect(listener).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
   });
 

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -3,7 +3,7 @@ import { WorkItemState } from '../models/workItem';
 import { ACTIVITY_TYPES, type ActivityType } from '../models/activityLog';
 import { WorkGraph } from '../services/workGraph';
 import { ActionRegistry } from '../services/actionRegistry';
-import { ProviderRegistry } from '../services/providerRegistry';
+import { ProviderRegistry, type ProviderRefreshProgress } from '../services/providerRegistry';
 import { InboxStateStore, type InboxState } from '../storage/inboxStateStore';
 import type { ProviderLabelCache } from '../storage/providerLabelCache';
 import type { ReadStateStore } from '../storage/readStateStore';
@@ -595,14 +595,63 @@ async function handleFocusMoveDown(workGraph: WorkGraph, item?: { id?: string })
   await workGraph.moveItem(item.id, 'down');
 }
 
+type PendingProvider = ProviderRefreshProgress['pendingProviders'][number];
+
+function formatWaitingProviders(providers: readonly PendingProvider[]): string {
+  const labels = providers.map(provider => provider.label);
+  if (labels.length <= 2) {
+    return labels.join(' and ');
+  }
+  return `${labels.slice(0, 2).join(', ')}, and ${labels.length - 2} more`;
+}
+
+function formatRefreshProgressMessage(
+  completed: number,
+  total: number,
+  pendingProviders: readonly PendingProvider[],
+  latestOutcome?: string,
+): string {
+  if (total === 0) {
+    return 'No providers registered';
+  }
+  const message = `Refreshing… ${completed}/${total} providers done`;
+  const detail = pendingProviders.length > 0
+    ? `${message} — waiting on ${formatWaitingProviders(pendingProviders)}`
+    : message;
+  return latestOutcome ? `${latestOutcome} — ${detail}` : detail;
+}
+
+function formatProviderOutcome(event: ProviderRefreshProgress): string {
+  switch (event.outcome) {
+    case 'success': return `${event.providerLabel} refreshed`;
+    case 'failed': return `${event.providerLabel} failed`;
+    case 'timedOut': return `${event.providerLabel} timed out`;
+    case 'cancelled': return `${event.providerLabel} cancelled`;
+  }
+}
+
 async function handleRefresh(providerRegistry: ProviderRegistry): Promise<void> {
   logger.info('Manual refresh triggered');
+  const providers = providerRegistry.getProviders().map(provider => ({ id: provider.id, label: provider.label }));
   await vscode.window.withProgress(
     {
-      location: vscode.ProgressLocation.Window,
-      title: 'DevDocket: Refreshing…',
+      location: vscode.ProgressLocation.Notification,
+      title: 'DevDocket: Refresh',
+      cancellable: true,
     },
-    () => providerRegistry.refreshAll(),
+    (progress, token) => {
+      progress.report({ message: formatRefreshProgressMessage(0, providers.length, providers) });
+      return providerRegistry.refreshAll(token, event => {
+        progress.report({
+          message: formatRefreshProgressMessage(
+            event.completed,
+            event.total,
+            event.pendingProviders,
+            formatProviderOutcome(event),
+          ),
+        });
+      });
+    },
   );
 }
 

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -614,7 +614,8 @@ function formatRefreshProgressMessage(
   if (total === 0) {
     return 'No providers registered';
   }
-  const message = `Refreshing… ${completed}/${total} providers done`;
+  const providerWord = total === 1 ? 'provider' : 'providers';
+  const message = `Refreshing… ${completed}/${total} ${providerWord} done`;
   const detail = pendingProviders.length > 0
     ? `${message} — waiting on ${formatWaitingProviders(pendingProviders)}`
     : message;

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -366,7 +366,14 @@ export class ProviderRegistry {
     this._pendingRefreshes.set(provider.id, entry);
     this._onDidChangeProviderRefreshState.fire(provider.id);
 
-    const refreshPromise = provider.refresh(cts.token)
+    let providerRefreshPromise: Promise<void>;
+    try {
+      providerRefreshPromise = Promise.resolve(provider.refresh(cts.token));
+    } catch (err) {
+      providerRefreshPromise = Promise.reject(err);
+    }
+
+    const refreshPromise = providerRefreshPromise
       .then<ProviderRefreshOutcome>(() => {
         if (timedOut) {
           return 'timedOut';

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -343,7 +343,8 @@ export class ProviderRegistry {
   async refreshProvider(providerId: string, token?: vscode.CancellationToken): Promise<ProviderRefreshOutcome> {
     const provider = this.providers.get(providerId);
     if (!provider) {
-      throw new Error(`Provider not registered: ${providerId}`);
+      logger.warn(`Provider not registered: ${providerId}`);
+      return 'cancelled';
     }
     if (token?.isCancellationRequested) {
       return 'cancelled';

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -607,6 +607,7 @@ export class ProviderRegistry {
     this._onDidRegisterProvider.dispose();
     this._onDidAddNewUnseenItems.dispose();
     this._onDidChangeProviderHealth.dispose();
+    this._onDidChangeProviderRefreshState.dispose();
     this._onDidRefreshProvider.dispose();
   }
 }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -439,6 +439,9 @@ export class ProviderRegistry {
   }
 
   private updateHealth(providerId: string, status: 'healthy' | 'unhealthy', lastError?: string): void {
+    if (this._disposed || !this.providers.has(providerId)) {
+      return;
+    }
     const prev = this.healthStatus.get(providerId);
     const next: ProviderHealthStatus = {
       status,
@@ -459,7 +462,7 @@ export class ProviderRegistry {
   }
 
   private async handleProviderItems(providerId: string, items: ProviderItem[]): Promise<void> {
-    if (this._disposed) {
+    if (this._disposed || !this.providers.has(providerId)) {
       return;
     }
     // Receiving items via onDidDiscoverItems is a "successful refresh" signal.

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -16,6 +16,17 @@ export interface ProviderHealthStatus {
   lastError?: string;
 }
 
+export type ProviderRefreshOutcome = 'success' | 'failed' | 'timedOut' | 'cancelled';
+
+export interface ProviderRefreshProgress {
+  providerId: string;
+  providerLabel: string;
+  completed: number;
+  total: number;
+  pendingProviders: Array<{ id: string; label: string }>;
+  outcome: ProviderRefreshOutcome;
+}
+
 function isActiveWorkItemState(state: WorkItemState | undefined): boolean {
   return state === WorkItemState.New || state === WorkItemState.InProgress || state === WorkItemState.Paused;
 }
@@ -49,6 +60,9 @@ export class ProviderRegistry {
   private readonly _onDidChangeProviderHealth = new vscode.EventEmitter<string>();
   /** Fired when a provider's health info changes (status, lastError, or lastRefreshTime), with the provider ID. */
   readonly onDidChangeProviderHealth = this._onDidChangeProviderHealth.event;
+  private readonly _onDidChangeProviderRefreshState = new vscode.EventEmitter<string>();
+  /** Fired when a provider starts or stops refreshing, with the provider ID. */
+  readonly onDidChangeProviderRefreshState = this._onDidChangeProviderRefreshState.event;
   private readonly _onDidRefreshProvider = new vscode.EventEmitter<string>();
   /**
    * Fired after a provider's provider items have been processed, carrying the
@@ -213,6 +227,11 @@ export class ProviderRegistry {
     return this.healthStatus.get(providerId) ?? { status: 'unknown' };
   }
 
+  /** Whether a provider refresh is currently in flight. */
+  isProviderRefreshing(providerId: string): boolean {
+    return this._pendingRefreshes.has(providerId);
+  }
+
   /**
    * Get the provider items for a specific provider.
    *
@@ -283,23 +302,52 @@ export class ProviderRegistry {
    * Errors from individual providers are logged but do not reject the
    * returned promise, so one failing provider does not block others.
    */
-  async refreshAll(): Promise<void> {
+  async refreshAll(
+    token?: vscode.CancellationToken,
+    onProgress?: (progress: ProviderRefreshProgress) => void,
+  ): Promise<void> {
     const providers = Array.from(this.providers.values());
-    const results = await Promise.allSettled(
-      providers.map((p) => {
-        logger.debug(`Provider ${p.id} refreshing...`);
-        return this.refreshWithTimeout(p);
-      }),
-    );
-    for (let i = 0; i < results.length; i++) {
-      const result = results[i];
-      if (result.status === 'rejected') {
-        logger.error(`Provider "${providers[i].id}" refresh failed`, result.reason);
+    const completedProviderIds = new Set<string>();
+    let completed = 0;
+
+    await Promise.all(providers.map(async (provider) => {
+      let outcome: ProviderRefreshOutcome;
+      if (token?.isCancellationRequested) {
+        outcome = 'cancelled';
+      } else {
+        logger.debug(`Provider ${provider.id} refreshing...`);
+        outcome = await this.refreshWithTimeout(provider, token);
       }
-    }
+
+      completedProviderIds.add(provider.id);
+      completed++;
+      onProgress?.({
+        providerId: provider.id,
+        providerLabel: provider.label,
+        completed,
+        total: providers.length,
+        pendingProviders: providers
+          .filter(p => !completedProviderIds.has(p.id))
+          .map(p => ({ id: p.id, label: p.label })),
+        outcome,
+      });
+    }));
   }
 
-  private refreshWithTimeout(provider: DevDocketProvider): Promise<void> {
+  /** Refresh a single registered provider by ID. */
+  async refreshProvider(providerId: string, token?: vscode.CancellationToken): Promise<ProviderRefreshOutcome> {
+    const provider = this.providers.get(providerId);
+    if (!provider) {
+      throw new Error(`Provider not registered: ${providerId}`);
+    }
+    if (token?.isCancellationRequested) {
+      return 'cancelled';
+    }
+    logger.debug(`Provider ${provider.id} refreshing...`);
+    return this.refreshWithTimeout(provider, token);
+  }
+
+  private refreshWithTimeout(provider: DevDocketProvider, parentToken?: vscode.CancellationToken): Promise<ProviderRefreshOutcome> {
     this.cancelPendingRefresh(provider.id);
     const cts = new vscode.CancellationTokenSource();
     let timedOut = false;
@@ -310,38 +358,58 @@ export class ProviderRegistry {
       }
       cts.cancel();
     }, ProviderRegistry.REFRESH_TIMEOUT_MS);
+    const parentSub = parentToken?.onCancellationRequested?.(() => cts.cancel());
+    if (parentToken?.isCancellationRequested) {
+      cts.cancel();
+    }
     const entry = { cts, timeoutId };
     this._pendingRefreshes.set(provider.id, entry);
+    this._onDidChangeProviderRefreshState.fire(provider.id);
 
     const refreshPromise = provider.refresh(cts.token)
-      .then(() => {
-        if (!cts.token.isCancellationRequested) {
-          this.updateHealth(provider.id, 'healthy');
+      .then<ProviderRefreshOutcome>(() => {
+        if (timedOut) {
+          return 'timedOut';
         }
+        if (cts.token.isCancellationRequested) {
+          return 'cancelled';
+        }
+        this.updateHealth(provider.id, 'healthy');
+        return 'success';
       })
-      .catch((err: unknown) => {
-        if (!cts.token.isCancellationRequested) {
-          logger.error(`Provider "${provider.id}" refresh failed`, err);
-          const message = err instanceof Error ? err.message : String(err);
-          this.updateHealth(provider.id, 'unhealthy', message);
+      .catch<ProviderRefreshOutcome>((err: unknown) => {
+        if (timedOut) {
+          return 'timedOut';
         }
+        if (cts.token.isCancellationRequested) {
+          logger.debug(`Provider "${provider.id}" refresh cancelled`, err);
+          return 'cancelled';
+        }
+        logger.error(`Provider "${provider.id}" refresh failed`, err);
+        const message = err instanceof Error ? err.message : String(err);
+        this.updateHealth(provider.id, 'unhealthy', message);
+        return 'failed';
       });
 
-    const cancelledPromise = new Promise<void>((resolve) => {
+    const cancelledPromise = new Promise<ProviderRefreshOutcome>((resolve) => {
       cts.token.onCancellationRequested(() => {
         if (timedOut) {
           this.updateHealth(provider.id, 'unhealthy', 'Refresh timed out');
+          resolve('timedOut');
+          return;
         }
-        resolve();
+        resolve('cancelled');
       });
     });
 
     return Promise.race([refreshPromise, cancelledPromise])
       .finally(() => {
         clearTimeout(timeoutId);
+        parentSub?.dispose();
         // Only clean up if this entry is still the current one for this provider
         if (this._pendingRefreshes.get(provider.id) === entry) {
           this._pendingRefreshes.delete(provider.id);
+          this._onDidChangeProviderRefreshState.fire(provider.id);
         }
         cts.dispose();
       });
@@ -354,6 +422,7 @@ export class ProviderRegistry {
       pending.cts.cancel();
       // CTS is disposed in refreshWithTimeout's finally block
       this._pendingRefreshes.delete(providerId);
+      this._onDidChangeProviderRefreshState.fire(providerId);
     }
   }
 

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -321,7 +321,7 @@ export class ProviderRegistry {
 
       completedProviderIds.add(provider.id);
       completed++;
-      onProgress?.({
+      const progressEvent: ProviderRefreshProgress = {
         providerId: provider.id,
         providerLabel: provider.label,
         completed,
@@ -330,7 +330,12 @@ export class ProviderRegistry {
           .filter(p => !completedProviderIds.has(p.id))
           .map(p => ({ id: p.id, label: p.label })),
         outcome,
-      });
+      };
+      try {
+        onProgress?.(progressEvent);
+      } catch (err) {
+        logger.warn('Provider refresh progress callback failed', err);
+      }
     }));
   }
 

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -95,7 +95,7 @@ function createMockStateStore(): { [K in keyof UsedStateStoreMethods]: Mock } {
   };
 }
 
-type UsedProviderRegistryMethods = Pick<ProviderRegistry, 'refreshAll' | 'resolveUrl' | 'getAllProviderItems' | 'getProviderItems' | 'getProviderLabel'>;
+type UsedProviderRegistryMethods = Pick<ProviderRegistry, 'refreshAll' | 'resolveUrl' | 'getAllProviderItems' | 'getProviderItems' | 'getProviderLabel' | 'getProviders'>;
 
 function createMockProviderRegistry(): { [K in keyof UsedProviderRegistryMethods]: Mock } {
   return {
@@ -104,6 +104,10 @@ function createMockProviderRegistry(): { [K in keyof UsedProviderRegistryMethods
     getAllProviderItems: vi.fn().mockReturnValue(new Map()),
     getProviderItems: vi.fn().mockReturnValue([]),
     getProviderLabel: vi.fn((providerId: string) => providerId),
+    getProviders: vi.fn().mockReturnValue([
+      { id: 'github', label: 'GitHub' },
+      { id: 'ado', label: 'Azure DevOps' },
+    ]),
   };
 }
 
@@ -229,14 +233,40 @@ describe('registerCommands', () => {
   // ── refresh ──────────────────────────────────────────────────────
 
   describe('devdocket.refresh', () => {
-    it('calls providerRegistry.refreshAll and shows progress', async () => {
+    it('calls providerRegistry.refreshAll with cancellable notification progress', async () => {
+      const report = vi.fn();
+      const token = { isCancellationRequested: false, onCancellationRequested: vi.fn() };
+      (vscode.window.withProgress as Mock).mockImplementationOnce((_options: any, task: any) =>
+        task({ report }, token),
+      );
+
       await invoke('devdocket.refresh');
 
       expect(vscode.window.withProgress).toHaveBeenCalledWith(
-        expect.objectContaining({ location: vscode.ProgressLocation.Window }),
+        expect.objectContaining({
+          location: vscode.ProgressLocation.Notification,
+          title: 'DevDocket: Refresh',
+          cancellable: true,
+        }),
         expect.any(Function),
       );
-      expect(providerRegistry.refreshAll).toHaveBeenCalled();
+      expect(report).toHaveBeenCalledWith({
+        message: 'Refreshing… 0/2 providers done — waiting on GitHub and Azure DevOps',
+      });
+      expect(providerRegistry.refreshAll).toHaveBeenCalledWith(token, expect.any(Function));
+
+      const onProgress = providerRegistry.refreshAll.mock.calls[0][1];
+      onProgress({
+        providerId: 'github',
+        providerLabel: 'GitHub',
+        completed: 1,
+        total: 2,
+        pendingProviders: [{ id: 'ado', label: 'Azure DevOps' }],
+        outcome: 'success',
+      });
+      expect(report).toHaveBeenCalledWith({
+        message: 'GitHub refreshed — Refreshing… 1/2 providers done — waiting on Azure DevOps',
+      });
     });
   });
 

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -268,6 +268,21 @@ describe('registerCommands', () => {
         message: 'GitHub refreshed — Refreshing… 1/2 providers done — waiting on Azure DevOps',
       });
     });
+
+    it('uses singular provider wording for one registered provider', async () => {
+      const report = vi.fn();
+      const token = { isCancellationRequested: false, onCancellationRequested: vi.fn() };
+      providerRegistry.getProviders.mockReturnValueOnce([{ id: 'github', label: 'GitHub' }] as any);
+      (vscode.window.withProgress as Mock).mockImplementationOnce((_options: any, task: any) =>
+        task({ report }, token),
+      );
+
+      await invoke('devdocket.refresh');
+
+      expect(report).toHaveBeenCalledWith({
+        message: 'Refreshing… 0/1 provider done — waiting on GitHub',
+      });
+    });
   });
 
   describe('devdocket.showWatchesQuickPick', () => {

--- a/packages/core/src/test/providerHealthStatusBar.test.ts
+++ b/packages/core/src/test/providerHealthStatusBar.test.ts
@@ -3,17 +3,20 @@ import * as vscode from 'vscode';
 import { ProviderHealthStatusBar, showProviderHealthQuickPick } from '../views/providerHealthStatusBar';
 import type { ProviderRegistry } from '../services/providerRegistry';
 
-function createRegistry(options: { refreshing?: string[] } = {}) {
+function createRegistry(options: { refreshing?: string[]; unhealthy?: string[] } = {}) {
   const refreshing = new Set(options.refreshing ?? []);
+  const unhealthy = new Set(options.unhealthy ?? []);
   const providers = [
     { id: 'github', label: 'GitHub' },
     { id: 'ado', label: 'Azure DevOps' },
   ];
   return {
     getProviders: vi.fn(() => providers),
-    getProviderHealth: vi.fn((id: string) => id === 'ado'
-      ? { status: 'healthy' as const }
-      : { status: 'unknown' as const }),
+    getProviderHealth: vi.fn((id: string) => unhealthy.has(id)
+      ? { status: 'unhealthy' as const, lastError: 'network error' }
+      : id === 'ado'
+        ? { status: 'healthy' as const }
+        : { status: 'unknown' as const }),
     isProviderRefreshing: vi.fn((id: string) => refreshing.has(id)),
     onDidChangeProviderHealth: vi.fn(() => ({ dispose: vi.fn() })),
     onDidChangeProviderRefreshState: vi.fn(() => ({ dispose: vi.fn() })),
@@ -36,6 +39,19 @@ describe('ProviderHealthStatusBar', () => {
 
     expect(item.text).toBe('$(sync~spin) 1 provider refreshing');
     expect(item.show).toHaveBeenCalled();
+
+    statusBar.dispose();
+  });
+
+  it('preserves warning styling while refreshing with unhealthy providers', () => {
+    const registry = createRegistry({ refreshing: ['ado'], unhealthy: ['github'] });
+
+    const statusBar = new ProviderHealthStatusBar(registry);
+    const item = (vscode.window.createStatusBarItem as Mock).mock.results[0].value;
+
+    expect(item.text).toBe('$(sync~spin) 1 refreshing, 1 unhealthy');
+    expect(item.backgroundColor.id).toBe('statusBarItem.warningBackground');
+    expect(item.color.id).toBe('statusBarItem.warningForeground');
 
     statusBar.dispose();
   });

--- a/packages/core/src/test/providerHealthStatusBar.test.ts
+++ b/packages/core/src/test/providerHealthStatusBar.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import * as vscode from 'vscode';
+import { ProviderHealthStatusBar, showProviderHealthQuickPick } from '../views/providerHealthStatusBar';
+import type { ProviderRegistry } from '../services/providerRegistry';
+
+function createRegistry(options: { refreshing?: string[] } = {}) {
+  const refreshing = new Set(options.refreshing ?? []);
+  const providers = [
+    { id: 'github', label: 'GitHub' },
+    { id: 'ado', label: 'Azure DevOps' },
+  ];
+  return {
+    getProviders: vi.fn(() => providers),
+    getProviderHealth: vi.fn((id: string) => id === 'ado'
+      ? { status: 'healthy' as const }
+      : { status: 'unknown' as const }),
+    isProviderRefreshing: vi.fn((id: string) => refreshing.has(id)),
+    onDidChangeProviderHealth: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidChangeProviderRefreshState: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidRegisterProvider: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidChangeProviderItems: vi.fn(() => ({ dispose: vi.fn() })),
+    refreshProvider: vi.fn().mockResolvedValue('success'),
+  } as unknown as ProviderRegistry & { refreshProvider: Mock };
+}
+
+describe('ProviderHealthStatusBar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows a spinner status bar item while providers are refreshing', () => {
+    const registry = createRegistry({ refreshing: ['ado'] });
+
+    const statusBar = new ProviderHealthStatusBar(registry);
+    const item = (vscode.window.createStatusBarItem as Mock).mock.results[0].value;
+
+    expect(item.text).toBe('$(sync~spin) 1 provider refreshing');
+    expect(item.show).toHaveBeenCalled();
+
+    statusBar.dispose();
+  });
+
+  it('marks refreshing providers in the health quick pick', async () => {
+    const registry = createRegistry({ refreshing: ['ado'] });
+    (vscode.window.showQuickPick as Mock).mockResolvedValueOnce(undefined);
+
+    await showProviderHealthQuickPick(registry);
+
+    const items = (vscode.window.showQuickPick as Mock).mock.calls[0][0];
+    expect(items[0]).toMatchObject({
+      label: '$(sync~spin) Azure DevOps',
+      description: 'refreshing',
+      providerId: 'ado',
+    });
+  });
+
+  it('refreshes only the selected provider from the quick pick', async () => {
+    const registry = createRegistry();
+    (vscode.window.showQuickPick as Mock).mockResolvedValueOnce({ providerId: 'github' });
+    (vscode.window.showInformationMessage as Mock).mockResolvedValueOnce('Refresh');
+
+    await showProviderHealthQuickPick(registry);
+
+    expect(vscode.window.withProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        location: vscode.ProgressLocation.Notification,
+        title: 'DevDocket: Refresh GitHub',
+        cancellable: true,
+      }),
+      expect.any(Function),
+    );
+    expect(registry.refreshProvider).toHaveBeenCalledWith('github', expect.any(Object));
+  });
+});

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { EventEmitter } from 'vscode';
+import { CancellationTokenSource, EventEmitter } from 'vscode';
 import { DevDocketProvider, ProviderItem } from '../api/types';
 import { WorkGraph } from '../services/workGraph';
 import { ProviderRegistry } from '../services/providerRegistry';
@@ -199,6 +199,75 @@ describe('ProviderRegistry', () => {
 
     // Should not throw
     await expect(registry.refreshAll()).resolves.toBeUndefined();
+  });
+
+  it('cancels provider refresh tokens when refreshAll token is cancelled', async () => {
+    const provider = createMockProvider('cancel');
+    registry.register(provider);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    vi.mocked(provider.refresh).mockClear();
+
+    let providerToken: { isCancellationRequested: boolean } | undefined;
+    vi.mocked(provider.refresh).mockImplementationOnce((token?: any) => {
+      providerToken = token;
+      return new Promise<void>(() => {});
+    });
+    const listener = vi.fn();
+    registry.onDidChangeProviderRefreshState(listener);
+    const cts = new CancellationTokenSource();
+
+    const refreshPromise = registry.refreshAll(cts.token);
+    await vi.waitFor(() => expect(registry.isProviderRefreshing('cancel')).toBe(true));
+    expect(providerToken?.isCancellationRequested).toBe(false);
+
+    cts.cancel();
+    await refreshPromise;
+
+    expect(providerToken?.isCancellationRequested).toBe(true);
+    expect(registry.isProviderRefreshing('cancel')).toBe(false);
+    expect(registry.getProviderHealth('cancel').status).not.toBe('unhealthy');
+    expect(listener).toHaveBeenCalledWith('cancel');
+    cts.dispose();
+  });
+
+  it('reports refreshAll progress as each provider completes', async () => {
+    const p1 = createMockProvider('p1');
+    const p2 = createMockProvider('p2');
+    registry.register(p1);
+    registry.register(p2);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    vi.mocked(p1.refresh).mockClear();
+    vi.mocked(p2.refresh).mockClear();
+
+    let resolveP1!: () => void;
+    let resolveP2!: () => void;
+    vi.mocked(p1.refresh).mockImplementationOnce(() => new Promise<void>(resolve => { resolveP1 = resolve; }));
+    vi.mocked(p2.refresh).mockImplementationOnce(() => new Promise<void>(resolve => { resolveP2 = resolve; }));
+    const onProgress = vi.fn();
+
+    const refreshPromise = registry.refreshAll(undefined, onProgress);
+    await vi.waitFor(() => expect(p2.refresh).toHaveBeenCalledTimes(1));
+
+    resolveP2();
+    await vi.waitFor(() => expect(onProgress).toHaveBeenCalledWith({
+      providerId: 'p2',
+      providerLabel: 'Provider p2',
+      completed: 1,
+      total: 2,
+      pendingProviders: [{ id: 'p1', label: 'Provider p1' }],
+      outcome: 'success',
+    }));
+
+    resolveP1();
+    await refreshPromise;
+    expect(onProgress).toHaveBeenCalledWith({
+      providerId: 'p1',
+      providerLabel: 'Provider p1',
+      completed: 2,
+      total: 2,
+      pendingProviders: [],
+      outcome: 'success',
+    });
   });
 
   it('cleans up all subscriptions on dispose', () => {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -283,6 +283,19 @@ describe('ProviderRegistry', () => {
     });
   });
 
+  it('does not reject refreshAll when progress reporting throws', async () => {
+    const provider = createMockProvider('progress-throws');
+    registry.register(provider);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    vi.mocked(provider.refresh).mockClear();
+    const onProgress = vi.fn(() => { throw new Error('progress broke'); });
+
+    await expect(registry.refreshAll(undefined, onProgress)).resolves.toBeUndefined();
+
+    expect(provider.refresh).toHaveBeenCalledTimes(1);
+    expect(registry.getProviderHealth('progress-throws').status).toBe('healthy');
+  });
+
   it('cleans up all subscriptions on dispose', () => {
     const p1 = createMockProvider('p1');
     const p2 = createMockProvider('p2');

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -1521,6 +1521,26 @@ describe('ProviderRegistry', () => {
       expect(registry.getProviderHealth('temp')).toEqual({ status: 'unknown' });
     });
 
+    it('ignores queued provider item updates after the provider is unregistered', async () => {
+      let releaseFirstUpdate!: () => void;
+      const firstUpdate = new Promise<void>(resolve => { releaseFirstUpdate = resolve; });
+      stateStore.setStates.mockImplementationOnce(() => firstUpdate);
+      const { provider } = createDeferredProvider('stale-items');
+      const disposable = registry.register(provider);
+
+      provider.fireItems([{ externalId: 'first', title: 'First' }]);
+      provider.fireItems([{ externalId: 'second', title: 'Second' }]);
+      await vi.waitFor(() => expect(registry.getProviderHealth('stale-items').status).toBe('healthy'));
+
+      disposable.dispose();
+      releaseFirstUpdate();
+      await nextTick();
+      await nextTick();
+
+      expect(registry.getProviderHealth('stale-items')).toEqual({ status: 'unknown' });
+      expect(registry.getProviderItems('stale-items')).toEqual([]);
+    });
+
     it('preserves lastRefreshTime from previous healthy state on failure', async () => {
       const provider = createMockProvider('flaky');
       registry.register(provider);

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -296,6 +296,10 @@ describe('ProviderRegistry', () => {
     expect(registry.getProviderHealth('progress-throws').status).toBe('healthy');
   });
 
+  it('returns cancelled when refreshing an unregistered provider by id', async () => {
+    await expect(registry.refreshProvider('missing')).resolves.toBe('cancelled');
+  });
+
   it('cleans up all subscriptions on dispose', () => {
     const p1 = createMockProvider('p1');
     const p2 = createMockProvider('p2');

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -201,6 +201,19 @@ describe('ProviderRegistry', () => {
     await expect(registry.refreshAll()).resolves.toBeUndefined();
   });
 
+  it('handles synchronous refresh throws gracefully in refreshAll', async () => {
+    const p1 = createMockProvider('sync-throw');
+    registry.register(p1);
+    await new Promise(resolve => setTimeout(resolve, 0));
+    vi.mocked(p1.refresh).mockClear();
+    vi.mocked(p1.refresh).mockImplementationOnce(() => { throw new Error('sync boom'); });
+
+    await expect(registry.refreshAll()).resolves.toBeUndefined();
+
+    expect(registry.isProviderRefreshing('sync-throw')).toBe(false);
+    expect(registry.getProviderHealth('sync-throw').lastError).toBe('sync boom');
+  });
+
   it('cancels provider refresh tokens when refreshAll token is cancelled', async () => {
     const provider = createMockProvider('cancel');
     registry.register(provider);

--- a/packages/core/src/views/providerHealthStatusBar.ts
+++ b/packages/core/src/views/providerHealthStatusBar.ts
@@ -12,6 +12,20 @@ function sanitizeError(error: string, maxLength = 100): string {
   return trimmed.length > maxLength ? trimmed.substring(0, maxLength) + '…' : trimmed;
 }
 
+async function refreshProviderWithProgress(
+  providerRegistry: ProviderRegistry,
+  provider: { id: string; label: string },
+): Promise<void> {
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: `DevDocket: Refresh ${provider.label}`,
+      cancellable: true,
+    },
+    (_progress, token) => providerRegistry.refreshProvider(provider.id, token),
+  );
+}
+
 /**
  * Status bar item that shows a warning when any provider is unhealthy.
  * Click to open quick-pick with provider health details.
@@ -19,6 +33,7 @@ function sanitizeError(error: string, maxLength = 100): string {
 export class ProviderHealthStatusBar implements vscode.Disposable {
   private statusBarItem: vscode.StatusBarItem;
   private healthChangeSub: vscode.Disposable;
+  private refreshStateSub: vscode.Disposable;
   private registerSub: vscode.Disposable;
   private discoveredChangesSub: vscode.Disposable;
 
@@ -28,6 +43,10 @@ export class ProviderHealthStatusBar implements vscode.Disposable {
     
     // Update on provider health changes
     this.healthChangeSub = providerRegistry.onDidChangeProviderHealth(() => {
+      this.update();
+    });
+
+    this.refreshStateSub = providerRegistry.onDidChangeProviderRefreshState(() => {
       this.update();
     });
     
@@ -52,10 +71,24 @@ export class ProviderHealthStatusBar implements vscode.Disposable {
       return;
     }
 
+    const refreshingProviders = providers.filter(p => this.providerRegistry.isProviderRefreshing(p.id));
     const unhealthyProviders = providers.filter(p => {
       const health = this.providerRegistry.getProviderHealth(p.id);
       return health.status === 'unhealthy';
     });
+
+    if (refreshingProviders.length > 0) {
+      const refreshingCount = refreshingProviders.length;
+      const unhealthyCount = unhealthyProviders.length;
+      this.statusBarItem.text = unhealthyCount > 0
+        ? `$(sync~spin) ${refreshingCount} refreshing, ${unhealthyCount} unhealthy`
+        : `$(sync~spin) ${refreshingCount} provider${refreshingCount === 1 ? '' : 's'} refreshing`;
+      this.statusBarItem.tooltip = 'Click to view provider health details';
+      this.statusBarItem.backgroundColor = undefined;
+      this.statusBarItem.color = undefined;
+      this.statusBarItem.show();
+      return;
+    }
 
     if (unhealthyProviders.length === 0) {
       this.statusBarItem.hide();
@@ -72,6 +105,7 @@ export class ProviderHealthStatusBar implements vscode.Disposable {
 
   dispose(): void {
     this.healthChangeSub.dispose();
+    this.refreshStateSub.dispose();
     this.registerSub.dispose();
     this.discoveredChangesSub.dispose();
     this.statusBarItem.dispose();
@@ -89,8 +123,14 @@ export async function showProviderHealthQuickPick(providerRegistry: ProviderRegi
     return;
   }
 
-  // Sort: unhealthy first, then by label
+  // Sort: in-flight first, then unhealthy, then by label
   const sortedProviders = providers.slice().sort((a, b) => {
+    const aRefreshing = providerRegistry.isProviderRefreshing(a.id);
+    const bRefreshing = providerRegistry.isProviderRefreshing(b.id);
+    if (aRefreshing !== bRefreshing) {
+      return aRefreshing ? -1 : 1;
+    }
+
     const aHealth = providerRegistry.getProviderHealth(a.id);
     const bHealth = providerRegistry.getProviderHealth(b.id);
     
@@ -110,13 +150,15 @@ export async function showProviderHealthQuickPick(providerRegistry: ProviderRegi
 
   const items: ProviderQuickPickItem[] = sortedProviders.map(provider => {
     const health = providerRegistry.getProviderHealth(provider.id);
-    const icon = health.status === 'unhealthy' ? '$(warning)' : 
+    const isRefreshing = providerRegistry.isProviderRefreshing(provider.id);
+    const icon = isRefreshing ? '$(sync~spin)' :
+                 health.status === 'unhealthy' ? '$(warning)' :
                  health.status === 'healthy' ? '$(pass)' :
                  '$(circle-outline)';
     
-    let description: string = health.status;
+    let description: string = isRefreshing ? 'refreshing' : health.status;
     if (health.lastError) {
-      description = `${health.status} — ${sanitizeError(health.lastError)}`;
+      description = `${description} — ${sanitizeError(health.lastError)}`;
     }
     
     return {
@@ -134,20 +176,21 @@ export async function showProviderHealthQuickPick(providerRegistry: ProviderRegi
   if (selected) {
     const provider = providers.find(p => p.id === selected.providerId);
     if (provider) {
+      if (providerRegistry.isProviderRefreshing(provider.id)) {
+        void vscode.window.showInformationMessage(`${provider.label} is currently refreshing.`);
+        return;
+      }
+
       const health = providerRegistry.getProviderHealth(provider.id);
+      const message = health.status === 'unhealthy' && health.lastError
+        ? `${provider.label} is unhealthy: ${sanitizeError(health.lastError, 200)}`
+        : `${provider.label} is ${health.status}.`;
+      const action = health.status === 'unhealthy'
+        ? await vscode.window.showWarningMessage(message, 'Refresh')
+        : await vscode.window.showInformationMessage(message, 'Refresh');
       
-      // Show detailed message based on health status
-      if (health.status === 'unhealthy' && health.lastError) {
-        const action = await vscode.window.showWarningMessage(
-          `${provider.label} is unhealthy: ${sanitizeError(health.lastError, 200)}`,
-          'Refresh',
-        );
-        
-        if (action === 'Refresh') {
-          await vscode.commands.executeCommand('devdocket.refresh');
-        }
-      } else {
-        void vscode.window.showInformationMessage(`${provider.label} is ${health.status}.`);
+      if (action === 'Refresh') {
+        await refreshProviderWithProgress(providerRegistry, provider);
       }
     }
   }

--- a/packages/core/src/views/providerHealthStatusBar.ts
+++ b/packages/core/src/views/providerHealthStatusBar.ts
@@ -84,8 +84,12 @@ export class ProviderHealthStatusBar implements vscode.Disposable {
         ? `$(sync~spin) ${refreshingCount} refreshing, ${unhealthyCount} unhealthy`
         : `$(sync~spin) ${refreshingCount} provider${refreshingCount === 1 ? '' : 's'} refreshing`;
       this.statusBarItem.tooltip = 'Click to view provider health details';
-      this.statusBarItem.backgroundColor = undefined;
-      this.statusBarItem.color = undefined;
+      this.statusBarItem.backgroundColor = unhealthyCount > 0
+        ? new vscode.ThemeColor('statusBarItem.warningBackground')
+        : undefined;
+      this.statusBarItem.color = unhealthyCount > 0
+        ? new vscode.ThemeColor('statusBarItem.warningForeground')
+        : undefined;
       this.statusBarItem.show();
       return;
     }


### PR DESCRIPTION
## Summary

- Shows manual refresh in a cancellable notification with per-provider completion messages.
- Tracks provider refresh in-flight state for the health status bar and quick pick.
- Wires refresh cancellation through ProviderRegistry and avoids clearing ADO items on cancellation.

## Validation

- npm run build
- npm run test
- superpowers:code-reviewer clean

Closes #544
