### PR TITLE
Add DevDocket prefix and drop verbose words from CI Watches status bar

### DIFF
--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -104,7 +104,7 @@ The manual Watch URL flow is **idempotent** for already-watched URLs and force-r
 DevDocket contributes two right-aligned status bar items (priorities `100000` and `100001`, immediately to the left of the Copilot button). Quick access to the sidebar itself is via the activity-bar container, not the status bar.
 
 - **Provider Health** (priority `100000`) — `✓ DevDocket • N providers` when every provider is healthy, `○ DevDocket • N providers` while provider health is still unknown, and `⚠ N providers unhealthy` when degraded; click to open the Provider Health quick pick.
-- **Watches** (priority `100001`) — eye icon + run counts (`🔄 N active · ✓ N passed · ✗ N failed`); always visible. Turns amber when at least one watched run has failed and the failure has not yet been acknowledged. Click to open the CI Watches panel.
+- **Watches** (priority `100001`) — `👁 DevDocket • Watches` when empty and `👁 DevDocket • 🔄 N · ✓ N · ✗ N` when watches exist; always visible. Turns amber when at least one watched run has failed and the failure has not yet been acknowledged. Click to open the CI Watches panel.
 
 ## Item Lifecycle
 

--- a/packages/core/src/test/watchesStatusBar.test.ts
+++ b/packages/core/src/test/watchesStatusBar.test.ts
@@ -34,9 +34,15 @@ describe('WatchesStatusBar', () => {
     new WatchesStatusBar(watcherService as any);
 
     const statusBarItem = (window.createStatusBarItem as ReturnType<typeof vi.fn>).mock.results[0].value;
-    expect(statusBarItem.text).toBe('🔄 2 active · ✓ 1 passed · ✗ 2 failed');
+    expect(statusBarItem.text).toBe('👁 DevDocket • 🔄 2 · ✓ 1 · ✗ 2');
     expect(statusBarItem.command).toBe('devdocket.showWatchesQuickPick');
-    expect(statusBarItem.tooltip).toBe('Click to open CI watch details');
+    expect(statusBarItem.tooltip).toBe([
+      'DevDocket CI Watches',
+      '  🔄 2 running',
+      '  ✓ 1 passed',
+      '  ✗ 2 failed',
+      'Click to open CI Watches panel.',
+    ].join('\n'));
     expect(statusBarItem.backgroundColor).toEqual(new ThemeColor('statusBarItem.warningBackground'));
     expect(statusBarItem.color).toEqual(new ThemeColor('statusBarItem.warningForeground'));
     expect(statusBarItem.show).toHaveBeenCalled();
@@ -48,16 +54,20 @@ describe('WatchesStatusBar', () => {
 
     const statusBarItem = (vscode.window.createStatusBarItem as ReturnType<typeof vi.fn>).mock.results[0].value;
     expect(statusBarItem.command).toBe('devdocket.showWatchPanel');
-    expect(statusBarItem.text).toBe('👁 Watches');
+    expect(statusBarItem.text).toBe('👁 DevDocket • Watches');
+    expect(statusBarItem.tooltip).toContain('  🔄 0 running');
+    expect(statusBarItem.tooltip).toContain('  ✓ 0 passed');
+    expect(statusBarItem.tooltip).toContain('  ✗ 0 failed');
     expect(statusBarItem.show).toHaveBeenCalledTimes(1);
     expect(statusBarItem.hide).not.toHaveBeenCalled();
 
     watcherService.setWatches([{ status: { overallState: 'running' } }]);
-    expect(statusBarItem.text).toBe('🔄 1 active · ✓ 0 passed · ✗ 0 failed');
+    expect(statusBarItem.text).toBe('👁 DevDocket • 🔄 1 · ✓ 0 · ✗ 0');
+    expect(statusBarItem.tooltip).toContain('  🔄 1 running');
     expect(statusBarItem.show).toHaveBeenCalledTimes(2);
 
     watcherService.setWatches([]);
-    expect(statusBarItem.text).toBe('👁 Watches');
+    expect(statusBarItem.text).toBe('👁 DevDocket • Watches');
     expect(statusBarItem.show).toHaveBeenCalledTimes(3);
     expect(statusBarItem.hide).not.toHaveBeenCalled();
   });

--- a/packages/core/src/views/watchesStatusBar.ts
+++ b/packages/core/src/views/watchesStatusBar.ts
@@ -24,8 +24,8 @@ export class WatchesStatusBar implements vscode.Disposable {
   private update(): void {
     const watches = this.watcherService.getActiveWatches();
     if (watches.length === 0) {
-      this.statusBarItem.text = '👁 Watches';
-      this.statusBarItem.tooltip = 'Click to open CI watch details';
+      this.statusBarItem.text = '👁 DevDocket • Watches';
+      this.statusBarItem.tooltip = this.buildTooltip(0, 0, 0);
       this.statusBarItem.backgroundColor = undefined;
       this.statusBarItem.color = undefined;
       this.statusBarItem.show();
@@ -70,8 +70,8 @@ export class WatchesStatusBar implements vscode.Disposable {
       }
     }
 
-    this.statusBarItem.text = `🔄 ${runningCount} active · ✓ ${passedCount} passed · ✗ ${failedCount} failed`;
-    this.statusBarItem.tooltip = 'Click to open CI watch details';
+    this.statusBarItem.text = `👁 DevDocket • 🔄 ${runningCount} · ✓ ${passedCount} · ✗ ${failedCount}`;
+    this.statusBarItem.tooltip = this.buildTooltip(runningCount, passedCount, failedCount);
     // Only highlight the status bar with the warning color if there is at
     // least one failed watch the user hasn't seen yet — once they open the
     // watch panel, acknowledge clears the alert until a NEW failure arrives.
@@ -82,6 +82,16 @@ export class WatchesStatusBar implements vscode.Disposable {
       ? new vscode.ThemeColor('statusBarItem.warningForeground')
       : undefined;
     this.statusBarItem.show();
+  }
+
+  private buildTooltip(runningCount: number, passedCount: number, failedCount: number): string {
+    return [
+      'DevDocket CI Watches',
+      `  🔄 ${runningCount} running`,
+      `  ✓ ${passedCount} passed`,
+      `  ✗ ${failedCount} failed`,
+      'Click to open CI Watches panel.',
+    ].join('\n');
   }
 
   dispose(): void {


### PR DESCRIPTION
## Summary

- Add DevDocket branding to the CI Watches status bar item.
- Shorten populated watch counts to symbols and numbers only.
- Expand the tooltip so the concise status bar text still has accessible labels for each count.

## Before / After

```text
Before (empty):     👁 Watches
After (empty):      👁 DevDocket • Watches

Before (populated): 🔄 3 active · ✓ 12 passed · ✗ 1 failed
After (populated):  👁 DevDocket • 🔄 3 · ✓ 12 · ✗ 1
```

The tooltip now spells out running, passed, and failed counts for accessibility.

Closes #563
