### PR TITLE
Preserve Azure DevOps partial-success runs

### DIFF
--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -85,7 +85,7 @@ A floating webview that monitors GitHub Actions / Azure DevOps Pipeline runs and
 - **PR Watches** — pull requests being monitored. Each PR renders as one card with a checks roll-up; expand the card to see individual CI runs. PRs auto-expand when a child run fails, and the failure preview appears on the PR card.
 - **Run Watches** — standalone pipeline runs you've added directly. These continue to render as flat run cards.
 
-Completed runs are grouped into three health categories: **Passed** (green), **Succeeded with issues** (amber, used for Azure DevOps partial success), and **Failed** (red). Other completed non-result conclusions, such as cancelled, skipped, neutral, timed out, and action required, retain their own labels. Runs that succeeded with issues do not count as failures and do not auto-expand their parent PR card.
+Completed runs are grouped into three health categories: **Passed** (green), **Succeeded with issues** (amber, used for Azure DevOps partial success), and **Failed** (red). Other completed conclusions retain their own labels: cancelled, skipped, and neutral are non-failures, while timed out and action required count as failures. Runs that succeeded with issues do not count as failures and do not auto-expand their parent PR card.
 
 ### Adding watches
 

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -107,7 +107,7 @@ The manual Watch URL flow is **idempotent** for already-watched URLs and force-r
 DevDocket contributes two right-aligned status bar items (priorities `100000` and `100001`, immediately to the left of the Copilot button). Quick access to the sidebar itself is via the activity-bar container, not the status bar.
 
 - **Provider Health** (priority `100000`) — `✓ DevDocket • N providers` when every provider is healthy, `○ DevDocket • N providers` while provider health is still unknown, and `⚠ N providers unhealthy` when degraded; click to open the Provider Health quick pick.
-- **Watches** (priority `100001`) — `👁 DevDocket • Watches` when empty and `👁 DevDocket • 🔄 N · ✓ N · ✗ N` when watches exist; always visible. Turns amber when at least one watched run has failed and the failure has not yet been acknowledged. Click to open the CI Watches panel.
+- **Watches** (priority `100001`) — `👁 DevDocket • Watches` when empty and `👁 DevDocket • 🔄 N · ✓ N · ✗ N` when watches exist, with an additional `⚠ N` segment when runs have succeeded with issues; always visible. Turns amber when at least one watched run has failed and the failure has not yet been acknowledged. Click to open the CI Watches panel.
 
 ## Item Lifecycle
 

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -78,21 +78,20 @@ A read-only variant of the editor used when you click an Incoming item or an una
 
 ## CI Watches Panel
 
-A floating webview that monitors GitHub Actions / Azure DevOps Pipeline runs and pull request lifecycle status (open / merged / closed). Open it from the **eye icon** in the status bar — the icon shows the current watch count and turns amber when a watched run fails.
+A floating webview that monitors CI runs and pull request lifecycle status (open / merged / closed). Open it from the **eye icon** in the status bar — the icon shows the current watch count and turns amber when a watched run fails.
 
 ### Two sections
 
 - **PR Watches** — pull requests being monitored. Each PR renders as one card with a checks roll-up; expand the card to see individual CI runs. PRs auto-expand when a child run fails, and the failure preview appears on the PR card.
 - **Run Watches** — standalone pipeline runs you've added directly. These continue to render as flat run cards.
 
-Completed runs are grouped into three health categories: **Passed** (green), **Succeeded with issues** (amber, used for Azure DevOps partial success), and **Failed** (red). Other completed conclusions retain their own labels: cancelled, skipped, and neutral are non-failures, while timed out and action required count as failures. Runs that succeeded with issues do not count as failures and do not auto-expand their parent PR card.
+Completed runs are grouped into three health categories: **Passed** (green), **Succeeded with issues** (amber), and **Failed** (red). Other completed conclusions retain their own labels: cancelled, skipped, and neutral are non-failures, while timed out and action required count as failures. Runs that succeeded with issues do not count as failures and do not auto-expand their parent PR card.
 
 ### Adding watches
 
 - Inside the panel, click **+ Watch URL** in the header. Paste a supported URL — DevDocket detects whether it is a PR or run, and validates the URL before submission. Examples: `https://github.com/owner/repo/pull/123` and `https://github.com/owner/repo/actions/runs/12345`.
 - From the command palette: **DevDocket: Watch URL…**.
-- Supported surfaces include GitHub PR URLs, GitHub Actions run URLs, Azure DevOps PR URLs, and Azure DevOps Pipeline run URLs.
-- GitHub PRs you authored can be auto-watched on discovery — see `devDocket.watches.autoWatchAuthoredPRs`.
+- PRs you authored can be auto-watched on discovery — see `devDocket.watches.autoWatchAuthoredPRs`.
 
 The manual Watch URL flow is **idempotent** for already-watched URLs and force-recreates the watch when a PR is in a bad state (e.g. all child runs were dismissed making it invisible).
 

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -85,6 +85,8 @@ A floating webview that monitors GitHub Actions / Azure DevOps Pipeline runs and
 - **PR Watches** — pull requests being monitored. Each PR renders as one card with a checks roll-up; expand the card to see individual CI runs. PRs auto-expand when a child run fails, and the failure preview appears on the PR card.
 - **Run Watches** — standalone pipeline runs you've added directly. These continue to render as flat run cards.
 
+Completed runs render in three distinct states: **Passed** (green), **Succeeded with issues** (amber, used for Azure DevOps partial success), and **Failed** (red). Runs that succeeded with issues do not count as failures and do not auto-expand their parent PR card.
+
 ### Adding watches
 
 - Inside the panel, click **+ Watch URL** in the header. Paste a supported URL — DevDocket detects whether it is a PR or run, and validates the URL before submission. Examples: `https://github.com/owner/repo/pull/123` and `https://github.com/owner/repo/actions/runs/12345`.

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -105,8 +105,8 @@ The manual Watch URL flow is **idempotent** for already-watched URLs and force-r
 
 DevDocket contributes two right-aligned status bar items (priorities `100000` and `100001`, immediately to the left of the Copilot button). Quick access to the sidebar itself is via the activity-bar container, not the status bar.
 
-- **Provider Health** (priority `100000`) — `✓ DevDocket • N providers` when every provider is healthy, `○ DevDocket • N providers` while provider health is still unknown, and `⚠ N providers unhealthy` when degraded; click to open the Provider Health quick pick.
-- **Watches** (priority `100001`) — `👁 DevDocket • Watches` when empty and `👁 DevDocket • 🔄 N · ✓ N · ✗ N` when watches exist, with an additional `⚠ N` segment when runs have succeeded with issues; always visible. Turns amber when at least one watched run has failed and the failure has not yet been acknowledged. Click to open the CI Watches panel.
+- **Provider Health** — `✓ DevDocket • N providers` when every provider is healthy, `○ DevDocket • N providers` while provider health is still unknown, and `⚠ N providers unhealthy` when degraded; click to open the Provider Health quick pick.
+- **Watches** — `👁 DevDocket • Watches` when empty and `👁 DevDocket • 🔄 N · ✓ N · ✗ N` when watches exist, with an additional `⚠ N` segment when runs have succeeded with issues; always visible. Turns amber when at least one watched run has failed and the failure has not yet been acknowledged. Click to open the CI Watches panel.
 
 ## Item Lifecycle
 

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -85,7 +85,7 @@ A floating webview that monitors GitHub Actions / Azure DevOps Pipeline runs and
 - **PR Watches** — pull requests being monitored. Each PR renders as one card with a checks roll-up; expand the card to see individual CI runs. PRs auto-expand when a child run fails, and the failure preview appears on the PR card.
 - **Run Watches** — standalone pipeline runs you've added directly. These continue to render as flat run cards.
 
-Completed runs render in three distinct states: **Passed** (green), **Succeeded with issues** (amber, used for Azure DevOps partial success), and **Failed** (red). Runs that succeeded with issues do not count as failures and do not auto-expand their parent PR card.
+Completed runs are grouped into three health categories: **Passed** (green), **Succeeded with issues** (amber, used for Azure DevOps partial success), and **Failed** (red). Other completed non-result conclusions, such as cancelled, skipped, neutral, timed out, and action required, retain their own labels. Runs that succeeded with issues do not count as failures and do not auto-expand their parent PR card.
 
 ### Adding watches
 

