### PR TITLE
Show work item authors in DevDocket

### DIFF
--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -171,6 +171,17 @@ interface ResolvedItem {
 Each discovered item must have a unique `externalId` within the provider:
 
 ```ts
+interface ProviderItemAuthor {
+  /** Display name preferred for UI, e.g. "Octocat" or "Jane Doe". */
+  displayName: string;
+  /** Optional stable handle, e.g. GitHub login or ADO uniqueName. */
+  handle?: string;
+  /** Optional avatar URL for future richer rendering. */
+  avatarUrl?: string;
+  /** Optional URL to the author's source-system profile. */
+  profileUrl?: string;
+}
+
 interface ProviderItem {
   /**
    * Unique identifier for this item within the provider.
@@ -199,6 +210,14 @@ interface ProviderItem {
    * setting and a per-refresh cap).
    */
   authored?: boolean;
+
+  /**
+   * Optional metadata about who created the underlying item upstream.
+   * Independent of `authored`, which is only a self-reference flag.
+   * When present, DevDocket shows the author's display name or handle in
+   * the sidebar annotation and editor Details section.
+   */
+  author?: ProviderItemAuthor;
 
   /**
    * Optional notification reason explaining why this item was surfaced

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -215,7 +215,7 @@ interface ProviderItem {
    * Optional metadata about who created the underlying item upstream.
    * Independent of `authored`, which is only a self-reference flag.
    * When present, DevDocket shows the author's display name or handle in
-   * the sidebar annotation and editor Details section.
+   * the sidebar card annotation and editor header annotation.
    */
   author?: ProviderItemAuthor;
 

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -50,7 +50,7 @@ The drag handle (left side of the card) appears on hover for tiers that support 
 Each card shows:
 
 - **Title** (with a blue dot prefix for unread Incoming items)
-- **Repo annotation** (diminished text below the title) — typically `owner/repo` for provider items
+- **Repo annotation** (diminished text below the title) — typically `owner/repo` for provider items. When the provider supplies author metadata, the same annotation adds the author inline (for example, `owner/repo · @octocat`), except for items marked as authored by you.
 - **Badges** — Provider (GitHub / ADO / Manual), Type (Issue / PR), provider-declared badges (e.g. `Mentioned`, `Review requested`, `Approved`), and CI badges (`CI passed` / `CI failed`) when a watcher is active for the item
 
 ### Sources tab
@@ -66,6 +66,7 @@ A browsable library of everything providers know about, organized as **Provider 
 Clicking a non-incoming work item opens the editor in a tab. It contains:
 
 - A **header** with the item title (clickable for provider items — opens the source URL), inline copy-title and copy-URL buttons, the **state-dependent transition buttons** offered by the editor (Start / Pause / Resume / Complete / Requeue / Archive — only the ones valid for the current state are shown), the **Run Action…** button when at least one registered action declares `canRun(item) === true`, and badges for provider, type, and provider-supplied state.
+- A **Details** section when editable details or provider author metadata are available. Provider authors are shown as read-only plain text with the display name first and `@handle` as secondary text when present.
 - A **Description** section (markdown-rendered) for provider items, when one is present.
 - A **Notes** section (auto-saving textarea) for your own notes — hidden when previewing an unaccepted incoming item.
 - A collapsible **Activity Log** that records every state transition, action invocation, version change, etc.

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -65,8 +65,7 @@ A browsable library of everything providers know about, organized as **Provider 
 
 Clicking a non-incoming work item opens the editor in a tab. It contains:
 
-- A **header** with the item title (clickable for provider items — opens the source URL), inline copy-title and copy-URL buttons, the **state-dependent transition buttons** offered by the editor (Start / Pause / Resume / Complete / Requeue / Archive — only the ones valid for the current state are shown), the **Run Action…** button when at least one registered action declares `canRun(item) === true`, and badges for provider, type, and provider-supplied state.
-- A **Details** section for editable manual-item fields. Provider item authors appear inline in the header's repo annotation instead (for example, `owner/repo · @octocat`), matching the sidebar card presentation.
+- A **header** with the item title, inline copy-title and copy-URL buttons, repo/author annotation (for example, `owner/repo · @octocat`, except for items authored by you), the **state-dependent transition buttons** offered by the editor (Start / Pause / Resume / Complete / Requeue / Archive — only the ones valid for the current state are shown), the **Run Action…** button when at least one registered action declares `canRun(item) === true`, and badges for provider, type, and provider-supplied state. When an item has a safe URL, provider-managed item titles link to that source; manual items keep editable title and URL controls in the header.
 - A **Description** section (markdown-rendered) for provider items, when one is present.
 - A **Notes** section (auto-saving textarea) for your own notes — hidden when previewing an unaccepted incoming item.
 - A collapsible **Activity Log** that records every state transition, action invocation, version change, etc.

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -66,7 +66,7 @@ A browsable library of everything providers know about, organized as **Provider 
 Clicking a non-incoming work item opens the editor in a tab. It contains:
 
 - A **header** with the item title (clickable for provider items — opens the source URL), inline copy-title and copy-URL buttons, the **state-dependent transition buttons** offered by the editor (Start / Pause / Resume / Complete / Requeue / Archive — only the ones valid for the current state are shown), the **Run Action…** button when at least one registered action declares `canRun(item) === true`, and badges for provider, type, and provider-supplied state.
-- A **Details** section when editable details or provider author metadata are available. Provider authors are shown as read-only plain text with the display name first and `@handle` as secondary text when present.
+- A **Details** section for editable manual-item fields. Provider item authors appear inline in the header's repo annotation instead (for example, `owner/repo · @octocat`), matching the sidebar card presentation.
 - A **Description** section (markdown-rendered) for provider items, when one is present.
 - A **Notes** section (auto-saving textarea) for your own notes — hidden when previewing an unaccepted incoming item.
 - A collapsible **Activity Log** that records every state transition, action invocation, version change, etc.

--- a/packages/ado/src/adoMyPrsProvider.ts
+++ b/packages/ado/src/adoMyPrsProvider.ts
@@ -18,11 +18,12 @@ export class AdoMyPrsProvider extends BaseAdoPrProvider {
   protected override mapPrToItem(pr: AdoPullRequest, org: string): ProviderItem {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { resurfaceVersion: _resurfaceVersion, ...item } = super.mapPrToItem(pr, org);
+    const authoredItem = { ...item, authored: true };
     if (pr.isDraft) {
       const badge = buildAdoMyPrsStateBadge('Draft');
-      return { ...item, state: 'Draft', ...(badge ? { badges: [badge] } : {}) };
+      return { ...authoredItem, state: 'Draft', ...(badge ? { badges: [badge] } : {}) };
     }
-    return item;
+    return authoredItem;
   }
 
   protected override async postProcessItems(items: ProviderItem[], token: string, signal?: AbortSignal): Promise<void> {

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -18,6 +18,10 @@ interface AdoWorkItem {
     'System.TeamProject': string;
     'System.WorkItemType': string;
     'System.State': string;
+    'System.CreatedBy'?: {
+      displayName?: string;
+      uniqueName?: string;
+    };
   };
   _links: {
     html: { href: string };
@@ -309,6 +313,12 @@ export class AdoWorkItemProvider extends BaseProvider {
         title: `${wiType} ${wi.id}: ${wi.fields['System.Title']}`,
         description: wi.fields['System.Description']?.replace(/<[^>]*(>|$)/g, '') ?? undefined,
         url: wi._links.html.href,
+        ...(wi.fields['System.CreatedBy']?.displayName ? {
+          author: {
+            displayName: wi.fields['System.CreatedBy'].displayName,
+            handle: wi.fields['System.CreatedBy'].uniqueName,
+          },
+        } : {}),
         group: `${org}/${projectName}`,
         reason: 'assigned',
         state,

--- a/packages/ado/src/baseAdoPrProvider.ts
+++ b/packages/ado/src/baseAdoPrProvider.ts
@@ -25,6 +25,10 @@ export interface AdoPullRequest {
     id?: string;
     vote?: number;
   }>;
+  createdBy?: {
+    displayName?: string;
+    uniqueName?: string;
+  };
   repository: {
     name: string;
     project: { name: string };
@@ -391,6 +395,12 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
       title: `PR ${pr.pullRequestId}: ${pr.title}`,
       description: pr.description ?? undefined,
       url: `${repoUrl}/pullrequest/${pr.pullRequestId}`,
+      ...(pr.createdBy?.displayName ? {
+        author: {
+          displayName: pr.createdBy.displayName,
+          handle: pr.createdBy.uniqueName,
+        },
+      } : {}),
       group: `${projectName}/${repoName}`,
       itemType: 'pr',
       capabilities: { gitWork: this.createPrGitWork(pr, org) },

--- a/packages/ado/src/test/adoMyPrsProvider.test.ts
+++ b/packages/ado/src/test/adoMyPrsProvider.test.ts
@@ -114,7 +114,11 @@ describe('AdoMyPrsProvider', () => {
       .mockResolvedValueOnce(mockConnectionData('author-123'))
       .mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ value: [createMockPr(101, 'Fix bug')] }),
+        json: async () => ({
+          value: [createMockPr(101, 'Fix bug', 'MyProject', 'myrepo', {
+            createdBy: { displayName: 'Jane Doe', uniqueName: 'jane@example.com' },
+          })],
+        }),
       })
       .mockResolvedValueOnce({
         ok: true,
@@ -135,6 +139,11 @@ describe('AdoMyPrsProvider', () => {
       title: 'PR 101: Fix bug',
       description: 'Description for PR 101',
       url: 'https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/101',
+      author: {
+        displayName: 'Jane Doe',
+        handle: 'jane@example.com',
+      },
+      authored: true,
       group: 'MyProject/myrepo',
       reason: 'You authored this PR',
       state: 'Waiting on reviews',

--- a/packages/ado/src/test/adoPrReviewProvider.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.test.ts
@@ -4,7 +4,7 @@ import { AdoPrReviewProvider } from '../adoPrReviewProvider';
 
 const mockFetch = vi.fn();
 
-function createMockPr(id: number, title: string, project = 'MyProject', repo = 'myrepo') {
+function createMockPr(id: number, title: string, project = 'MyProject', repo = 'myrepo', extra: Record<string, unknown> = {}) {
   return {
     pullRequestId: id,
     title,
@@ -14,6 +14,7 @@ function createMockPr(id: number, title: string, project = 'MyProject', repo = '
       project: { name: project },
       webUrl: `https://dev.azure.com/myorg/${project}/_git/${repo}`,
     },
