### PR TITLE
Group PR watch runs into a single expandable card

### DIFF
--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -82,8 +82,8 @@ A floating webview that monitors GitHub Actions / Azure DevOps Pipeline runs and
 
 ### Two sections
 
-- **PR Watches** — pull requests being monitored, with each PR's CI runs flattened beneath it (the PR card and its run cards appear adjacent in the list).
-- **Run Watches** — standalone pipeline runs you've added directly.
+- **PR Watches** — pull requests being monitored. Each PR renders as one card with a checks roll-up; expand the card to see individual CI runs. PRs auto-expand when a child run fails, and the failure preview appears on the PR card.
+- **Run Watches** — standalone pipeline runs you've added directly. These continue to render as flat run cards.
 
 ### Adding watches
 
@@ -96,7 +96,8 @@ The manual Watch URL flow is **idempotent** for already-watched URLs and force-r
 
 ### Dismissing watches
 
-- Hover any watch card and click the **✗** button.
+- Hover a PR card and click the **✗** button to dismiss the whole PR watch, including its child runs. Child run cards inside an expanded PR are informational and do not have their own dismiss button.
+- Hover a standalone run card and click the **✗** button to dismiss that run watch.
 - **Dismiss Completed** in the panel header clears all merged / closed PRs and finished runs in one click.
 
 ### Status bar