--- a/packages/ado/src/adoPipelineWatcher.ts
+++ b/packages/ado/src/adoPipelineWatcher.ts
@@ -181,6 +181,7 @@ export class AdoPipelineWatcher implements DevDocketRunWatcher {
       case 'failed':
         return 'failure';
       case 'partiallySucceeded':
+      case 'succeededWithIssues':
         return 'partial_success';
       case 'canceled':
         return 'cancelled';

--- a/packages/ado/src/adoPipelineWatcher.ts
+++ b/packages/ado/src/adoPipelineWatcher.ts
@@ -179,8 +179,9 @@ export class AdoPipelineWatcher implements DevDocketRunWatcher {
       case 'succeeded':
         return 'success';
       case 'failed':
-      case 'partiallySucceeded':
         return 'failure';
+      case 'partiallySucceeded':
+        return 'partial_success';
       case 'canceled':
         return 'cancelled';
       default:

--- a/packages/ado/src/test/adoPipelineWatcher.test.ts
+++ b/packages/ado/src/test/adoPipelineWatcher.test.ts
@@ -102,6 +102,41 @@ describe('AdoPipelineWatcher', () => {
       fetchSpy.mockRestore();
     });
 
+    it('maps partiallySucceeded builds to partial_success', async () => {
+      const fetchSpy = vi.spyOn(globalThis, 'fetch')
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            id: 2955325,
+            buildNumber: '20240101.2',
+            definition: { name: 'CI' },
+            status: 'completed',
+            result: 'partiallySucceeded',
+          }),
+        } as Response)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            records: [
+              { id: 'job-1', name: 'Build', type: 'Job', state: 'completed', result: 'partiallySucceeded' },
+            ],
+          }),
+        } as Response);
+
+      const result = await watcher.getRunStatus({
+        providerId: 'ado-pipelines',
+        runId: '2955325',
+        displayName: 'Build 2955325',
+        url: 'https://dev.azure.com/dnceng/internal/_build/results?buildId=2955325',
+        repo: 'dnceng/internal',
+      });
+
+      expect(result.conclusion).toBe('partial_success');
+      expect(result.jobs[0].conclusion).toBe('partial_success');
+
+      fetchSpy.mockRestore();
+    });
+
     it('maps inProgress status to running', async () => {
       const fetchSpy = vi.spyOn(globalThis, 'fetch')
         .mockResolvedValueOnce({

--- a/packages/ado/src/test/adoPipelineWatcher.test.ts
+++ b/packages/ado/src/test/adoPipelineWatcher.test.ts
@@ -118,7 +118,7 @@ describe('AdoPipelineWatcher', () => {
           ok: true,
           json: async () => ({
             records: [
-              { id: 'job-1', name: 'Build', type: 'Job', state: 'completed', result: 'partiallySucceeded' },
+              { id: 'job-1', name: 'Build', type: 'Job', state: 'completed', result: 'succeededWithIssues' },
             ],
           }),
         } as Response);

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -26,7 +26,7 @@ import { isSafeUrl } from './utils/url';
 import { logger, setLogger } from './services/logger';
 import { syncProviderTitles } from './services/titleSync';
 import { syncProviderDescriptions } from './services/descriptionSync';
-import { toRunCompletionLabel } from './webview/shared/runConclusionLabels';
+import { isFailedConclusion, toRunCompletionLabel } from './webview/shared/runConclusionLabels';
 import { performance } from 'perf_hooks';
 
 export type { DevDocketApi, DevDocketProvider, DevDocketAction, ProviderItem, Disposable, ActivityLogEntry, ActivityType, StateTransitionEvent, DevDocketPRWatcher } from './api/types';
@@ -330,11 +330,10 @@ function wireEvents(
   }));
 
   const runCompleteSub = watcherService.onDidCompleteRun(safeHandler('Error handling run completion', (run) => {
-    const isSuccess = run.status.conclusion === 'success';
-    const isPartialSuccess = run.status.conclusion === 'partial_success';
+    const isFailed = isFailedConclusion(run.status.conclusion);
     const message = `${run.identifier.displayName} ${toRunCompletionLabel(run.status.conclusion)}`;
 
-    if (isSuccess || isPartialSuccess) {
+    if (!isFailed) {
       void vscode.window.showInformationMessage(message, 'View Run').then(action => {
         if (action === 'View Run') {
           const safe = isSafeUrl(run.identifier.url);

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -330,9 +330,10 @@ function wireEvents(
 
   const runCompleteSub = watcherService.onDidCompleteRun(safeHandler('Error handling run completion', (run) => {
     const isSuccess = run.status.conclusion === 'success';
-    const message = `${run.identifier.displayName} ${isSuccess ? 'succeeded' : run.status.conclusion || 'completed'}`;
+    const isPartialSuccess = run.status.conclusion === 'partial_success';
+    const message = `${run.identifier.displayName} ${isSuccess ? 'succeeded' : isPartialSuccess ? 'succeeded with issues' : run.status.conclusion || 'completed'}`;
 
-    if (isSuccess) {
+    if (isSuccess || isPartialSuccess) {
       void vscode.window.showInformationMessage(message, 'View Run').then(action => {
         if (action === 'View Run') {
           const safe = isSafeUrl(run.identifier.url);

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -331,7 +331,7 @@ function wireEvents(
   const runCompleteSub = watcherService.onDidCompleteRun(safeHandler('Error handling run completion', (run) => {
     const isSuccess = run.status.conclusion === 'success';
     const isPartialSuccess = run.status.conclusion === 'partial_success';
-    const message = `${run.identifier.displayName} ${isSuccess ? 'succeeded' : isPartialSuccess ? 'succeeded with issues' : run.status.conclusion || 'completed'}`;
+    const message = `${run.identifier.displayName} ${toRunCompletionLabel(run.status.conclusion)}`;
 
     if (isSuccess || isPartialSuccess) {
       void vscode.window.showInformationMessage(message, 'View Run').then(action => {
@@ -441,6 +441,23 @@ function wireEvents(
     autoWatchCleanup,
     autoCompleteCleanup,
   ];
+}
+
+function toRunCompletionLabel(conclusion?: string): string {
+  if (!conclusion) {
+    return 'completed';
+  }
+  if (conclusion === 'success') {
+    return 'succeeded';
+  }
+  if (conclusion === 'partial_success') {
+    return 'succeeded with issues';
+  }
+  if (conclusion === 'failure') {
+    return 'failed';
+  }
+  const label = conclusion.replace(/_/g, ' ');
+  return label.charAt(0).toUpperCase() + label.slice(1);
 }
 
 /**

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -26,6 +26,7 @@ import { isSafeUrl } from './utils/url';
 import { logger, setLogger } from './services/logger';
 import { syncProviderTitles } from './services/titleSync';
 import { syncProviderDescriptions } from './services/descriptionSync';
+import { toRunCompletionLabel } from './webview/shared/runConclusionLabels';
 import { performance } from 'perf_hooks';
 
 export type { DevDocketApi, DevDocketProvider, DevDocketAction, ProviderItem, Disposable, ActivityLogEntry, ActivityType, StateTransitionEvent, DevDocketPRWatcher } from './api/types';
@@ -443,22 +444,6 @@ function wireEvents(
   ];
 }
 
-function toRunCompletionLabel(conclusion?: string): string {
-  if (!conclusion) {
-    return 'completed';
-  }
-  if (conclusion === 'success') {
-    return 'succeeded';
-  }
-  if (conclusion === 'partial_success') {
-    return 'succeeded with issues';
-  }
-  if (conclusion === 'failure') {
-    return 'failed';
-  }
-  const label = conclusion.replace(/_/g, ' ');
-  return label.charAt(0).toUpperCase() + label.slice(1);
-}
 
 /**
  * Activate the DevDocket extension.

--- a/packages/core/src/services/runWatchPool.ts
+++ b/packages/core/src/services/runWatchPool.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import type { JobStatus, RunIdentifier, RunStatus } from '@devdocket/shared';
 import { WatcherRegistry } from './watcherRegistry';
 import type { WatchedRun } from './watcherService';
+import { isFailedConclusion } from '../webview/shared/runConclusionLabels';
 
 type WatcherLogger = {
   info: (msg: string) => void;
@@ -332,10 +333,7 @@ export class RunWatchPool implements vscode.Disposable {
   private static isFailedRun(watch: WatchedRun): boolean {
     if (watch.hasWarning) return true;
     if (watch.status.overallState !== 'completed') return false;
-    const conclusion = watch.status.conclusion;
-    if (conclusion === undefined || conclusion === 'success') return false;
-    if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral' || conclusion === 'partial_success') return false;
-    return true;
+    return isFailedConclusion(watch.status.conclusion);
   }
 
   dispose(): void {

--- a/packages/core/src/services/runWatchPool.ts
+++ b/packages/core/src/services/runWatchPool.ts
@@ -334,7 +334,7 @@ export class RunWatchPool implements vscode.Disposable {
     if (watch.status.overallState !== 'completed') return false;
     const conclusion = watch.status.conclusion;
     if (conclusion === undefined || conclusion === 'success') return false;
-    if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral') return false;
+    if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral' || conclusion === 'partial_success') return false;
     return true;
   }
 

--- a/packages/core/src/test/ciWatchSection.test.ts
+++ b/packages/core/src/test/ciWatchSection.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { CIWatchSection } from '../webview/editor/components/CIWatchSection';
+
+function collectText(node: unknown): string[] {
+  if (node === null || node === undefined || typeof node === 'boolean') {
+    return [];
+  }
+  if (typeof node === 'string' || typeof node === 'number') {
+    return [String(node)];
+  }
+  if (Array.isArray(node)) {
+    return node.flatMap(collectText);
+  }
+  if (typeof node === 'object' && 'props' in node) {
+    return collectText((node as { props?: { children?: unknown } }).props?.children);
+  }
+  return [];
+}
+
+function findByClass(node: unknown, className: string): unknown {
+  if (Array.isArray(node)) {
+    return node.map(child => findByClass(child, className)).find(Boolean);
+  }
+  if (node === null || node === undefined || typeof node !== 'object') {
+    return undefined;
+  }
+  if ('props' in node) {
+    const props = (node as { props?: { class?: string; className?: string; children?: unknown } }).props;
+    const classes = props?.class ?? props?.className;
+    if (classes?.split(' ').includes(className)) {
+      return node;
+    }
+    return findByClass(props?.children, className);
+  }
+  return undefined;
+}
+
+describe('CIWatchSection', () => {
+  it('renders partial-success runs with an amber warning chip', () => {
+    const section = CIWatchSection({
+      ciWatch: {
+        state: 'open',
+        runs: [{ id: 'run-1', name: 'Publish artifacts', state: 'completed', conclusion: 'partial_success' }],
+        totalActive: 0,
+        totalFailing: 0,
+      },
+      onOpenWatches: () => undefined,
+    });
+
+    const chip = findByClass(section, 'ci-watch-chip--warn') as { props?: { children?: unknown } } | undefined;
+    expect(chip).toBeDefined();
+    expect(collectText(chip).join('')).toBe('⚠Publish artifacts (Succeeded with issues)');
+  });
+});

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -218,6 +218,39 @@ describe('activate()', () => {
     expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
   });
 
+  it('formats non-success run completion conclusions for notifications', async () => {
+    vi.useFakeTimers();
+    const api = await activate(context);
+    const url = 'https://example.com/runs/timed-out';
+    let statusCallCount = 0;
+
+    api.registerRunWatcher({
+      id: 'test-runs',
+      label: 'Test Runs',
+      canWatch: (candidate: string) => candidate === url,
+      parseRunUrl: () => ({
+        providerId: 'test-runs',
+        runId: 'timed-out',
+        displayName: 'ADO Build',
+        url,
+      }),
+      getRunStatus: vi.fn(async () => {
+        statusCallCount += 1;
+        return statusCallCount === 1
+          ? { overallState: 'running' as const, jobs: [] }
+          : { overallState: 'completed' as const, conclusion: 'timed_out' as const, jobs: [] };
+      }),
+    });
+    (vscode.window.showInputBox as ReturnType<typeof vi.fn>).mockResolvedValue(url);
+
+    await getCommandHandler('devdocket.watchUrl')();
+    vi.mocked(vscode.window.showInformationMessage).mockClear();
+    vi.mocked(vscode.window.showWarningMessage).mockClear();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(vscode.window.showWarningMessage).toHaveBeenCalledWith('ADO Build Timed out', 'View Run');
+  });
+
   it('prunes stale read-state and inbox-state records after non-empty provider refresh', async () => {
     const globalState = context.globalState as InstanceType<typeof MockMemento>;
     await globalState.update('devdocket.migrated', true);

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -63,6 +63,7 @@ describe('activate()', () => {
     for (const sub of [...context.subscriptions].reverse()) {
       try { (sub as any).dispose?.(); } catch (e) { errors.push(e); }
     }
+    vi.useRealTimers();
     if (errors.length > 0) {
       throw new Error(
         `Failed to dispose ${errors.length} subscription(s): ` +
@@ -181,6 +182,40 @@ describe('activate()', () => {
     await getCommandHandler('devdocket.showWatchesQuickPick')();
 
     expect(openSpy).toHaveBeenCalled();
+  });
+
+  it('announces partial-success run completions as succeeded with issues', async () => {
+    vi.useFakeTimers();
+    const api = await activate(context);
+    const url = 'https://example.com/runs/partial-success';
+    let statusCallCount = 0;
+
+    api.registerRunWatcher({
+      id: 'test-runs',
+      label: 'Test Runs',
+      canWatch: (candidate: string) => candidate === url,
+      parseRunUrl: () => ({
+        providerId: 'test-runs',
+        runId: 'partial-success',
+        displayName: 'ADO Build',
+        url,
+      }),
+      getRunStatus: vi.fn(async () => {
+        statusCallCount += 1;
+        return statusCallCount === 1
+          ? { overallState: 'running' as const, jobs: [] }
+          : { overallState: 'completed' as const, conclusion: 'partial_success' as const, jobs: [] };
+      }),
+    });
+    (vscode.window.showInputBox as ReturnType<typeof vi.fn>).mockResolvedValue(url);
+
+    await getCommandHandler('devdocket.watchUrl')();
+    vi.mocked(vscode.window.showInformationMessage).mockClear();
+    vi.mocked(vscode.window.showWarningMessage).mockClear();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith('ADO Build succeeded with issues', 'View Run');
+    expect(vscode.window.showWarningMessage).not.toHaveBeenCalled();
   });
 
   it('prunes stale read-state and inbox-state records after non-empty provider refresh', async () => {

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -246,6 +246,7 @@ describe('activate()', () => {
     await getCommandHandler('devdocket.watchUrl')();
     vi.mocked(vscode.window.showInformationMessage).mockClear();
     vi.mocked(vscode.window.showWarningMessage).mockClear();
+    vi.mocked(vscode.window.showWarningMessage).mockResolvedValue(undefined);
     await vi.advanceTimersByTimeAsync(60_000);
 
     expect(vscode.window.showWarningMessage).toHaveBeenCalledWith('ADO Build Timed out', 'View Run');

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -307,6 +307,40 @@ describe('MainViewProvider', () => {
     expect(doneTier.items[0].badges).toContainEqual({ label: 'CI passed', type: 'ci', variant: 'ci-pass' });
   });
 
+  it('does not classify partial-success run badges as failed', async () => {
+    vi.useFakeTimers();
+    const workGraph = createMockWorkGraph([
+      makeWorkItem({
+        id: 'partial-run-item',
+        title: 'Partial run item',
+        state: WorkItemState.New,
+        providerId: 'ado',
+        externalId: 'partial-run-item',
+        url: 'https://dev.azure.com/org/project/_build/results?buildId=570',
+      }),
+    ]);
+    const providerRegistry = createProviderRegistry({
+      ado: [{ externalId: 'partial-run-item', title: 'Partial run item', url: 'https://dev.azure.com/org/project/_build/results?buildId=570' }],
+    });
+    const stateStore = createStateStore({ 'ado::partial-run-item': 'accepted' });
+    const watcherService = createWatcherService({
+      runs: [{
+        identifier: { providerId: 'ado-pipelines', runId: '570', url: 'https://dev.azure.com/org/project/_build/results?buildId=570' },
+        status: { overallState: 'completed', conclusion: 'partial_success' },
+      }],
+    });
+    const provider = createProvider(workGraph, providerRegistry, stateStore, watcherService);
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    await vi.advanceTimersByTimeAsync(50);
+
+    const updateItems = findPostedMessage(mockView, 'updateItems');
+    const readyTier = updateItems.tiers.find((tier: { id: string }) => tier.id === 'ready-to-start');
+    expect(readyTier.items[0].badges).not.toContainEqual({ label: 'CI failed', type: 'ci', variant: 'ci-fail' });
+    expect(readyTier.items[0].badges).toContainEqual({ label: 'CI passed', type: 'ci', variant: 'ci-pass' });
+  });
+
   it('filters empty tiers out of the refresh payload', async () => {
     vi.useFakeTimers();
     const provider = createProvider(

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -342,6 +342,41 @@ describe('MainViewProvider', () => {
     expect(readyTier.items[0].badges).toContainEqual({ label: 'CI issues', type: 'ci', variant: 'ci-warn' });
   });
 
+  it('leaves unknown completed run conclusions neutral in the sidebar', async () => {
+    vi.useFakeTimers();
+    const workGraph = createMockWorkGraph([
+      makeWorkItem({
+        id: 'custom-run-item',
+        title: 'Custom run item',
+        state: WorkItemState.New,
+        providerId: 'ado',
+        externalId: 'custom-run-item',
+        url: 'https://dev.azure.com/org/project/_build/results?buildId=999',
+      }),
+    ]);
+    const providerRegistry = createProviderRegistry({
+      ado: [{ externalId: 'custom-run-item', title: 'Custom run item', url: 'https://dev.azure.com/org/project/_build/results?buildId=999' }],
+    });
+    const stateStore = createStateStore({ 'ado::custom-run-item': 'accepted' });
+    const watcherService = createWatcherService({
+      runs: [{
+        identifier: { providerId: 'ado-pipelines', runId: '999', url: 'https://dev.azure.com/org/project/_build/results?buildId=999' },
+        status: { overallState: 'completed', conclusion: 'provider_future_value' },
+      }],
+    });
+    const provider = createProvider(workGraph, providerRegistry, stateStore, watcherService);
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    await vi.advanceTimersByTimeAsync(50);
+
+    const updateItems = findPostedMessage(mockView, 'updateItems');
+    const readyTier = updateItems.tiers.find((tier: { id: string }) => tier.id === 'ready-to-start');
+    expect(readyTier.items[0].badges).not.toContainEqual({ label: 'CI failed', type: 'ci', variant: 'ci-fail' });
+    expect(readyTier.items[0].badges).not.toContainEqual({ label: 'CI passed', type: 'ci', variant: 'ci-pass' });
+    expect(readyTier.items[0].badges.some((badge: { type: string }) => badge.type === 'ci')).toBe(false);
+  });
+
   it('filters empty tiers out of the refresh payload', async () => {
     vi.useFakeTimers();
     const provider = createProvider(

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -338,7 +338,8 @@ describe('MainViewProvider', () => {
     const updateItems = findPostedMessage(mockView, 'updateItems');
     const readyTier = updateItems.tiers.find((tier: { id: string }) => tier.id === 'ready-to-start');
     expect(readyTier.items[0].badges).not.toContainEqual({ label: 'CI failed', type: 'ci', variant: 'ci-fail' });
-    expect(readyTier.items[0].badges).toContainEqual({ label: 'CI passed', type: 'ci', variant: 'ci-pass' });
+    expect(readyTier.items[0].badges).not.toContainEqual({ label: 'CI passed', type: 'ci', variant: 'ci-pass' });
+    expect(readyTier.items[0].badges).toContainEqual({ label: 'CI issues', type: 'ci', variant: 'ci-warn' });
   });
 
   it('filters empty tiers out of the refresh payload', async () => {

--- a/packages/core/src/test/runConclusionLabels.test.ts
+++ b/packages/core/src/test/runConclusionLabels.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isFailedConclusion } from '../webview/shared/runConclusionLabels';
+
+describe('runConclusionLabels', () => {
+  it('classifies only explicit failure conclusions as failures', () => {
+    expect(isFailedConclusion('failure')).toBe(true);
+    expect(isFailedConclusion('timed_out')).toBe(true);
+    expect(isFailedConclusion('action_required')).toBe(true);
+
+    expect(isFailedConclusion(undefined)).toBe(false);
+    expect(isFailedConclusion('success')).toBe(false);
+    expect(isFailedConclusion('partial_success')).toBe(false);
+    expect(isFailedConclusion('cancelled')).toBe(false);
+    expect(isFailedConclusion('skipped')).toBe(false);
+    expect(isFailedConclusion('neutral')).toBe(false);
+    expect(isFailedConclusion('provider_specific_future_value')).toBe(false);
+  });
+});

--- a/packages/core/src/test/watchApp.test.ts
+++ b/packages/core/src/test/watchApp.test.ts
@@ -119,7 +119,7 @@ describe('WatchApp PR watch rendering', () => {
     expect(prCard).toBeInstanceOf(HTMLDivElement);
     expect(prCard!.classList.contains('item-card--urgent')).toBe(false);
     expect(prCard!.querySelector('.watch-row-preview')).toBeNull();
-    expect(prSection.textContent).toContain('Checks: ✓ 1 passed · ✗ 0 failed · ⏳ 0 running · • 1 other (2 total)');
+    expect(prSection.textContent).toContain('Checks: ✓ 1 passed · ✗ 0 failed · ⏳ 0 running · ⚠ 1 succeeded with issues (2 total)');
     expect(prSection.querySelector('.watch-card-details')).toBeNull();
   });
 

--- a/packages/core/src/test/watchApp.test.ts
+++ b/packages/core/src/test/watchApp.test.ts
@@ -76,6 +76,20 @@ describe('WatchApp PR watch rendering', () => {
     expect(prSection.textContent).toContain('E2E tests');
   });
 
+  it('renders completed runs without conclusions as neutral non-failures', async () => {
+    await mountWatchApp();
+    await sendUpdate([], [
+      makeRunWatch({ id: 'run-completed', name: 'Completed run', state: 'completed' }),
+    ]);
+
+    const runSection = getSection('Run Watches');
+    const runCard = runSection.querySelector('.tier-items > .item-card');
+    expect(runCard).toBeInstanceOf(HTMLDivElement);
+    expect(runCard!.classList.contains('item-card--done')).toBe(true);
+    expect(runCard!.querySelector('.badge-pill')?.textContent).toBe('Completed');
+    expect(runCard!.querySelector('.watch-row-preview')).toBeNull();
+  });
+
   it('renders partial-success runs as amber non-failures', async () => {
     await mountWatchApp();
     await sendUpdate([], [

--- a/packages/core/src/test/watchApp.test.ts
+++ b/packages/core/src/test/watchApp.test.ts
@@ -90,6 +90,21 @@ describe('WatchApp PR watch rendering', () => {
     expect(runCard!.querySelector('.watch-row-preview')).toBeNull();
   });
 
+  it('renders unknown completed conclusions as neutral non-failures', async () => {
+    await mountWatchApp();
+    await sendUpdate([], [
+      makeRunWatch({ id: 'run-custom', name: 'Custom run', state: 'completed', conclusion: 'provider_future_value' }),
+    ]);
+
+    const runSection = getSection('Run Watches');
+    const runCard = runSection.querySelector('.tier-items > .item-card');
+    expect(runCard).toBeInstanceOf(HTMLDivElement);
+    expect(runCard!.classList.contains('item-card--done')).toBe(true);
+    expect(runCard!.classList.contains('item-card--urgent')).toBe(false);
+    expect((runCard!.querySelector('.badge-pill') as HTMLElement).className).toContain('badge-pill--neutral');
+    expect(runCard!.querySelector('.badge-pill')?.textContent).toBe('Provider future value');
+  });
+
   it('renders partial-success runs as amber non-failures', async () => {
     await mountWatchApp();
     await sendUpdate([], [

--- a/packages/core/src/test/watchApp.test.ts
+++ b/packages/core/src/test/watchApp.test.ts
@@ -101,7 +101,6 @@ describe('WatchApp PR watch rendering', () => {
     expect(runCard).toBeInstanceOf(HTMLDivElement);
     expect(runCard!.classList.contains('item-card--done')).toBe(true);
     expect(runCard!.classList.contains('item-card--urgent')).toBe(false);
-    expect((runCard!.querySelector('.badge-pill') as HTMLElement).className).toContain('badge-pill--neutral');
     expect(runCard!.querySelector('.badge-pill')?.textContent).toBe('Provider future value');
   });
 

--- a/packages/core/src/test/watchApp.test.ts
+++ b/packages/core/src/test/watchApp.test.ts
@@ -76,6 +76,71 @@ describe('WatchApp PR watch rendering', () => {
     expect(prSection.textContent).toContain('E2E tests');
   });
 
+  it('renders partial-success runs as amber non-failures', async () => {
+    await mountWatchApp();
+    await sendUpdate([], [
+      makeRunWatch({
+        id: 'run-warn',
+        name: 'Publish artifacts',
+        state: 'completed',
+        conclusion: 'partial_success',
+        failurePreview: 'Conclusion: Succeeded with issues',
+      }),
+    ]);
+
+    const runSection = getSection('Run Watches');
+    const runCard = runSection.querySelector('.tier-items > .item-card');
+    expect(runCard).toBeInstanceOf(HTMLDivElement);
+    expect(runCard!.classList.contains('item-card--paused')).toBe(true);
+    expect(runCard!.querySelector('.badge-pill')?.textContent).toBe('Succeeded with issues');
+    expect((runCard!.querySelector('.badge-pill') as HTMLElement).style.color).toBe('rgb(204, 167, 0)');
+    expect(runCard!.querySelector('.watch-row-preview')?.classList.contains('warning')).toBe(false);
+  });
+
+  it('does not auto-expand or show failure previews for partial-success PR child runs', async () => {
+    await mountWatchApp();
+    await sendUpdate([
+      makePRWatch({
+        runs: [
+          makeRunWatch({ id: 'run-unit', name: 'Unit tests', state: 'completed', conclusion: 'success' }),
+          makeRunWatch({
+            id: 'run-publish',
+            name: 'Publish artifacts',
+            state: 'completed',
+            conclusion: 'partial_success',
+            failurePreview: 'Conclusion: Succeeded with issues',
+          }),
+        ],
+      }),
+    ]);
+
+    const prSection = getSection('PR Watches');
+    const prCard = prSection.querySelector('.tier-items > .item-card');
+    expect(prCard).toBeInstanceOf(HTMLDivElement);
+    expect(prCard!.classList.contains('item-card--urgent')).toBe(false);
+    expect(prCard!.querySelector('.watch-row-preview')).toBeNull();
+    expect(prSection.textContent).toContain('Checks: ✓ 1 passed · ✗ 0 failed · ⏳ 0 running · • 1 other (2 total)');
+    expect(prSection.querySelector('.watch-card-details')).toBeNull();
+  });
+
+  it('title-cases conclusion badge labels', async () => {
+    await mountWatchApp();
+    await sendUpdate([], [
+      makeRunWatch({ id: 'run-failure', name: 'Failure run', state: 'completed', conclusion: 'failure' }),
+      makeRunWatch({ id: 'run-timeout', name: 'Timeout run', state: 'completed', conclusion: 'timed_out' }),
+      makeRunWatch({ id: 'run-action', name: 'Action run', state: 'completed', conclusion: 'action_required' }),
+      makeRunWatch({ id: 'run-neutral', name: 'Neutral run', state: 'completed', conclusion: 'neutral' }),
+    ]);
+
+    const runSection = getSection('Run Watches');
+    expect(Array.from(runSection.querySelectorAll('.badge-pill')).map(badge => badge.textContent)).toEqual([
+      'Failure',
+      'Timed out',
+      'Action required',
+      'Neutral',
+    ]);
+  });
+
   it('hides roll-up and disclosure controls for PR watches without runs', async () => {
     await mountWatchApp();
     await sendUpdate([makePRWatch()]);

--- a/packages/core/src/test/watchPanelProvider.test.ts
+++ b/packages/core/src/test/watchPanelProvider.test.ts
@@ -248,6 +248,41 @@ describe('WatchPanelProvider', () => {
     }));
   });
 
+  it('uses title-cased partial-success previews in watch panel data', () => {
+    const mockPanel = createMockWebviewPanel();
+    vi.mocked(window.createWebviewPanel).mockReturnValue(mockPanel.panel as any);
+    const watcherService = createWatcherService();
+    vi.mocked(watcherService.getActiveStandaloneWatches).mockReturnValue([{
+      identifier: {
+        providerId: 'ado-pipelines',
+        runId: '570',
+        displayName: 'Publish artifacts',
+        url: 'https://dev.azure.com/org/project/_build/results?buildId=570',
+      },
+      status: {
+        overallState: 'completed',
+        conclusion: 'partial_success',
+        jobs: [],
+      },
+      watchedAt: new Date(Date.now() - 120_000).toISOString(),
+    }]);
+
+    const provider = new WatchPanelProvider(
+      vscode.Uri.file('C:\\repo') as any,
+      watcherService as any,
+      createMockWorkGraph(),
+      createMockProviderRegistry(),
+    );
+    provider.open();
+
+    const message = getUpdateWatchPanelMessage(mockPanel);
+    expect(message.runWatches[0]).toEqual(expect.objectContaining({
+      state: 'completed',
+      conclusion: 'partial_success',
+      failurePreview: 'Conclusion: Succeeded with issues',
+    }));
+  });
+
   it('adds linkedItemId when a matching PR work item exists', () => {
     const mockPanel = createMockWebviewPanel();
     vi.mocked(window.createWebviewPanel).mockReturnValue(mockPanel.panel as any);

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -158,6 +158,20 @@ describe('WatcherService', () => {
       expect(service.isFailureAcknowledged(watch)).toBe(false);
     });
 
+    it('does not acknowledge partial-success runs as failures', async () => {
+      const watcher = createMockWatcher('test', async () => ({
+        overallState: 'completed' as const,
+        conclusion: 'partial_success' as const,
+        jobs: [],
+      }));
+      registry.register(watcher);
+      const watch = await service.startWatch(createIdentifier());
+
+      service.acknowledgeAllFailures();
+
+      expect(service.isFailureAcknowledged(watch)).toBe(false);
+    });
+
     it('clears the acknowledgement when a dismissed watch is re-watched', async () => {
       const watcher = createMockWatcher('test', async () => ({
         overallState: 'completed' as const,

--- a/packages/core/src/test/watchesStatusBar.test.ts
+++ b/packages/core/src/test/watchesStatusBar.test.ts
@@ -63,6 +63,20 @@ describe('WatchesStatusBar', () => {
     expect(statusBarItem.backgroundColor).toBeUndefined();
   });
 
+  it('does not count unknown completed conclusions as passed or failed', () => {
+    const watcherService = createWatcherService([
+      { status: { overallState: 'completed', conclusion: 'provider_future_value' } },
+    ]);
+
+    new WatchesStatusBar(watcherService as any);
+
+    const statusBarItem = (window.createStatusBarItem as ReturnType<typeof vi.fn>).mock.results[0].value;
+    expect(statusBarItem.text).toBe('👁 DevDocket • Watches');
+    expect(statusBarItem.tooltip).toContain('  ✓ 0 passed');
+    expect(statusBarItem.tooltip).toContain('  ✗ 0 failed');
+    expect(statusBarItem.backgroundColor).toBeUndefined();
+  });
+
   it('updates text when watch activity changes and remains visible when empty', () => {
     const watcherService = createWatcherService([]);
     new WatchesStatusBar(watcherService as any, 'devdocket.showWatchPanel');

--- a/packages/core/src/test/watchesStatusBar.test.ts
+++ b/packages/core/src/test/watchesStatusBar.test.ts
@@ -48,6 +48,20 @@ describe('WatchesStatusBar', () => {
     expect(statusBarItem.show).toHaveBeenCalled();
   });
 
+  it('counts partial-success runs as passed instead of failed', () => {
+    const watcherService = createWatcherService([
+      { status: { overallState: 'completed', conclusion: 'partial_success' } },
+    ]);
+
+    new WatchesStatusBar(watcherService as any);
+
+    const statusBarItem = (window.createStatusBarItem as ReturnType<typeof vi.fn>).mock.results[0].value;
+    expect(statusBarItem.text).toBe('👁 DevDocket • 🔄 0 · ✓ 1 · ✗ 0');
+    expect(statusBarItem.tooltip).toContain('  ✓ 1 passed');
+    expect(statusBarItem.tooltip).toContain('  ✗ 0 failed');
+    expect(statusBarItem.backgroundColor).toBeUndefined();
+  });
+
   it('updates text when watch activity changes and remains visible when empty', () => {
     const watcherService = createWatcherService([]);
     new WatchesStatusBar(watcherService as any, 'devdocket.showWatchPanel');

--- a/packages/core/src/test/watchesStatusBar.test.ts
+++ b/packages/core/src/test/watchesStatusBar.test.ts
@@ -48,7 +48,7 @@ describe('WatchesStatusBar', () => {
     expect(statusBarItem.show).toHaveBeenCalled();
   });
 
-  it('counts partial-success runs as passed instead of failed', () => {
+  it('counts partial-success runs separately from passed and failed', () => {
     const watcherService = createWatcherService([
       { status: { overallState: 'completed', conclusion: 'partial_success' } },
     ]);
@@ -56,8 +56,9 @@ describe('WatchesStatusBar', () => {
     new WatchesStatusBar(watcherService as any);
 
     const statusBarItem = (window.createStatusBarItem as ReturnType<typeof vi.fn>).mock.results[0].value;
-    expect(statusBarItem.text).toBe('👁 DevDocket • 🔄 0 · ✓ 1 · ✗ 0');
-    expect(statusBarItem.tooltip).toContain('  ✓ 1 passed');
+    expect(statusBarItem.text).toBe('👁 DevDocket • 🔄 0 · ✓ 0 · ⚠ 1 · ✗ 0');
+    expect(statusBarItem.tooltip).toContain('  ✓ 0 passed');
+    expect(statusBarItem.tooltip).toContain('  ⚠ 1 succeeded with issues');
     expect(statusBarItem.tooltip).toContain('  ✗ 0 failed');
     expect(statusBarItem.backgroundColor).toBeUndefined();
   });

--- a/packages/core/src/test/watchesStatusBar.test.ts
+++ b/packages/core/src/test/watchesStatusBar.test.ts
@@ -71,7 +71,7 @@ describe('WatchesStatusBar', () => {
     new WatchesStatusBar(watcherService as any);
 
     const statusBarItem = (window.createStatusBarItem as ReturnType<typeof vi.fn>).mock.results[0].value;
-    expect(statusBarItem.text).toBe('👁 DevDocket • Watches');
+    expect(statusBarItem.text).toBe('👁 DevDocket • 🔄 0 · ✓ 0 · ✗ 0');
     expect(statusBarItem.tooltip).toContain('  ✓ 0 passed');
     expect(statusBarItem.tooltip).toContain('  ✗ 0 failed');
     expect(statusBarItem.backgroundColor).toBeUndefined();

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -384,6 +384,32 @@ describe('WorkItemEditorPanel', () => {
     });
   });
 
+  it('excludes partial-success child runs from CI watch failing totals', () => {
+    const item = makeItem({
+      title: 'Watched PR',
+      providerId: 'github-my-prs',
+      externalId: 'owner/repo#42',
+      itemType: 'pr',
+    });
+    const watch = makeWatchedPR();
+    const runs = [
+      makeWatchedRun({
+        identifier: { ...makeWatchedRun().identifier, runId: 'run-partial', displayName: 'publish' },
+        status: { overallState: 'completed', conclusion: 'partial_success', jobs: [] },
+      }),
+    ];
+    const watcherService = createMockWatcherService(watch, runs);
+
+    const { mock } = openPanel(item, createMockWorkGraph(item), createMockProviderRegistry(), createMockActionRegistry(), createMockStateStore(), watcherService);
+    const bootstrap = getBootstrapItem(mock.panel.webview.html);
+
+    expect(bootstrap.ciWatch).toEqual(expect.objectContaining({
+      runs: [{ id: 'github-actions:owner/repo:run-partial', name: 'publish', state: 'completed', conclusion: 'partial_success' }],
+      totalActive: 0,
+      totalFailing: 0,
+    }));
+  });
+
   it('omits CI watch data when the PR is not watched', () => {
     const item = makeItem({
       title: 'Unwatched PR',

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -523,9 +523,16 @@ export function getEditorPanelHtml({ cspSource, scriptUri, initialItem }: Editor
     }
 
     .ci-watch-chip--warn {
-      color: #CCA700;
+      color: var(--vscode-editorWarning-foreground, #CCA700);
       border-color: rgba(204, 167, 0, 0.35);
       background: rgba(204, 167, 0, 0.12);
+    }
+
+    body.vscode-light .ci-watch-chip--warn,
+    body.vscode-high-contrast-light .ci-watch-chip--warn {
+      color: var(--vscode-editorWarning-foreground, #8A6100);
+      border-color: rgba(138, 97, 0, 0.35);
+      background: rgba(138, 97, 0, 0.10);
     }
 
     .ci-watch-chip--running {

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -522,6 +522,12 @@ export function getEditorPanelHtml({ cspSource, scriptUri, initialItem }: Editor
       background: rgba(241, 76, 76, 0.12);
     }
 
+    .ci-watch-chip--warn {
+      color: #CCA700;
+      border-color: rgba(204, 167, 0, 0.35);
+      background: rgba(204, 167, 0, 0.12);
+    }
+
     .ci-watch-chip--running {
       color: var(--vscode-progressBar-background, var(--vscode-textLink-foreground));
       border-color: rgba(0, 122, 204, 0.35);

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -1395,9 +1395,9 @@ function isFailedRun(runWatch: WatchedRun): boolean {
   if (runWatch.status.overallState !== 'completed') return false;
   const conclusion = runWatch.status.conclusion;
   if (conclusion === undefined || conclusion === 'success') return false;
-  // Cancelled / skipped / neutral runs aren't failures from a CI-health
-  // standpoint — they're explicit non-results. Don't paint them red.
-  if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral') return false;
+  // Cancelled / skipped / neutral / partial-success runs aren't failures
+  // from a CI-health standpoint. Don't paint them red.
+  if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral' || conclusion === 'partial_success') return false;
   return true;
 }
 

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -419,7 +419,10 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     if (watchedRun.status.conclusion === 'partial_success') {
       return { label: 'CI issues', type: 'ci', variant: 'ci-warn' };
     }
-    return { label: 'CI passed', type: 'ci', variant: 'ci-pass' };
+    if (watchedRun.status.conclusion === 'success') {
+      return { label: 'CI passed', type: 'ci', variant: 'ci-pass' };
+    }
+    return undefined;
   }
 
   private getPRCIBadge(watchedPR: WatchedPR): BadgeData | undefined {

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -415,6 +415,9 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     if (watchedRun.status.overallState !== 'completed') {
       return { label: 'CI running', type: 'ci', variant: 'ci-running' };
     }
+    if (watchedRun.status.conclusion === 'partial_success') {
+      return { label: 'CI issues', type: 'ci', variant: 'ci-warn' };
+    }
     return { label: 'CI passed', type: 'ci', variant: 'ci-pass' };
   }
 
@@ -435,6 +438,9 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     }
     if (childRuns.every(runWatch => runWatch.status.conclusion === 'success')) {
       return { label: 'CI passed', type: 'ci', variant: 'ci-pass' };
+    }
+    if (childRuns.some(runWatch => runWatch.status.conclusion === 'partial_success')) {
+      return { label: 'CI issues', type: 'ci', variant: 'ci-warn' };
     }
     return undefined;
   }

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -14,6 +14,7 @@ import { InboxStateStore } from '../storage/inboxStateStore';
 import { ReadStateStore } from '../storage/readStateStore';
 import { isSafeUrl } from '../utils/url';
 import { buildTierColorCss } from '../webview/shared/colors';
+import { isFailedConclusion } from '../webview/shared/runConclusionLabels';
 import { buildProviderBadge, buildProviderBadges, buildTypeBadge } from './badges';
 import { getProviderItemKey, parseProviderItemKey } from './providerItemKey';
 import type {
@@ -1399,12 +1400,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
 
 function isFailedRun(runWatch: WatchedRun): boolean {
   if (runWatch.status.overallState !== 'completed') return false;
-  const conclusion = runWatch.status.conclusion;
-  if (conclusion === undefined || conclusion === 'success') return false;
-  // Cancelled / skipped / neutral / partial-success runs aren't failures
-  // from a CI-health standpoint. Don't paint them red.
-  if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral' || conclusion === 'partial_success') return false;
-  return true;
+  return isFailedConclusion(runWatch.status.conclusion);
 }
 
 function normalizeText(value?: string): string {

--- a/packages/core/src/views/watchPanelProvider.ts
+++ b/packages/core/src/views/watchPanelProvider.ts
@@ -660,7 +660,7 @@ function getFailurePreview(runWatch: WatchedRun): string | undefined {
   }
 
   if (runWatch.status.overallState === 'completed' && runWatch.status.conclusion && runWatch.status.conclusion !== 'success') {
-    return `Conclusion: ${toDisplayLabel(runWatch.status.conclusion)}`;
+    return `Conclusion: ${toConclusionLabel(runWatch.status.conclusion)}`;
   }
 
   return undefined;
@@ -736,10 +736,10 @@ function isFailedRun(runWatch: RunWatchData): boolean {
   if (runWatch.state !== 'completed') return false;
   const conclusion = runWatch.conclusion;
   if (conclusion === undefined || conclusion === 'success') return false;
-  // cancelled / skipped / neutral are explicit non-results, not failures.
+  // cancelled / skipped / neutral / partial success are explicit non-failures.
   // Mirrors the canonical definition in mainViewProvider.ts so the watch
   // panel and the sidebar agree on what counts as a failed run.
-  if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral') return false;
+  if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral' || conclusion === 'partial_success') return false;
   return true;
 }
 
@@ -747,8 +747,12 @@ function truncate(value: string, maxLength = 140): string {
   return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
 }
 
-function toDisplayLabel(value: string): string {
-  return value.replace(/_/g, ' ');
+function toConclusionLabel(value: string): string {
+  if (value === 'partial_success') {
+    return 'Succeeded with issues';
+  }
+  const label = value.replace(/_/g, ' ');
+  return label.charAt(0).toUpperCase() + label.slice(1);
 }
 
 function resolveCodiconsResources(): CodiconsResources | undefined {

--- a/packages/core/src/views/watchPanelProvider.ts
+++ b/packages/core/src/views/watchPanelProvider.ts
@@ -9,7 +9,7 @@ import type { ProviderRegistry } from '../services/providerRegistry';
 import type { WorkGraph } from '../services/workGraph';
 import { isSafeUrl } from '../utils/url';
 import { buildTierColorCss } from '../webview/shared/colors';
-import { toConclusionLabel } from '../webview/shared/runConclusionLabels';
+import { isFailedConclusion, toConclusionLabel } from '../webview/shared/runConclusionLabels';
 import { parseProviderItemKey } from './providerItemKey';
 import type { PRWatchData, RunWatchData, WebviewMessage } from './mainTypes';
 
@@ -735,13 +735,9 @@ function getRunPriority(runWatch: RunWatchData): number {
 
 function isFailedRun(runWatch: RunWatchData): boolean {
   if (runWatch.state !== 'completed') return false;
-  const conclusion = runWatch.conclusion;
-  if (conclusion === undefined || conclusion === 'success') return false;
-  // cancelled / skipped / neutral / partial success are explicit non-failures.
   // Mirrors the canonical definition in mainViewProvider.ts so the watch
   // panel and the sidebar agree on what counts as a failed run.
-  if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral' || conclusion === 'partial_success') return false;
-  return true;
+  return isFailedConclusion(runWatch.conclusion);
 }
 
 function truncate(value: string, maxLength = 140): string {

--- a/packages/core/src/views/watchPanelProvider.ts
+++ b/packages/core/src/views/watchPanelProvider.ts
@@ -735,8 +735,7 @@ function getRunPriority(runWatch: RunWatchData): number {
 
 function isFailedRun(runWatch: RunWatchData): boolean {
   if (runWatch.state !== 'completed') return false;
-  // Mirrors the canonical definition in mainViewProvider.ts so the watch
-  // panel and the sidebar agree on what counts as a failed run.
+  // Delegate to the shared helper so all CI watch surfaces agree on what counts as a failed run.
   return isFailedConclusion(runWatch.conclusion);
 }
 

--- a/packages/core/src/views/watchPanelProvider.ts
+++ b/packages/core/src/views/watchPanelProvider.ts
@@ -9,6 +9,7 @@ import type { ProviderRegistry } from '../services/providerRegistry';
 import type { WorkGraph } from '../services/workGraph';
 import { isSafeUrl } from '../utils/url';
 import { buildTierColorCss } from '../webview/shared/colors';
+import { toConclusionLabel } from '../webview/shared/runConclusionLabels';
 import { parseProviderItemKey } from './providerItemKey';
 import type { PRWatchData, RunWatchData, WebviewMessage } from './mainTypes';
 
@@ -747,13 +748,6 @@ function truncate(value: string, maxLength = 140): string {
   return value.length > maxLength ? `${value.slice(0, maxLength - 1)}…` : value;
 }
 
-function toConclusionLabel(value: string): string {
-  if (value === 'partial_success') {
-    return 'Succeeded with issues';
-  }
-  const label = value.replace(/_/g, ' ');
-  return label.charAt(0).toUpperCase() + label.slice(1);
-}
 
 function resolveCodiconsResources(): CodiconsResources | undefined {
   try {

--- a/packages/core/src/views/watchesStatusBar.ts
+++ b/packages/core/src/views/watchesStatusBar.ts
@@ -57,10 +57,10 @@ export class WatchesStatusBar implements vscode.Disposable {
         passedCount += 1;
         continue;
       }
-      // cancelled / skipped / neutral are explicit non-results, not failures.
+      // cancelled / skipped / neutral / partial success are explicit non-failures.
       // Mirrors the canonical isFailedRun in mainViewProvider.ts and the
       // watch panel webview so the status bar agrees with the panel UI.
-      if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral') {
+      if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral' || conclusion === 'partial_success') {
         passedCount += 1;
         continue;
       }

--- a/packages/core/src/views/watchesStatusBar.ts
+++ b/packages/core/src/views/watchesStatusBar.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { WatcherService } from '../services/watcherService';
+import { isFailedConclusion } from '../webview/shared/runConclusionLabels';
 
 /**
  * Status bar item that shows running/passed/failed watch counts.
@@ -62,10 +63,9 @@ export class WatchesStatusBar implements vscode.Disposable {
         partialSuccessCount += 1;
         continue;
       }
-      // cancelled / skipped / neutral are explicit non-results, not failures.
       // Mirrors the canonical isFailedRun in mainViewProvider.ts and the
       // watch panel webview so the status bar agrees with the panel UI.
-      if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral') {
+      if (!isFailedConclusion(conclusion)) {
         passedCount += 1;
         continue;
       }

--- a/packages/core/src/views/watchesStatusBar.ts
+++ b/packages/core/src/views/watchesStatusBar.ts
@@ -64,13 +64,11 @@ export class WatchesStatusBar implements vscode.Disposable {
         continue;
       }
       // Delegate to the shared helper so the status bar matches the CI watch surfaces.
-      if (!isFailedConclusion(conclusion)) {
-        passedCount += 1;
-        continue;
-      }
-      failedCount += 1;
-      if (!this.watcherService.isFailureAcknowledged(watch)) {
-        unacknowledgedFailedCount += 1;
+      if (isFailedConclusion(conclusion)) {
+        failedCount += 1;
+        if (!this.watcherService.isFailureAcknowledged(watch)) {
+          unacknowledgedFailedCount += 1;
+        }
       }
     }
 

--- a/packages/core/src/views/watchesStatusBar.ts
+++ b/packages/core/src/views/watchesStatusBar.ts
@@ -63,8 +63,7 @@ export class WatchesStatusBar implements vscode.Disposable {
         partialSuccessCount += 1;
         continue;
       }
-      // Mirrors the canonical isFailedRun in mainViewProvider.ts and the
-      // watch panel webview so the status bar agrees with the panel UI.
+      // Delegate to the shared helper so the status bar matches the CI watch surfaces.
       if (!isFailedConclusion(conclusion)) {
         passedCount += 1;
         continue;

--- a/packages/core/src/views/watchesStatusBar.ts
+++ b/packages/core/src/views/watchesStatusBar.ts
@@ -25,7 +25,7 @@ export class WatchesStatusBar implements vscode.Disposable {
     const watches = this.watcherService.getActiveWatches();
     if (watches.length === 0) {
       this.statusBarItem.text = '👁 DevDocket • Watches';
-      this.statusBarItem.tooltip = this.buildTooltip(0, 0, 0);
+      this.statusBarItem.tooltip = this.buildTooltip(0, 0, 0, 0);
       this.statusBarItem.backgroundColor = undefined;
       this.statusBarItem.color = undefined;
       this.statusBarItem.show();
@@ -34,6 +34,7 @@ export class WatchesStatusBar implements vscode.Disposable {
 
     let runningCount = 0;
     let passedCount = 0;
+    let partialSuccessCount = 0;
     let failedCount = 0;
     let unacknowledgedFailedCount = 0;
 
@@ -57,10 +58,14 @@ export class WatchesStatusBar implements vscode.Disposable {
         passedCount += 1;
         continue;
       }
-      // cancelled / skipped / neutral / partial success are explicit non-failures.
+      if (conclusion === 'partial_success') {
+        partialSuccessCount += 1;
+        continue;
+      }
+      // cancelled / skipped / neutral are explicit non-results, not failures.
       // Mirrors the canonical isFailedRun in mainViewProvider.ts and the
       // watch panel webview so the status bar agrees with the panel UI.
-      if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral' || conclusion === 'partial_success') {
+      if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral') {
         passedCount += 1;
         continue;
       }
@@ -70,8 +75,9 @@ export class WatchesStatusBar implements vscode.Disposable {
       }
     }
 
-    this.statusBarItem.text = `👁 DevDocket • 🔄 ${runningCount} · ✓ ${passedCount} · ✗ ${failedCount}`;
-    this.statusBarItem.tooltip = this.buildTooltip(runningCount, passedCount, failedCount);
+    const partialText = partialSuccessCount > 0 ? ` · ⚠ ${partialSuccessCount}` : '';
+    this.statusBarItem.text = `👁 DevDocket • 🔄 ${runningCount} · ✓ ${passedCount}${partialText} · ✗ ${failedCount}`;
+    this.statusBarItem.tooltip = this.buildTooltip(runningCount, passedCount, partialSuccessCount, failedCount);
     // Only highlight the status bar with the warning color if there is at
     // least one failed watch the user hasn't seen yet — once they open the
     // watch panel, acknowledge clears the alert until a NEW failure arrives.
@@ -84,11 +90,12 @@ export class WatchesStatusBar implements vscode.Disposable {
     this.statusBarItem.show();
   }
 
-  private buildTooltip(runningCount: number, passedCount: number, failedCount: number): string {
+  private buildTooltip(runningCount: number, passedCount: number, partialSuccessCount: number, failedCount: number): string {
     return [
       'DevDocket CI Watches',
       `  🔄 ${runningCount} running`,
       `  ✓ ${passedCount} passed`,
+      ...(partialSuccessCount > 0 ? [`  ⚠ ${partialSuccessCount} succeeded with issues`] : []),
       `  ✗ ${failedCount} failed`,
       'Click to open CI Watches panel.',
     ].join('\n');

--- a/packages/core/src/views/watchesStatusBar.ts
+++ b/packages/core/src/views/watchesStatusBar.ts
@@ -55,7 +55,7 @@ export class WatchesStatusBar implements vscode.Disposable {
         continue;
       }
       const conclusion = watch.status.conclusion;
-      if (conclusion === undefined || conclusion === 'success') {
+      if (conclusion === 'success') {
         passedCount += 1;
         continue;
       }

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -10,6 +10,7 @@ import type { WatcherService, WatchedPR, WatchedRun } from '../services/watcherS
 import type { InboxStateStore } from '../storage/inboxStateStore';
 import { isSafeUrl } from '../utils/url';
 import { buildProviderBadge, buildProviderBadges, buildTypeBadge } from './badges';
+import { isFailedConclusion } from '../webview/shared/runConclusionLabels';
 import { parseProviderItemKey } from './providerItemKey';
 import { getEditorPanelHtml, renderMarkdown } from './editorPanelHtml';
 import type { BadgeData, EditorItemData } from './mainTypes';
@@ -758,9 +759,7 @@ function toEditorRunState(state: WatchedRun['status']['overallState']): NonNulla
 function isFailingOrWarningRun(run: WatchedRun): boolean {
   if (run.hasWarning) return true;
   if (run.status.overallState !== 'completed') return false;
-  const conclusion = run.status.conclusion;
-  if (conclusion === undefined || conclusion === 'success') return false;
-  return conclusion !== 'cancelled' && conclusion !== 'skipped' && conclusion !== 'neutral' && conclusion !== 'partial_success';
+  return isFailedConclusion(run.status.conclusion);
 }
 
 /**

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -760,7 +760,7 @@ function isFailingOrWarningRun(run: WatchedRun): boolean {
   if (run.status.overallState !== 'completed') return false;
   const conclusion = run.status.conclusion;
   if (conclusion === undefined || conclusion === 'success') return false;
-  return conclusion !== 'cancelled' && conclusion !== 'skipped' && conclusion !== 'neutral';
+  return conclusion !== 'cancelled' && conclusion !== 'skipped' && conclusion !== 'neutral' && conclusion !== 'partial_success';
 }
 
 /**

--- a/packages/core/src/webview/editor/components/CIWatchSection.tsx
+++ b/packages/core/src/webview/editor/components/CIWatchSection.tsx
@@ -1,3 +1,4 @@
+import { toConclusionLabel } from '../../shared/runConclusionLabels';
 import type { EditorCIWatchData } from '../../shared/types';
 
 interface CIWatchSectionProps {
@@ -97,13 +98,6 @@ function isFailedRun(run: CIRun): boolean {
   return conclusion !== 'cancelled' && conclusion !== 'skipped' && conclusion !== 'neutral' && conclusion !== 'partial_success';
 }
 
-function toConclusionLabel(conclusion: string): string {
-  if (conclusion === 'partial_success') {
-    return 'Succeeded with issues';
-  }
-  const label = conclusion.replace(/_/g, ' ');
-  return label.charAt(0).toUpperCase() + label.slice(1);
-}
 
 function formatCount(count: number, label: string): string {
   return `${count} ${label}${count === 1 ? '' : 's'}`;

--- a/packages/core/src/webview/editor/components/CIWatchSection.tsx
+++ b/packages/core/src/webview/editor/components/CIWatchSection.tsx
@@ -1,4 +1,4 @@
-import { toConclusionLabel } from '../../shared/runConclusionLabels';
+import { isFailedConclusion, toConclusionLabel } from '../../shared/runConclusionLabels';
 import type { EditorCIWatchData } from '../../shared/types';
 
 interface CIWatchSectionProps {
@@ -93,9 +93,7 @@ function getRunLabel(run: CIRun): string {
 
 function isFailedRun(run: CIRun): boolean {
   if (run.state !== 'completed') return false;
-  const conclusion = run.conclusion;
-  if (conclusion === undefined || conclusion === 'success') return false;
-  return conclusion !== 'cancelled' && conclusion !== 'skipped' && conclusion !== 'neutral' && conclusion !== 'partial_success';
+  return isFailedConclusion(run.conclusion);
 }
 
 

--- a/packages/core/src/webview/editor/components/CIWatchSection.tsx
+++ b/packages/core/src/webview/editor/components/CIWatchSection.tsx
@@ -55,6 +55,9 @@ function getRunIcon(run: CIRun): string {
   if (run.conclusion === 'success') {
     return '✓';
   }
+  if (run.conclusion === 'partial_success') {
+    return '⚠';
+  }
   return '○';
 }
 
@@ -67,6 +70,9 @@ function getRunVariant(run: CIRun): string {
   }
   if (run.conclusion === 'success') {
     return 'pass';
+  }
+  if (run.conclusion === 'partial_success') {
+    return 'warn';
   }
   return 'neutral';
 }

--- a/packages/core/src/webview/editor/components/CIWatchSection.tsx
+++ b/packages/core/src/webview/editor/components/CIWatchSection.tsx
@@ -81,14 +81,22 @@ function getRunLabel(run: CIRun): string {
   if (run.state === 'in_progress') {
     return 'in progress';
   }
-  return run.conclusion?.replace(/_/g, ' ') ?? 'completed';
+  return run.conclusion ? toConclusionLabel(run.conclusion) : 'completed';
 }
 
 function isFailedRun(run: CIRun): boolean {
   if (run.state !== 'completed') return false;
   const conclusion = run.conclusion;
   if (conclusion === undefined || conclusion === 'success') return false;
-  return conclusion !== 'cancelled' && conclusion !== 'skipped' && conclusion !== 'neutral';
+  return conclusion !== 'cancelled' && conclusion !== 'skipped' && conclusion !== 'neutral' && conclusion !== 'partial_success';
+}
+
+function toConclusionLabel(conclusion: string): string {
+  if (conclusion === 'partial_success') {
+    return 'Succeeded with issues';
+  }
+  const label = conclusion.replace(/_/g, ' ');
+  return label.charAt(0).toUpperCase() + label.slice(1);
 }
 
 function formatCount(count: number, label: string): string {

--- a/packages/core/src/webview/shared/colors.ts
+++ b/packages/core/src/webview/shared/colors.ts
@@ -31,7 +31,7 @@ export const providerBadgeColors = {
 // State badge colors  (semantic: red = action needed, green = positive, etc.)
 // ---------------------------------------------------------------------------
 
-export interface ThemedColor { dark: { bg: string; fg: string }; light: { bg: string; fg: string } }
+export interface ThemedColor { dark: { bg: string; fg: string; border?: string }; light: { bg: string; fg: string; border?: string } }
 
 export const stateBadgeColors: Record<string, ThemedColor> = {
   'changes-requested': {
@@ -76,6 +76,10 @@ export const ciBadgeColors: Record<string, ThemedColor> = {
   'ci-fail': {
     dark:  { bg: 'rgba(241,76,76,0.15)',   fg: '#F14C4C' },
     light: { bg: 'rgba(205,45,45,0.10)',   fg: '#CD2D2D' },
+  },
+  'ci-warn': {
+    dark:  { bg: 'rgba(204,167,0,0.15)',   fg: tierColors.paused.dark, border: tierColors.paused.dark },
+    light: { bg: 'rgba(191,136,3,0.10)',   fg: tierColors.paused.light, border: tierColors.paused.light },
   },
   'ci-running': {
     dark:  { bg: 'rgba(55,148,255,0.15)',  fg: '#3794FF' },

--- a/packages/core/src/webview/shared/components/BadgePill.tsx
+++ b/packages/core/src/webview/shared/components/BadgePill.tsx
@@ -43,7 +43,11 @@ function getBadgeColors(badge: BadgeData): JSX.CSSProperties {
   const themed = palette[badge.variant];
   if (themed) {
     const pair = isLightTheme() ? themed.light : themed.dark;
-    return { backgroundColor: pair.bg, color: pair.fg };
+    return {
+      backgroundColor: pair.bg,
+      color: pair.fg,
+      ...(pair.border ? { border: `1px solid ${pair.border}` } : {}),
+    };
   }
 
   return outlineFallback;

--- a/packages/core/src/webview/shared/runConclusionLabels.ts
+++ b/packages/core/src/webview/shared/runConclusionLabels.ts
@@ -26,3 +26,12 @@ export function toRunCompletionLabel(conclusion?: RunConclusion): string {
   }
   return toConclusionLabel(conclusion);
 }
+
+export function isFailedConclusion(conclusion?: RunConclusion): boolean {
+  return conclusion !== undefined
+    && conclusion !== 'success'
+    && conclusion !== 'cancelled'
+    && conclusion !== 'skipped'
+    && conclusion !== 'neutral'
+    && conclusion !== 'partial_success';
+}

--- a/packages/core/src/webview/shared/runConclusionLabels.ts
+++ b/packages/core/src/webview/shared/runConclusionLabels.ts
@@ -27,7 +27,7 @@ export function toRunCompletionLabel(conclusion?: RunConclusion): string {
   return toConclusionLabel(conclusion);
 }
 
-export function isFailedConclusion(conclusion?: RunConclusion): boolean {
+export function isFailedConclusion(conclusion?: string): boolean {
   return conclusion !== undefined
     && conclusion !== 'success'
     && conclusion !== 'cancelled'

--- a/packages/core/src/webview/shared/runConclusionLabels.ts
+++ b/packages/core/src/webview/shared/runConclusionLabels.ts
@@ -1,0 +1,28 @@
+import type { RunConclusion } from '@devdocket/shared';
+
+export function toConclusionLabel(conclusion?: string): string {
+  if (!conclusion) {
+    return 'Completed';
+  }
+  if (conclusion === 'partial_success') {
+    return 'Succeeded with issues';
+  }
+  const label = conclusion.replace(/_/g, ' ');
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+export function toRunCompletionLabel(conclusion?: RunConclusion): string {
+  if (!conclusion) {
+    return 'completed';
+  }
+  if (conclusion === 'success') {
+    return 'succeeded';
+  }
+  if (conclusion === 'partial_success') {
+    return 'succeeded with issues';
+  }
+  if (conclusion === 'failure') {
+    return 'failed';
+  }
+  return toConclusionLabel(conclusion);
+}

--- a/packages/core/src/webview/shared/runConclusionLabels.ts
+++ b/packages/core/src/webview/shared/runConclusionLabels.ts
@@ -27,11 +27,8 @@ export function toRunCompletionLabel(conclusion?: RunConclusion): string {
   return toConclusionLabel(conclusion);
 }
 
+const failedConclusions = new Set(['failure', 'timed_out', 'action_required']);
+
 export function isFailedConclusion(conclusion?: string): boolean {
-  return conclusion !== undefined
-    && conclusion !== 'success'
-    && conclusion !== 'cancelled'
-    && conclusion !== 'skipped'
-    && conclusion !== 'neutral'
-    && conclusion !== 'partial_success';
+  return conclusion !== undefined && failedConclusions.has(conclusion);
 }

--- a/packages/core/src/webview/watchPanel/WatchApp.tsx
+++ b/packages/core/src/webview/watchPanel/WatchApp.tsx
@@ -380,10 +380,10 @@ function getRunBadge(runWatch: RunWatchData): BadgeData {
   if (runWatch.conclusion === 'partial_success') {
     return { label: 'Succeeded with issues', type: 'ci', variant: 'ci-warn' };
   }
-  if (runWatch.conclusion === 'cancelled' || runWatch.conclusion === 'skipped' || runWatch.conclusion === 'neutral') {
-    return { label: toConclusionLabel(runWatch.conclusion), type: 'ci', variant: 'neutral' };
+  if (isFailedConclusion(runWatch.conclusion)) {
+    return { label: toConclusionLabel(runWatch.conclusion), type: 'ci', variant: 'ci-fail' };
   }
-  return { label: toConclusionLabel(runWatch.conclusion), type: 'ci', variant: 'ci-fail' };
+  return { label: toConclusionLabel(runWatch.conclusion), type: 'ci', variant: 'neutral' };
 }
 
 interface RunSummary {

--- a/packages/core/src/webview/watchPanel/WatchApp.tsx
+++ b/packages/core/src/webview/watchPanel/WatchApp.tsx
@@ -373,6 +373,9 @@ function getRunBadge(runWatch: RunWatchData): BadgeData {
   if (runWatch.conclusion === 'success') {
     return { label: 'Passed', type: 'ci', variant: 'ci-pass' };
   }
+  if (runWatch.conclusion === 'partial_success') {
+    return { label: 'Succeeded with issues', type: 'ci', variant: 'ci-warn' };
+  }
   return { label: toConclusionLabel(runWatch.conclusion), type: 'ci', variant: 'ci-fail' };
 }
 
@@ -440,6 +443,9 @@ function getRunTierClass(runWatch: RunWatchData): string {
   if (runWatch.conclusion === 'success') {
     return 'in-progress';
   }
+  if (runWatch.conclusion === 'partial_success') {
+    return 'paused';
+  }
   if (runWatch.conclusion === 'cancelled' || runWatch.conclusion === 'skipped' || runWatch.conclusion === 'neutral') {
     return 'done';
   }
@@ -450,10 +456,10 @@ function isFailedRun(runWatch: RunWatchData): boolean {
   if (runWatch.state !== 'completed') return false;
   const conclusion = runWatch.conclusion;
   if (conclusion === undefined || conclusion === 'success') return false;
-  // cancelled / skipped / neutral are explicit non-results, not failures.
+  // cancelled / skipped / neutral / partial success are explicit non-failures.
   // Mirrors the canonical definition in mainViewProvider.ts so the watch
   // panel webview and the sidebar agree on what counts as a failed run.
-  if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral') return false;
+  if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral' || conclusion === 'partial_success') return false;
   return true;
 }
 
@@ -461,5 +467,9 @@ function toConclusionLabel(conclusion?: string): string {
   if (!conclusion) {
     return 'Completed';
   }
-  return conclusion.replace(/_/g, ' ');
+  if (conclusion === 'partial_success') {
+    return 'Succeeded with issues';
+  }
+  const label = conclusion.replace(/_/g, ' ');
+  return label.charAt(0).toUpperCase() + label.slice(1);
 }

--- a/packages/core/src/webview/watchPanel/WatchApp.tsx
+++ b/packages/core/src/webview/watchPanel/WatchApp.tsx
@@ -376,6 +376,9 @@ function getRunBadge(runWatch: RunWatchData): BadgeData {
   if (runWatch.conclusion === 'partial_success') {
     return { label: 'Succeeded with issues', type: 'ci', variant: 'ci-warn' };
   }
+  if (runWatch.conclusion === 'cancelled' || runWatch.conclusion === 'skipped' || runWatch.conclusion === 'neutral') {
+    return { label: toConclusionLabel(runWatch.conclusion), type: 'ci', variant: 'neutral' };
+  }
   return { label: toConclusionLabel(runWatch.conclusion), type: 'ci', variant: 'ci-fail' };
 }
 

--- a/packages/core/src/webview/watchPanel/WatchApp.tsx
+++ b/packages/core/src/webview/watchPanel/WatchApp.tsx
@@ -456,16 +456,10 @@ function getRunTierClass(runWatch: RunWatchData): string {
   if (runWatch.conclusion === 'success') {
     return 'in-progress';
   }
-  if (runWatch.conclusion === undefined) {
-    return 'done';
-  }
   if (runWatch.conclusion === 'partial_success') {
     return 'paused';
   }
-  if (runWatch.conclusion === 'cancelled' || runWatch.conclusion === 'skipped' || runWatch.conclusion === 'neutral') {
-    return 'done';
-  }
-  return 'urgent';
+  return isFailedConclusion(runWatch.conclusion) ? 'urgent' : 'done';
 }
 
 function isFailedRun(runWatch: RunWatchData): boolean {

--- a/packages/core/src/webview/watchPanel/WatchApp.tsx
+++ b/packages/core/src/webview/watchPanel/WatchApp.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'preact/hooks';
 import type { BadgeData, ExtensionMessage, PRWatchData, RunWatchData } from '../shared/types';
 import { postMessage, setWebviewState } from '../shared/messaging';
 import { BadgePill } from '../shared/components/BadgePill';
-import { toConclusionLabel } from '../shared/runConclusionLabels';
+import { isFailedConclusion, toConclusionLabel } from '../shared/runConclusionLabels';
 import { useThemeChangeCounter } from '../shared/theme';
 
 export function WatchApp() {
@@ -470,12 +470,8 @@ function getRunTierClass(runWatch: RunWatchData): string {
 
 function isFailedRun(runWatch: RunWatchData): boolean {
   if (runWatch.state !== 'completed') return false;
-  const conclusion = runWatch.conclusion;
-  if (conclusion === undefined || conclusion === 'success') return false;
-  // cancelled / skipped / neutral / partial success are explicit non-failures.
   // Mirrors the canonical definition in mainViewProvider.ts so the watch
   // panel webview and the sidebar agree on what counts as a failed run.
-  if (conclusion === 'cancelled' || conclusion === 'skipped' || conclusion === 'neutral' || conclusion === 'partial_success') return false;
-  return true;
+  return isFailedConclusion(runWatch.conclusion);
 }
 

--- a/packages/core/src/webview/watchPanel/WatchApp.tsx
+++ b/packages/core/src/webview/watchPanel/WatchApp.tsx
@@ -470,8 +470,7 @@ function getRunTierClass(runWatch: RunWatchData): string {
 
 function isFailedRun(runWatch: RunWatchData): boolean {
   if (runWatch.state !== 'completed') return false;
-  // Mirrors the canonical definition in mainViewProvider.ts so the watch
-  // panel webview and the sidebar agree on what counts as a failed run.
+  // Delegate to the shared helper so all CI watch surfaces agree on what counts as a failed run.
   return isFailedConclusion(runWatch.conclusion);
 }
 

--- a/packages/core/src/webview/watchPanel/WatchApp.tsx
+++ b/packages/core/src/webview/watchPanel/WatchApp.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'preact/hooks';
 import type { BadgeData, ExtensionMessage, PRWatchData, RunWatchData } from '../shared/types';
 import { postMessage, setWebviewState } from '../shared/messaging';
 import { BadgePill } from '../shared/components/BadgePill';
+import { toConclusionLabel } from '../shared/runConclusionLabels';
 import { useThemeChangeCounter } from '../shared/theme';
 
 export function WatchApp() {
@@ -370,6 +371,9 @@ function getRunBadge(runWatch: RunWatchData): BadgeData {
   if (runWatch.state !== 'completed') {
     return { label: runWatch.state === 'queued' ? 'Queued' : 'Running', type: 'ci', variant: 'ci-running' };
   }
+  if (runWatch.conclusion === undefined) {
+    return { label: toConclusionLabel(runWatch.conclusion), type: 'ci', variant: 'neutral' };
+  }
   if (runWatch.conclusion === 'success') {
     return { label: 'Passed', type: 'ci', variant: 'ci-pass' };
   }
@@ -452,6 +456,9 @@ function getRunTierClass(runWatch: RunWatchData): string {
   if (runWatch.conclusion === 'success') {
     return 'in-progress';
   }
+  if (runWatch.conclusion === undefined) {
+    return 'done';
+  }
   if (runWatch.conclusion === 'partial_success') {
     return 'paused';
   }
@@ -472,13 +479,3 @@ function isFailedRun(runWatch: RunWatchData): boolean {
   return true;
 }
 
-function toConclusionLabel(conclusion?: string): string {
-  if (!conclusion) {
-    return 'Completed';
-  }
-  if (conclusion === 'partial_success') {
-    return 'Succeeded with issues';
-  }
-  const label = conclusion.replace(/_/g, ' ');
-  return label.charAt(0).toUpperCase() + label.slice(1);
-}

--- a/packages/core/src/webview/watchPanel/WatchApp.tsx
+++ b/packages/core/src/webview/watchPanel/WatchApp.tsx
@@ -384,6 +384,7 @@ function getRunBadge(runWatch: RunWatchData): BadgeData {
 
 interface RunSummary {
   passed: number;
+  partialSuccess: number;
   failed: number;
   running: number;
   other: number;
@@ -401,12 +402,14 @@ function summarizeRuns(runs: RunWatchData[]): RunSummary {
       summary.running += 1;
     } else if (run.conclusion === 'success') {
       summary.passed += 1;
+    } else if (run.conclusion === 'partial_success') {
+      summary.partialSuccess += 1;
     } else {
       summary.other += 1;
     }
     summary.total += 1;
     return summary;
-  }, { passed: 0, failed: 0, running: 0, other: 0, total: 0 });
+  }, { passed: 0, partialSuccess: 0, failed: 0, running: 0, other: 0, total: 0 });
 }
 
 function formatRunSummary(summary: RunSummary): string {
@@ -415,6 +418,9 @@ function formatRunSummary(summary: RunSummary): string {
     `✗ ${summary.failed} failed`,
     `⏳ ${summary.running} running`,
   ];
+  if (summary.partialSuccess > 0) {
+    parts.push(`⚠ ${summary.partialSuccess} succeeded with issues`);
+  }
   if (summary.other > 0) {
     parts.push(`• ${summary.other} other`);
   }

--- a/packages/shared/src/runWatcher.ts
+++ b/packages/shared/src/runWatcher.ts
@@ -6,7 +6,7 @@ export type RunState = 'queued' | 'running' | 'completed';
 /**
  * Conclusion of a pipeline run or job (only meaningful when state is 'completed').
  */
-export type RunConclusion = 'success' | 'failure' | 'cancelled' | 'skipped' | 'timed_out' | 'action_required' | 'neutral';
+export type RunConclusion = 'success' | 'failure' | 'cancelled' | 'skipped' | 'timed_out' | 'action_required' | 'neutral' | 'partial_success';
 
 /**
  * Minimal cancellation token interface compatible with vscode.CancellationToken.


### PR DESCRIPTION
Closes #570

## Summary
- Adds the `partial_success` `RunConclusion` value and maps Azure DevOps `partiallySucceeded` builds to it.
- Renders partial-success runs as amber "Succeeded with issues" cards in CI Watches and excludes them from failed-run totals, PR auto-expand, and failure acknowledgement.
- Title-cases conclusion labels and documents the Passed / Succeeded with issues / Failed run states.

## Testing
- `npm run build`
- `npm run test`

## Migration Notes
`RunConclusion` now includes a new `partial_success` member. Consumers that exhaustively switch on `RunConclusion`, for example `switch (conclusion) { case 'success': ... case 'failure': ... }`, must extend their switches to handle `partial_success`. When extending, prefer treating unknown future conclusion values as `neutral` (no decision) rather than as failures. All first-party consumers in this monorepo are updated in this PR.