+    ...extra,
   };
 }
 
@@ -141,7 +142,9 @@ describe('AdoPrReviewProvider', () => {
       .mockResolvedValueOnce({
         ok: true,
         json: async () => ({
-          value: [createMockPr(101, 'Fix bug')],
+          value: [createMockPr(101, 'Fix bug', 'MyProject', 'myrepo', {
+            createdBy: { displayName: 'Jane Doe', uniqueName: 'jane@example.com' },
+          })],
         }),
       })
       .mockResolvedValueOnce(mockGraphDescriptor())
@@ -181,6 +184,10 @@ describe('AdoPrReviewProvider', () => {
       title: 'PR 101: Fix bug',
       description: 'Description for PR 101',
       url: 'https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/101',
+      author: {
+        displayName: 'Jane Doe',
+        handle: 'jane@example.com',
+      },
       group: 'MyProject/myrepo',
       reason: 'review_requested',
       itemType: 'pr',

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -132,6 +132,35 @@ describe('AdoWorkItemProvider', () => {
     });
   });
 
+  it('populates author from ADO System.CreatedBy', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => createWiqlResponse([1]) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          value: [{
+            ...createWorkItemDetail(1, 'Fix login bug'),
+            fields: {
+              ...createWorkItemDetail(1, 'Fix login bug').fields,
+              'System.CreatedBy': {
+                displayName: 'Jane Doe',
+                uniqueName: 'jane@example.com',
+              },
+            },
+          }],
+        }),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener.mock.calls[0][0][0].author).toEqual({
+      displayName: 'Jane Doe',
+      handle: 'jane@example.com',
+    });
+  });
+
   it('populates gitWork when a work item has an associated Git repo relation', async () => {
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: async () => createWiqlResponse([1]) })

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -1,5 +1,5 @@
 // Canonical type declarations live in @devdocket/shared; re-export for
 // existing intra-core imports (e.g. `from '../api/types'`).
-export type { Disposable, Event, ProviderItem, ProviderItemCapabilities, GitWorkInfo, ProviderBadge, RelatedItemRef, ResolvedItem, DevDocketRunWatcher, DevDocketPRWatcher } from '@devdocket/shared';
+export type { Disposable, Event, ProviderItem, ProviderItemAuthor, ProviderItemCapabilities, GitWorkInfo, ProviderBadge, RelatedItemRef, ResolvedItem, DevDocketRunWatcher, DevDocketPRWatcher } from '@devdocket/shared';
 export type { ActivityLogEntry, ActivityType } from '@devdocket/shared';
 export type { StateTransitionEvent, DevDocketProvider, DevDocketAction, DevDocketApi } from '@devdocket/shared';

--- a/packages/core/src/test/authorRendering.test.ts
+++ b/packages/core/src/test/authorRendering.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment jsdom
+import { h, render } from 'preact';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ProviderItem } from '../api/types';
+import { WorkItemState, type WorkItem } from '../models/workItem';
+import { MainViewProvider } from '../views/mainViewProvider';
+import type { EditorItemData, ItemCardData } from '../views/mainTypes';
+import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
+import { ItemCard } from '../webview/sidebar/components/ItemCard';
+
+declare global {
+  interface Window {
+    __DEVDOCKET_EDITOR_BOOTSTRAP__?: EditorItemData;
+  }
+}
+
+const badge = { label: 'GitHub', type: 'provider' as const, variant: 'github' };
+
+function makeCardItem(overrides: Partial<ItemCardData> = {}): ItemCardData {
+  return {
+    id: 'item-1',
+    title: 'Fix bug',
+    badges: [badge],
+    repoAnnotation: 'owner/repo',
+    tierType: 'incoming',
+    ...overrides,
+  };
+}
+
+function makeEditorItem(overrides: Partial<EditorItemData> = {}): EditorItemData {
+  const now = Date.now();
+  return {
+    id: 'item-1',
+    title: 'Fix bug',
+    state: 'New',
+    notes: '',
+    createdAt: now,
+    updatedAt: now,
+    badges: [],
+    isProviderManaged: true,
+    validTransitions: [],
+    hasActions: false,
+    activityLog: [],
+    relatedItems: [],
+    ...overrides,
+  };
+}
+
+function renderCard(item: ItemCardData): HTMLDivElement {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  render(h(ItemCard, { item, tabIndex: 0, onClick: vi.fn() }), container);
+  return container;
+}
+
+function createMainViewProvider(): MainViewProvider {
+  return new MainViewProvider(
+    {} as any,
+    {} as any,
+    { getProviderLabel: () => 'GitHub' } as any,
+    {} as any,
+    { has: () => false } as any,
+    { getActiveWatches: () => [], getActivePRWatches: () => [] } as any,
+    {} as any,
+  );
+}
+
+afterEach(() => {
+  render(null, document.body);
+  document.body.innerHTML = '';
+  delete window.__DEVDOCKET_EDITOR_BOOTSTRAP__;
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe('author view-model plumbing', () => {
+  it('copies provider author onto incoming card data', () => {
+    const provider = createMainViewProvider();
+    const providerItem: ProviderItem = {
+      externalId: 'owner/repo#1',
+      title: '#1: Fix bug',
+      group: 'owner/repo',
+      author: { displayName: 'Octocat', handle: 'octocat', avatarUrl: 'https://example.test/avatar.png' },
+    };
+
+    const card = (provider as any).buildIncomingCardData('github', providerItem, new Map()) as ItemCardData;
+
+    expect(card.author).toEqual({ displayName: 'Octocat', handle: 'octocat' });
+  });
+
+  it('copies provider author onto editor data for linked work items', () => {
+    const providerItem: ProviderItem = {
+      externalId: 'owner/repo#1',
+      title: '#1: Fix bug',
+      author: { displayName: 'Octocat', handle: 'octocat' },
+    };
+    const panel = Object.create(WorkItemEditorPanel.prototype) as any;
+    panel.getProviderItem = () => providerItem;
+    panel.providerRegistry = { getProviderLabel: () => 'GitHub', getProvider: () => ({}), getAllProviderItems: () => new Map() };
+    panel.actionRegistry = { hasActionsFor: () => false };
+    panel.workGraph = {};
+    panel.buildCIWatchData = () => undefined;
+
+    const workItem: WorkItem = {
+      id: 'item-1',
+      title: 'Fix bug',
+      state: WorkItemState.New,
+      createdAt: 1,
+      updatedAt: 2,
+      providerId: 'github',
+      externalId: 'owner/repo#1',
+      activityLog: [],
+    };
+
+    const editorItem = panel.buildEditorItemData(workItem, new Map()) as EditorItemData;
+
+    expect(editorItem.author).toEqual({ displayName: 'Octocat', handle: 'octocat' });
+  });
+});
+
+describe('ItemCard author annotation', () => {
+  it('renders author inline with the repo annotation', () => {
+    const container = renderCard(makeCardItem({ author: { displayName: 'Octocat', handle: 'octocat' } }));
+
+    expect(container.querySelector('.item-repo-annotation')?.textContent).toBe('owner/repo · @octocat');
+  });
+
+  it('renders unchanged when author is missing', () => {
+    const container = renderCard(makeCardItem());
+
+    expect(container.querySelector('.item-repo-annotation')?.textContent).toBe('owner/repo');
+  });
+
+  it('suppresses the author annotation for self-authored items', () => {
+    const container = renderCard(makeCardItem({ author: { displayName: 'Octocat', handle: 'octocat' }, authored: true }));
+
+    expect(container.querySelector('.item-repo-annotation')?.textContent).toBe('owner/repo');
+  });
+});
+
+describe('EditorApp author details', () => {
+  async function renderEditor(item: EditorItemData): Promise<HTMLDivElement> {
+    vi.stubGlobal('acquireVsCodeApi', () => ({
+      postMessage: vi.fn(),
+      getState: vi.fn(),
+      setState: vi.fn(),
+    }));
+    window.__DEVDOCKET_EDITOR_BOOTSTRAP__ = item;
+    const { EditorApp } = await import('../webview/editor/EditorApp');
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    render(h(EditorApp, {}), container);
+    return container;
+  }
+
+  it('renders a read-only Author row when author is present', async () => {
+    const container = await renderEditor(makeEditorItem({ author: { displayName: 'Octocat', handle: 'octocat' } }));
+
+    expect(container.textContent).toContain('Author');
+    expect(container.querySelector('.editor-readonly-value')?.textContent).toContain('Octocat');
+    expect(container.querySelector('.editor-readonly-value')?.textContent).toContain('@octocat');
+    expect(container.querySelector('a[href="https://github.com/octocat"]')).toBeNull();
+  });
+
+  it('omits the Author row when author is missing', async () => {
+    const container = await renderEditor(makeEditorItem());
+
+    expect(container.textContent).not.toContain('Author');
+  });
+});

--- a/packages/core/src/test/authorRendering.test.ts
+++ b/packages/core/src/test/authorRendering.test.ts
@@ -182,4 +182,17 @@ describe('EditorApp author annotation', () => {
     expect(container.querySelector('.editor-repo-annotation')?.textContent).toBe('owner/repo');
     expect(container.textContent).not.toContain('@octocat');
   });
+
+  it('does not render a Details section for manual items', async () => {
+    const container = await renderEditor(makeEditorItem({
+      isProviderManaged: false,
+      url: 'https://example.com/work/1',
+    }));
+
+    expect(container.querySelector('#editor-details-heading')).toBeNull();
+    expect(container.textContent).not.toContain('Details');
+    expect(container.querySelector<HTMLInputElement>('input.editor-title-input')?.value).toBe('Fix bug');
+    expect(container.querySelector<HTMLInputElement>('input.editor-url-input')?.value).toBe('https://example.com/work/1');
+    expect(container.querySelector('a.editor-url-link')?.getAttribute('href')).toBe('https://example.com/work/1');
+  });
 });

