### PR TITLE
Render structured work-started activity entries with labelled fields

### DIFF
--- a/packages/core/src/test/activityLog.test.ts
+++ b/packages/core/src/test/activityLog.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+import { h, render } from 'preact';
+import { act } from 'preact/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ActivityLog } from '../webview/editor/components/ActivityLog';
+
+interface TestActivityEntry {
+  timestamp: number;
+  type: string;
+  detail?: string;
+}
+
+describe('ActivityLog', () => {
+  let container: HTMLDivElement | undefined;
+
+  afterEach(() => {
+    if (container) {
+      render(null, container);
+      container.remove();
+      container = undefined;
+    }
+  });
+
+  it('renders work-started JSON detail as labelled fields', () => {
+    renderActivityLog([{
+      timestamp: Date.now(),
+      type: 'work-started',
+      detail: JSON.stringify({
+        branchName: 'feature/activity-renderer',
+        worktreePath: 'C:\\repos\\devdocket-activity-renderer',
+        repoPath: 'C:\\repos\\devdocket',
+      }),
+    }]);
+
+    expandActivityLog();
+
+    const detail = container!.querySelector('.activity-entry-detail--structured');
+    expect(detail).toBeInstanceOf(HTMLDListElement);
+    expect(detail!.textContent).toContain('Branch:');
+    expect(detail!.textContent).toContain('feature/activity-renderer');
+    expect(detail!.textContent).toContain('Worktree:');
+    expect(detail!.textContent).toContain('C:\\repos\\devdocket-activity-renderer');
+    expect(detail!.textContent).toContain('Repo:');
+    expect(detail!.textContent).toContain('C:\\repos\\devdocket');
+  });
+
+  it('falls back to raw detail when work-started JSON is invalid', () => {
+    const rawDetail = '{"branchName":';
+    renderActivityLog([{ timestamp: Date.now(), type: 'work-started', detail: rawDetail }]);
+
+    expandActivityLog();
+
+    const detail = container!.querySelector('.activity-entry-detail');
+    expect(detail).toBeInstanceOf(HTMLSpanElement);
+    expect(detail!.textContent).toBe(rawDetail);
+  });
+
+  it('renders other activity type details verbatim', () => {
+    renderActivityLog([{ timestamp: Date.now(), type: 'state-changed', detail: 'New → InProgress' }]);
+
+    expandActivityLog();
+
+    const detail = container!.querySelector('.activity-entry-detail');
+    expect(detail).toBeInstanceOf(HTMLSpanElement);
+    expect(detail!.textContent).toBe('New → InProgress');
+  });
+
+  function renderActivityLog(entries: TestActivityEntry[]) {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    render(h(ActivityLog, { entries }), container);
+  }
+
+  function expandActivityLog() {
+    const toggle = container!.querySelector('button.editor-section-heading') as HTMLButtonElement | null;
+    expect(toggle).toBeInstanceOf(HTMLButtonElement);
+    act(() => {
+      toggle!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+  }
+});

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -594,6 +594,29 @@ export function getEditorPanelHtml({ cspSource, scriptUri, initialItem }: Editor
       color: var(--vscode-descriptionForeground);
     }
 
+    .activity-entry-detail--structured {
+      display: grid;
+      grid-template-columns: max-content minmax(0, 1fr);
+      column-gap: 8px;
+      row-gap: 2px;
+      margin: 2px 0 0;
+      align-self: flex-start;
+    }
+
+    .activity-detail-row {
+      display: contents;
+    }
+
+    .activity-detail-label {
+      font-weight: 600;
+      color: var(--vscode-foreground);
+    }
+
+    .activity-detail-value {
+      margin: 0;
+      word-break: break-all;
+    }
+
     .activity-entry-time {
       flex-shrink: 0;
       color: var(--vscode-descriptionForeground);

--- a/packages/core/src/webview/editor/components/ActivityLog.tsx
+++ b/packages/core/src/webview/editor/components/ActivityLog.tsx
@@ -1,3 +1,4 @@
+import type { VNode } from 'preact';
 import { useState } from 'preact/hooks';
 import { formatRelativeTime } from '../../shared/timeUtils';
 import type { EditorItemData } from '../../shared/types';
@@ -37,7 +38,7 @@ export function ActivityLog({ entries }: ActivityLogProps) {
             <div class="activity-entry" key={`${entry.timestamp}-${entry.type}-${index}`}>
               <div class="activity-entry-main">
                 <span class="activity-entry-type">{activityTypeLabel(entry.type)}</span>
-                {entry.detail ? <span class="activity-entry-detail">{entry.detail}</span> : null}
+                {entry.detail ? renderActivityDetail(entry.type, entry.detail) : null}
               </div>
               <span class="activity-entry-time">{formatRelativeTime(entry.timestamp)}</span>
             </div>
@@ -45,5 +46,75 @@ export function ActivityLog({ entries }: ActivityLogProps) {
         </div>
       ) : null}
     </section>
+  );
+}
+
+type ActivityDetailRenderer = (detail: string) => VNode;
+
+const activityDetailRenderers: Partial<Record<string, ActivityDetailRenderer>> = {
+  'work-started': renderWorkStartedDetail,
+};
+
+function renderActivityDetail(type: string, detail: string): VNode {
+  const renderer = activityDetailRenderers[type] ?? renderPlainActivityDetail;
+  return renderer(detail);
+}
+
+function renderPlainActivityDetail(detail: string): VNode {
+  return <span class="activity-entry-detail">{detail}</span>;
+}
+
+interface WorkStartedDetail {
+  branchName?: string;
+  worktreePath?: string;
+  repoPath?: string;
+}
+
+function parseWorkStartedDetail(raw: string): WorkStartedDetail | undefined {
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return undefined;
+    }
+
+    const values = parsed as Record<string, unknown>;
+    const detail: WorkStartedDetail = {};
+    if (typeof values.branchName === 'string') {
+      detail.branchName = values.branchName;
+    }
+    if (typeof values.worktreePath === 'string') {
+      detail.worktreePath = values.worktreePath;
+    }
+    if (typeof values.repoPath === 'string') {
+      detail.repoPath = values.repoPath;
+    }
+
+    return detail.branchName || detail.worktreePath || detail.repoPath ? detail : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function renderWorkStartedDetail(raw: string): VNode {
+  const detail = parseWorkStartedDetail(raw);
+  if (!detail) {
+    return renderPlainActivityDetail(raw);
+  }
+
+  return (
+    <dl class="activity-entry-detail activity-entry-detail--structured">
+      {detail.branchName ? renderDetailRow('Branch', detail.branchName) : null}
+      {detail.worktreePath ? renderDetailRow('Worktree', detail.worktreePath) : null}
+      {detail.repoPath ? renderDetailRow('Repo', detail.repoPath) : null}
+    </dl>
+  );
+}
+
+function renderDetailRow(label: string, value: string): VNode {
+  return (
+    <div class="activity-detail-row" key={label}>
+      <dt class="activity-detail-label">{label}:</dt>
+      <dd class="activity-detail-value">{value}</dd>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

This PR applies Option A for issue #561: a presentation-only fix in the editor activity log. `work-started` entries keep their existing string `detail` payload, but the editor renderer recognizes the JSON shape emitted by the start-git-work action and displays the fields as labelled lines.

## Before / after

Before, `work-started` activity details rendered as raw JSON:

```json
{"branchName":"fix-example","worktreePath":"C:\\repos\\devdocket-example","repoPath":"C:\\repos\\devdocket"}
```

After, the same entry renders as labelled fields:

```text
Branch: fix-example
Worktree: C:\repos\devdocket-example
Repo: C:\repos\devdocket
```

Invalid JSON and all other activity types continue to render as plain text.

## Deferred work

Option B, adding a typed `data` field to `ActivityLogEntry`, is intentionally deferred. This change does not alter the activity log data model or public API surface.

Closes #561
