### PR TITLE
Restore webview panels after reload

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,10 @@
     "Other"
   ],
   "activationEvents": [
-    "onView:devdocket.main"
+    "onView:devdocket.main",
+    "onWebviewPanel:devdocket.editItem",
+    "onWebviewPanel:devdocket.previewItem",
+    "onWebviewPanel:devdocket.watchPanel"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -19,6 +19,7 @@ import { WatchesStatusBar } from './views/watchesStatusBar';
 import { ProviderHealthStatusBar } from './views/providerHealthStatusBar';
 import { WatchPanelProvider } from './views/watchPanelProvider';
 import { WorkItemEditorPanel, PanelManager } from './views/workItemEditorPanel';
+import { IncomingPreviewPanel } from './views/incomingPreviewPanel';
 import { MainViewProvider } from './views/mainViewProvider';
 import { registerCommands } from './commands/commands';
 import { isSafeUrl } from './utils/url';
@@ -550,6 +551,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   // before WorkGraph is disposed.
   context.subscriptions.push(
     panelManager,
+    vscode.window.registerWebviewPanelSerializer(
+      WorkItemEditorPanel.viewType,
+      WorkItemEditorPanel.createSerializer(context, wg, pr),
+    ),
+    vscode.window.registerWebviewPanelSerializer(
+      IncomingPreviewPanel.viewType,
+      IncomingPreviewPanel.createSerializer(context, pr, ss, readStateStore, wg),
+    ),
+    vscode.window.registerWebviewPanelSerializer(
+      WatchPanelProvider.viewType,
+      watchPanelProvider.createSerializer(),
+    ),
     ...eventDisposables,
     mainProvider,
     watchPanelProvider,

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -89,6 +89,7 @@ const window = {
     };
   }),
   createWebviewPanel: vi.fn(),