--- a/packages/core/src/test/authorRendering.test.ts
+++ b/packages/core/src/test/authorRendering.test.ts
@@ -194,5 +194,7 @@ describe('EditorApp author annotation', () => {
     expect(container.querySelector<HTMLInputElement>('input.editor-title-input')?.value).toBe('Fix bug');
     expect(container.querySelector<HTMLInputElement>('input.editor-url-input')?.value).toBe('https://example.com/work/1');
     expect(container.querySelector('a.editor-url-link')?.getAttribute('href')).toBe('https://example.com/work/1');
+    expect(container.querySelector('h1.editor-title input')).toBeNull();
+    expect(container.querySelector('h1.editor-title')?.textContent).toBe('Fix bug');
   });
 });

--- a/packages/core/src/test/authorRendering.test.ts
+++ b/packages/core/src/test/authorRendering.test.ts
@@ -92,6 +92,7 @@ describe('author view-model plumbing', () => {
     const providerItem: ProviderItem = {
       externalId: 'owner/repo#1',
       title: '#1: Fix bug',
+      authored: true,
       author: { displayName: 'Octocat', handle: 'octocat' },
     };
     const panel = Object.create(WorkItemEditorPanel.prototype) as any;
@@ -115,6 +116,7 @@ describe('author view-model plumbing', () => {
     const editorItem = panel.buildEditorItemData(workItem, new Map()) as EditorItemData;
 
     expect(editorItem.author).toEqual({ displayName: 'Octocat', handle: 'octocat' });
+    expect(editorItem.authored).toBe(true);
   });
 });
 
@@ -138,7 +140,7 @@ describe('ItemCard author annotation', () => {
   });
 });
 