--- a/packages/core/src/test/watchApp.test.ts
+++ b/packages/core/src/test/watchApp.test.ts
@@ -1,0 +1,153 @@
+// @vitest-environment jsdom
+import { h, render } from 'preact';
+import { act } from 'preact/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { PRWatchData, RunWatchData } from '../views/mainTypes';
+
+describe('WatchApp PR watch rendering', () => {
+  let container: HTMLDivElement | undefined;
+
+  afterEach(() => {
+    if (container) {
+      render(null, container);
+      container.remove();
+      container = undefined;
+    }
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it('renders one top-level PR card with a roll-up and expands passing/running runs on demand', async () => {
+    await mountWatchApp();
+    await sendUpdate([
+      makePRWatch({
+        runs: [
+          makeRunWatch({ id: 'run-unit', name: 'Unit tests', state: 'completed', conclusion: 'success' }),
+          makeRunWatch({ id: 'run-lint', name: 'Lint', state: 'in_progress' }),
+        ],
+      }),
+    ]);
+
+    const prSection = getSection('PR Watches');
+    expect(prSection.querySelectorAll('.tier-items > .item-card')).toHaveLength(1);
+    expect(prSection.textContent).toContain('Checks: ✓ 1 passed · ✗ 0 failed · ⏳ 1 running (2 total)');
+    expect(prSection.textContent).not.toContain('Unit tests');
+    expect(prSection.textContent).not.toContain('Lint');
+
+    const expandButton = prSection.querySelector<HTMLButtonElement>('button[aria-label="Expand runs for Add grouped PR watches"]');
+    expect(expandButton).toBeInstanceOf(HTMLButtonElement);
+
+    await act(async () => {
+      expandButton!.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+
+    expect(prSection.querySelectorAll('.tier-items > .item-card')).toHaveLength(1);
+    expect(prSection.querySelectorAll('.watch-card-details .item-card')).toHaveLength(2);
+    expect(prSection.textContent).toContain('Unit tests');
+    expect(prSection.textContent).toContain('Lint');
+    expect(findButton(prSection, label => label.startsWith('Dismiss Unit tests'))).toBeUndefined();
+    expect(findButton(prSection, label => label.startsWith('Dismiss Lint'))).toBeUndefined();
+  });
+
+  it('auto-expands failing runs and previews the child failure on the PR card', async () => {
+    await mountWatchApp();
+    await sendUpdate([
+      makePRWatch({
+        runs: [
+          makeRunWatch({ id: 'run-unit', name: 'Unit tests', state: 'completed', conclusion: 'success' }),
+          makeRunWatch({
+            id: 'run-e2e',
+            name: 'E2E tests',
+            state: 'completed',
+            conclusion: 'failure',
+            failurePreview: 'Failed job: e2e',
+          }),
+        ],
+      }),
+    ]);
+
+    const prSection = getSection('PR Watches');
+    const prCard = prSection.querySelector('.tier-items > .item-card');
+    expect(prCard).toBeInstanceOf(HTMLDivElement);
+    expect(prCard!.classList.contains('item-card--urgent')).toBe(true);
+    expect(prCard!.querySelector('.watch-row-preview')?.textContent).toBe('Failed job: e2e');
+    expect(prSection.textContent).toContain('Checks: ✓ 1 passed · ✗ 1 failed · ⏳ 0 running (2 total)');
+    expect(prSection.querySelectorAll('.watch-card-details .item-card')).toHaveLength(2);
+    expect(prSection.textContent).toContain('E2E tests');
+  });
+
+  it('keeps standalone run watches as flat cards', async () => {
+    await mountWatchApp();
+    await sendUpdate([], [
+      makeRunWatch({ id: 'run-deploy', name: 'Deploy', state: 'in_progress' }),
+      makeRunWatch({ id: 'run-smoke', name: 'Smoke tests', state: 'completed', conclusion: 'success' }),
+    ]);
+
+    const runSection = getSection('Run Watches');
+    expect(runSection.querySelectorAll('.tier-items > .item-card')).toHaveLength(2);
+    expect(runSection.querySelectorAll('.watch-card-details .item-card')).toHaveLength(0);
+    expect(runSection.textContent).toContain('Deploy');
+    expect(runSection.textContent).toContain('Smoke tests');
+  });
+
+  async function mountWatchApp() {
+    vi.stubGlobal('acquireVsCodeApi', () => ({
+      postMessage: vi.fn(),
+      getState: vi.fn(),
+      setState: vi.fn(),
+    }));
+    const { WatchApp } = await import('../webview/watchPanel/WatchApp');
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    await act(async () => {
+      render(h(WatchApp, {}), container!);
+    });
+  }
+
+  async function sendUpdate(prWatches: PRWatchData[], runWatches: RunWatchData[] = []) {
+    await act(async () => {
+      window.dispatchEvent(new MessageEvent('message', {
+        data: {
+          type: 'updateWatchPanel',
+          prWatches,
+          runWatches,
+        },
+      }));
+    });
+  }
+
+  function getSection(name: string): HTMLElement {
+    const section = Array.from(container!.querySelectorAll<HTMLElement>('.tier-section'))
+      .find(candidate => candidate.textContent?.includes(name));
+    expect(section).toBeInstanceOf(HTMLElement);
+    return section!;
+  }
+
+  function findButton(root: HTMLElement, predicate: (ariaLabel: string) => boolean): HTMLButtonElement | undefined {
+    return Array.from(root.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => predicate(button.getAttribute('aria-label') ?? ''));
+  }
+});
+
+function makePRWatch(overrides: Partial<PRWatchData> = {}): PRWatchData {
+  return {
+    id: 'pr:github-pr:owner/repo:42',
+    title: 'Add grouped PR watches',
+    repo: 'owner/repo',
+    state: 'open',
+    url: 'https://github.com/owner/repo/pull/42',
+    runs: [],
+    ...overrides,
+  };
+}
+
+function makeRunWatch(overrides: Partial<RunWatchData> = {}): RunWatchData {
+  return {
+    id: 'run-ci',
+    name: 'CI',
+    repo: 'owner/repo',
+    state: 'queued',
+    url: 'https://github.com/owner/repo/actions/runs/100',
+    ...overrides,
+  };
+}

--- a/packages/core/src/test/watchApp.test.ts
+++ b/packages/core/src/test/watchApp.test.ts
@@ -76,6 +76,17 @@ describe('WatchApp PR watch rendering', () => {
     expect(prSection.textContent).toContain('E2E tests');
   });
 
+  it('hides roll-up and disclosure controls for PR watches without runs', async () => {
+    await mountWatchApp();
+    await sendUpdate([makePRWatch()]);
+
+    const prSection = getSection('PR Watches');
+    expect(prSection.querySelectorAll('.tier-items > .item-card')).toHaveLength(1);
+    expect(prSection.querySelector('.watch-run-summary')).toBeNull();
+    expect(findButton(prSection, label => label === 'Expand runs for Add grouped PR watches')).toBeUndefined();
+    expect(prSection.querySelector('.watch-card-details')).toBeNull();
+  });
+
   it('keeps standalone run watches as flat cards', async () => {
     await mountWatchApp();
     await sendUpdate([], [

--- a/packages/core/src/test/watchPanelProvider.test.ts
+++ b/packages/core/src/test/watchPanelProvider.test.ts
@@ -215,6 +215,10 @@ describe('WatchPanelProvider', () => {
     );
     expect(mockPanel.panel.title).toBe('CI Watches (2)');
     expect(mockPanel.panel.webview.html).toContain('watchPanel.js');
+    const message = getUpdateWatchPanelMessage(mockPanel);
+    expect(message.prWatches).toHaveLength(1);
+    expect(message.prWatches[0].runs).toHaveLength(1);
+    expect(message.runWatches).toHaveLength(1);
     expect(mockPanel.panel.webview.postMessage).toHaveBeenCalledWith(expect.objectContaining({
       type: 'updateWatchPanel',
       prWatches: [expect.objectContaining({

--- a/packages/core/src/views/watchPanelProvider.ts
+++ b/packages/core/src/views/watchPanelProvider.ts
@@ -407,13 +407,19 @@ export class WatchPanelProvider implements vscode.Disposable {
     .item-card {
       position: relative;
       display: flex;
-      align-items: stretch;
-      gap: 10px;
+      flex-direction: column;
+      gap: 8px;
       padding: 8px 10px 8px 12px;
       border-radius: 6px;
       background: var(--vscode-editor-background);
       border-left: 3px solid transparent;
       cursor: pointer;
+    }
+    .item-card-row {
+      position: relative;
+      display: flex;
+      align-items: stretch;
+      gap: 10px;
     }
     .item-card:focus-visible {
       outline: 1px solid var(--vscode-focusBorder);
@@ -467,6 +473,50 @@ export class WatchPanelProvider implements vscode.Disposable {
     }
     .watch-row-preview.warning {
       color: var(--vscode-testing-iconFailed, var(--vscode-errorForeground));
+    }
+    .watch-run-summary {
+      font-size: 12px;
+      color: var(--vscode-descriptionForeground);
+    }
+    .watch-disclosure-button {
+      flex: 0 0 auto;
+      width: 18px;
+      height: 18px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0;
+      padding: 0;
+      border: none;
+      border-radius: 4px;
+      background: transparent;
+      color: var(--vscode-descriptionForeground);
+      cursor: pointer;
+      font: inherit;
+      line-height: 1;
+    }
+    .watch-disclosure-button:hover {
+      background: var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.25));
+      color: var(--vscode-foreground);
+    }
+    .watch-disclosure-button:focus-visible {
+      outline: 1px solid var(--vscode-focusBorder);
+      outline-offset: -1px;
+    }
+    .watch-card-details {
+      margin-left: 10px;
+      padding-left: 10px;
+      border-left: 1px solid var(--vscode-widget-border, rgba(127, 127, 127, 0.35));
+    }
+    .nested-run-list {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .watch-card-details .item-card {
+      padding: 7px 9px;
+      background: var(--vscode-sideBar-background, var(--vscode-editor-background));
+      border-left-width: 2px;
     }
     .badge-row {
       display: flex;

--- a/packages/core/src/webview/watchPanel/WatchApp.tsx
+++ b/packages/core/src/webview/watchPanel/WatchApp.tsx
@@ -7,6 +7,7 @@ import { useThemeChangeCounter } from '../shared/theme';
 export function WatchApp() {
   const [prWatches, setPrWatches] = useState<PRWatchData[]>([]);
   const [runWatches, setRunWatches] = useState<RunWatchData[]>([]);
+  const [expandedPRRuns, setExpandedPRRuns] = useState<Map<string, boolean>>(() => new Map());
   // Re-render badges when the user switches VS Code theme.
   useThemeChangeCounter();
 
@@ -39,24 +40,13 @@ export function WatchApp() {
     [prWatches, runWatches],
   );
   const totalCount = prWatches.length + runWatches.length;
-
-  // Flatten PR watches with their child runs into a single ordered list so
-  // each row is a top-level item-card (matching the sidebar tier rendering).
-  // Children stay adjacent to their parent so the visual grouping is preserved
-  // by ordering rather than nesting.
-  const prSectionItems = useMemo(() => {
-    const items: Array<
-      | { kind: 'pr'; pr: PRWatchData }
-      | { kind: 'run'; run: RunWatchData; parentTitle: string }
-    > = [];
-    for (const pr of prWatches) {
-      items.push({ kind: 'pr', pr });
-      for (const run of pr.runs) {
-        items.push({ kind: 'run', run, parentTitle: pr.title });
-      }
-    }
-    return items;
-  }, [prWatches]);
+  const togglePRRuns = (prId: string, currentlyExpanded: boolean) => {
+    setExpandedPRRuns(current => {
+      const next = new Map(current);
+      next.set(prId, !currentlyExpanded);
+      return next;
+    });
+  };
 
   return (
     <div class="watch-panel">
@@ -90,38 +80,47 @@ export function WatchApp() {
         <div class="tiers">
           {prWatches.length > 0 ? (
             <CollapsibleSection icon="🔀" name="PR Watches" count={prWatches.length}>
-              {prSectionItems.map(entry => {
-                if (entry.kind === 'pr') {
-                  return (
-                    <WatchCard
-                      key={`pr-${entry.pr.id}`}
-                      title={entry.pr.title}
-                      meta={entry.pr.repo}
-                      preview={entry.pr.errorMessage}
-                      previewIsWarning={entry.pr.hasWarning}
-                      badge={getPRBadge(entry.pr)}
-                      tierClass={getPRTierClass(entry.pr)}
-                      url={entry.pr.url}
-                      watchId={entry.pr.id}
-                      linkedItemId={entry.pr.linkedItemId}
-                      linkedSourceProviderId={entry.pr.linkedSourceProviderId}
-                      linkedSourceExternalId={entry.pr.linkedSourceExternalId}
-                    />
-                  );
-                }
+              {prWatches.map(prWatch => {
+                const summary = summarizeRuns(prWatch.runs);
+                const explicitExpanded = expandedPRRuns.get(prWatch.id);
+                const expanded = explicitExpanded ?? summary.failed > 0;
+                const preview = getPRPreview(prWatch, summary);
                 return (
                   <WatchCard
-                    key={`run-${entry.run.id}`}
-                    title={entry.run.name}
-                    meta={`${entry.run.repo} · run on ${entry.parentTitle}`}
-                    preview={entry.run.failurePreview}
-                    previewIsWarning={entry.run.hasWarning || isFailedRun(entry.run)}
-                    badge={getRunBadge(entry.run)}
-                    tierClass={getRunTierClass(entry.run)}
-                    elapsedTime={entry.run.elapsedTime}
-                    url={entry.run.url}
-                    watchId={entry.run.id}
-                  />
+                    key={`pr-${prWatch.id}`}
+                    title={prWatch.title}
+                    meta={prWatch.repo}
+                    preview={preview}
+                    previewIsWarning={prWatch.hasWarning || summary.failed > 0}
+                    summary={formatRunSummary(summary)}
+                    badge={getPRBadge(prWatch)}
+                    tierClass={summary.failed > 0 ? 'urgent' : getPRTierClass(prWatch)}
+                    url={prWatch.url}
+                    watchId={prWatch.id}
+                    linkedItemId={prWatch.linkedItemId}
+                    linkedSourceProviderId={prWatch.linkedSourceProviderId}
+                    linkedSourceExternalId={prWatch.linkedSourceExternalId}
+                    expanded={expanded}
+                    onToggleExpanded={() => togglePRRuns(prWatch.id, expanded)}
+                  >
+                    <div class="nested-run-list" aria-label={`Runs for ${prWatch.title}`}>
+                      {prWatch.runs.map(run => (
+                        <WatchCard
+                          key={`run-${run.id}`}
+                          title={run.name}
+                          meta={`${run.repo} · run on ${prWatch.title}`}
+                          preview={run.failurePreview}
+                          previewIsWarning={run.hasWarning || isFailedRun(run)}
+                          badge={getRunBadge(run)}
+                          tierClass={getRunTierClass(run)}
+                          elapsedTime={run.elapsedTime}
+                          url={run.url}
+                          watchId={run.id}
+                          dismissible={false}
+                        />
+                      ))}
+                    </div>
+                  </WatchCard>
                 );
               })}
             </CollapsibleSection>
@@ -194,6 +193,7 @@ interface WatchCardProps {
   meta: string;
   preview?: string;
   previewIsWarning?: boolean;
+  summary?: string;
   badge: BadgeData;
   tierClass: string;
   elapsedTime?: string;
@@ -202,6 +202,10 @@ interface WatchCardProps {
   linkedItemId?: string;
   linkedSourceProviderId?: string;
   linkedSourceExternalId?: string;
+  expanded?: boolean;
+  onToggleExpanded?: () => void;
+  dismissible?: boolean;
+  children?: preact.ComponentChildren;
 }
 
 function WatchCard({
@@ -209,6 +213,7 @@ function WatchCard({
   meta,
   preview,
   previewIsWarning,
+  summary,
   badge,
   tierClass,
   elapsedTime,
@@ -217,6 +222,10 @@ function WatchCard({
   linkedItemId,
   linkedSourceProviderId,
   linkedSourceExternalId,
+  expanded,
+  onToggleExpanded,
+  dismissible = true,
+  children,
 }: WatchCardProps) {
   const clickable = Boolean(url);
   const openWatch = () => {
@@ -226,6 +235,8 @@ function WatchCard({
   };
   const hasLinkedSource = Boolean(linkedSourceProviderId && linkedSourceExternalId);
   const hasLinkedTarget = Boolean(linkedItemId || hasLinkedSource);
+  const hasActions = hasLinkedTarget || dismissible;
+  const hasDetails = Boolean(onToggleExpanded && children);
   const openLinkedItem = () => {
     if (linkedItemId) {
       postMessage({ type: 'openItem', itemId: linkedItemId });
@@ -258,51 +269,82 @@ function WatchCard({
       onClick={openWatch}
       onKeyDown={handleKeyDown}
     >
-      <div class="item-card-main">
-        <div class="item-line-1">
-          <div class="item-title-wrap">
-            <span class="item-title">{title}</span>
+      <div class="item-card-row">
+        <div class="item-card-main">
+          <div class="item-line-1">
+            <div class="item-title-wrap">
+              {onToggleExpanded ? (
+                <button
+                  type="button"
+                  class="watch-disclosure-button"
+                  aria-label={`${expanded ? 'Collapse' : 'Expand'} runs for ${title}`}
+                  aria-expanded={expanded}
+                  onKeyDown={(event) => event.stopPropagation()}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onToggleExpanded();
+                  }}
+                >
+                  <span aria-hidden="true">{expanded ? '▾' : '▸'}</span>
+                </button>
+              ) : null}
+              <span class="item-title">{title}</span>
+            </div>
+          </div>
+          <div class="item-repo-annotation">{meta}</div>
+          {preview ? (
+            <div class={`watch-row-preview ${previewIsWarning ? 'warning' : ''}`.trim()}>{preview}</div>
+          ) : null}
+          {summary ? <div class="watch-run-summary">{summary}</div> : null}
+          <div class="badge-row">
+            <BadgePill badge={badge} />
+            {elapsedTime ? <span class="watch-time">{elapsedTime}</span> : null}
           </div>
         </div>
-        <div class="item-repo-annotation">{meta}</div>
-        {preview ? (
-          <div class={`watch-row-preview ${previewIsWarning ? 'warning' : ''}`.trim()}>{preview}</div>
+        {hasActions ? (
+          <div class="item-actions" role="group" aria-label={`${title} actions`}>
+            {hasLinkedTarget ? (
+              <button
+                type="button"
+                class="item-action-btn"
+                title="Open in DevDocket"
+                aria-label="Open in DevDocket"
+                onKeyDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  openLinkedItem();
+                }}
+              >
+                <span class="codicon codicon-go-to-file" aria-hidden="true" />
+              </button>
+            ) : null}
+            {dismissible ? (
+              <button
+                type="button"
+                class="item-action-btn"
+                title="Dismiss watch"
+                aria-label={`Dismiss ${title}`}
+                onKeyDown={(event) => event.stopPropagation()}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  postMessage({ type: 'dismissWatch', watchId });
+                }}
+              >
+                ✗
+              </button>
+            ) : null}
+          </div>
         ) : null}
-        <div class="badge-row">
-          <BadgePill badge={badge} />
-          {elapsedTime ? <span class="watch-time">{elapsedTime}</span> : null}
-        </div>
       </div>
-      <div class="item-actions" role="group" aria-label={`${title} actions`}>
-        {hasLinkedTarget ? (
-          <button
-            type="button"
-            class="item-action-btn"
-            title="Open in DevDocket"
-            aria-label="Open in DevDocket"
-            onKeyDown={(event) => event.stopPropagation()}
-            onClick={(event) => {
-              event.stopPropagation();
-              openLinkedItem();
-            }}
-          >
-            <span class="codicon codicon-go-to-file" aria-hidden="true" />
-          </button>
-        ) : null}
-        <button
-          type="button"
-          class="item-action-btn"
-          title="Dismiss watch"
-          aria-label={`Dismiss ${title}`}
+      {hasDetails && expanded ? (
+        <div
+          class="watch-card-details"
+          onClick={(event) => event.stopPropagation()}
           onKeyDown={(event) => event.stopPropagation()}
-          onClick={(event) => {
-            event.stopPropagation();
-            postMessage({ type: 'dismissWatch', watchId });
-          }}
         >
-          ✗
-        </button>
-      </div>
+          {children}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -329,6 +371,52 @@ function getRunBadge(runWatch: RunWatchData): BadgeData {
     return { label: 'Passed', type: 'ci', variant: 'ci-pass' };
   }
   return { label: toConclusionLabel(runWatch.conclusion), type: 'ci', variant: 'ci-fail' };
+}
+
+interface RunSummary {
+  passed: number;
+  failed: number;
+  running: number;
+  other: number;
+  total: number;
+  failurePreview?: string;
+}
+
+function summarizeRuns(runs: RunWatchData[]): RunSummary {
+  return runs.reduce<RunSummary>((summary, run) => {
+    const runFailed = run.hasWarning || isFailedRun(run);
+    if (runFailed) {
+      summary.failed += 1;
+      summary.failurePreview ??= run.failurePreview;
+    } else if (run.state !== 'completed') {
+      summary.running += 1;
+    } else if (run.conclusion === 'success') {
+      summary.passed += 1;
+    } else {
+      summary.other += 1;
+    }
+    summary.total += 1;
+    return summary;
+  }, { passed: 0, failed: 0, running: 0, other: 0, total: 0 });
+}
+
+function formatRunSummary(summary: RunSummary): string {
+  const parts = [
+    `✓ ${summary.passed} passed`,
+    `✗ ${summary.failed} failed`,
+    `⏳ ${summary.running} running`,
+  ];
+  if (summary.other > 0) {
+    parts.push(`• ${summary.other} other`);
+  }
+  return `Checks: ${parts.join(' · ')} (${summary.total} total)`;
+}
+
+function getPRPreview(prWatch: PRWatchData, summary: RunSummary): string | undefined {
+  if (summary.failurePreview && prWatch.errorMessage) {
+    return `${summary.failurePreview} · ${prWatch.errorMessage}`;
+  }
+  return summary.failurePreview ?? prWatch.errorMessage;
 }
 
 function getPRTierClass(prWatch: PRWatchData): string {

--- a/packages/core/src/webview/watchPanel/WatchApp.tsx
+++ b/packages/core/src/webview/watchPanel/WatchApp.tsx
@@ -82,6 +82,7 @@ export function WatchApp() {
             <CollapsibleSection icon="🔀" name="PR Watches" count={prWatches.length}>
               {prWatches.map(prWatch => {
                 const summary = summarizeRuns(prWatch.runs);
+                const hasRuns = summary.total > 0;
                 const explicitExpanded = expandedPRRuns.get(prWatch.id);
                 const expanded = explicitExpanded ?? summary.failed > 0;
                 const preview = getPRPreview(prWatch, summary);
@@ -92,7 +93,7 @@ export function WatchApp() {
                     meta={prWatch.repo}
                     preview={preview}
                     previewIsWarning={prWatch.hasWarning || summary.failed > 0}
-                    summary={formatRunSummary(summary)}
+                    summary={hasRuns ? formatRunSummary(summary) : undefined}
                     badge={getPRBadge(prWatch)}
                     tierClass={summary.failed > 0 ? 'urgent' : getPRTierClass(prWatch)}
                     url={prWatch.url}
@@ -100,26 +101,28 @@ export function WatchApp() {
                     linkedItemId={prWatch.linkedItemId}
                     linkedSourceProviderId={prWatch.linkedSourceProviderId}
                     linkedSourceExternalId={prWatch.linkedSourceExternalId}
-                    expanded={expanded}
-                    onToggleExpanded={() => togglePRRuns(prWatch.id, expanded)}
+                    expanded={hasRuns ? expanded : undefined}
+                    onToggleExpanded={hasRuns ? () => togglePRRuns(prWatch.id, expanded) : undefined}
                   >
-                    <div class="nested-run-list" aria-label={`Runs for ${prWatch.title}`}>
-                      {prWatch.runs.map(run => (
-                        <WatchCard
-                          key={`run-${run.id}`}
-                          title={run.name}
-                          meta={`${run.repo} · run on ${prWatch.title}`}
-                          preview={run.failurePreview}
-                          previewIsWarning={run.hasWarning || isFailedRun(run)}
-                          badge={getRunBadge(run)}
-                          tierClass={getRunTierClass(run)}
-                          elapsedTime={run.elapsedTime}
-                          url={run.url}
-                          watchId={run.id}
-                          dismissible={false}
-                        />
-                      ))}
-                    </div>
+                    {hasRuns ? (
+                      <div class="nested-run-list" aria-label={`Runs for ${prWatch.title}`}>
+                        {prWatch.runs.map(run => (
+                          <WatchCard
+                            key={`run-${run.id}`}
+                            title={run.name}
+                            meta={`${run.repo} · run on ${prWatch.title}`}
+                            preview={run.failurePreview}
+                            previewIsWarning={run.hasWarning || isFailedRun(run)}
+                            badge={getRunBadge(run)}
+                            tierClass={getRunTierClass(run)}
+                            elapsedTime={run.elapsedTime}
+                            url={run.url}
+                            watchId={run.id}
+                            dismissible={false}
+                          />
+                        ))}
+                      </div>
+                    ) : null}
                   </WatchCard>
                 );
               })}


### PR DESCRIPTION
## Summary

Group CI Watches for the same pull request into one top-level PR card with a rolled-up run summary and expandable run details.

## Before / after

- Before: each run for a PR appeared as its own top-level row, so PRs with many runs produced N+1 cards and cluttered the panel.
- After: each PR appears as one card with passed/failed/running counts; users can expand the card to inspect individual runs.

## Acceptance criteria

- PR Watches render as one top-level card per PR with all associated runs grouped under it.
- The PR card shows a rolled-up summary of run counts and surfaces failure previews on the parent card.
- Failing PR watch cards auto-expand so failing run details are visible without extra clicks.
- Users can expand and collapse PR run details on demand.
- PR-level dismiss remains available and dismisses the grouped PR watch; per-run dismiss controls are removed from expanded PR details.
- Standalone Run Watches that are not associated with a PR continue to render as flat, independently dismissible rows.
- CI Watches status bar behavior remains unchanged.

Closes #562