+  registerWebviewPanelSerializer: vi.fn(() => ({ dispose: vi.fn() })),
   registerWebviewViewProvider: vi.fn(() => ({ dispose: vi.fn() })),
   createOutputChannel: vi.fn(() => ({
     info: vi.fn(),

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -80,6 +80,16 @@ describe('getEditorPanelHtml', () => {
     expect(html).not.toContain('<script>alert(1)</script>');
     expect(html).toContain('\\u003cscript\\u003ealert(1)\\u003c/script\\u003e');
   });
+
+  it('escapes line separators before embedding bootstrap data in script', () => {
+    const html = getEditorPanelHtml({
+      cspSource: 'https://example.test',
+      scriptUri: 'https://example.test/editor.js',
+      initialItem: makeEditorItem({ title: 'Line\u2028Paragraph\u2029End' }),
+    });
+
+    expect(html).toContain('Line\\u2028Paragraph\\u2029End');
+  });
 });
 
 describe('renderMarkdown', () => {

--- a/packages/core/src/test/editorPanelHtml.test.ts
+++ b/packages/core/src/test/editorPanelHtml.test.ts
@@ -40,6 +40,17 @@ describe('getEditorPanelHtml', () => {
     expect(html).not.toContain('unsafe-inline');
   });
 
+  it('seeds serialized webview state without acquiring the VS Code API twice', () => {
+    const html = getEditorPanelHtml({
+      cspSource: 'https://example.test',
+      scriptUri: 'https://example.test/editor.js',
+      initialItem: makeEditorItem(),
+    });
+
+    expect(html).toContain('window.__DEVDOCKET_VSCODE_API__ = window.__DEVDOCKET_VSCODE_API__ || acquireVsCodeApi();');
+    expect(html).toContain('window.__DEVDOCKET_VSCODE_API__.setState({"version":1,"itemId":"item-1"});');
+  });
+
   it('bootstraps the editor app with transitions, activity, and related item data', () => {
     const html = getEditorPanelHtml({
       cspSource: 'https://example.test',

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -110,6 +110,19 @@ describe('activate()', () => {
   // ------------------------------------------------------------------
   // 4. Registers commands
   // ------------------------------------------------------------------
+  it('registers webview panel serializers for restorable panels', async () => {
+    await activate(context);
+
+    const registerSerializer = vscode.window.registerWebviewPanelSerializer as ReturnType<typeof vi.fn>;
+    const viewTypes = registerSerializer.mock.calls.map((call: any[]) => call[0]);
+
+    expect(viewTypes).toEqual(expect.arrayContaining([
+      'devdocket.editItem',
+      'devdocket.previewItem',
+      'devdocket.watchPanel',
+    ]));
+  });
+
   it('registers extension commands', async () => {
     await activate(context);
     const registerCommand = vscode.commands.registerCommand as ReturnType<typeof vi.fn>;

--- a/packages/core/src/test/webviewPanelSerializers.test.ts
+++ b/packages/core/src/test/webviewPanelSerializers.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { EventEmitter } from 'vscode';
+import { IncomingPreviewPanel } from '../views/incomingPreviewPanel';
+import { WatchPanelProvider } from '../views/watchPanelProvider';
+import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
+import { WorkItem, WorkItemState } from '../models/workItem';
+
+type MessageHandler = (message: unknown) => void | Promise<void>;
+type DisposeHandler = () => void;
+
+function makeItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  const now = Date.now();
+  return {
+    id: 'item-1',
+    title: 'Restored work item',
+    state: WorkItemState.New,
+    createdAt: now,
+    updatedAt: now,
+    activityLog: [],
+    ...overrides,
+  };
+}
+
+function createContext(): vscode.ExtensionContext {
+  return {
+    subscriptions: [],
+    extensionUri: vscode.Uri.file('C:\\repo\\packages\\core'),
+  } as unknown as vscode.ExtensionContext;
+}
+
+function createMockWebviewPanel() {
+  let messageHandler: MessageHandler | undefined;
+  let disposeHandler: DisposeHandler | undefined;
+  const panel = {
+    title: '',
+    active: false,
+    webview: {
+      html: '',
+      options: undefined as vscode.WebviewOptions | undefined,
+      cspSource: 'mock-csp-source',
+      asWebviewUri: vi.fn((uri: { fsPath?: string; path?: string; toString?: () => string }) => ({
+        toString: () => `webview-resource:${uri.fsPath ?? uri.path ?? uri.toString?.() ?? ''}`,
+      })),
+      onDidReceiveMessage: vi.fn((handler: MessageHandler) => {
+        messageHandler = handler;
+        return { dispose: vi.fn(() => { messageHandler = undefined; }) };
+      }),
+      postMessage: vi.fn(async () => true),
+    },
+    onDidDispose: vi.fn((handler: DisposeHandler) => {
+      disposeHandler = handler;
+      return { dispose: vi.fn() };
+    }),
+    onDidChangeViewState: vi.fn(() => ({ dispose: vi.fn() })),
+    dispose: vi.fn(() => disposeHandler?.()),
+    reveal: vi.fn(),
+  };
+
+  return {
+    panel,
+    simulateMessage: (message: unknown) => messageHandler?.(message) ?? Promise.resolve(),
+    simulateDispose: () => disposeHandler?.(),
+  };
+}
+
+function createMockWorkGraph(items: WorkItem[] = []) {
+  const changeEmitter = new EventEmitter<void>();
+  const itemMap = new Map(items.map(item => [item.id, item]));
+  return {
+    getAll: vi.fn(() => Array.from(itemMap.values())),
+    getItem: vi.fn((id: string) => itemMap.get(id)),
+    findItemByProvenance: vi.fn((providerId: string, externalId: string) =>
+      Array.from(itemMap.values()).find(item => item.providerId === providerId && item.externalId === externalId)),
+    onDidChange: changeEmitter.event,
+  };
+}
+
+function createMockProviderRegistry(providerItems: Record<string, any[]> = {}) {
+  const providerItemsEmitter = new EventEmitter<void>();
+  const providerRefreshEmitter = new EventEmitter<string>();
+  const registerEmitter = new EventEmitter<void>();
+  const registry: any = {
+    getProviderItems: vi.fn((providerId: string) => providerItems[providerId] ?? []),
+    getAllProviderItems: vi.fn(() => new Map(Object.entries(providerItems))),
+    getProvider: vi.fn((providerId: string) => providerId ? { id: providerId, label: providerId } : undefined),
+    getProviderLabel: vi.fn((providerId: string) => providerId === 'github' ? 'GitHub' : providerId),
+    onDidChangeProviderItems: providerItemsEmitter.event,
+    onDidRefreshProvider: providerRefreshEmitter.event,
+    onDidRegisterProvider: registerEmitter.event,
+    fireProviderItemsChanged: () => providerItemsEmitter.fire(),
+    fireProviderRefreshed: (providerId: string) => providerRefreshEmitter.fire(providerId),
+  };
+  registry.findProviderItem = vi.fn((providerId: string, externalId: string) =>
+    registry.getProviderItems(providerId).find((item: any) => item.externalId === externalId));
+  return registry;
+}
+
+function createMockInboxStateStore() {
+  const changeEmitter = new EventEmitter<void>();
+  return {
+    getState: vi.fn(() => 'unseen'),
+    setState: vi.fn(async () => undefined),
+    onDidChange: changeEmitter.event,
+  };
+}
+
+function createMockReadStateStore() {
+  return {
+    add: vi.fn(async () => undefined),
+  };
+}
+
+function createMockWatcherService() {
+  return {
+    getActivePRWatches: vi.fn(() => []),
+    getActiveStandaloneWatches: vi.fn(() => []),
+    getActiveWatches: vi.fn(() => []),
+    getPRWatchKey: vi.fn(),
+    getChildRuns: vi.fn(() => []),
+    getProviderLabel: vi.fn(),
+    acknowledgeAllFailures: vi.fn(),
+    dismissPRWatch: vi.fn(),
+    dismissWatch: vi.fn(),
+  };
+}
+
+describe('webview panel serializers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    WorkItemEditorPanel.clearPanelCache();
+  });
+
+  it('restores a work item editor panel from serialized item state', async () => {
+    const context = createContext();
+    const item = makeItem({ providerId: 'github', externalId: 'owner/repo#1' });
+    const workGraph = createMockWorkGraph([item]);
+    const providerRegistry = createMockProviderRegistry();
+    const mockPanel = createMockWebviewPanel();
+
+    const serializer = WorkItemEditorPanel.createSerializer(context, workGraph as any, providerRegistry as any);
+    await serializer.deserializeWebviewPanel(mockPanel.panel as any, { version: 1, itemId: item.id });
+
+    expect(mockPanel.panel.title).toBe('Edit: Restored work item');
+    expect(mockPanel.panel.webview.options).toMatchObject({ enableScripts: true });
+    expect(mockPanel.panel.webview.html).toContain('Restored work item');
+    expect(mockPanel.panel.webview.onDidReceiveMessage).toHaveBeenCalled();
+  });
+
+  it('shows a hardened unavailable page when work item editor state is invalid', async () => {
+    const context = createContext();
+    const mockPanel = createMockWebviewPanel();
+
+    const serializer = WorkItemEditorPanel.createSerializer(
+      context,
+      createMockWorkGraph() as any,
+      createMockProviderRegistry() as any,
+    );
+    await serializer.deserializeWebviewPanel(mockPanel.panel as any, { version: 2, itemId: 'item-1' });
+
+    expect(mockPanel.panel.title).toBe('Work item unavailable');
+    expect(mockPanel.panel.webview.html).toContain("default-src 'none'");
+    expect(mockPanel.panel.webview.html).toContain('Work item editor state is unavailable');
+  });
+
+  it('restores an incoming preview after provider items are available', async () => {
+    const context = createContext();
+    const providerItems = {
+      github: [{ externalId: 'owner/repo#2', title: 'Restored incoming item', description: 'Incoming description', itemType: 'issue' }],
+    };
+    const providerRegistry = createMockProviderRegistry(providerItems);
+    const mockPanel = createMockWebviewPanel();
+
+    const serializer = IncomingPreviewPanel.createSerializer(
+      context,
+      providerRegistry as any,
+      createMockInboxStateStore() as any,
+      createMockReadStateStore() as any,
+      createMockWorkGraph() as any,
+    );
+    await serializer.deserializeWebviewPanel(mockPanel.panel as any, { version: 1, providerId: 'github', externalId: 'owner/repo#2' });
+
+    expect(mockPanel.panel.title).toBe('Preview: Restored incoming item');
+    expect(mockPanel.panel.webview.options).toMatchObject({ enableScripts: true });
+    expect(mockPanel.panel.webview.html).toContain('Restored incoming item');
+    expect(mockPanel.panel.webview.onDidReceiveMessage).toHaveBeenCalled();
+  });
+
+  it('keeps a restored incoming preview alive while waiting for provider refresh', async () => {
+    const context = createContext();
+    const providerItems: Record<string, any[]> = { github: [] };
+    const providerRegistry = createMockProviderRegistry(providerItems);
+    const mockPanel = createMockWebviewPanel();
+
+    const serializer = IncomingPreviewPanel.createSerializer(
+      context,
+      providerRegistry as any,
+      createMockInboxStateStore() as any,
+      createMockReadStateStore() as any,
+      createMockWorkGraph() as any,
+    );
+    await serializer.deserializeWebviewPanel(mockPanel.panel as any, { version: 1, providerId: 'github', externalId: 'owner/repo#3' });
+
+    expect(mockPanel.panel.title).toBe('Preview: Loading…');
+    expect(mockPanel.panel.dispose).not.toHaveBeenCalled();
+    expect(mockPanel.panel.webview.html).toContain('Loading incoming item from provider');
+
+    providerItems.github = [{ externalId: 'owner/repo#3', title: 'Eventually restored item', itemType: 'issue' }];
+    providerRegistry.fireProviderItemsChanged();
+
+    expect(mockPanel.panel.title).toBe('Preview: Eventually restored item');
+    expect(mockPanel.panel.webview.html).toContain('Eventually restored item');
+  });
+
+  it('shows an unavailable message when a restored incoming preview is still missing after refresh', async () => {
+    const context = createContext();
+    const providerRegistry = createMockProviderRegistry({ github: [] });
+    const mockPanel = createMockWebviewPanel();
+
+    const serializer = IncomingPreviewPanel.createSerializer(
+      context,
+      providerRegistry as any,
+      createMockInboxStateStore() as any,
+      createMockReadStateStore() as any,
+      createMockWorkGraph() as any,
+    );
+    await serializer.deserializeWebviewPanel(mockPanel.panel as any, { version: 1, providerId: 'github', externalId: 'owner/repo#4' });
+
+    providerRegistry.fireProviderRefreshed('github');
+
+    expect(mockPanel.panel.title).toBe('Preview unavailable');
+    expect(mockPanel.panel.dispose).not.toHaveBeenCalled();
+    expect(mockPanel.panel.webview.html).toContain('not found after the provider refreshed');
+    expect(mockPanel.panel.webview.html).toContain('window.__DEVDOCKET_VSCODE_API__.setState');
+  });
+
+  it('shows a hardened unavailable page when incoming preview state is invalid', async () => {
+    const context = createContext();
+    const mockPanel = createMockWebviewPanel();
+
+    const serializer = IncomingPreviewPanel.createSerializer(
+      context,
+      createMockProviderRegistry() as any,
+      createMockInboxStateStore() as any,
+      createMockReadStateStore() as any,
+      createMockWorkGraph() as any,
+    );
+    await serializer.deserializeWebviewPanel(mockPanel.panel as any, { version: 2, providerId: 'github', externalId: 'owner/repo#5' });
+
+    expect(mockPanel.panel.title).toBe('Incoming preview unavailable');
+    expect(mockPanel.panel.webview.html).toContain("default-src 'none'");
+    expect(mockPanel.panel.webview.html).toContain('Incoming preview state is unavailable');
+  });
+
+  it('restores the CI watches panel and posts the current watch snapshot', async () => {
+    const provider = new WatchPanelProvider(
+      vscode.Uri.file('C:\\repo\\packages\\core') as any,
+      createMockWatcherService() as any,
+      createMockWorkGraph() as any,
+      createMockProviderRegistry() as any,
+    );
+    const mockPanel = createMockWebviewPanel();
+
+    const serializer = provider.createSerializer();
+    await serializer.deserializeWebviewPanel(mockPanel.panel as any, { version: 1, panel: 'watchPanel' });
+
+    expect(mockPanel.panel.title).toBe('CI Watches');
+    expect(mockPanel.panel.webview.options).toMatchObject({ enableScripts: true });
+    expect(mockPanel.panel.webview.html).toContain('watchPanel.js');
+    expect(mockPanel.panel.webview.postMessage).toHaveBeenCalledWith({
+      type: 'updateWatchPanel',
+      prWatches: [],
+      runWatches: [],
+    });
+  });
+});

--- a/packages/core/src/test/webviewPanelSerializers.test.ts
+++ b/packages/core/src/test/webviewPanelSerializers.test.ts
@@ -212,6 +212,26 @@ describe('webview panel serializers', () => {
     expect(mockPanel.panel.webview.html).toContain('Eventually restored item');
   });
 
+  it('does not rewrite pending incoming preview HTML when the restore message is unchanged', async () => {
+    const context = createContext();
+    const providerRegistry = createMockProviderRegistry({ github: [] });
+    const mockPanel = createMockWebviewPanel();
+
+    const serializer = IncomingPreviewPanel.createSerializer(
+      context,
+      providerRegistry as any,
+      createMockInboxStateStore() as any,
+      createMockReadStateStore() as any,
+      createMockWorkGraph() as any,
+    );
+    await serializer.deserializeWebviewPanel(mockPanel.panel as any, { version: 1, providerId: 'github', externalId: 'owner/repo#4' });
+    const initialHtml = mockPanel.panel.webview.html;
+
+    providerRegistry.fireProviderItemsChanged();
+
+    expect(mockPanel.panel.webview.html).toBe(initialHtml);
+  });
+
   it('shows an unavailable message when a restored incoming preview is still missing after refresh', async () => {
     const context = createContext();
     const providerRegistry = createMockProviderRegistry({ github: [] });

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -663,7 +663,9 @@ function serializeForScript(value: unknown): string {
   return JSON.stringify(value)
     .replace(/</g, '\\u003c')
     .replace(/>/g, '\\u003e')
-    .replace(/&/g, '\\u0026');
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
 }
 
 function escapeAttr(value: string): string {

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'crypto';
 import { marked } from 'marked';
 import sanitizeHtml from 'sanitize-html';
+import { getSerializedEditorState } from '../webview/shared/editorState';
 import type { EditorItemData } from './mainTypes';
 
 export interface EditorHtmlOptions {
@@ -656,25 +657,6 @@ export function renderMarkdown(markdown: string): string {
 
 function getNonce(): string {
   return crypto.randomBytes(16).toString('hex');
-}
-
-function getSerializedEditorState(item: EditorItemData): unknown {
-  if (item.isIncoming && item.providerId && item.externalId) {
-    return {
-      version: 1,
-      providerId: item.providerId,
-      externalId: item.externalId,
-    };
-  }
-
-  if (!item.isIncoming) {
-    return {
-      version: 1,
-      itemId: item.id,
-    };
-  }
-
-  return undefined;
 }
 
 function serializeForScript(value: unknown): string {

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -11,6 +11,10 @@ export interface EditorHtmlOptions {
 
 export function getEditorPanelHtml({ cspSource, scriptUri, initialItem }: EditorHtmlOptions): string {
   const nonce = getNonce();
+  const initialState = getSerializedEditorState(initialItem);
+  const initialStateScript = initialState
+    ? `\n    window.__DEVDOCKET_VSCODE_API__ = window.__DEVDOCKET_VSCODE_API__ || acquireVsCodeApi();\n    window.__DEVDOCKET_VSCODE_API__.setState(${serializeForScript(initialState)});`
+    : '';
 
   return /* html */ `<!DOCTYPE html>
 <html lang="en">
@@ -619,7 +623,7 @@ export function getEditorPanelHtml({ cspSource, scriptUri, initialItem }: Editor
 </head>
 <body>
   <div id="root"></div>
-  <script nonce="${nonce}">
+  <script nonce="${nonce}">${initialStateScript}
     window.__DEVDOCKET_EDITOR_BOOTSTRAP__ = ${serializeForScript(initialItem)};
   </script>
   <script nonce="${nonce}" type="module" src="${escapeAttr(scriptUri)}"></script>
@@ -654,7 +658,26 @@ function getNonce(): string {
   return crypto.randomBytes(16).toString('hex');
 }
 
-function serializeForScript(value: EditorItemData): string {
+function getSerializedEditorState(item: EditorItemData): unknown {
+  if (item.isIncoming && item.providerId && item.externalId) {
+    return {
+      version: 1,
+      providerId: item.providerId,
+      externalId: item.externalId,
+    };
+  }
+
+  if (!item.isIncoming) {
+    return {
+      version: 1,
+      itemId: item.id,
+    };
+  }
+
+  return undefined;
+}
+
+function serializeForScript(value: unknown): string {
   return JSON.stringify(value)
     .replace(/</g, '\\u003c')
     .replace(/>/g, '\\u003e')

--- a/packages/core/src/views/incomingPreviewPanel.ts
+++ b/packages/core/src/views/incomingPreviewPanel.ts
@@ -433,12 +433,16 @@ function parseIncomingPreviewPanelState(state: unknown): IncomingPreviewPanelSta
 }
 
 function getUnavailableHtml(title: string, message: string): string {
+  const nonce = crypto.randomBytes(16).toString('hex');
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}';">
   <title>${escapeHtml(title)}</title>
+  <style nonce="${nonce}">
+    body { color: var(--vscode-foreground); background: var(--vscode-editor-background); font-family: var(--vscode-font-family); padding: 16px; }
+  </style>
 </head>
 <body>
   <p>${escapeHtml(message)}</p>

--- a/packages/core/src/views/incomingPreviewPanel.ts
+++ b/packages/core/src/views/incomingPreviewPanel.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as crypto from 'node:crypto';
 import type { ProviderItem } from '../api/types';
 import { logger } from '../services/logger';
 import { ProviderRegistry } from '../services/providerRegistry';
@@ -24,7 +25,7 @@ import { composeEditorBadges } from './workItemEditorPanel';
  * editor; Dismiss closes the preview.
  */
 export class IncomingPreviewPanel {
-  private static readonly viewType = 'devdocket.previewItem';
+  static readonly viewType = 'devdocket.previewItem';
   private static readonly openPanels = new Map<string, IncomingPreviewPanel>();
 
   private readonly panel: vscode.WebviewPanel;
@@ -38,6 +39,37 @@ export class IncomingPreviewPanel {
   private readonly subscriptions: vscode.Disposable[] = [];
   private htmlInitialized = false;
   private disposed = false;
+  private providerRefreshObserved = false;
+
+  static createSerializer(
+    context: vscode.ExtensionContext,
+    providerRegistry: ProviderRegistry,
+    stateStore: InboxStateStore,
+    readStateStore: ReadStateStore,
+    workGraph: WorkGraph,
+  ): vscode.WebviewPanelSerializer {
+    return {
+      async deserializeWebviewPanel(panel, state): Promise<void> {
+        const restoredState = parseIncomingPreviewPanelState(state);
+        panel.webview.options = IncomingPreviewPanel.getWebviewOptions(context);
+        if (!restoredState) {
+          IncomingPreviewPanel.showUnavailable(panel, 'Incoming preview state is unavailable. Close this tab and reopen the item from DevDocket.');
+          return;
+        }
+
+        IncomingPreviewPanel.revive(
+          context,
+          providerRegistry,
+          stateStore,
+          readStateStore,
+          workGraph,
+          panel,
+          restoredState.providerId,
+          restoredState.externalId,
+        );
+      },
+    };
+  }
 
   static open(
     context: vscode.ExtensionContext,
@@ -69,17 +101,49 @@ export class IncomingPreviewPanel {
       `Preview: ${providerItem.title}`,
       vscode.ViewColumn.One,
       {
-        enableScripts: true,
+        ...IncomingPreviewPanel.getWebviewOptions(context),
         retainContextWhenHidden: true,
-        localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, 'webview-dist')],
       },
     );
 
-    const preview = new IncomingPreviewPanel(panel, providerRegistry, stateStore, readStateStore, workGraph, providerId, externalId, context.extensionUri);
+    const preview = new IncomingPreviewPanel(panel, providerRegistry, stateStore, readStateStore, workGraph, providerId, externalId, context.extensionUri, false);
     IncomingPreviewPanel.openPanels.set(key, preview);
     // Panel cleanup is wired in the constructor via panel.onDidDispose →
     // this.dispose(). Pushing onto context.subscriptions would leak a
     // closure per open (panels self-dispose long before the extension does).
+  }
+
+  private static revive(
+    context: vscode.ExtensionContext,
+    providerRegistry: ProviderRegistry,
+    stateStore: InboxStateStore,
+    readStateStore: ReadStateStore,
+    workGraph: WorkGraph,
+    panel: vscode.WebviewPanel,
+    providerId: string,
+    externalId: string,
+  ): void {
+    const key = IncomingPreviewPanel.cacheKey(providerId, externalId);
+    const existing = IncomingPreviewPanel.openPanels.get(key);
+    if (existing) {
+      existing.dispose();
+    }
+
+    panel.webview.options = IncomingPreviewPanel.getWebviewOptions(context);
+    const preview = new IncomingPreviewPanel(panel, providerRegistry, stateStore, readStateStore, workGraph, providerId, externalId, context.extensionUri, true);
+    IncomingPreviewPanel.openPanels.set(key, preview);
+  }
+
+  private static getWebviewOptions(context: vscode.ExtensionContext): vscode.WebviewOptions {
+    return {
+      enableScripts: true,
+      localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, 'webview-dist')],
+    };
+  }
+
+  private static showUnavailable(panel: vscode.WebviewPanel, message: string): void {
+    panel.title = 'Incoming preview unavailable';
+    panel.webview.html = getUnavailableHtml('Incoming preview unavailable', message);
   }
 
   private constructor(
@@ -91,6 +155,7 @@ export class IncomingPreviewPanel {
     providerId: string,
     externalId: string,
     extensionUri: vscode.Uri,
+    private readonly restoredFromSerializer: boolean,
   ) {
     this.panel = panel;
     this.providerRegistry = providerRegistry;
@@ -105,6 +170,13 @@ export class IncomingPreviewPanel {
 
     this.subscriptions.push(
       this.providerRegistry.onDidChangeProviderItems(() => this.update()),
+      this.providerRegistry.onDidRegisterProvider(() => this.update()),
+      this.providerRegistry.onDidRefreshProvider((providerId) => {
+        if (providerId === this.providerId) {
+          this.providerRefreshObserved = true;
+          this.update();
+        }
+      }),
       this.stateStore.onDidChange(() => this.checkInboxState()),
       this.panel.webview.onDidReceiveMessage((msg) => {
         void this.handleMessage(msg);
@@ -230,6 +302,10 @@ export class IncomingPreviewPanel {
     if (this.disposed) return;
     const providerItem = this.findProviderItem();
     if (!providerItem) {
+      if (this.restoredFromSerializer) {
+        this.showPendingRestore();
+        return;
+      }
       // The provider no longer surfaces this item; close the preview.
       this.dispose();
       return;
@@ -253,6 +329,22 @@ export class IncomingPreviewPanel {
     }
 
     void this.panel.webview.postMessage({ type: 'updateEditorItem', item: editorItem });
+  }
+
+  private showPendingRestore(): void {
+    this.htmlInitialized = false;
+    const providerMissing = !this.providerRegistry.getProvider(this.providerId) && !this.providerRegistry.loading;
+    const unavailable = this.providerRefreshObserved || providerMissing;
+    this.panel.title = unavailable ? 'Preview unavailable' : 'Preview: Loading…';
+    const message = this.providerRefreshObserved
+      ? 'This incoming item was not found after the provider refreshed. It may have been completed, dismissed, or removed.'
+      : providerMissing
+        ? 'The provider for this incoming item is not registered. If the provider extension is still loading, this preview will restore after its items refresh.'
+        : 'Loading incoming item from provider…';
+    this.panel.webview.html = getStatePreservingHtml(
+      message,
+      { version: 1, providerId: this.providerId, externalId: this.externalId },
+    );
   }
 
   private findProviderItem(): ProviderItem | undefined {
@@ -316,5 +408,81 @@ export class IncomingPreviewPanel {
     this.subscriptions.length = 0;
     try { this.panel.dispose(); } catch { /* ignore */ }
   }
+}
+
+interface IncomingPreviewPanelState {
+  providerId: string;
+  externalId: string;
+}
+
+function parseIncomingPreviewPanelState(state: unknown): IncomingPreviewPanelState | undefined {
+  if (!state || typeof state !== 'object') {
+    return undefined;
+  }
+  const candidate = state as { version?: unknown; providerId?: unknown; externalId?: unknown };
+  if (candidate.version !== undefined && candidate.version !== 1) {
+    return undefined;
+  }
+  if (typeof candidate.providerId !== 'string' || candidate.providerId.length === 0) {
+    return undefined;
+  }
+  if (typeof candidate.externalId !== 'string' || candidate.externalId.length === 0) {
+    return undefined;
+  }
+  return { providerId: candidate.providerId, externalId: candidate.externalId };
+}
+
+function getUnavailableHtml(title: string, message: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none';">
+  <title>${escapeHtml(title)}</title>
+</head>
+<body>
+  <p>${escapeHtml(message)}</p>
+</body>
+</html>`;
+}
+
+function getStatePreservingHtml(message: string, state: unknown): string {
+  const nonce = crypto.randomBytes(16).toString('hex');
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}';">
+  <title>Incoming preview</title>
+  <style nonce="${nonce}">
+    body { color: var(--vscode-foreground); background: var(--vscode-editor-background); font-family: var(--vscode-font-family); padding: 16px; }
+  </style>
+</head>
+<body>
+  <p>${escapeHtml(message)}</p>
+  <script nonce="${nonce}">
+    window.__DEVDOCKET_VSCODE_API__ = window.__DEVDOCKET_VSCODE_API__ || acquireVsCodeApi();
+    window.__DEVDOCKET_VSCODE_API__.setState(${serializeForScript(state)});
+  </script>
+</body>
+</html>`;
+}
+
+function serializeForScript(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 

--- a/packages/core/src/views/incomingPreviewPanel.ts
+++ b/packages/core/src/views/incomingPreviewPanel.ts
@@ -40,6 +40,7 @@ export class IncomingPreviewPanel {
   private htmlInitialized = false;
   private disposed = false;
   private providerRefreshObserved = false;
+  private lastPendingRestoreSignature: string | undefined;
 
   static createSerializer(
     context: vscode.ExtensionContext,
@@ -311,6 +312,7 @@ export class IncomingPreviewPanel {
       return;
     }
 
+    this.lastPendingRestoreSignature = undefined;
     const relatedItemsIndex = buildRelatedItemsIndex(this.providerRegistry, this.workGraph);
     const editorItem = this.buildEditorItemData(providerItem, relatedItemsIndex);
     this.panel.title = `Preview: ${providerItem.title}`;
@@ -332,15 +334,22 @@ export class IncomingPreviewPanel {
   }
 
   private showPendingRestore(): void {
-    this.htmlInitialized = false;
     const providerMissing = !this.providerRegistry.getProvider(this.providerId) && !this.providerRegistry.loading;
     const unavailable = this.providerRefreshObserved || providerMissing;
-    this.panel.title = unavailable ? 'Preview unavailable' : 'Preview: Loading…';
+    const title = unavailable ? 'Preview unavailable' : 'Preview: Loading…';
     const message = this.providerRefreshObserved
       ? 'This incoming item was not found after the provider refreshed. It may have been completed, dismissed, or removed.'
       : providerMissing
         ? 'The provider for this incoming item is not registered. If the provider extension is still loading, this preview will restore after its items refresh.'
         : 'Loading incoming item from provider…';
+    const signature = `${title}\n${message}`;
+    if (this.lastPendingRestoreSignature === signature) {
+      return;
+    }
+
+    this.htmlInitialized = false;
+    this.lastPendingRestoreSignature = signature;
+    this.panel.title = title;
     this.panel.webview.html = getStatePreservingHtml(
       message,
       { version: 1, providerId: this.providerId, externalId: this.externalId },

--- a/packages/core/src/views/watchPanelProvider.ts
+++ b/packages/core/src/views/watchPanelProvider.ts
@@ -37,6 +37,14 @@ export class WatchPanelProvider implements vscode.Disposable {
     ];
   }
 
+  createSerializer(): vscode.WebviewPanelSerializer {
+    return {
+      deserializeWebviewPanel: async (panel): Promise<void> => {
+        this.revive(panel);
+      },
+    };
+  }
+
   open(): void {
     if (this.panel) {
       this.panel.reveal(vscode.ViewColumn.Beside);
@@ -44,21 +52,27 @@ export class WatchPanelProvider implements vscode.Disposable {
       return;
     }
 
-    const localResourceRoots = [vscode.Uri.joinPath(this.extensionUri, 'webview-dist')];
-    if (this.codiconsResources) {
-      localResourceRoots.push(vscode.Uri.file(this.codiconsResources.distDir));
-    }
-
-    this.panel = vscode.window.createWebviewPanel(
+    const panel = vscode.window.createWebviewPanel(
       WatchPanelProvider.viewType,
       'CI Watches',
       vscode.ViewColumn.Beside,
-      {
-        enableScripts: true,
-        localResourceRoots,
-      },
+      this.getWebviewOptions(),
     );
 
+    this.attachPanel(panel);
+  }
+
+  revive(panel: vscode.WebviewPanel): void {
+    if (this.panel && this.panel !== panel) {
+      this.panel.dispose();
+    }
+    this.attachPanel(panel);
+  }
+
+  private attachPanel(panel: vscode.WebviewPanel): void {
+    this.clearPanel();
+    this.panel = panel;
+    this.panel.webview.options = this.getWebviewOptions();
     this.panel.webview.html = this.getHtml(this.panel.webview);
     this.panelDisposables = [
       this.panel.webview.onDidReceiveMessage((message: WebviewMessage) => {
@@ -78,6 +92,18 @@ export class WatchPanelProvider implements vscode.Disposable {
     ];
 
     this.refresh();
+  }
+
+  private getWebviewOptions(): vscode.WebviewPanelOptions & vscode.WebviewOptions {
+    const localResourceRoots = [vscode.Uri.joinPath(this.extensionUri, 'webview-dist')];
+    if (this.codiconsResources) {
+      localResourceRoots.push(vscode.Uri.file(this.codiconsResources.distDir));
+    }
+
+    return {
+      enableScripts: true,
+      localResourceRoots,
+    };
   }
 
   refresh(): void {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -52,7 +52,7 @@ export class PanelManager {
 }
 
 export class WorkItemEditorPanel {
-  private static readonly viewType = 'devdocket.editItem';
+  static readonly viewType = 'devdocket.editItem';
   private static panelManager = new PanelManager();
   private static actionRegistry?: ActionRegistry;
   private static stateStore?: InboxStateStore;
@@ -99,6 +99,32 @@ export class WorkItemEditorPanel {
     WorkItemEditorPanel.watcherService = watcherService;
   }
 
+  static createSerializer(
+    context: vscode.ExtensionContext,
+    workGraph: WorkGraph,
+    providerRegistry: ProviderRegistry,
+  ): vscode.WebviewPanelSerializer {
+    return {
+      async deserializeWebviewPanel(panel, state): Promise<void> {
+        const itemId = parseEditorPanelState(state);
+        panel.webview.options = WorkItemEditorPanel.getWebviewOptions(context);
+        if (!itemId) {
+          WorkItemEditorPanel.showUnavailable(panel, 'Work item editor state is unavailable. Close this tab and reopen the item from DevDocket.');
+          return;
+        }
+
+        const item = workGraph.getItem(itemId);
+        if (!item) {
+          WorkItemEditorPanel.showUnavailable(panel, 'Work item no longer exists. Close this tab and reopen it from DevDocket if it is still available.');
+          return;
+        }
+
+        const providerLabel = item.providerId ? providerRegistry.getProviderLabel(item.providerId) : undefined;
+        WorkItemEditorPanel.revive(context, workGraph, providerRegistry, panel, item, providerLabel);
+      },
+    };
+  }
+
   static open(
     context: vscode.ExtensionContext,
     workGraph: WorkGraph,
@@ -120,15 +146,43 @@ export class WorkItemEditorPanel {
       `Edit: ${item.title}`,
       vscode.ViewColumn.One,
       {
-        enableScripts: true,
+        ...WorkItemEditorPanel.getWebviewOptions(context),
         retainContextWhenHidden: true,
-        localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, 'webview-dist')],
       },
     );
 
+    WorkItemEditorPanel.revive(context, workGraph, providerRegistry, panel, item, providerLabel);
+  }
+
+  private static revive(
+    context: vscode.ExtensionContext,
+    workGraph: WorkGraph,
+    providerRegistry: ProviderRegistry,
+    panel: vscode.WebviewPanel,
+    item: WorkItem,
+    providerLabel?: string,
+  ): void {
+    const manager = WorkItemEditorPanel.panelManager;
+    const existing = manager.openPanels.get(item.id);
+    if (existing) {
+      existing.dispose();
+    }
+
+    panel.webview.options = WorkItemEditorPanel.getWebviewOptions(context);
     const editor = new WorkItemEditorPanel(panel, workGraph, providerRegistry, item.id, manager, context.extensionUri, providerLabel);
     manager.openPanels.set(item.id, editor);
-    context.subscriptions.push({ dispose: () => editor.dispose() });
+  }
+
+  private static getWebviewOptions(context: vscode.ExtensionContext): vscode.WebviewOptions {
+    return {
+      enableScripts: true,
+      localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, 'webview-dist')],
+    };
+  }
+
+  private static showUnavailable(panel: vscode.WebviewPanel, message: string): void {
+    panel.title = 'Work item unavailable';
+    panel.webview.html = getUnavailableHtml('Work item unavailable', message);
   }
 
   /** @internal Exposed for testing only. */
@@ -625,6 +679,41 @@ export class WorkItemEditorPanel {
       void vscode.window.showErrorMessage(`Failed to dismiss item: ${message}`);
     }
   }
+}
+
+function getUnavailableHtml(title: string, message: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none';">
+  <title>${escapeHtml(title)}</title>
+</head>
+<body>
+  <p>${escapeHtml(message)}</p>
+</body>
+</html>`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function parseEditorPanelState(state: unknown): string | undefined {
+  if (!state || typeof state !== 'object') {
+    return undefined;
+  }
+  const candidate = state as { version?: unknown; itemId?: unknown };
+  if (candidate.version !== undefined && candidate.version !== 1) {
+    return undefined;
+  }
+  const itemId = candidate.itemId;
+  return typeof itemId === 'string' && itemId.length > 0 ? itemId : undefined;
 }
 
 function isPRWorkItem(item: WorkItem | undefined): item is WorkItem & { itemType: 'pr' } {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import * as crypto from 'node:crypto';
 import type { ProviderItem } from '../api/types';
 import { WorkItem, WorkItemInput, WorkItemState } from '../models/workItem';
 import { ActionRegistry } from '../services/actionRegistry';
@@ -682,12 +683,16 @@ export class WorkItemEditorPanel {
 }
 
 function getUnavailableHtml(title: string, message: string): string {
+  const nonce = crypto.randomBytes(16).toString('hex');
   return `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none';">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'nonce-${nonce}';">
   <title>${escapeHtml(title)}</title>
+  <style nonce="${nonce}">
+    body { color: var(--vscode-foreground); background: var(--vscode-editor-background); font-family: var(--vscode-font-family); padding: 16px; }
+  </style>
 </head>
 <body>
   <p>${escapeHtml(message)}</p>

--- a/packages/core/src/webview/editor/EditorApp.tsx
+++ b/packages/core/src/webview/editor/EditorApp.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
+import { getSerializedEditorState } from '../shared/editorState';
 import { postMessage, setWebviewState } from '../shared/messaging';
 import type { EditorItemData, ExtensionMessage } from '../shared/types';
 import { useThemeChangeCounter } from '../shared/theme';
@@ -239,25 +240,6 @@ export function EditorApp() {
     itemRef.current = updatedItem;
     titleRef.current = resolvedTitle;
   }
-}
-
-function getSerializedEditorState(item: EditorItemData): unknown {
-  if (item.isIncoming && item.providerId && item.externalId) {
-    return {
-      version: 1,
-      providerId: item.providerId,
-      externalId: item.externalId,
-    };
-  }
-
-  if (!item.isIncoming) {
-    return {
-      version: 1,
-      itemId: item.id,
-    };
-  }
-
-  return undefined;
 }
 
 function shouldPreserveEditableField(item: EditorItemData | null, draftValue: string, persistedValue?: string): boolean {

--- a/packages/core/src/webview/editor/EditorApp.tsx
+++ b/packages/core/src/webview/editor/EditorApp.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'preact/hooks';
-import { postMessage } from '../shared/messaging';
+import { postMessage, setWebviewState } from '../shared/messaging';
 import type { EditorItemData, ExtensionMessage } from '../shared/types';
 import { useThemeChangeCounter } from '../shared/theme';
 import { ActivityLog } from './components/ActivityLog';
@@ -33,6 +33,13 @@ export function EditorApp() {
   useEffect(() => {
     itemRef.current = item;
   }, [item]);
+
+  useEffect(() => {
+    const state = item ? getSerializedEditorState(item) : undefined;
+    if (state) {
+      setWebviewState(state);
+    }
+  }, [item?.id, item?.isIncoming, item?.providerId, item?.externalId]);
 
   useEffect(() => {
     titleRef.current = title;
@@ -232,6 +239,25 @@ export function EditorApp() {
     itemRef.current = updatedItem;
     titleRef.current = resolvedTitle;
   }
+}
+
+function getSerializedEditorState(item: EditorItemData): unknown {
+  if (item.isIncoming && item.providerId && item.externalId) {
+    return {
+      version: 1,
+      providerId: item.providerId,
+      externalId: item.externalId,
+    };
+  }
+
+  if (!item.isIncoming) {
+    return {
+      version: 1,
+      itemId: item.id,
+    };
+  }
+
+  return undefined;
 }
 
 function shouldPreserveEditableField(item: EditorItemData | null, draftValue: string, persistedValue?: string): boolean {

--- a/packages/core/src/webview/shared/editorState.ts
+++ b/packages/core/src/webview/shared/editorState.ts
@@ -1,0 +1,24 @@
+import type { EditorItemData } from './types';
+
+export type SerializedEditorState =
+  | { version: 1; itemId: string }
+  | { version: 1; providerId: string; externalId: string };
+
+export function getSerializedEditorState(item: EditorItemData): SerializedEditorState | undefined {
+  if (item.isIncoming && item.providerId && item.externalId) {
+    return {
+      version: 1,
+      providerId: item.providerId,
+      externalId: item.externalId,
+    };
+  }
+
+  if (!item.isIncoming) {
+    return {
+      version: 1,
+      itemId: item.id,
+    };
+  }
+
+  return undefined;
+}

--- a/packages/core/src/webview/shared/messaging.ts
+++ b/packages/core/src/webview/shared/messaging.ts
@@ -6,15 +6,32 @@ declare const acquireVsCodeApi: () => {
   setState(state: unknown): void;
 };
 
-let vscodeApi: ReturnType<typeof acquireVsCodeApi> | undefined;
+type VsCodeApi = ReturnType<typeof acquireVsCodeApi>;
+
+declare global {
+  interface Window {
+    __DEVDOCKET_VSCODE_API__?: VsCodeApi;
+  }
+}
+
+let vscodeApi: VsCodeApi | undefined;
 
 export function getVsCodeApi() {
   if (!vscodeApi) {
-    vscodeApi = acquireVsCodeApi();
+    vscodeApi = window.__DEVDOCKET_VSCODE_API__ ?? acquireVsCodeApi();
+    window.__DEVDOCKET_VSCODE_API__ = vscodeApi;
   }
   return vscodeApi;
 }
 
 export function postMessage(message: WebviewMessage): void {
   getVsCodeApi().postMessage(message);
+}
+
+export function setWebviewState(state: unknown): void {
+  getVsCodeApi().setState(state);
+}
+
+export function getWebviewState(): unknown {
+  return getVsCodeApi().getState();
 }

--- a/packages/core/src/webview/watchPanel/WatchApp.tsx
+++ b/packages/core/src/webview/watchPanel/WatchApp.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'preact/hooks';
 import type { BadgeData, ExtensionMessage, PRWatchData, RunWatchData } from '../shared/types';
-import { postMessage } from '../shared/messaging';
+import { postMessage, setWebviewState } from '../shared/messaging';
 import { BadgePill } from '../shared/components/BadgePill';
 import { useThemeChangeCounter } from '../shared/theme';
 
@@ -11,6 +11,8 @@ export function WatchApp() {
   useThemeChangeCounter();
 
   useEffect(() => {
+    setWebviewState({ version: 1, panel: 'watchPanel' });
+
     const handler = (event: MessageEvent<ExtensionMessage>) => {
       const message = event.data;
       if (message.type === 'updateWatchPanel') {


### PR DESCRIPTION
## Summary
- Register serializers and activation events for restored work item editor, incoming preview, and CI Watches panels.
- Persist minimal webview state so restored panels can rehydrate from live stores/provider data.
- Keep restored incoming previews alive while provider data refreshes and add serializer coverage.

## Validation
- npm run build
- npm run test
- superpowers:code-reviewer clean

Closes #532