-describe('EditorApp author details', () => {
+describe('EditorApp author annotation', () => {
   async function renderEditor(item: EditorItemData): Promise<HTMLDivElement> {
     vi.stubGlobal('acquireVsCodeApi', () => ({
       postMessage: vi.fn(),
@@ -153,18 +155,31 @@ describe('EditorApp author details', () => {
     return container;
   }
 
-  it('renders a read-only Author row when author is present', async () => {
-    const container = await renderEditor(makeEditorItem({ author: { displayName: 'Octocat', handle: 'octocat' } }));
+  it('renders author inline with the repo annotation', async () => {
+    const container = await renderEditor(makeEditorItem({
+      group: 'owner/repo',
+      author: { displayName: 'Octocat', handle: 'octocat' },
+    }));
 
-    expect(container.textContent).toContain('Author');
-    expect(container.querySelector('.editor-readonly-value')?.textContent).toContain('Octocat');
-    expect(container.querySelector('.editor-readonly-value')?.textContent).toContain('@octocat');
-    expect(container.querySelector('a[href="https://github.com/octocat"]')).toBeNull();
+    expect(container.querySelector('.editor-repo-annotation')?.textContent).toBe('owner/repo · @octocat');
+    expect(container.textContent).not.toContain('Author');
   });
 
-  it('omits the Author row when author is missing', async () => {
-    const container = await renderEditor(makeEditorItem());
+  it('renders unchanged when author is missing', async () => {
+    const container = await renderEditor(makeEditorItem({ group: 'owner/repo' }));
 
+    expect(container.querySelector('.editor-repo-annotation')?.textContent).toBe('owner/repo');
     expect(container.textContent).not.toContain('Author');
+  });
+
+  it('suppresses the author annotation for self-authored items', async () => {
+    const container = await renderEditor(makeEditorItem({
+      group: 'owner/repo',
+      author: { displayName: 'Octocat', handle: 'octocat' },
+      authored: true,
+    }));
+
+    expect(container.querySelector('.editor-repo-annotation')?.textContent).toBe('owner/repo');
+    expect(container.textContent).not.toContain('@octocat');
   });
 });

--- a/packages/core/src/test/authorRendering.test.ts
+++ b/packages/core/src/test/authorRendering.test.ts
@@ -133,6 +133,12 @@ describe('ItemCard author annotation', () => {
     expect(container.querySelector('.item-repo-annotation')?.textContent).toBe('owner/repo');
   });
 
+  it('prefers display name when the handle is an email address', () => {
+    const container = renderCard(makeCardItem({ author: { displayName: 'Jane Example', handle: 'jane@example.com' } }));
+
+    expect(container.querySelector('.item-repo-annotation')?.textContent).toBe('owner/repo · Jane Example');
+  });
+
   it('suppresses the author annotation for self-authored items', () => {
     const container = renderCard(makeCardItem({ author: { displayName: 'Octocat', handle: 'octocat' }, authored: true }));
 

--- a/packages/core/src/test/authorRendering.test.ts
+++ b/packages/core/src/test/authorRendering.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { h, render } from 'preact';
+import { act } from 'preact/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { ProviderItem } from '../api/types';
 import { WorkItemState, type WorkItem } from '../models/workItem';
@@ -69,7 +70,9 @@ afterEach(() => {
   render(null, document.body);
   document.body.innerHTML = '';
   delete window.__DEVDOCKET_EDITOR_BOOTSTRAP__;
+  delete (window as any).__DEVDOCKET_VSCODE_API__;
   vi.unstubAllGlobals();
+  vi.useRealTimers();
   vi.resetModules();
 });
 
@@ -147,9 +150,11 @@ describe('ItemCard author annotation', () => {
 });
 
 describe('EditorApp author annotation', () => {
-  async function renderEditor(item: EditorItemData): Promise<HTMLDivElement> {
+  async function renderEditorWithPostMessage(item: EditorItemData): Promise<{ container: HTMLDivElement; postMessage: ReturnType<typeof vi.fn> }> {
+    const postMessage = vi.fn();
+    delete (window as any).__DEVDOCKET_VSCODE_API__;
     vi.stubGlobal('acquireVsCodeApi', () => ({
-      postMessage: vi.fn(),
+      postMessage,
       getState: vi.fn(),
       setState: vi.fn(),
     }));
@@ -158,7 +163,11 @@ describe('EditorApp author annotation', () => {
     const container = document.createElement('div');
     document.body.appendChild(container);
     render(h(EditorApp, {}), container);
-    return container;
+    return { container, postMessage };
+  }
+
+  async function renderEditor(item: EditorItemData): Promise<HTMLDivElement> {
+    return (await renderEditorWithPostMessage(item)).container;
   }
 
   it('renders author inline with the repo annotation', async () => {
@@ -202,5 +211,30 @@ describe('EditorApp author annotation', () => {
     expect(container.querySelector('a.editor-url-link')?.getAttribute('href')).toBe('https://example.com/work/1');
     expect(container.querySelector('h1.editor-title input')).toBeNull();
     expect(container.querySelector('h1.editor-title')?.textContent).toBe('Fix bug');
+  });
+
+  it('autosaves manual notes while the title draft is empty', async () => {
+    vi.useFakeTimers();
+    const { container, postMessage } = await renderEditorWithPostMessage(makeEditorItem({
+      isProviderManaged: false,
+      notes: 'Existing note',
+    }));
+    const titleInput = container.querySelector<HTMLInputElement>('input.editor-title-input');
+    const notesInput = container.querySelector<HTMLTextAreaElement>('textarea.editor-textarea');
+
+    expect(titleInput).not.toBeNull();
+    expect(notesInput).not.toBeNull();
+
+    await act(async () => {
+      titleInput!.value = '';
+      titleInput!.dispatchEvent(new Event('input', { bubbles: true }));
+      notesInput!.value = 'Draft note';
+      notesInput!.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(postMessage).toHaveBeenLastCalledWith({ type: 'autosave', data: { notes: 'Draft note' } });
   });
 });

--- a/packages/core/src/test/filter.test.ts
+++ b/packages/core/src/test/filter.test.ts
@@ -102,6 +102,14 @@ describe('filterTiers', () => {
     expect(resultByHandle.tiers[0].items.map(item => item.id)).toEqual(['one']);
   });
 
+  it('does not match hidden author text for self-authored items', () => {
+    const result = filterTiers([tier({
+      items: [{ id: 'one', title: 'Fix bug', badges: [], tierType: 'readyToStart', author: { displayName: 'Octo Cat', handle: 'octocat' }, authored: true }],
+    })], '@octocat');
+
+    expect(result.tiers).toEqual([]);
+  });
+
   it('reports pre-filter total counts', () => {
     const result = filterTiers([tier({ id: 'ready' }), tier({ id: 'done', items: [] })], 'layout');
 

--- a/packages/core/src/test/filter.test.ts
+++ b/packages/core/src/test/filter.test.ts
@@ -90,6 +90,18 @@ describe('filterTiers', () => {
     expect(result.tiers[0].items.map(item => item.id)).toEqual(['two']);
   });
 
+  it('matches against author display name and rendered handle', () => {
+    const resultByName = filterTiers([tier({
+      items: [{ id: 'one', title: 'Fix bug', badges: [], tierType: 'readyToStart', author: { displayName: 'Octo Cat', handle: 'octocat' } }],
+    })], 'octo cat');
+    const resultByHandle = filterTiers([tier({
+      items: [{ id: 'one', title: 'Fix bug', badges: [], tierType: 'readyToStart', author: { displayName: 'Octo Cat', handle: 'octocat' } }],
+    })], '@octocat');
+
+    expect(resultByName.tiers[0].items.map(item => item.id)).toEqual(['one']);
+    expect(resultByHandle.tiers[0].items.map(item => item.id)).toEqual(['one']);
+  });
+
   it('reports pre-filter total counts', () => {
     const result = filterTiers([tier({ id: 'ready' }), tier({ id: 'done', items: [] })], 'layout');
 

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -574,6 +574,22 @@ describe('WorkItemEditorPanel', () => {
     });
   });
 
+  it('saves manual notes without requiring title or URL fields', async () => {
+    vi.useFakeTimers();
+    const item = makeItem({ title: 'Original' });
+    const workGraph = createMockWorkGraph(item);
+    const { mock } = openPanel(item, workGraph);
+
+    mock.simulateMessage({
+      type: 'autosave',
+      data: { notes: ' Draft note ' },
+    });
+
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(workGraph.updateItem).toHaveBeenCalledWith('item-1', { notes: 'Draft note' });
+  });
+
   it('only saves notes for provider-managed items', async () => {
     vi.useFakeTimers();
     const item = makeItem({ providerId: 'github', externalId: '42', title: 'Provider item' });

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -366,7 +366,6 @@ export function getEditorPanelHtml({ cspSource, scriptUri, initialItem }: Editor
       color: var(--vscode-disabledForeground, var(--vscode-foreground));
     }
 
-
     .editor-textarea {
       resize: none;
       line-height: 1.5;

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -150,6 +150,17 @@ export function getEditorPanelHtml({ cspSource, scriptUri, initialItem }: Editor
       word-break: break-word;
       display: inline;
     }
+    .editor-title--visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0 0 0 0);
+      white-space: nowrap;
+      border: 0;
+    }
     .editor-title-input {
       box-sizing: border-box;
       width: min(100%, 720px);

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -366,22 +366,6 @@ export function getEditorPanelHtml({ cspSource, scriptUri, initialItem }: Editor
       color: var(--vscode-disabledForeground, var(--vscode-foreground));
     }
 
-    .editor-readonly-value {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 6px;
-      align-items: baseline;
-      min-height: 38px;
-      padding: 9px 10px;
-      border-radius: 6px;
-      background: var(--vscode-editor-inactiveSelectionBackground, rgba(128, 128, 128, 0.12));
-      color: var(--vscode-foreground);
-    }
-
-    .editor-readonly-secondary {
-      color: var(--vscode-descriptionForeground);
-      font-size: 12px;
-    }
 
     .editor-textarea {
       resize: none;

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -150,6 +150,19 @@ export function getEditorPanelHtml({ cspSource, scriptUri, initialItem }: Editor
       word-break: break-word;
       display: inline;
     }
+    .editor-title-input {
+      box-sizing: border-box;
+      width: min(100%, 720px);
+      border: 1px solid var(--vscode-input-border, transparent);
+      border-radius: 6px;
+      background: var(--vscode-input-background);
+      color: var(--vscode-input-foreground);
+      font: inherit;
+      font-size: 22px;
+      font-weight: 700;
+      line-height: 1.2;
+      padding: 6px 8px;
+    }
     /*
      * When the heading wraps an anchor (item has a URL) the anchor
      * inherits the heading's font but takes its own link colors so it
@@ -175,6 +188,34 @@ export function getEditorPanelHtml({ cspSource, scriptUri, initialItem }: Editor
       opacity: 0.85;
       word-break: break-all;
       margin-top: 4px;
+    }
+    .editor-url-field {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      flex-wrap: wrap;
+      margin-top: 8px;
+      color: var(--vscode-descriptionForeground);
+    }
+    .editor-url-label {
+      font-size: 12px;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+    .editor-url-input {
+      flex: 1 1 260px;
+      max-width: 520px;
+      min-width: 180px;
+    }
+    .editor-url-link {
+      color: var(--vscode-textLink-foreground);
+      text-decoration: none;
+      white-space: nowrap;
+    }
+    .editor-url-link:hover {
+      color: var(--vscode-textLink-activeForeground, var(--vscode-textLink-foreground));
+      text-decoration: underline;
     }
     .icon-button--inline {
       width: 22px;
@@ -251,6 +292,7 @@ export function getEditorPanelHtml({ cspSource, scriptUri, initialItem }: Editor
 
     .icon-button:focus-visible,
     .editor-button:focus-visible,
+    .editor-title-input:focus-visible,
     .editor-input:focus-visible,
     .related-item:focus-visible {
       outline: 1px solid var(--vscode-focusBorder);

--- a/packages/core/src/views/editorPanelHtml.ts
+++ b/packages/core/src/views/editorPanelHtml.ts
@@ -366,6 +366,23 @@ export function getEditorPanelHtml({ cspSource, scriptUri, initialItem }: Editor
       color: var(--vscode-disabledForeground, var(--vscode-foreground));
     }
 
+    .editor-readonly-value {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      align-items: baseline;
+      min-height: 38px;
+      padding: 9px 10px;
+      border-radius: 6px;
+      background: var(--vscode-editor-inactiveSelectionBackground, rgba(128, 128, 128, 0.12));
+      color: var(--vscode-foreground);
+    }
+
+    .editor-readonly-secondary {
+      color: var(--vscode-descriptionForeground);
+      font-size: 12px;
+    }
+
     .editor-textarea {
       resize: none;
       line-height: 1.5;

--- a/packages/core/src/views/incomingPreviewPanel.ts
+++ b/packages/core/src/views/incomingPreviewPanel.ts
@@ -407,6 +407,7 @@ export class IncomingPreviewPanel {
       author: providerItem.author
         ? { displayName: providerItem.author.displayName, handle: providerItem.author.handle }
         : undefined,
+      authored: providerItem.authored,
       createdAt: Date.now(),
       updatedAt: Date.now(),
       badges: composeEditorBadges(this.providerId, providerItem, this.providerRegistry.getProviderLabel(this.providerId)),

--- a/packages/core/src/views/incomingPreviewPanel.ts
+++ b/packages/core/src/views/incomingPreviewPanel.ts
@@ -404,6 +404,9 @@ export class IncomingPreviewPanel {
       state: 'New',
       providerLabel,
       group: providerItem.group,
+      author: providerItem.author
+        ? { displayName: providerItem.author.displayName, handle: providerItem.author.handle }
+        : undefined,
       createdAt: Date.now(),
       updatedAt: Date.now(),
       badges: composeEditorBadges(this.providerId, providerItem, this.providerRegistry.getProviderLabel(this.providerId)),

--- a/packages/core/src/views/incomingPreviewPanel.ts
+++ b/packages/core/src/views/incomingPreviewPanel.ts
@@ -8,6 +8,7 @@ import { WorkGraph } from '../services/workGraph';
 import { InboxStateStore } from '../storage/inboxStateStore';
 import { ReadStateStore } from '../storage/readStateStore';
 import { isSafeUrl } from '../utils/url';
+import { toItemAuthorData } from './itemAuthorData';
 import { getProviderItemKey, parseProviderItemKey } from './providerItemKey';
 import { getEditorPanelHtml, renderMarkdown } from './editorPanelHtml';
 import type { EditorItemData } from './mainTypes';
@@ -404,9 +405,7 @@ export class IncomingPreviewPanel {
       state: 'New',
       providerLabel,
       group: providerItem.group,
-      author: providerItem.author
-        ? { displayName: providerItem.author.displayName, handle: providerItem.author.handle }
-        : undefined,
+      author: toItemAuthorData(providerItem),
       authored: providerItem.authored,
       createdAt: Date.now(),
       updatedAt: Date.now(),

--- a/packages/core/src/views/itemAuthorData.ts
+++ b/packages/core/src/views/itemAuthorData.ts
@@ -1,0 +1,8 @@
+import type { ProviderItem } from '../api/types';
+import type { ItemAuthorData } from './mainTypes';
+
+export function toItemAuthorData(providerItem: ProviderItem | undefined): ItemAuthorData | undefined {
+  return providerItem?.author
+    ? { displayName: providerItem.author.displayName, handle: providerItem.author.handle }
+    : undefined;
+}

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -47,12 +47,19 @@ export interface TierData {
   collapsed: boolean;
 }
 
+export interface ItemAuthorData {
+  displayName: string;
+  handle?: string;
+}
+
 export interface ItemCardData {
   id: string;
   title: string;
   badges: BadgeData[];
   /** Compact repo/source label rendered as a subtle annotation below the title (e.g. "owner/repo"). */
   repoAnnotation?: string;
+  author?: ItemAuthorData;
+  authored?: boolean;
   tierType: 'incoming' | 'inProgress' | 'readyToStart' | 'paused' | 'done';
   isUnseen?: boolean;
   isUrgent?: boolean;
@@ -90,6 +97,7 @@ export interface EditorItemData {
   state: string;
   providerLabel?: string;
   group?: string;
+  author?: ItemAuthorData;
   createdAt: number;
   updatedAt: number;
   badges: BadgeData[];

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -98,6 +98,7 @@ export interface EditorItemData {
   providerLabel?: string;
   group?: string;
   author?: ItemAuthorData;
+  authored?: boolean;
   createdAt: number;
   updatedAt: number;
   badges: BadgeData[];

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -16,6 +16,7 @@ import { isSafeUrl } from '../utils/url';
 import { buildTierColorCss } from '../webview/shared/colors';
 import { isFailedConclusion } from '../webview/shared/runConclusionLabels';
 import { buildProviderBadge, buildProviderBadges, buildTypeBadge } from './badges';
+import { toItemAuthorData } from './itemAuthorData';
 import { getProviderItemKey, parseProviderItemKey } from './providerItemKey';
 import type {
   BadgeData,
@@ -1412,12 +1413,6 @@ function isFailedRun(runWatch: WatchedRun): boolean {
 
 function normalizeText(value?: string): string {
   return value?.trim().toLowerCase().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ') ?? '';
-}
-
-function toItemAuthorData(providerItem: ProviderItem | undefined): ItemCardData['author'] {
-  return providerItem?.author
-    ? { displayName: providerItem.author.displayName, handle: providerItem.author.handle }
-    : undefined;
 }
 
 function getNonce(): string {

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -315,6 +315,8 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       title: providerItem.title,
       badges: this.buildBadges(providerId, providerItem, providerItem.url),
       repoAnnotation: providerItem.group ?? existingWorkItem?.group,
+      author: toItemAuthorData(providerItem),
+      authored: providerItem.authored,
       tierType: 'incoming',
       isUnseen: !this.readStateStore.has(key),
       isUrgent: this.isUrgentProviderItem(providerItem),
@@ -336,6 +338,8 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       title: item.title,
       badges: this.buildBadges(item.providerId, providerItem, item.url),
       repoAnnotation: item.group ?? providerItem?.group,
+      author: toItemAuthorData(providerItem),
+      authored: providerItem?.authored,
       tierType,
       isUrgent: this.isUrgentWorkItem(item, providerItemMap),
       hasRelatedItems: item.providerId && item.externalId
@@ -1408,6 +1412,12 @@ function isFailedRun(runWatch: WatchedRun): boolean {
 
 function normalizeText(value?: string): string {
   return value?.trim().toLowerCase().replace(/[_-]+/g, ' ').replace(/\s+/g, ' ') ?? '';
+}
+
+function toItemAuthorData(providerItem: ProviderItem | undefined): ItemCardData['author'] {
+  return providerItem?.author
+    ? { displayName: providerItem.author.displayName, handle: providerItem.author.handle }
+    : undefined;
 }
 
 function getNonce(): string {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -11,6 +11,7 @@ import type { InboxStateStore } from '../storage/inboxStateStore';
 import { isSafeUrl } from '../utils/url';
 import { buildProviderBadge, buildProviderBadges, buildTypeBadge } from './badges';
 import { isFailedConclusion } from '../webview/shared/runConclusionLabels';
+import { toItemAuthorData } from './itemAuthorData';
 import { parseProviderItemKey } from './providerItemKey';
 import { getEditorPanelHtml, renderMarkdown } from './editorPanelHtml';
 import type { BadgeData, EditorItemData } from './mainTypes';
@@ -474,9 +475,7 @@ export class WorkItemEditorPanel {
       state: item.state,
       providerLabel,
       group: item.group,
-      author: providerItem?.author
-        ? { displayName: providerItem.author.displayName, handle: providerItem.author.handle }
-        : undefined,
+      author: toItemAuthorData(providerItem),
       authored: providerItem?.authored,
       createdAt: item.createdAt,
       updatedAt: item.updatedAt,

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -475,6 +475,7 @@ export class WorkItemEditorPanel {
       author: providerItem?.author
         ? { displayName: providerItem.author.displayName, handle: providerItem.author.handle }
         : undefined,
+      authored: providerItem?.authored,
       createdAt: item.createdAt,
       updatedAt: item.updatedAt,
       badges: composeEditorBadges(item.providerId, providerItem, providerLabel),

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -472,6 +472,9 @@ export class WorkItemEditorPanel {
       state: item.state,
       providerLabel,
       group: item.group,
+      author: providerItem?.author
+        ? { displayName: providerItem.author.displayName, handle: providerItem.author.handle }
+        : undefined,
       createdAt: item.createdAt,
       updatedAt: item.updatedAt,
       badges: composeEditorBadges(item.providerId, providerItem, providerLabel),

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -398,11 +398,13 @@ export class WorkItemEditorPanel {
     const patch: Partial<WorkItemInput> = {};
 
     if (!managed) {
-      const title = data.title?.trim() ?? '';
-      if (!title) {
-        return;
+      if ('title' in data) {
+        const title = data.title?.trim() ?? '';
+        if (!title) {
+          return;
+        }
+        patch.title = title;
       }
-      patch.title = title;
 
       if ('url' in data) {
         const rawUrl = data.url?.trim() ?? '';

--- a/packages/core/src/webview/editor/EditorApp.tsx
+++ b/packages/core/src/webview/editor/EditorApp.tsx
@@ -126,6 +126,8 @@ export function EditorApp() {
     return <div class="editor-empty-state">Loading item…</div>;
   }
 
+  const authorHandle = item.author?.handle ? `@${item.author.handle}` : undefined;
+
   return (
     <div class="editor-app" onClickCapture={handleEditorClick}>
       <EditorHeader
@@ -142,33 +144,44 @@ export function EditorApp() {
           />
         }
       />
-      {item.isProviderManaged ? null : (
+      {!item.isProviderManaged || item.author ? (
         <section class="editor-section" aria-labelledby="editor-details-heading">
           <div class="editor-section-heading" id="editor-details-heading">Details</div>
           <div class="editor-fields-grid">
-            <EditableField
-              label="Title"
-              value={title}
-              readOnly={false}
-              onInput={value => {
-                setTitle(value);
-                setAutosaveVersion(version => version + 1);
-              }}
-            />
-            <EditableField
-              label="URL"
-              value={url}
-              type="url"
-              placeholder="https://..."
-              readOnly={false}
-              onInput={value => {
-                setUrl(value);
-                setAutosaveVersion(version => version + 1);
-              }}
-            />
+            {!item.isProviderManaged ? (
+              <>
+                <EditableField
+                  label="Title"
+                  value={title}
+                  readOnly={false}
+                  onInput={value => {
+                    setTitle(value);
+                    setAutosaveVersion(version => version + 1);
+                  }}
+                />
+                <EditableField
+                  label="URL"
+                  value={url}
+                  type="url"
+                  placeholder="https://..."
+                  readOnly={false}
+                  onInput={value => {
+                    setUrl(value);
+                    setAutosaveVersion(version => version + 1);
+                  }}
+                />
+              </>
+            ) : null}
+            {item.author ? (
+              <ReadOnlyDetailField
+                label="Author"
+                value={item.author.displayName}
+                secondary={authorHandle}
+              />
+            ) : null}
           </div>
         </section>
-      )}
+      ) : null}
       {description || !item.isIncoming ? (
         <section class="editor-section" aria-labelledby={description ? 'editor-description-heading' : undefined}>
           {description ? (
@@ -240,6 +253,18 @@ export function EditorApp() {
     itemRef.current = updatedItem;
     titleRef.current = resolvedTitle;
   }
+}
+
+function ReadOnlyDetailField({ label, value, secondary }: { label: string; value: string; secondary?: string }) {
+  return (
+    <div class="editor-field">
+      <span class="editor-field-label">{label}</span>
+      <div class="editor-readonly-value">
+        <span>{value}</span>
+        {secondary ? <span class="editor-readonly-secondary">{secondary}</span> : null}
+      </div>
+    </div>
+  );
 }
 
 function shouldPreserveEditableField(item: EditorItemData | null, draftValue: string, persistedValue?: string): boolean {

--- a/packages/core/src/webview/editor/EditorApp.tsx
+++ b/packages/core/src/webview/editor/EditorApp.tsx
@@ -86,11 +86,11 @@ export function EditorApp() {
       };
 
       if (!item.isProviderManaged) {
-        data.title = titleRef.current.trim();
-        if (!data.title) {
-          return;
+        const nextTitle = titleRef.current.trim();
+        if (nextTitle) {
+          data.title = nextTitle;
+          data.url = urlRef.current.trim();
         }
-        data.url = urlRef.current.trim();
       }
 
       postMessage({ type: 'autosave', data });

--- a/packages/core/src/webview/editor/EditorApp.tsx
+++ b/packages/core/src/webview/editor/EditorApp.tsx
@@ -81,19 +81,19 @@ export function EditorApp() {
     }
 
     const timer = window.setTimeout(() => {
-      const nextTitle = titleRef.current.trim();
-      if (!item.isProviderManaged && nextTitle.length === 0) {
-        return;
+      const data: { title?: string; notes?: string; url?: string } = {
+        notes: notesRef.current.trim(),
+      };
+
+      if (!item.isProviderManaged) {
+        data.title = titleRef.current.trim();
+        if (!data.title) {
+          return;
+        }
+        data.url = urlRef.current.trim();
       }
 
-      postMessage({
-        type: 'autosave',
-        data: {
-          title: nextTitle,
-          notes: notesRef.current.trim(),
-          url: urlRef.current.trim(),
-        },
-      });
+      postMessage({ type: 'autosave', data });
     }, 500);
 
     return () => {
@@ -131,7 +131,16 @@ export function EditorApp() {
       <EditorHeader
         item={item}
         title={title}
+        url={url}
         onCopyText={text => postMessage({ type: 'copyToClipboard', text })}
+        onTitleInput={!item.isProviderManaged && !item.isIncoming ? value => {
+          setTitle(value);
+          setAutosaveVersion(version => version + 1);
+        } : undefined}
+        onUrlInput={!item.isProviderManaged && !item.isIncoming ? value => {
+          setUrl(value);
+          setAutosaveVersion(version => version + 1);
+        } : undefined}
         actionButtons={
           <ActionBar
             item={item}
@@ -142,33 +151,6 @@ export function EditorApp() {
           />
         }
       />
-      {item.isProviderManaged ? null : (
-        <section class="editor-section" aria-labelledby="editor-details-heading">
-          <div class="editor-section-heading" id="editor-details-heading">Details</div>
-          <div class="editor-fields-grid">
-            <EditableField
-              label="Title"
-              value={title}
-              readOnly={false}
-              onInput={value => {
-                setTitle(value);
-                setAutosaveVersion(version => version + 1);
-              }}
-            />
-            <EditableField
-              label="URL"
-              value={url}
-              type="url"
-              placeholder="https://..."
-              readOnly={false}
-              onInput={value => {
-                setUrl(value);
-                setAutosaveVersion(version => version + 1);
-              }}
-            />
-          </div>
-        </section>
-      )}
       {description || !item.isIncoming ? (
         <section class="editor-section" aria-labelledby={description ? 'editor-description-heading' : undefined}>
           {description ? (

--- a/packages/core/src/webview/editor/EditorApp.tsx
+++ b/packages/core/src/webview/editor/EditorApp.tsx
@@ -126,8 +126,6 @@ export function EditorApp() {
     return <div class="editor-empty-state">Loading item…</div>;
   }
 
-  const authorHandle = item.author?.handle ? `@${item.author.handle}` : undefined;
-
   return (
     <div class="editor-app" onClickCapture={handleEditorClick}>
       <EditorHeader
@@ -144,44 +142,33 @@ export function EditorApp() {
           />
         }
       />
-      {!item.isProviderManaged || item.author ? (
+      {item.isProviderManaged ? null : (
         <section class="editor-section" aria-labelledby="editor-details-heading">
           <div class="editor-section-heading" id="editor-details-heading">Details</div>
           <div class="editor-fields-grid">
-            {!item.isProviderManaged ? (
-              <>
-                <EditableField
-                  label="Title"
-                  value={title}
-                  readOnly={false}
-                  onInput={value => {
-                    setTitle(value);
-                    setAutosaveVersion(version => version + 1);
-                  }}
-                />
-                <EditableField
-                  label="URL"
-                  value={url}
-                  type="url"
-                  placeholder="https://..."
-                  readOnly={false}
-                  onInput={value => {
-                    setUrl(value);
-                    setAutosaveVersion(version => version + 1);
-                  }}
-                />
-              </>
-            ) : null}
-            {item.author ? (
-              <ReadOnlyDetailField
-                label="Author"
-                value={item.author.displayName}
-                secondary={authorHandle}
-              />
-            ) : null}
+            <EditableField
+              label="Title"
+              value={title}
+              readOnly={false}
+              onInput={value => {
+                setTitle(value);
+                setAutosaveVersion(version => version + 1);
+              }}
+            />
+            <EditableField
+              label="URL"
+              value={url}
+              type="url"
+              placeholder="https://..."
+              readOnly={false}
+              onInput={value => {
+                setUrl(value);
+                setAutosaveVersion(version => version + 1);
+              }}
+            />
           </div>
         </section>
-      ) : null}
+      )}
       {description || !item.isIncoming ? (
         <section class="editor-section" aria-labelledby={description ? 'editor-description-heading' : undefined}>
           {description ? (
@@ -253,18 +240,6 @@ export function EditorApp() {
     itemRef.current = updatedItem;
     titleRef.current = resolvedTitle;
   }
-}
-
-function ReadOnlyDetailField({ label, value, secondary }: { label: string; value: string; secondary?: string }) {
-  return (
-    <div class="editor-field">
-      <span class="editor-field-label">{label}</span>
-      <div class="editor-readonly-value">
-        <span>{value}</span>
-        {secondary ? <span class="editor-readonly-secondary">{secondary}</span> : null}
-      </div>
-    </div>
-  );
 }
 
 function shouldPreserveEditableField(item: EditorItemData | null, draftValue: string, persistedValue?: string): boolean {

--- a/packages/core/src/webview/editor/components/EditorHeader.tsx
+++ b/packages/core/src/webview/editor/components/EditorHeader.tsx
@@ -8,26 +8,33 @@ import { isSafeUrl } from '../../../utils/url';
 interface EditorHeaderProps {
   item: EditorItemData;
   title: string;
+  url?: string;
   onCopyText: (text: string) => void;
+  onTitleInput?: (value: string) => void;
+  onUrlInput?: (value: string) => void;
   /** Action buttons rendered on the right side of the title row (state transitions, run action, etc). */
   actionButtons?: ComponentChildren;
 }
 
-export function EditorHeader({ item, title, onCopyText, actionButtons }: EditorHeaderProps) {
+export function EditorHeader({ item, title, url = item.url ?? '', onCopyText, onTitleInput, onUrlInput, actionButtons }: EditorHeaderProps) {
   // Always render the title inside an <h1> so the page has a primary
-  // heading regardless of whether the item has a URL. When url is set,
-  // the heading wraps an anchor so it's still keyboard-activatable and
-  // styled as a link.
+  // heading. When a read-only item has a URL, the heading wraps an anchor
+  // so it's still keyboard-activatable and styled as a link.
   //
-  // Defense-in-depth: validate item.url with isSafeUrl before binding
-  // it to href. The delegated click handler routes through postMessage
-  // which re-validates extension-side, but middle-click / right-click /
-  // "Copy link" use the raw href and bypass that handler. A malicious
-  // provider that supplies a `javascript:` URL would otherwise expose
-  // the user to a vector that the webview CSP only mitigates rather
-  // than blocks. Fall back to plain text (no anchor) when invalid.
-  const safeUrl = item.url ? isSafeUrl(item.url) : null;
-  const titleContent = safeUrl ? (
+  // Defense-in-depth: validate the URL with isSafeUrl before binding it
+  // to href. The delegated click handler routes through postMessage which
+  // re-validates extension-side, but middle-click / right-click / "Copy link"
+  // use the raw href and bypass that handler. Fall back to plain text (no
+  // anchor) when invalid.
+  const safeUrl = url ? isSafeUrl(url) : null;
+  const titleContent = onTitleInput ? (
+    <input
+      class="editor-title-input"
+      aria-label="Title"
+      value={title}
+      onInput={event => onTitleInput(event.currentTarget.value)}
+    />
+  ) : safeUrl ? (
     <a class="editor-title-link" href={safeUrl.href}>
       {title}
     </a>
@@ -53,19 +60,35 @@ export function EditorHeader({ item, title, onCopyText, actionButtons }: EditorH
           >
             ⧉
           </button>
-          {item.url ? (
+          {url ? (
             <button
               type="button"
               class="icon-button icon-button--inline"
               aria-label="Copy URL"
               title="Copy URL"
-              onClick={() => onCopyText(item.url!)}
+              onClick={() => onCopyText(url)}
             >
               🔗
             </button>
           ) : null}
           {annotation ? (
             <div class="editor-repo-annotation">{annotation}</div>
+          ) : null}
+          {onUrlInput ? (
+            <div class="editor-url-field">
+              <span class="editor-url-label">URL</span>
+              <input
+                class="editor-input editor-url-input"
+                type="url"
+                aria-label="URL"
+                placeholder="https://..."
+                value={url}
+                onInput={event => onUrlInput(event.currentTarget.value)}
+              />
+              {safeUrl ? (
+                <a class="editor-url-link" href={safeUrl.href}>Open source</a>
+              ) : null}
+            </div>
           ) : null}
         </div>
         <div class="editor-title-actions">

--- a/packages/core/src/webview/editor/components/EditorHeader.tsx
+++ b/packages/core/src/webview/editor/components/EditorHeader.tsx
@@ -17,9 +17,11 @@ interface EditorHeaderProps {
 }
 
 export function EditorHeader({ item, title, url = item.url ?? '', onCopyText, onTitleInput, onUrlInput, actionButtons }: EditorHeaderProps) {
-  // Always render the title inside an <h1> so the page has a primary
-  // heading. When a read-only item has a URL, the heading wraps an anchor
-  // so it's still keyboard-activatable and styled as a link.
+  // Always render an <h1> so the page has a primary heading. Editable manual
+  // items keep that heading as screen-reader text and place the input beside it
+  // in the header, avoiding interactive controls nested inside the heading.
+  // When a read-only item has a URL, the heading wraps an anchor so it's still
+  // keyboard-activatable and styled as a link.
   //
   // Defense-in-depth: validate the URL with isSafeUrl before binding it
   // to href. The delegated click handler routes through postMessage which
@@ -27,22 +29,25 @@ export function EditorHeader({ item, title, url = item.url ?? '', onCopyText, on
   // use the raw href and bypass that handler. Fall back to plain text (no
   // anchor) when invalid.
   const safeUrl = url ? isSafeUrl(url) : null;
-  const titleContent = onTitleInput ? (
-    <input
-      class="editor-title-input"
-      aria-label="Title"
-      value={title}
-      onInput={event => onTitleInput(event.currentTarget.value)}
-    />
-  ) : safeUrl ? (
+  const readOnlyTitleContent = safeUrl ? (
     <a class="editor-title-link" href={safeUrl.href}>
       {title}
     </a>
   ) : (
     title
   );
-  const titleNode = (
-    <h1 class="editor-title">{titleContent}</h1>
+  const titleNode = onTitleInput ? (
+    <>
+      <h1 class="editor-title editor-title--visually-hidden">{title || 'Untitled work item'}</h1>
+      <input
+        class="editor-title-input"
+        aria-label="Title"
+        value={title}
+        onInput={event => onTitleInput(event.currentTarget.value)}
+      />
+    </>
+  ) : (
+    <h1 class="editor-title">{readOnlyTitleContent}</h1>
   );
   const annotation = formatProviderAnnotation({ source: item.group, author: item.author, authored: item.authored });
 

--- a/packages/core/src/webview/editor/components/EditorHeader.tsx
+++ b/packages/core/src/webview/editor/components/EditorHeader.tsx
@@ -36,6 +36,7 @@ export function EditorHeader({ item, title, onCopyText, actionButtons }: EditorH
   const titleNode = (
     <h1 class="editor-title">{titleContent}</h1>
   );
+  const annotation = getEditorAnnotation(item);
 
   return (
     <header class="editor-header">
@@ -62,8 +63,8 @@ export function EditorHeader({ item, title, onCopyText, actionButtons }: EditorH
               🔗
             </button>
           ) : null}
-          {item.group ? (
-            <div class="editor-repo-annotation">{item.group}</div>
+          {annotation ? (
+            <div class="editor-repo-annotation">{annotation}</div>
           ) : null}
         </div>
         <div class="editor-title-actions">
@@ -82,4 +83,12 @@ export function EditorHeader({ item, title, onCopyText, actionButtons }: EditorH
       </div>
     </header>
   );
+}
+
+function getEditorAnnotation(item: EditorItemData): string | undefined {
+  const parts = [item.group];
+  if (item.author && item.authored !== true) {
+    parts.push(item.author.handle ? `@${item.author.handle}` : item.author.displayName);
+  }
+  return parts.filter((value): value is string => Boolean(value)).join(' · ') || undefined;
 }

--- a/packages/core/src/webview/editor/components/EditorHeader.tsx
+++ b/packages/core/src/webview/editor/components/EditorHeader.tsx
@@ -1,5 +1,6 @@
 import type { ComponentChildren } from 'preact';
 import { BadgePill } from '../../shared/components/BadgePill';
+import { formatProviderAnnotation } from '../../shared/providerAnnotation';
 import type { EditorItemData } from '../../shared/types';
 import { stateLabel, stateTone } from '../editorUtils';
 import { isSafeUrl } from '../../../utils/url';
@@ -36,7 +37,7 @@ export function EditorHeader({ item, title, onCopyText, actionButtons }: EditorH
   const titleNode = (
     <h1 class="editor-title">{titleContent}</h1>
   );
-  const annotation = getEditorAnnotation(item);
+  const annotation = formatProviderAnnotation({ source: item.group, author: item.author, authored: item.authored });
 
   return (
     <header class="editor-header">
@@ -83,12 +84,4 @@ export function EditorHeader({ item, title, onCopyText, actionButtons }: EditorH
       </div>
     </header>
   );
-}
-
-function getEditorAnnotation(item: EditorItemData): string | undefined {
-  const parts = [item.group];
-  if (item.author && item.authored !== true) {
-    parts.push(item.author.handle ? `@${item.author.handle}` : item.author.displayName);
-  }
-  return parts.filter((value): value is string => Boolean(value)).join(' · ') || undefined;
 }

--- a/packages/core/src/webview/shared/providerAnnotation.ts
+++ b/packages/core/src/webview/shared/providerAnnotation.ts
@@ -1,0 +1,15 @@
+import type { ItemAuthorData } from './types';
+
+interface ProviderAnnotationOptions {
+  source?: string;
+  author?: ItemAuthorData;
+  authored?: boolean;
+}
+
+export function formatProviderAnnotation({ source, author, authored }: ProviderAnnotationOptions): string | undefined {
+  const parts = [source];
+  if (author && authored !== true) {
+    parts.push(author.handle ? `@${author.handle}` : author.displayName);
+  }
+  return parts.filter((value): value is string => Boolean(value)).join(' · ') || undefined;
+}

--- a/packages/core/src/webview/shared/providerAnnotation.ts
+++ b/packages/core/src/webview/shared/providerAnnotation.ts
@@ -9,7 +9,11 @@ interface ProviderAnnotationOptions {
 export function formatProviderAnnotation({ source, author, authored }: ProviderAnnotationOptions): string | undefined {
   const parts = [source];
   if (author && authored !== true) {
-    parts.push(author.handle ? `@${author.handle}` : author.displayName);
+    parts.push(formatAuthorAnnotation(author));
   }
   return parts.filter((value): value is string => Boolean(value)).join(' · ') || undefined;
+}
+
+function formatAuthorAnnotation(author: ItemAuthorData): string {
+  return author.handle && !author.handle.includes('@') ? `@${author.handle}` : author.displayName;
 }

--- a/packages/core/src/webview/shared/types.ts
+++ b/packages/core/src/webview/shared/types.ts
@@ -3,6 +3,7 @@ export type {
   EditorCIWatchData,
   EditorItemData,
   ExtensionMessage,
+  ItemAuthorData,
   ItemCardData,
   SourceGroupData,
   SourceItemData,

--- a/packages/core/src/webview/sidebar/components/ItemCard.tsx
+++ b/packages/core/src/webview/sidebar/components/ItemCard.tsx
@@ -56,6 +56,7 @@ export function ItemCard({
   const isDraggable = !disableDragReorder && (item.tierType === 'readyToStart' || item.tierType === 'inProgress');
   const [actionsOpen, setActionsOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
+  const annotation = getItemAnnotation(item);
   const itemElementRef = useRef<HTMLDivElement | null>(null);
   const actionButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
 
@@ -186,8 +187,8 @@ export function ItemCard({
             {item.hasRelatedItems ? <span class="related-indicator" aria-hidden="true">🔗</span> : null}
           </div>
         </div>
-        {item.repoAnnotation ? (
-          <div class="item-repo-annotation"><HighlightedText text={item.repoAnnotation} query={query} /></div>
+        {annotation ? (
+          <div class="item-repo-annotation"><HighlightedText text={annotation} query={query} /></div>
         ) : null}
         {item.badges.length > 0 ? (
           <div class="badge-row">
@@ -228,6 +229,14 @@ export function ItemCard({
   );
 }
 
+function getItemAnnotation(item: ItemCardData): string | undefined {
+  const parts = [item.repoAnnotation];
+  if (item.author && item.authored !== true) {
+    parts.push(item.author.handle ? `@${item.author.handle}` : item.author.displayName);
+  }
+  return parts.filter((value): value is string => Boolean(value)).join(' · ') || undefined;
+}
+
 function buildItemAriaLabel(item: ItemCardData): string {
   // aria-label fully overrides child text for screen readers, so build the
   // announcement from every visible piece of context: the title, repo
@@ -239,7 +248,8 @@ function buildItemAriaLabel(item: ItemCardData): string {
   if (item.isUnseen) parts.push('unread');
   if (item.isUrgent) parts.push('urgent');
   parts.push(item.title);
-  if (item.repoAnnotation) parts.push(item.repoAnnotation);
+  const annotation = getItemAnnotation(item);
+  if (annotation) parts.push(annotation);
   for (const badge of item.badges) {
     parts.push(badge.label);
   }

--- a/packages/core/src/webview/sidebar/components/ItemCard.tsx
+++ b/packages/core/src/webview/sidebar/components/ItemCard.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from 'preact/hooks';
+import { formatProviderAnnotation } from '../../shared/providerAnnotation';
 import type { ItemCardData } from '../../shared/types';
 import { BadgePill } from './BadgePill';
 import { HighlightedText } from './HighlightedText';
@@ -56,7 +57,7 @@ export function ItemCard({
   const isDraggable = !disableDragReorder && (item.tierType === 'readyToStart' || item.tierType === 'inProgress');
   const [actionsOpen, setActionsOpen] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
-  const annotation = getItemAnnotation(item);
+  const annotation = formatProviderAnnotation({ source: item.repoAnnotation, author: item.author, authored: item.authored });
   const itemElementRef = useRef<HTMLDivElement | null>(null);
   const actionButtonRefs = useRef<Record<string, HTMLButtonElement | null>>({});
 
@@ -229,14 +230,6 @@ export function ItemCard({
   );
 }
 
-function getItemAnnotation(item: ItemCardData): string | undefined {
-  const parts = [item.repoAnnotation];
-  if (item.author && item.authored !== true) {
-    parts.push(item.author.handle ? `@${item.author.handle}` : item.author.displayName);
-  }
-  return parts.filter((value): value is string => Boolean(value)).join(' · ') || undefined;
-}
-
 function buildItemAriaLabel(item: ItemCardData): string {
   // aria-label fully overrides child text for screen readers, so build the
   // announcement from every visible piece of context: the title, repo
@@ -248,7 +241,7 @@ function buildItemAriaLabel(item: ItemCardData): string {
   if (item.isUnseen) parts.push('unread');
   if (item.isUrgent) parts.push('urgent');
   parts.push(item.title);
-  const annotation = getItemAnnotation(item);
+  const annotation = formatProviderAnnotation({ source: item.repoAnnotation, author: item.author, authored: item.authored });
   if (annotation) parts.push(annotation);
   for (const badge of item.badges) {
     parts.push(badge.label);

--- a/packages/core/src/webview/sidebar/filter.ts
+++ b/packages/core/src/webview/sidebar/filter.ts
@@ -23,8 +23,8 @@ export function filterTiers(tiers: TierData[], query: string): { tiers: TierData
         items: tier.items.filter(item =>
           matchesNormalizedQuery(item.title, normalizedQuery)
           || (item.repoAnnotation ? matchesNormalizedQuery(item.repoAnnotation, normalizedQuery) : false)
-          || (item.author?.displayName ? matchesNormalizedQuery(item.author.displayName, normalizedQuery) : false)
-          || (item.author?.handle ? matchesNormalizedQuery(item.author.handle, normalizedQuery) || matchesNormalizedQuery(`@${item.author.handle}`, normalizedQuery) : false),
+          || (item.authored !== true && item.author?.displayName ? matchesNormalizedQuery(item.author.displayName, normalizedQuery) : false)
+          || (item.authored !== true && item.author?.handle ? matchesNormalizedQuery(item.author.handle, normalizedQuery) || matchesNormalizedQuery(`@${item.author.handle}`, normalizedQuery) : false),
         ),
       }))
       .filter(tier => tier.items.length > 0),

--- a/packages/core/src/webview/sidebar/filter.ts
+++ b/packages/core/src/webview/sidebar/filter.ts
@@ -22,7 +22,9 @@ export function filterTiers(tiers: TierData[], query: string): { tiers: TierData
         ...tier,
         items: tier.items.filter(item =>
           matchesNormalizedQuery(item.title, normalizedQuery)
-          || (item.repoAnnotation ? matchesNormalizedQuery(item.repoAnnotation, normalizedQuery) : false),
+          || (item.repoAnnotation ? matchesNormalizedQuery(item.repoAnnotation, normalizedQuery) : false)
+          || (item.author?.displayName ? matchesNormalizedQuery(item.author.displayName, normalizedQuery) : false)
+          || (item.author?.handle ? matchesNormalizedQuery(item.author.handle, normalizedQuery) : false),
         ),
       }))
       .filter(tier => tier.items.length > 0),

--- a/packages/core/src/webview/sidebar/filter.ts
+++ b/packages/core/src/webview/sidebar/filter.ts
@@ -24,7 +24,7 @@ export function filterTiers(tiers: TierData[], query: string): { tiers: TierData
           matchesNormalizedQuery(item.title, normalizedQuery)
           || (item.repoAnnotation ? matchesNormalizedQuery(item.repoAnnotation, normalizedQuery) : false)
           || (item.author?.displayName ? matchesNormalizedQuery(item.author.displayName, normalizedQuery) : false)
-          || (item.author?.handle ? matchesNormalizedQuery(item.author.handle, normalizedQuery) : false),
+          || (item.author?.handle ? matchesNormalizedQuery(item.author.handle, normalizedQuery) || matchesNormalizedQuery(`@${item.author.handle}`, normalizedQuery) : false),
         ),
       }))
       .filter(tier => tier.items.length > 0),

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -12,6 +12,11 @@ export interface GitHubIssue {
   comments_url?: string;
   comments?: number;
   updated_at?: string;
+  user?: {
+    login?: string;
+    avatar_url?: string;
+    html_url?: string;
+  };
   pull_request?: { url: string };
   merged_at?: string | null;
   merged?: boolean;

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -126,6 +126,14 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
         title: `#${issue.number}: ${issue.title}`,
         description: issue.body ?? undefined,
         url: issue.html_url,
+        ...(issue.user?.login ? {
+          author: {
+            displayName: issue.user.login,
+            handle: issue.user.login,
+            avatarUrl: issue.user.avatar_url,
+            profileUrl: issue.user.html_url,
+          },
+        } : {}),
         group: repoName,
         reason: 'mentioned',
         canonicalId: `github:${isPr ? 'pull' : 'issue'}:${repoName}#${issue.number}`,

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -136,6 +136,14 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
         title: `#${pr.number}: ${pr.title}`,
         description: pr.body ?? undefined,
         url: pr.html_url,
+        ...(pr.user?.login ? {
+          author: {
+            displayName: pr.user.login,
+            handle: pr.user.login,
+            avatarUrl: pr.user.avatar_url,
+            profileUrl: pr.user.html_url,
+          },
+        } : {}),
         authored: true,
         group: repoName,
         reason: 'You authored this PR',
@@ -158,6 +166,14 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
         title: `#${pr.number}: ${pr.title}`,
         description: pr.body ?? undefined,
         url: pr.html_url,
+        ...(pr.user?.login ? {
+          author: {
+            displayName: pr.user.login,
+            handle: pr.user.login,
+            avatarUrl: pr.user.avatar_url,
+            profileUrl: pr.user.html_url,
+          },
+        } : {}),
         group: repoName,
         reason: 'You are assigned to this PR',
         state: status,

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -85,6 +85,14 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
         title: `#${pr.number}: ${pr.title}`,
         description: pr.body ?? undefined,
         url: pr.html_url,
+        ...(pr.user?.login ? {
+          author: {
+            displayName: pr.user.login,
+            handle: pr.user.login,
+            avatarUrl: pr.user.avatar_url,
+            profileUrl: pr.user.html_url,
+          },
+        } : {}),
         group: repoName,
         reason: 'review_requested',
         canonicalId: `github:pull:${repoName}#${pr.number}`,

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -42,6 +42,14 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
         title: `#${issue.number}: ${issue.title}`,
         description: issue.body ?? undefined,
         url: issue.html_url,
+        ...(issue.user?.login ? {
+          author: {
+            displayName: issue.user.login,
+            handle: issue.user.login,
+            avatarUrl: issue.user.avatar_url,
+            profileUrl: issue.user.html_url,
+          },
+        } : {}),
         group: repoName,
         reason: 'assigned',
         canonicalId: `github:issue:${repoName}#${issue.number}`,

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -154,6 +154,36 @@ describe('GitHubMentionsProvider', () => {
     }));
   });
 
+  it('populates author from the mentioned issue author', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          items: [{
+            ...createMockIssue(10, 'Bug report', 'org/repo'),
+            user: {
+              login: 'issue-author',
+              avatar_url: 'https://avatars.githubusercontent.com/u/10?v=4',
+              html_url: 'https://github.com/issue-author',
+            },
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ login: 'testuser' }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => [] });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener.mock.calls[0][0][0].author).toEqual({
+      displayName: 'issue-author',
+      handle: 'issue-author',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/10?v=4',
+      profileUrl: 'https://github.com/issue-author',
+    });
+  });
+
   it('excludes merged PRs by fetching details for closed mentioned search results before publishing', async () => {
     const mergedPr = {
       ...createMockPr(20, 'Already merged', 'org/repo'),

--- a/packages/github/src/test/githubMyPrsProvider.test.ts
+++ b/packages/github/src/test/githubMyPrsProvider.test.ts
@@ -5,7 +5,7 @@ import { setLogger } from '../logger';
 
 const mockFetch = vi.fn();
 
-function createMockPr(number: number, title: string, repo = 'owner/repo') {
+function createMockPr(number: number, title: string, repo = 'owner/repo', extra: Record<string, unknown> = {}) {
   return {
     number,
     title,
@@ -14,6 +14,7 @@ function createMockPr(number: number, title: string, repo = 'owner/repo') {
     html_url: `https://github.com/${repo}/pull/${number}`,
     repository_url: `https://api.github.com/repos/${repo}`,
     pull_request: { url: `https://api.github.com/repos/${repo}/pulls/${number}` },
+    ...extra,
   };
 }
 
@@ -433,8 +434,12 @@ describe('GitHubMyPrsProvider', () => {
   });
 
   it('discovers assigned PRs alongside authored PRs', async () => {
-    const authoredPr = createMockPr(1, 'My PR');
-    const assignedPr = createMockPr(2, 'Assigned to me', 'other/repo');
+    const authoredPr = createMockPr(1, 'My PR', 'owner/repo', {
+      user: { login: 'me', avatar_url: 'https://avatars.githubusercontent.com/u/2?v=4', html_url: 'https://github.com/me' },
+    });
+    const assignedPr = createMockPr(2, 'Assigned to me', 'other/repo', {
+      user: { login: 'teammate', avatar_url: 'https://avatars.githubusercontent.com/u/3?v=4', html_url: 'https://github.com/teammate' },
+    });
 
     mockFetch.mockImplementation(async (url: string) => {
       if (url.includes('search/issues') && url.includes('author:@me')) {
@@ -469,10 +474,22 @@ describe('GitHubMyPrsProvider', () => {
     expect(items[0].externalId).toBe('owner/repo#1');
     expect(items[0].reason).toBe('You authored this PR');
     expect(items[0].authored).toBe(true);
+    expect(items[0].author).toEqual({
+      displayName: 'me',
+      handle: 'me',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/2?v=4',
+      profileUrl: 'https://github.com/me',
+    });
 
     expect(items[1].externalId).toBe('other/repo#2');
     expect(items[1].reason).toBe('You are assigned to this PR');
     expect(items[1].authored).toBeUndefined();
+    expect(items[1].author).toEqual({
+      displayName: 'teammate',
+      handle: 'teammate',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/3?v=4',
+      profileUrl: 'https://github.com/teammate',
+    });
   });
 
   it('excludes self-authored PRs from assigned results', async () => {

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -201,7 +201,14 @@ describe('GitHubPrReviewProvider', () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({
-        items: [createMockPr(42, 'Add feature', 'org/myrepo')],
+        items: [{
+          ...createMockPr(42, 'Add feature', 'org/myrepo'),
+          user: {
+            login: 'octocat',
+            avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4',
+            html_url: 'https://github.com/octocat',
+          },
+        }],
       }),
     });
 
@@ -216,6 +223,12 @@ describe('GitHubPrReviewProvider', () => {
       title: '#42: Add feature',
       description: 'Body for PR 42',
       url: 'https://github.com/org/myrepo/pull/42',
+      author: {
+        displayName: 'octocat',
+        handle: 'octocat',
+        avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+        profileUrl: 'https://github.com/octocat',
+      },
       group: 'org/myrepo',
       reason: 'review_requested',
       canonicalId: 'github:pull:org/myrepo#42',

--- a/packages/github/src/test/githubProvider.test.ts
+++ b/packages/github/src/test/githubProvider.test.ts
@@ -172,6 +172,32 @@ describe('GitHubIssueProvider', () => {
     });
   });
 
+  it('populates author from the GitHub issue user', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{
+        ...createMockIssue(11, 'Authored issue'),
+        user: {
+          login: 'octocat',
+          avatar_url: 'https://avatars.githubusercontent.com/u/1?v=4',
+          html_url: 'https://github.com/octocat',
+        },
+      }],
+      headers: { get: () => null },
+    });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener.mock.calls[0][0][0].author).toEqual({
+      displayName: 'octocat',
+      handle: 'octocat',
+      avatarUrl: 'https://avatars.githubusercontent.com/u/1?v=4',
+      profileUrl: 'https://github.com/octocat',
+    });
+  });
+
   it('should include state when issue has a state field', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -78,6 +78,17 @@ export interface ProviderItemCapabilities {
   gitWork?: GitWorkInfo | (() => Promise<GitWorkInfo | undefined>);
 }
 
+export interface ProviderItemAuthor {
+  /** Display name preferred for UI, e.g. "Octocat" or "Jane Doe". */
+  displayName: string;
+  /** Optional stable handle, e.g. GitHub login or ADO uniqueName. */
+  handle?: string;
+  /** Optional avatar URL for future richer rendering. */
+  avatarUrl?: string;
+  /** Optional URL to the author's source-system profile. */
+  profileUrl?: string;
+}
+
 /**
  * An item discovered by a provider.
  * Provider data is kept in memory and read live — only the inbox state is persisted.
@@ -93,6 +104,8 @@ export interface ProviderItem {
   url?: string;
   /** Optional flag indicating the current user authored the item. */
   authored?: boolean;
+  /** Optional metadata about who created the underlying item upstream. */
+  author?: ProviderItemAuthor;
   /** Optional grouping key used to organize items in the UI (for example, in the Inbox and Sources views). */
   group?: string;
   /** Optional notification reason explaining why this item was surfaced (e.g. `"assigned"`, `"review_requested"`). */

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,7 +5,7 @@
 export { createLoggerService, LogLevel, resolveLogLevel, serializeArg } from './logger';
 export type { Logger, LogOutput, LoggerService } from './logger';
 export { BaseProvider } from './baseProvider';
-export type { ProviderItem, ProviderItemCapabilities, Disposable, Event, EventEmitterLike, GitWorkInfo, ProviderBadge, RelatedItemRef, ResolvedItem } from './baseProvider';
+export type { ProviderItem, ProviderItemAuthor, ProviderItemCapabilities, Disposable, Event, EventEmitterLike, GitWorkInfo, ProviderBadge, RelatedItemRef, ResolvedItem } from './baseProvider';
 export { isValidUrlSegment, isValidGitHubRepo, isValidRepoSlug, sanitizeUrlSegment, safeDecodeComponent } from './urlValidation';
 export { validateRefreshInterval } from './refreshInterval';
 export type { DevDocketRunWatcher, RunIdentifier, RunStatus, JobStatus, RunState, RunConclusion, CancellationTokenLike } from './runWatcher';


### PR DESCRIPTION
## Summary

- Add optional `ProviderItemAuthor` / `ProviderItem.author` to the shared provider API and re-export it.
- Populate author metadata in GitHub and Azure DevOps providers.
- Show provider authors in sidebar annotations, editor Details, and sidebar filtering.

## Validation

- `npm run build && npm run test`
- Local `superpowers:code-reviewer` review clean

Closes #567
