### PR TITLE
Prompt for Start Git Work names

### DIFF
--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -207,7 +207,7 @@ Registers **AI Code Review** and **AI Walkthrough** actions that can be run on a
 
 Registers a **Start Git Work** action available on **In Progress** GitHub and ADO work items. Prompts for repository path and base branch (with cached defaults), creates a feature branch, sets up a git worktree when requested, and runs any configured post-worktree commands.
 
-By default, Start Git Work also prompts for the branch name on issue flows and the worktree path on worktree flows. These prompts are prefilled with the same auto-derived values that would be used silently.
+By default, Start Git Work also prompts for the branch name on issue flows, the local branch name on PR flows, and the worktree path on worktree flows. These prompts are prefilled with the same auto-derived values that would be used silently.
 
 ```jsonc
 // settings.json (user-level only — workspace settings are not supported)

--- a/docs/ux-guide.md
+++ b/docs/ux-guide.md
@@ -205,11 +205,14 @@ Registers **AI Code Review** and **AI Walkthrough** actions that can be run on a
 
 ### Start Git Work (`devdocket-start-git-work`)
 
-Registers a **Start Git Work** action available on **In Progress** GitHub and ADO work items. Prompts for repository path and base branch (with cached defaults), creates a feature branch named `issue{num}`, sets up a git worktree in a sibling directory, and runs any configured post-worktree commands.
+Registers a **Start Git Work** action available on **In Progress** GitHub and ADO work items. Prompts for repository path and base branch (with cached defaults), creates a feature branch, sets up a git worktree when requested, and runs any configured post-worktree commands.
+
+By default, Start Git Work also prompts for the branch name on issue flows and the worktree path on worktree flows. These prompts are prefilled with the same auto-derived values that would be used silently.
 
 ```jsonc
 // settings.json (user-level only — workspace settings are not supported)
 {
+  "devdocket.startGitWork.promptForNames": true,
   "devDocketStartGitWork.commands": [
     { "command": "code.cmd", "args": ["{path}"] },
     { "command": "wt", "args": ["-d", "{path}"] }
@@ -217,7 +220,7 @@ Registers a **Start Git Work** action available on **In Progress** GitHub and AD
 }
 ```
 
-Use `{path}` in args as a placeholder for the worktree path. Commands run in sequence; failures show a warning but don't block the action.
+Set `devdocket.startGitWork.promptForNames` to `false` to use the auto-derived branch and worktree names without prompting. Use `{path}` in args as a placeholder for the worktree path. Commands run in sequence; failures show a warning but don't block the action.
 
 > **Note:** On Windows, use the explicit `.cmd` extension for executables that are batch files (e.g., `code.cmd` instead of `code`).
 

--- a/packages/start-git-work/package.json
+++ b/packages/start-git-work/package.json
@@ -23,30 +23,36 @@
       {
         "title": "DevDocket Start Git Work",
         "properties": {
-        "devDocketStartGitWork.commands": {
-          "type": "array",
-          "scope": "application",
-          "items": {
-            "type": "object",
-            "properties": {
-              "command": {
-                "type": "string",
-                "description": "The executable to run."
-              },
-              "args": {
-                "type": "array",
-                "items": {
-                  "type": "string"
+          "devDocketStartGitWork.commands": {
+            "type": "array",
+            "scope": "application",
+            "items": {
+              "type": "object",
+              "properties": {
+                "command": {
+                  "type": "string",
+                  "description": "The executable to run."
                 },
-                "description": "Arguments passed to the command. Use {path} as a placeholder for the worktree path."
-              }
+                "args": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Arguments passed to the command. Use {path} as a placeholder for the worktree path."
+                }
+              },
+              "required": ["command"]
             },
-            "required": ["command"]
+            "default": [],
+            "description": "Commands to run after creating a worktree. Each entry specifies a command and optional args. Use {path} in args to reference the worktree path."
           },
-          "default": [],
-          "description": "Commands to run after creating a worktree. Each entry specifies a command and optional args. Use {path} in args to reference the worktree path."
+          "devdocket.startGitWork.promptForNames": {
+            "type": "boolean",
+            "scope": "application",
+            "default": true,
+            "description": "When enabled, Start Git Work prompts for branch name and worktree path, prefilled with auto-derived defaults. When disabled, the auto-derived values are used silently."
+          }
         }
-      }
       }
     ]
   },

--- a/packages/start-git-work/package.json
+++ b/packages/start-git-work/package.json
@@ -50,7 +50,7 @@
             "type": "boolean",
             "scope": "application",
             "default": true,
-            "description": "When enabled, Start Git Work prompts for branch name and worktree path, prefilled with auto-derived defaults. When disabled, the auto-derived values are used silently."
+            "description": "When enabled, Start Git Work prompts for issue branch names and worktree paths, prefilled with auto-derived defaults when applicable. When disabled, the auto-derived values are used silently."
           }
         }
       }

--- a/packages/start-git-work/package.json
+++ b/packages/start-git-work/package.json
@@ -50,7 +50,7 @@
             "type": "boolean",
             "scope": "application",
             "default": true,
-            "description": "When enabled, Start Git Work prompts for issue branch names and worktree paths, prefilled with auto-derived defaults when applicable. When disabled, the auto-derived values are used silently."
+            "description": "When enabled, Start Git Work prompts for issue branch names, PR local branch names, and worktree paths, prefilled with auto-derived defaults when applicable. When disabled, the auto-derived values are used silently."
           }
         }
       }

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -385,6 +385,7 @@ export class StartWorkAction implements DevDocketAction {
     let branchName = upstreamBranchName;
     let worktreePath: string | undefined;
     if (this.shouldPromptForNames()) {
+      // PR branch prompts rename only the local branch; fetch still uses the upstream ref.
       const promptedBranchName = await this.promptForBranchName(branchName, workMode);
       if (promptedBranchName === undefined) {
         return;

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -826,7 +826,7 @@ export class StartWorkAction implements DevDocketAction {
 
   private isPathInsideOrEqual(candidatePath: string, containerPath: string): boolean {
     const relative = path.relative(path.resolve(containerPath), path.resolve(candidatePath));
-    return relative === '' || (relative.length > 0 && !relative.startsWith('..') && !path.isAbsolute(relative));
+    return relative === '' || (relative.length > 0 && relative !== '..' && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
   }
 
   /**

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -872,10 +872,9 @@ export class StartWorkAction implements DevDocketAction {
     return path.join(path.dirname(repoPath), this.toWorktreeDirName(repoPath, ref, item));
   }
 
-  private toWorktreeDirName(repoPath: string, ref: string, item: Readonly<WorkItem>): string {
+  private toWorktreeDirName(repoPath: string, ref: string, _item: Readonly<WorkItem>): string {
     const repoBaseName = path.basename(repoPath);
-    const itemSuffix = this.toWorktreePathSuffix(item.externalId ?? item.id);
-    return `${repoBaseName}-${this.toWorktreePathSuffix(ref)}-${itemSuffix}`;
+    return `${repoBaseName}-${this.toWorktreePathSuffix(ref)}`;
   }
 
   private toWorktreePathSuffix(ref: string): string {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -81,6 +81,8 @@ type RepoPathPick = vscode.QuickPickItem & (
 
 interface PrBranchInfo {
   branchName: string;
+  upstreamBranchName: string;
+  sourceRef: string;
   /** Remote tracking ref when branch is on a non-origin remote (e.g. "devdocket-fork-contributor/fix-bug"). */
   trackingRef?: string;
 }
@@ -236,7 +238,7 @@ export class StartWorkAction implements DevDocketAction {
         branchName = promptedBranchName;
 
         if (workMode === 'worktree') {
-          worktreePath = await this.promptForWorktreePath(repoPath, branchName, item);
+          worktreePath = await this.promptForWorktreePath(repoPath, branchName, item, gitWork);
           if (worktreePath === undefined) {
             return;
           }
@@ -251,7 +253,7 @@ export class StartWorkAction implements DevDocketAction {
         },
         async (progress) => {
           if (workMode === 'worktree') {
-            await this.issueWorktreeFlow(item, repoPath, branchName, baseBranch, progress, worktreePath);
+            await this.issueWorktreeFlow(item, gitWork, repoPath, branchName, baseBranch, progress, worktreePath);
           } else {
             await this.issueCheckoutFlow(item, repoPath, branchName, baseBranch, progress, checkoutDirtyTreeChecked);
           }
@@ -266,13 +268,14 @@ export class StartWorkAction implements DevDocketAction {
 
   private async issueWorktreeFlow(
     item: Readonly<WorkItem>,
+    gitWork: ResolvedGitWork,
     repoPath: string,
     branchName: string,
     baseBranch: string,
     progress: vscode.Progress<{ message?: string }>,
     promptedWorktreePath?: string,
   ): Promise<void> {
-    const worktreePath = promptedWorktreePath ?? this.getDefaultWorktreePath(repoPath, branchName, item);
+    const worktreePath = promptedWorktreePath ?? this.getDefaultWorktreePath(repoPath, branchName, item, gitWork);
 
     if (fs.existsSync(worktreePath)) {
       void vscode.window.showErrorMessage(`DevDocket: Directory "${worktreePath}" already exists.`);
@@ -378,12 +381,21 @@ export class StartWorkAction implements DevDocketAction {
       return;
     }
 
+    const upstreamBranchName = this.normalizeBranchName(gitWork.ref);
+    let branchName = upstreamBranchName;
     let worktreePath: string | undefined;
-    if (workMode === 'worktree' && this.shouldPromptForNames()) {
-      const branchName = this.normalizeBranchName(gitWork.ref);
-      worktreePath = await this.promptForWorktreePath(repoPath, branchName, item);
-      if (worktreePath === undefined) {
+    if (this.shouldPromptForNames()) {
+      const promptedBranchName = await this.promptForBranchName(branchName, workMode);
+      if (promptedBranchName === undefined) {
         return;
+      }
+      branchName = promptedBranchName;
+
+      if (workMode === 'worktree') {
+        worktreePath = await this.promptForWorktreePath(repoPath, branchName, item, gitWork);
+        if (worktreePath === undefined) {
+          return;
+        }
       }
     }
 
@@ -397,13 +409,13 @@ export class StartWorkAction implements DevDocketAction {
         async (progress) => {
           progress.report({ message: 'Fetching PR branch...' });
 
-          const branchInfo = await this.fetchPrBranch(gitWork, repoPath);
+          const branchInfo = await this.fetchPrBranch(gitWork, repoPath, branchName);
           if (!branchInfo) {
             return;
           }
 
           if (workMode === 'worktree') {
-            await this.prWorktreeFlow(item, repoPath, branchInfo, progress, worktreePath);
+            await this.prWorktreeFlow(item, gitWork, repoPath, branchInfo, progress, worktreePath);
           } else {
             await this.prCheckoutFlow(item, repoPath, branchInfo, progress);
           }
@@ -416,33 +428,39 @@ export class StartWorkAction implements DevDocketAction {
     }
   }
 
-  private async fetchPrBranch(gitWork: ResolvedGitWork, repoPath: string): Promise<PrBranchInfo | undefined> {
-    const branchName = this.normalizeBranchName(gitWork.ref);
+  private async fetchPrBranch(
+    gitWork: ResolvedGitWork,
+    repoPath: string,
+    localBranchName?: string,
+  ): Promise<PrBranchInfo | undefined> {
+    const upstreamBranchName = this.normalizeBranchName(gitWork.ref);
+    const branchName = localBranchName ?? upstreamBranchName;
     const cloneUrl = gitWork.headCloneUrl ?? gitWork.cloneUrl;
 
-    logger.info(`Fetching provider-supplied PR branch "${branchName}"`);
+    logger.info(`Fetching provider-supplied PR branch "${upstreamBranchName}"`);
     const remoteName = await this.findOrAddRemote(cloneUrl, gitWork.repoLabel, repoPath);
+    const sourceRef = `${remoteName}/${upstreamBranchName}`;
 
     try {
       await execFileAsync('git', [
         'fetch',
         remoteName,
-        `+refs/heads/${branchName}:refs/remotes/${remoteName}/${branchName}`,
+        `+refs/heads/${upstreamBranchName}:refs/remotes/${remoteName}/${upstreamBranchName}`,
       ], { cwd: repoPath, timeout: GIT_CHECKOUT_TIMEOUT });
-      logger.debug(`Fetch complete for branch "${branchName}" from remote "${remoteName}"`);
+      logger.debug(`Fetch complete for branch "${upstreamBranchName}" from remote "${remoteName}"`);
     } catch (err) {
       const details = this.formatGitError(err);
-      logger.info(`Failed to fetch branch "${branchName}" from ${remoteName}: ${details}`);
+      logger.info(`Failed to fetch branch "${upstreamBranchName}" from ${remoteName}: ${details}`);
       void vscode.window.showErrorMessage(
-        `DevDocket: Could not fetch branch '${branchName}' from remote '${remoteName}'. ${details}`,
+        `DevDocket: Could not fetch branch '${upstreamBranchName}' from remote '${remoteName}'. ${details}`,
       );
       return undefined;
     }
 
     if (remoteName === 'origin') {
-      return { branchName };
+      return { branchName, upstreamBranchName, sourceRef };
     }
-    return { branchName, trackingRef: `${remoteName}/${branchName}` };
+    return { branchName, upstreamBranchName, sourceRef, trackingRef: sourceRef };
   }
 
   /**
@@ -489,13 +507,14 @@ export class StartWorkAction implements DevDocketAction {
 
   private async prWorktreeFlow(
     item: Readonly<WorkItem>,
+    gitWork: ResolvedGitWork,
     repoPath: string,
     branchInfo: PrBranchInfo,
     progress: vscode.Progress<{ message?: string }>,
     promptedWorktreePath?: string,
   ): Promise<void> {
-    const { branchName, trackingRef } = branchInfo;
-    const worktreePath = promptedWorktreePath ?? this.getDefaultWorktreePath(repoPath, branchName, item);
+    const { branchName, sourceRef, trackingRef } = branchInfo;
+    const worktreePath = promptedWorktreePath ?? this.getDefaultWorktreePath(repoPath, branchName, item, gitWork);
 
     if (fs.existsSync(worktreePath)) {
       void vscode.window.showErrorMessage(`DevDocket: Directory "${worktreePath}" already exists.`);
@@ -509,7 +528,7 @@ export class StartWorkAction implements DevDocketAction {
     // exists, to avoid using a stale/unrelated same-named local branch).
     // For same-repo PRs, the branch may only exist as origin/<branch> after fetch.
     const hasLocalBranch = await this.localBranchExists(branchName, repoPath);
-    const worktreeSourceRef = trackingRef ?? `origin/${branchName}`;
+    const worktreeSourceRef = sourceRef;
     // Only relevant when we'd otherwise run `git worktree add <path> <branch>`
     // (the local-branch path that's neither --detach nor -b). For trackingRef
     // and no-local-branch paths, the porcelain pre-check would be wasted work.
@@ -585,7 +604,7 @@ export class StartWorkAction implements DevDocketAction {
     branchInfo: PrBranchInfo,
     progress: vscode.Progress<{ message?: string }>,
   ): Promise<void> {
-    const { branchName, trackingRef } = branchInfo;
+    const { branchName, sourceRef, trackingRef } = branchInfo;
     const canProceed = await this.checkDirtyTree(repoPath);
     if (!canProceed) {
       return;
@@ -627,7 +646,7 @@ export class StartWorkAction implements DevDocketAction {
       checkoutArgs = ['checkout', '-b', branchName, trackingRef];
       createdBranch = true;
     } else {
-      checkoutArgs = ['checkout', '-b', branchName, '--track', `origin/${branchName}`];
+      checkoutArgs = ['checkout', '-b', branchName, '--track', sourceRef];
       createdBranch = true;
     }
 
@@ -781,8 +800,9 @@ export class StartWorkAction implements DevDocketAction {
     repoPath: string,
     branchName: string,
     item: Readonly<WorkItem>,
+    gitWork: ResolvedGitWork,
   ): Promise<string | undefined> {
-    const defaultWorktreePath = this.getDefaultWorktreePath(repoPath, branchName, item);
+    const defaultWorktreePath = this.getDefaultWorktreePath(repoPath, branchName, item, gitWork);
     const defaultDirName = path.basename(defaultWorktreePath);
     const selectedPath = await vscode.window.showInputBox({
       title: 'DevDocket: Worktree path',
@@ -882,13 +902,53 @@ export class StartWorkAction implements DevDocketAction {
     return detail ?? 'Check your network connection, permissions, and whether the branch still exists.';
   }
 
-  private getDefaultWorktreePath(repoPath: string, ref: string, item: Readonly<WorkItem>): string {
-    return path.join(path.dirname(repoPath), this.toWorktreeDirName(repoPath, ref, item));
+  private getDefaultWorktreePath(
+    repoPath: string,
+    ref: string,
+    item: Readonly<WorkItem>,
+    gitWork: ResolvedGitWork,
+  ): string {
+    return path.join(path.dirname(repoPath), this.toWorktreeDirName(repoPath, ref, item, gitWork));
   }
 
-  private toWorktreeDirName(repoPath: string, ref: string, _item: Readonly<WorkItem>): string {
+  private toWorktreeDirName(
+    repoPath: string,
+    ref: string,
+    item: Readonly<WorkItem>,
+    gitWork: ResolvedGitWork,
+  ): string {
+    const itemNumber = this.workItemNumber(item.externalId ?? item.id);
+    if (itemNumber) {
+      const repoBaseName = this.sourceRepoBaseName(gitWork, repoPath);
+      return `${repoBaseName}-${gitWork.kind}-${itemNumber}`;
+    }
+
     const repoBaseName = path.basename(repoPath);
     return `${repoBaseName}-${this.toWorktreePathSuffix(ref)}`;
+  }
+
+  private workItemNumber(externalId: string | undefined): string | undefined {
+    return externalId?.trim().match(/(?:#|!)(\d+)$/)?.[1]
+      ?? externalId?.trim().match(/(?:^|[\/\\_-])(\d+)$/)?.[1];
+  }
+
+  private sourceRepoBaseName(gitWork: ResolvedGitWork, repoPath: string): string {
+    const candidate = this.repoBaseNameFromLabel(gitWork.repoLabel)
+      ?? this.repoBaseNameFromCloneUrl(gitWork.cloneUrl)
+      ?? path.basename(repoPath);
+    return this.toWorktreePathSuffix(candidate);
+  }
+
+  private repoBaseNameFromLabel(repoLabel: string | undefined): string | undefined {
+    return repoLabel?.split(/[\\/]/).filter(Boolean).at(-1);
+  }
+
+  private repoBaseNameFromCloneUrl(cloneUrl: string): string | undefined {
+    try {
+      return new URL(cloneUrl).pathname.split('/').filter(Boolean).at(-1)?.replace(/\.git$/i, '');
+    } catch {
+      return cloneUrl.match(/^git@[^:]+:(.+)$/)?.[1].split('/').filter(Boolean).at(-1)?.replace(/\.git$/i, '');
+    }
   }
 
   private toWorktreePathSuffix(ref: string): string {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -202,7 +202,7 @@ export class StartWorkAction implements DevDocketAction {
     gitWork: ResolvedGitWork,
     repoPath: string,
   ): Promise<void> {
-    const branchName = this.normalizeBranchName(gitWork.ref);
+    let branchName = this.normalizeBranchName(gitWork.ref);
     const repoLabel = gitWork.repoLabel ?? gitWork.cloneUrl;
 
     const baseBranch = await this.promptForBaseBranch(repoLabel);
@@ -215,6 +215,22 @@ export class StartWorkAction implements DevDocketAction {
       return;
     }
 
+    let worktreePath: string | undefined;
+    if (this.shouldPromptForNames()) {
+      const promptedBranchName = await this.promptForBranchName(branchName, workMode);
+      if (promptedBranchName === undefined) {
+        return;
+      }
+      branchName = promptedBranchName;
+
+      if (workMode === 'worktree') {
+        worktreePath = await this.promptForWorktreePath(repoPath, branchName, item);
+        if (worktreePath === undefined) {
+          return;
+        }
+      }
+    }
+
     try {
       await vscode.window.withProgress(
         {
@@ -224,7 +240,7 @@ export class StartWorkAction implements DevDocketAction {
         },
         async (progress) => {
           if (workMode === 'worktree') {
-            await this.issueWorktreeFlow(item, repoPath, branchName, baseBranch, progress);
+            await this.issueWorktreeFlow(item, repoPath, branchName, baseBranch, progress, worktreePath);
           } else {
             await this.issueCheckoutFlow(item, repoPath, branchName, baseBranch, progress);
           }
@@ -243,9 +259,9 @@ export class StartWorkAction implements DevDocketAction {
     branchName: string,
     baseBranch: string,
     progress: vscode.Progress<{ message?: string }>,
+    promptedWorktreePath?: string,
   ): Promise<void> {
-    const worktreeDirName = this.toWorktreeDirName(repoPath, branchName, item);
-    const worktreePath = path.join(path.dirname(repoPath), worktreeDirName);
+    const worktreePath = promptedWorktreePath ?? this.getDefaultWorktreePath(repoPath, branchName, item);
 
     if (fs.existsSync(worktreePath)) {
       void vscode.window.showErrorMessage(`DevDocket: Directory "${worktreePath}" already exists.`);
@@ -348,6 +364,15 @@ export class StartWorkAction implements DevDocketAction {
       return;
     }
 
+    let worktreePath: string | undefined;
+    if (workMode === 'worktree' && this.shouldPromptForNames()) {
+      const branchName = this.normalizeBranchName(gitWork.ref);
+      worktreePath = await this.promptForWorktreePath(repoPath, branchName, item);
+      if (worktreePath === undefined) {
+        return;
+      }
+    }
+
     try {
       await vscode.window.withProgress(
         {
@@ -364,7 +389,7 @@ export class StartWorkAction implements DevDocketAction {
           }
 
           if (workMode === 'worktree') {
-            await this.prWorktreeFlow(item, repoPath, branchInfo, progress);
+            await this.prWorktreeFlow(item, repoPath, branchInfo, progress, worktreePath);
           } else {
             await this.prCheckoutFlow(item, repoPath, branchInfo, progress);
           }
@@ -453,10 +478,10 @@ export class StartWorkAction implements DevDocketAction {
     repoPath: string,
     branchInfo: PrBranchInfo,
     progress: vscode.Progress<{ message?: string }>,
+    promptedWorktreePath?: string,
   ): Promise<void> {
     const { branchName, trackingRef } = branchInfo;
-    const worktreeDirName = this.toWorktreeDirName(repoPath, branchName, item);
-    const worktreePath = path.join(path.dirname(repoPath), worktreeDirName);
+    const worktreePath = promptedWorktreePath ?? this.getDefaultWorktreePath(repoPath, branchName, item);
 
     if (fs.existsSync(worktreePath)) {
       void vscode.window.showErrorMessage(`DevDocket: Directory "${worktreePath}" already exists.`);
@@ -722,6 +747,76 @@ export class StartWorkAction implements DevDocketAction {
     return choice?.value;
   }
 
+  private shouldPromptForNames(): boolean {
+    return vscode.workspace.getConfiguration().get<boolean>('devdocket.startGitWork.promptForNames', true);
+  }
+
+  private async promptForBranchName(proposedBranchName: string, workMode: WorkMode): Promise<string | undefined> {
+    return vscode.window.showInputBox({
+      title: 'DevDocket: Branch name',
+      prompt: `Branch to ${workMode === 'worktree' ? 'create for the new worktree' : 'check out'}`,
+      value: proposedBranchName,
+      valueSelection: [0, proposedBranchName.length],
+      ignoreFocusOut: true,
+      validateInput: input => this.validateBranchName(input),
+    });
+  }
+
+  private async promptForWorktreePath(
+    repoPath: string,
+    branchName: string,
+    item: Readonly<WorkItem>,
+  ): Promise<string | undefined> {
+    const defaultWorktreePath = this.getDefaultWorktreePath(repoPath, branchName, item);
+    const defaultDirName = path.basename(defaultWorktreePath);
+    return vscode.window.showInputBox({
+      title: 'DevDocket: Worktree path',
+      prompt: 'Filesystem path where the new worktree will be created',
+      value: defaultWorktreePath,
+      valueSelection: [defaultWorktreePath.length - defaultDirName.length, defaultWorktreePath.length],
+      ignoreFocusOut: true,
+      validateInput: input => this.validateWorktreePath(input, repoPath),
+    });
+  }
+
+  private validateBranchName(input: string): string | undefined {
+    if (input.length === 0) {
+      return 'Branch name is required.';
+    }
+    if (!isValidRef(input)) {
+      return 'Branch name must be a valid git ref (letters, digits, ., _, /, -; no leading -, spaces, .., or control characters).';
+    }
+    return undefined;
+  }
+
+  private validateWorktreePath(input: string, repoPath: string): string | undefined {
+    if (input.trim().length === 0) {
+      return 'Worktree path is required.';
+    }
+    if (!path.isAbsolute(input)) {
+      return 'Worktree path must be absolute.';
+    }
+
+    const resolvedPath = path.resolve(input);
+    const parentPath = path.dirname(resolvedPath);
+    if (!fs.existsSync(parentPath)) {
+      return `Parent directory "${parentPath}" does not exist.`;
+    }
+    if (fs.existsSync(resolvedPath)) {
+      return `Worktree path "${resolvedPath}" already exists.`;
+    }
+    if (this.isPathInsideOrEqual(parentPath, repoPath)) {
+      return 'Worktree parent directory must not be inside the source repository.';
+    }
+
+    return undefined;
+  }
+
+  private isPathInsideOrEqual(candidatePath: string, containerPath: string): boolean {
+    const relative = path.relative(path.resolve(containerPath), path.resolve(candidatePath));
+    return relative === '' || (relative.length > 0 && !relative.startsWith('..') && !path.isAbsolute(relative));
+  }
+
   /**
    * Runs user-configured post-worktree commands.
    */
@@ -759,6 +854,10 @@ export class StartWorkAction implements DevDocketAction {
       .map(value => value?.trim())
       .find(Boolean);
     return detail ?? 'Check your network connection, permissions, and whether the branch still exists.';
+  }
+
+  private getDefaultWorktreePath(repoPath: string, ref: string, item: Readonly<WorkItem>): string {
+    return path.join(path.dirname(repoPath), this.toWorktreeDirName(repoPath, ref, item));
   }
 
   private toWorktreeDirName(repoPath: string, ref: string, item: Readonly<WorkItem>): string {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -787,7 +787,9 @@ export class StartWorkAction implements DevDocketAction {
   private async promptForBranchName(proposedBranchName: string, workMode: WorkMode): Promise<string | undefined> {
     const selectedBranchName = await vscode.window.showInputBox({
       title: 'DevDocket: Branch name',
-      prompt: `Branch to ${workMode === 'worktree' ? 'create for the new worktree' : 'check out'}`,
+      prompt: workMode === 'worktree'
+        ? 'Local branch name to use for the new worktree (created if needed)'
+        : 'Local branch name to check out (created if needed)',
       value: proposedBranchName,
       valueSelection: [0, proposedBranchName.length],
       ignoreFocusOut: true,

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -81,7 +81,6 @@ type RepoPathPick = vscode.QuickPickItem & (
 
 interface PrBranchInfo {
   branchName: string;
-  upstreamBranchName: string;
   sourceRef: string;
   /** Remote tracking ref when branch is on a non-origin remote (e.g. "devdocket-fork-contributor/fix-bug"). */
   trackingRef?: string;
@@ -447,9 +446,9 @@ export class StartWorkAction implements DevDocketAction {
     }
 
     if (remoteName === 'origin') {
-      return { branchName, upstreamBranchName, sourceRef };
+      return { branchName, sourceRef };
     }
-    return { branchName, upstreamBranchName, sourceRef, trackingRef: sourceRef };
+    return { branchName, sourceRef, trackingRef: sourceRef };
   }
 
   /**

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -215,23 +215,34 @@ export class StartWorkAction implements DevDocketAction {
       return;
     }
 
-    let worktreePath: string | undefined;
-    if (this.shouldPromptForNames()) {
-      const promptedBranchName = await this.promptForBranchName(branchName, workMode);
-      if (promptedBranchName === undefined) {
-        return;
-      }
-      branchName = promptedBranchName;
+    const promptForNames = this.shouldPromptForNames();
+    let checkoutDirtyTreeChecked = false;
 
-      if (workMode === 'worktree') {
-        worktreePath = await this.promptForWorktreePath(repoPath, branchName, item);
-        if (worktreePath === undefined) {
+    try {
+      if (promptForNames && workMode === 'checkout') {
+        const canProceed = await this.checkDirtyTree(repoPath);
+        checkoutDirtyTreeChecked = true;
+        if (!canProceed) {
           return;
         }
       }
-    }
 
-    try {
+      let worktreePath: string | undefined;
+      if (promptForNames) {
+        const promptedBranchName = await this.promptForBranchName(branchName, workMode);
+        if (promptedBranchName === undefined) {
+          return;
+        }
+        branchName = promptedBranchName;
+
+        if (workMode === 'worktree') {
+          worktreePath = await this.promptForWorktreePath(repoPath, branchName, item);
+          if (worktreePath === undefined) {
+            return;
+          }
+        }
+      }
+
       await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
@@ -242,7 +253,7 @@ export class StartWorkAction implements DevDocketAction {
           if (workMode === 'worktree') {
             await this.issueWorktreeFlow(item, repoPath, branchName, baseBranch, progress, worktreePath);
           } else {
-            await this.issueCheckoutFlow(item, repoPath, branchName, baseBranch, progress);
+            await this.issueCheckoutFlow(item, repoPath, branchName, baseBranch, progress, checkoutDirtyTreeChecked);
           }
         },
       );
@@ -328,10 +339,13 @@ export class StartWorkAction implements DevDocketAction {
     branchName: string,
     baseBranch: string,
     progress: vscode.Progress<{ message?: string }>,
+    dirtyTreeChecked = false,
   ): Promise<void> {
-    const canProceed = await this.checkDirtyTree(repoPath);
-    if (!canProceed) {
-      return;
+    if (!dirtyTreeChecked) {
+      const canProceed = await this.checkDirtyTree(repoPath);
+      if (!canProceed) {
+        return;
+      }
     }
 
     progress.report({ message: 'Creating and checking out branch...' });

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -769,7 +769,7 @@ export class StartWorkAction implements DevDocketAction {
   ): Promise<string | undefined> {
     const defaultWorktreePath = this.getDefaultWorktreePath(repoPath, branchName, item);
     const defaultDirName = path.basename(defaultWorktreePath);
-    return vscode.window.showInputBox({
+    const selectedPath = await vscode.window.showInputBox({
       title: 'DevDocket: Worktree path',
       prompt: 'Filesystem path where the new worktree will be created',
       value: defaultWorktreePath,
@@ -777,6 +777,7 @@ export class StartWorkAction implements DevDocketAction {
       ignoreFocusOut: true,
       validateInput: input => this.validateWorktreePath(input, repoPath),
     });
+    return selectedPath?.trim();
   }
 
   private validateBranchName(input: string): string | undefined {
@@ -790,14 +791,15 @@ export class StartWorkAction implements DevDocketAction {
   }
 
   private validateWorktreePath(input: string, repoPath: string): string | undefined {
-    if (input.trim().length === 0) {
+    const trimmedInput = input.trim();
+    if (trimmedInput.length === 0) {
       return 'Worktree path is required.';
     }
-    if (!path.isAbsolute(input)) {
+    if (!path.isAbsolute(trimmedInput)) {
       return 'Worktree path must be absolute.';
     }
 
-    const resolvedPath = path.resolve(input);
+    const resolvedPath = path.resolve(trimmedInput);
     const parentPath = path.dirname(resolvedPath);
     if (!fs.existsSync(parentPath)) {
       return `Parent directory "${parentPath}" does not exist.`;

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -914,7 +914,23 @@ export class StartWorkAction implements DevDocketAction {
     }
 
     const repoBaseName = path.basename(repoPath);
-    return `${repoBaseName}-${this.toWorktreePathSuffix(ref)}`;
+    const refSuffix = this.toWorktreePathSuffix(ref);
+    const identitySuffix = this.worktreeFallbackIdentity(item);
+    return identitySuffix ? `${repoBaseName}-${refSuffix}-${identitySuffix}` : `${repoBaseName}-${refSuffix}`;
+  }
+
+  private worktreeFallbackIdentity(item: Readonly<WorkItem>): string | undefined {
+    const identity = [item.providerId, item.externalId ?? item.id].filter(Boolean).join(':');
+    return identity ? this.shortStableHash(identity) : undefined;
+  }
+
+  private shortStableHash(value: string): string {
+    let hash = 0x811c9dc5;
+    for (const char of value) {
+      hash ^= char.charCodeAt(0);
+      hash = Math.imul(hash, 0x01000193) >>> 0;
+    }
+    return hash.toString(36).padStart(6, '0').slice(0, 6);
   }
 
   private workItemNumber(externalId: string | undefined): string | undefined {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -218,17 +218,8 @@ export class StartWorkAction implements DevDocketAction {
     }
 
     const promptForNames = this.shouldPromptForNames();
-    let checkoutDirtyTreeChecked = false;
 
     try {
-      if (promptForNames && workMode === 'checkout') {
-        const canProceed = await this.checkDirtyTree(repoPath);
-        checkoutDirtyTreeChecked = true;
-        if (!canProceed) {
-          return;
-        }
-      }
-
       let worktreePath: string | undefined;
       if (promptForNames) {
         const promptedBranchName = await this.promptForBranchName(branchName, workMode);
@@ -255,7 +246,7 @@ export class StartWorkAction implements DevDocketAction {
           if (workMode === 'worktree') {
             await this.issueWorktreeFlow(item, gitWork, repoPath, branchName, baseBranch, progress, worktreePath);
           } else {
-            await this.issueCheckoutFlow(item, repoPath, branchName, baseBranch, progress, checkoutDirtyTreeChecked);
+            await this.issueCheckoutFlow(item, repoPath, branchName, baseBranch, progress);
           }
         },
       );
@@ -342,13 +333,10 @@ export class StartWorkAction implements DevDocketAction {
     branchName: string,
     baseBranch: string,
     progress: vscode.Progress<{ message?: string }>,
-    dirtyTreeChecked = false,
   ): Promise<void> {
-    if (!dirtyTreeChecked) {
-      const canProceed = await this.checkDirtyTree(repoPath);
-      if (!canProceed) {
-        return;
-      }
+    const canProceed = await this.checkDirtyTree(repoPath);
+    if (!canProceed) {
+      return;
     }
 
     progress.report({ message: 'Creating and checking out branch...' });

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -752,7 +752,7 @@ export class StartWorkAction implements DevDocketAction {
   }
 
   private async promptForBranchName(proposedBranchName: string, workMode: WorkMode): Promise<string | undefined> {
-    return vscode.window.showInputBox({
+    const selectedBranchName = await vscode.window.showInputBox({
       title: 'DevDocket: Branch name',
       prompt: `Branch to ${workMode === 'worktree' ? 'create for the new worktree' : 'check out'}`,
       value: proposedBranchName,
@@ -760,6 +760,7 @@ export class StartWorkAction implements DevDocketAction {
       ignoreFocusOut: true,
       validateInput: input => this.validateBranchName(input),
     });
+    return selectedBranchName === undefined ? undefined : this.normalizePromptedBranchName(selectedBranchName);
   }
 
   private async promptForWorktreePath(
@@ -781,13 +782,22 @@ export class StartWorkAction implements DevDocketAction {
   }
 
   private validateBranchName(input: string): string | undefined {
-    if (input.length === 0) {
+    const trimmedInput = input.trim();
+    const branchName = this.normalizePromptedBranchName(input);
+    if (branchName.length === 0) {
       return 'Branch name is required.';
     }
-    if (!isValidRef(input)) {
+    if (trimmedInput.startsWith('refs/') && !trimmedInput.startsWith('refs/heads/')) {
+      return 'Branch name must be a branch ref, not another refs/ namespace.';
+    }
+    if (!isValidRef(branchName)) {
       return 'Branch name must be a valid git ref (letters, digits, ., _, /, -; no leading -, spaces, .., or control characters).';
     }
     return undefined;
+  }
+
+  private normalizePromptedBranchName(input: string): string {
+    return this.normalizeBranchName(input.trim());
   }
 
   private validateWorktreePath(input: string, repoPath: string): string | undefined {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -201,7 +201,7 @@ describe('StartWorkAction', () => {
       expect(vi.mocked(execFile).mock.calls[0][1]).toEqual(['branch', '--list', 'vendor/ABC-123']);
       expect(vi.mocked(execFile).mock.calls[1][1]).toEqual(['branch', 'vendor/ABC-123', 'origin/dev']);
       expect(vi.mocked(execFile).mock.calls[2][1]).toEqual([
-        'worktree', 'add', path.join('/mock', 'workspace-vendor-ABC-123'), 'vendor/ABC-123',
+        'worktree', 'add', path.join('/mock', 'Vendor-Repo-issue-123'), 'vendor/ABC-123',
       ]);
       expect(memento.update).toHaveBeenCalledWith('repoPath:Vendor Repo', '/mock/workspace');
     });
@@ -217,10 +217,10 @@ describe('StartWorkAction', () => {
       await action.run(item);
 
       expect(inputBoxOptions('DevDocket: Worktree path')).toEqual(expect.objectContaining({
-        value: path.join('/mock', 'sdk-issue-53921-fix-foo'),
+        value: path.join('/mock', 'sdk-issue-53921'),
       }));
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
-        'worktree', 'add', path.join('/mock', 'sdk-issue-53921-fix-foo'), 'issue-53921-fix-foo',
+        'worktree', 'add', path.join('/mock', 'sdk-issue-53921'), 'issue-53921-fix-foo',
       ]);
     });
 
@@ -250,7 +250,7 @@ describe('StartWorkAction', () => {
         valueSelection: [0, 'issue123'.length],
       }));
       expect(inputBoxOptions('DevDocket: Worktree path')).toEqual(expect.objectContaining({
-        value: path.join('/mock', 'workspace-team-custom-branch'),
+        value: path.join('/mock', 'repo-issue-1'),
       }));
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toEqual([
         ['branch', '--list', 'team/custom-branch'],
@@ -273,7 +273,7 @@ describe('StartWorkAction', () => {
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toEqual([
         ['branch', '--list', 'issue123'],
         ['branch', 'issue123', 'origin/dev'],
-        ['worktree', 'add', path.join('/mock', 'workspace-issue123'), 'issue123'],
+        ['worktree', 'add', path.join('/mock', 'repo-issue-1'), 'issue123'],
       ]);
     });
 
@@ -495,7 +495,7 @@ describe('StartWorkAction', () => {
         ['remote', 'add', 'devdocket-fork-contributor', 'https://example.com/contributor/repo.git'],
         ['fetch', 'devdocket-fork-contributor', '+refs/heads/feature/topic:refs/remotes/devdocket-fork-contributor/feature/topic'],
         ['rev-parse', '--verify', 'refs/heads/feature/topic'],
-        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'devdocket-fork-contributor/feature/topic'],
+        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'repo-pr-1'), 'devdocket-fork-contributor/feature/topic'],
       ]);
     });
 
@@ -512,14 +512,17 @@ describe('StartWorkAction', () => {
         ['remote', '-v'],
         ['fetch', 'origin', '+refs/heads/feature/topic:refs/remotes/origin/feature/topic'],
         ['rev-parse', '--verify', 'refs/heads/feature/topic'],
-        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'origin/feature/topic'],
+        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'repo-pr-1'), 'origin/feature/topic'],
       ]);
     });
 
-    it('prompts for PR worktree path but not branch name when promptForNames is enabled', async () => {
+    it('prompts for PR branch name and worktree path when promptForNames is enabled', async () => {
       mockNoLocalBranch();
       const customWorktreePath = path.join('/mock', 'custom-pr-worktree');
       vi.mocked(window.showInputBox).mockImplementation(async (options: any) => {
+        if (options?.title === 'DevDocket: Branch name') {
+          return 'custom-pr-branch';
+        }
         if (options?.title === 'DevDocket: Worktree path') {
           return customWorktreePath;
         }
@@ -532,12 +535,17 @@ describe('StartWorkAction', () => {
 
       await action.run(item);
 
-      expect(inputBoxOptions('DevDocket: Branch name')).toBeUndefined();
+      expect(inputBoxOptions('DevDocket: Branch name')).toEqual(expect.objectContaining({
+        value: 'feature/topic',
+      }));
       expect(inputBoxOptions('DevDocket: Worktree path')).toEqual(expect.objectContaining({
-        value: path.join('/mock', 'workspace-feature-topic'),
+        value: path.join('/mock', 'repo-pr-1'),
       }));
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
-        'worktree', 'add', '-b', 'feature/topic', customWorktreePath, 'origin/feature/topic',
+        'fetch', 'origin', '+refs/heads/feature/topic:refs/remotes/origin/feature/topic',
+      ]);
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
+        'worktree', 'add', '-b', 'custom-pr-branch', customWorktreePath, 'origin/feature/topic',
       ]);
     });
 
@@ -554,8 +562,70 @@ describe('StartWorkAction', () => {
       expect(inputBoxOptions('DevDocket: Branch name')).toBeUndefined();
       expect(inputBoxOptions('DevDocket: Worktree path')).toBeUndefined();
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
-        'worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'origin/feature/topic',
+        'worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'repo-pr-1'), 'origin/feature/topic',
       ]);
+    });
+
+    it('aborts without side effects when the PR branch-name prompt is cancelled', async () => {
+      vi.mocked(window.showInputBox).mockImplementation(async (options: any) => {
+        if (options?.title === 'DevDocket: Branch name') {
+          return undefined;
+        }
+        return options?.value;
+      });
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'pr', cloneUrl: 'https://example.com/acme/repo.git', ref: 'feature/topic', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(execFile).not.toHaveBeenCalled();
+      expect(window.withProgress).not.toHaveBeenCalled();
+    });
+
+    it('defaults PR worktree paths to source repo and PR number', async () => {
+      mockNoLocalBranch();
+      (workspace as any).workspaceFolders = [{ uri: { fsPath: '/mock/sdk' } }];
+      mockQuickPicks('/mock/sdk');
+      const item = createWorkItem({ externalId: 'dotnet/install-scripts#692' });
+      const { action } = createAction(discovered('provider', 'dotnet/install-scripts#692', {
+        kind: 'pr', cloneUrl: 'https://github.com/dotnet/install-scripts.git', ref: 'fix-incorrect-corrupted-size-message', repoLabel: 'dotnet/install-scripts',
+      }));
+
+      await action.run(item);
+
+      expect(inputBoxOptions('DevDocket: Worktree path')).toEqual(expect.objectContaining({
+        value: path.join('/mock', 'install-scripts-pr-692'),
+      }));
+    });
+
+    it('defaults ADO PR worktree paths from bang-delimited external ids', async () => {
+      mockNoLocalBranch();
+      const item = createWorkItem({ externalId: 'org/project/repo!42' });
+      const { action } = createAction(discovered('provider', 'org/project/repo!42', {
+        kind: 'pr', cloneUrl: 'https://dev.azure.com/org/project/_git/repo', ref: 'feature/topic', repoLabel: 'org/project/repo',
+      }));
+
+      await action.run(item);
+
+      expect(inputBoxOptions('DevDocket: Worktree path')).toEqual(expect.objectContaining({
+        value: path.join('/mock', 'repo-pr-42'),
+      }));
+    });
+
+    it('falls back to the local repo and ref slug when no work item number is derivable', async () => {
+      mockNoLocalBranch();
+      const item = createWorkItem({ externalId: 'work-item' });
+      const { action } = createAction(discovered('provider', 'work-item', {
+        kind: 'pr', cloneUrl: 'https://example.com/acme/repo.git', ref: 'feature/topic', repoLabel: undefined,
+      }));
+
+      await action.run(item);
+
+      expect(inputBoxOptions('DevDocket: Worktree path')).toEqual(expect.objectContaining({
+        value: path.join('/mock', 'workspace-feature-topic'),
+      }));
     });
 
     it('prompts for issue checkout branch name but skips worktree path', async () => {
@@ -581,9 +651,15 @@ describe('StartWorkAction', () => {
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual(['checkout', '-b', 'custom-checkout', 'origin/dev']);
     });
 
-    it('skips branch-name and worktree-path prompts for PR checkout', async () => {
+    it('prompts for PR checkout branch name but skips worktree path', async () => {
       mockQuickPicks('/mock/workspace', 'checkout');
       mockNoLocalBranch();
+      vi.mocked(window.showInputBox).mockImplementation(async (options: any) => {
+        if (options?.title === 'DevDocket: Branch name') {
+          return 'refs/heads/custom-pr-checkout';
+        }
+        return options?.value;
+      });
       const item = createWorkItem();
       const { action } = createAction(discovered('provider', 'item-1', {
         kind: 'pr', cloneUrl: 'https://example.com/acme/repo.git', ref: 'feature/topic', repoLabel: 'acme/repo',
@@ -591,9 +667,12 @@ describe('StartWorkAction', () => {
 
       await action.run(item);
 
-      expect(inputBoxOptions('DevDocket: Branch name')).toBeUndefined();
+      expect(inputBoxOptions('DevDocket: Branch name')).toBeDefined();
       expect(inputBoxOptions('DevDocket: Worktree path')).toBeUndefined();
-      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual(['checkout', '-b', 'feature/topic', '--track', 'origin/feature/topic']);
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
+        'fetch', 'origin', '+refs/heads/feature/topic:refs/remotes/origin/feature/topic',
+      ]);
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual(['checkout', '-b', 'custom-pr-checkout', '--track', 'origin/feature/topic']);
     });
 
     it('normalizes fully-qualified PR head refs before fetching and checking out', async () => {
@@ -609,7 +688,7 @@ describe('StartWorkAction', () => {
         ['remote', '-v'],
         ['fetch', 'origin', '+refs/heads/feature/topic:refs/remotes/origin/feature/topic'],
         ['rev-parse', '--verify', 'refs/heads/feature/topic'],
-        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'origin/feature/topic'],
+        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'repo-pr-1'), 'origin/feature/topic'],
       ]);
     });
 
@@ -653,7 +732,7 @@ describe('StartWorkAction', () => {
         "DevDocket: Could not fetch branch 'feature/topic' from remote 'origin'. Authentication failed",
       );
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).not.toContainEqual([
-        'worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'origin/feature/topic',
+        'worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'repo-pr-1'), 'origin/feature/topic',
       ]);
     });
 
@@ -759,7 +838,7 @@ describe('StartWorkAction', () => {
       expect(vi.mocked(execFile).mock.calls[0][1]).toEqual(['branch', '--list', 'vendor/ABC-123']);
       expect(vi.mocked(execFile).mock.calls[1][1]).toEqual(['branch', 'vendor/ABC-123', 'origin/dev']);
       expect(vi.mocked(execFile).mock.calls[2][1]).toEqual([
-        'worktree', 'add', path.join('/mock', 'workspace-vendor-ABC-123'), 'vendor/ABC-123',
+        'worktree', 'add', path.join('/mock', 'Vendor-Repo-issue-123'), 'vendor/ABC-123',
       ]);
     });
 
@@ -848,7 +927,7 @@ describe('StartWorkAction', () => {
       await action.run(item);
 
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
-        'worktree', 'add', '--detach', path.join('/mock', 'workspace-feature-topic'), 'devdocket-fork-contributor/feature/topic',
+        'worktree', 'add', '--detach', path.join('/mock', 'repo-pr-1'), 'devdocket-fork-contributor/feature/topic',
       ]);
     });
 
@@ -903,7 +982,7 @@ describe('StartWorkAction', () => {
       await action.run(item);
 
       expect(vi.mocked(execFile).mock.calls.map(call => [call[0], call[1], call[2]])).toContainEqual([
-        'npm', ['install', '--prefix', path.join('/mock', 'workspace-issue123')], { cwd: path.join('/mock', 'workspace-issue123'), timeout: 60_000 },
+        'npm', ['install', '--prefix', path.join('/mock', 'repo-issue-1')], { cwd: path.join('/mock', 'repo-issue-1'), timeout: 60_000 },
       ]);
     });
 
@@ -957,7 +1036,7 @@ describe('StartWorkAction', () => {
         expect(worktreeAddCalls).toHaveLength(1);
         expect(worktreeAddCalls[0]![1]).toEqual([
           'worktree', 'add', '--detach',
-          path.join('/mock', 'workspace-feature-topic'),
+          path.join('/mock', 'repo-pr-1'),
           'origin/feature/topic',
         ]);
         expect(window.showErrorMessage).not.toHaveBeenCalled();
@@ -985,7 +1064,7 @@ describe('StartWorkAction', () => {
         expect(worktreeAddCalls).toHaveLength(1);
         expect(worktreeAddCalls[0]![1]).toEqual([
           'worktree', 'add',
-          path.join('/mock', 'workspace-feature-topic'),
+          path.join('/mock', 'repo-pr-1'),
           'feature/topic',
         ]);
       });
@@ -1020,7 +1099,7 @@ describe('StartWorkAction', () => {
         expect(worktreeAddCalls).toHaveLength(1);
         expect(worktreeAddCalls[0]![1]).toEqual([
           'worktree', 'add',
-          path.join('/mock', 'workspace-feature-topic'),
+          path.join('/mock', 'repo-pr-1'),
           'feature/topic',
         ]);
       });
@@ -1054,7 +1133,7 @@ describe('StartWorkAction', () => {
         expect(worktreeAddCalls).toHaveLength(1);
         expect(worktreeAddCalls[0]![1]).toEqual([
           'worktree', 'add',
-          path.join('/mock', 'workspace-feature-topic'),
+          path.join('/mock', 'repo-pr-1'),
           'feature/topic',
         ]);
       });

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -273,6 +273,8 @@ describe('StartWorkAction', () => {
       expect(validateInput('bad..branch')).toContain('valid git ref');
       expect(validateInput('bad branch')).toContain('valid git ref');
       expect(validateInput('bad\nbranch')).toContain('valid git ref');
+      expect(validateInput('refs/tags/v1')).toContain('branch ref');
+      expect(validateInput('refs/heads/feature/good-branch')).toBeUndefined();
       expect(validateInput('feature/good-branch')).toBeUndefined();
     });
 
@@ -540,7 +542,7 @@ describe('StartWorkAction', () => {
           return 'origin/dev';
         }
         if (options?.title === 'DevDocket: Branch name') {
-          return 'custom-checkout';
+          return 'refs/heads/custom-checkout';
         }
         return options?.value;
       });

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -308,6 +308,11 @@ describe('StartWorkAction', () => {
       const nestedParent = path.dirname(nestedTarget);
       vi.mocked(fs.existsSync).mockImplementation((p: any) => path.resolve(p.toString()) === path.resolve(nestedParent));
       expect(validateInput(nestedTarget)).toBe('Worktree parent directory must not be inside the source repository.');
+
+      const dotDotPrefixTarget = path.join('/mock', 'workspace', '..worktrees', 'target');
+      const dotDotPrefixParent = path.dirname(dotDotPrefixTarget);
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => path.resolve(p.toString()) === path.resolve(dotDotPrefixParent));
+      expect(validateInput(dotDotPrefixTarget)).toBe('Worktree parent directory must not be inside the source repository.');
     });
 
     it('aborts without side effects when the branch-name prompt is cancelled', async () => {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -93,6 +93,11 @@ function inputBoxOptions(title: string): any {
   return call?.[0];
 }
 
+function inputBoxInvocationOrder(title: string): number | undefined {
+  const index = vi.mocked(window.showInputBox).mock.calls.findIndex(([options]) => (options as any)?.title === title);
+  return index === -1 ? undefined : vi.mocked(window.showInputBox).mock.invocationCallOrder[index];
+}
+
 function isRepoPathPickItems(items: unknown): items is Array<{ pickKind?: string; repoPath?: string }> {
   return Array.isArray(items) && items.some(item => ['repo', 'paste', 'browse'].includes((item as { pickKind?: string }).pickKind ?? ''));
 }
@@ -877,8 +882,46 @@ describe('StartWorkAction', () => {
         { modal: true },
         'Yes',
       );
-      expect(inputBoxOptions('DevDocket: Branch name')).toBeUndefined();
+      expect(inputBoxOptions('DevDocket: Branch name')).toBeDefined();
+      const branchPromptOrder = inputBoxInvocationOrder('DevDocket: Branch name');
+      const dirtyPromptOrder = vi.mocked(window.showWarningMessage).mock.invocationCallOrder[0];
+      expect(branchPromptOrder).toBeDefined();
+      expect(branchPromptOrder!).toBeLessThan(dirtyPromptOrder);
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).not.toContainEqual(['checkout', '-b', 'issue123', 'origin/dev']);
+    });
+
+    it('prompts for the issue checkout branch before proceeding through a dirty working tree', async () => {
+      mockQuickPicks('/mock/workspace', 'checkout');
+      vi.mocked(window.showWarningMessage).mockResolvedValue('Yes' as any);
+      vi.mocked(window.showInputBox).mockImplementation(async (options: any) => {
+        if (options?.prompt?.includes('base branch')) {
+          return 'origin/dev';
+        }
+        if (options?.title === 'DevDocket: Branch name') {
+          return 'custom-dirty-checkout';
+        }
+        return options?.value;
+      });
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'status') {
+          cb(null, ' M file.ts\n', '');
+          return;
+        }
+        cb(null, '', '');
+      }) as any);
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(inputBoxOptions('DevDocket: Branch name')).toBeDefined();
+      const branchPromptOrder = inputBoxInvocationOrder('DevDocket: Branch name');
+      const dirtyPromptOrder = vi.mocked(window.showWarningMessage).mock.invocationCallOrder[0];
+      expect(branchPromptOrder).toBeDefined();
+      expect(branchPromptOrder!).toBeLessThan(dirtyPromptOrder);
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual(['checkout', '-b', 'custom-dirty-checkout', 'origin/dev']);
     });
 
     it('checks out an existing same-repo PR branch directly', async () => {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -798,6 +798,7 @@ describe('StartWorkAction', () => {
         { modal: true },
         'Yes',
       );
+      expect(inputBoxOptions('DevDocket: Branch name')).toBeUndefined();
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).not.toContainEqual(['checkout', '-b', 'issue123', 'origin/dev']);
     });
 

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -201,9 +201,27 @@ describe('StartWorkAction', () => {
       expect(vi.mocked(execFile).mock.calls[0][1]).toEqual(['branch', '--list', 'vendor/ABC-123']);
       expect(vi.mocked(execFile).mock.calls[1][1]).toEqual(['branch', 'vendor/ABC-123', 'origin/dev']);
       expect(vi.mocked(execFile).mock.calls[2][1]).toEqual([
-        'worktree', 'add', path.join('/mock', 'workspace-vendor-ABC-123-ABC-123'), 'vendor/ABC-123',
+        'worktree', 'add', path.join('/mock', 'workspace-vendor-ABC-123'), 'vendor/ABC-123',
       ]);
       expect(memento.update).toHaveBeenCalledWith('repoPath:Vendor Repo', '/mock/workspace');
+    });
+
+    it('does not duplicate the external id in the default issue worktree path', async () => {
+      (workspace as any).workspaceFolders = [{ uri: { fsPath: '/mock/sdk' } }];
+      mockQuickPicks('/mock/sdk');
+      const item = createWorkItem({ externalId: 'dotnet/sdk#53921' });
+      const { action } = createAction(discovered('provider', 'dotnet/sdk#53921', {
+        kind: 'issue', cloneUrl: 'https://example.com/dotnet/sdk.git', ref: 'issue-53921-fix-foo', repoLabel: 'dotnet/sdk',
+      }));
+
+      await action.run(item);
+
+      expect(inputBoxOptions('DevDocket: Worktree path')).toEqual(expect.objectContaining({
+        value: path.join('/mock', 'sdk-issue-53921-fix-foo'),
+      }));
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
+        'worktree', 'add', path.join('/mock', 'sdk-issue-53921-fix-foo'), 'issue-53921-fix-foo',
+      ]);
     });
 
     it('prompts for issue branch name and worktree path when promptForNames is enabled', async () => {
@@ -232,7 +250,7 @@ describe('StartWorkAction', () => {
         valueSelection: [0, 'issue123'.length],
       }));
       expect(inputBoxOptions('DevDocket: Worktree path')).toEqual(expect.objectContaining({
-        value: path.join('/mock', 'workspace-team-custom-branch-item-1'),
+        value: path.join('/mock', 'workspace-team-custom-branch'),
       }));
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toEqual([
         ['branch', '--list', 'team/custom-branch'],
@@ -255,7 +273,7 @@ describe('StartWorkAction', () => {
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toEqual([
         ['branch', '--list', 'issue123'],
         ['branch', 'issue123', 'origin/dev'],
-        ['worktree', 'add', path.join('/mock', 'workspace-issue123-item-1'), 'issue123'],
+        ['worktree', 'add', path.join('/mock', 'workspace-issue123'), 'issue123'],
       ]);
     });
 
@@ -477,7 +495,7 @@ describe('StartWorkAction', () => {
         ['remote', 'add', 'devdocket-fork-contributor', 'https://example.com/contributor/repo.git'],
         ['fetch', 'devdocket-fork-contributor', '+refs/heads/feature/topic:refs/remotes/devdocket-fork-contributor/feature/topic'],
         ['rev-parse', '--verify', 'refs/heads/feature/topic'],
-        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic-item-1'), 'devdocket-fork-contributor/feature/topic'],
+        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'devdocket-fork-contributor/feature/topic'],
       ]);
     });
 
@@ -494,7 +512,7 @@ describe('StartWorkAction', () => {
         ['remote', '-v'],
         ['fetch', 'origin', '+refs/heads/feature/topic:refs/remotes/origin/feature/topic'],
         ['rev-parse', '--verify', 'refs/heads/feature/topic'],
-        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic-item-1'), 'origin/feature/topic'],
+        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'origin/feature/topic'],
       ]);
     });
 
@@ -516,7 +534,7 @@ describe('StartWorkAction', () => {
 
       expect(inputBoxOptions('DevDocket: Branch name')).toBeUndefined();
       expect(inputBoxOptions('DevDocket: Worktree path')).toEqual(expect.objectContaining({
-        value: path.join('/mock', 'workspace-feature-topic-item-1'),
+        value: path.join('/mock', 'workspace-feature-topic'),
       }));
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
         'worktree', 'add', '-b', 'feature/topic', customWorktreePath, 'origin/feature/topic',
@@ -536,7 +554,7 @@ describe('StartWorkAction', () => {
       expect(inputBoxOptions('DevDocket: Branch name')).toBeUndefined();
       expect(inputBoxOptions('DevDocket: Worktree path')).toBeUndefined();
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
-        'worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic-item-1'), 'origin/feature/topic',
+        'worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'origin/feature/topic',
       ]);
     });
 
@@ -591,7 +609,7 @@ describe('StartWorkAction', () => {
         ['remote', '-v'],
         ['fetch', 'origin', '+refs/heads/feature/topic:refs/remotes/origin/feature/topic'],
         ['rev-parse', '--verify', 'refs/heads/feature/topic'],
-        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic-item-1'), 'origin/feature/topic'],
+        ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'origin/feature/topic'],
       ]);
     });
 
@@ -635,7 +653,7 @@ describe('StartWorkAction', () => {
         "DevDocket: Could not fetch branch 'feature/topic' from remote 'origin'. Authentication failed",
       );
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).not.toContainEqual([
-        'worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic-item-1'), 'origin/feature/topic',
+        'worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic'), 'origin/feature/topic',
       ]);
     });
 
@@ -741,7 +759,7 @@ describe('StartWorkAction', () => {
       expect(vi.mocked(execFile).mock.calls[0][1]).toEqual(['branch', '--list', 'vendor/ABC-123']);
       expect(vi.mocked(execFile).mock.calls[1][1]).toEqual(['branch', 'vendor/ABC-123', 'origin/dev']);
       expect(vi.mocked(execFile).mock.calls[2][1]).toEqual([
-        'worktree', 'add', path.join('/mock', 'workspace-vendor-ABC-123-ABC-123'), 'vendor/ABC-123',
+        'worktree', 'add', path.join('/mock', 'workspace-vendor-ABC-123'), 'vendor/ABC-123',
       ]);
     });
 
@@ -829,7 +847,7 @@ describe('StartWorkAction', () => {
       await action.run(item);
 
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
-        'worktree', 'add', '--detach', path.join('/mock', 'workspace-feature-topic-item-1'), 'devdocket-fork-contributor/feature/topic',
+        'worktree', 'add', '--detach', path.join('/mock', 'workspace-feature-topic'), 'devdocket-fork-contributor/feature/topic',
       ]);
     });
 
@@ -884,7 +902,7 @@ describe('StartWorkAction', () => {
       await action.run(item);
 
       expect(vi.mocked(execFile).mock.calls.map(call => [call[0], call[1], call[2]])).toContainEqual([
-        'npm', ['install', '--prefix', path.join('/mock', 'workspace-issue123-item-1')], { cwd: path.join('/mock', 'workspace-issue123-item-1'), timeout: 60_000 },
+        'npm', ['install', '--prefix', path.join('/mock', 'workspace-issue123')], { cwd: path.join('/mock', 'workspace-issue123'), timeout: 60_000 },
       ]);
     });
 
@@ -938,7 +956,7 @@ describe('StartWorkAction', () => {
         expect(worktreeAddCalls).toHaveLength(1);
         expect(worktreeAddCalls[0]![1]).toEqual([
           'worktree', 'add', '--detach',
-          path.join('/mock', 'workspace-feature-topic-item-1'),
+          path.join('/mock', 'workspace-feature-topic'),
           'origin/feature/topic',
         ]);
         expect(window.showErrorMessage).not.toHaveBeenCalled();
@@ -966,7 +984,7 @@ describe('StartWorkAction', () => {
         expect(worktreeAddCalls).toHaveLength(1);
         expect(worktreeAddCalls[0]![1]).toEqual([
           'worktree', 'add',
-          path.join('/mock', 'workspace-feature-topic-item-1'),
+          path.join('/mock', 'workspace-feature-topic'),
           'feature/topic',
         ]);
       });
@@ -1001,7 +1019,7 @@ describe('StartWorkAction', () => {
         expect(worktreeAddCalls).toHaveLength(1);
         expect(worktreeAddCalls[0]![1]).toEqual([
           'worktree', 'add',
-          path.join('/mock', 'workspace-feature-topic-item-1'),
+          path.join('/mock', 'workspace-feature-topic'),
           'feature/topic',
         ]);
       });
@@ -1035,7 +1053,7 @@ describe('StartWorkAction', () => {
         expect(worktreeAddCalls).toHaveLength(1);
         expect(worktreeAddCalls[0]![1]).toEqual([
           'worktree', 'add',
-          path.join('/mock', 'workspace-feature-topic-item-1'),
+          path.join('/mock', 'workspace-feature-topic'),
           'feature/topic',
         ]);
       });

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -75,8 +75,22 @@ function mockInputBox(repoPath: string | undefined, baseBranch = 'origin/dev') {
     if (options?.prompt?.includes('base branch')) {
       return baseBranch;
     }
+    if (options?.title === 'DevDocket: Branch name' || options?.title === 'DevDocket: Worktree path') {
+      return options.value;
+    }
     return undefined;
   });
+}
+
+function setPromptForNames(enabled: boolean) {
+  vi.mocked(workspace.getConfiguration).mockReturnValue({
+    get: vi.fn((key: string, defaultValue?: any) => key === 'devdocket.startGitWork.promptForNames' ? enabled : defaultValue),
+  } as any);
+}
+
+function inputBoxOptions(title: string): any {
+  const call = vi.mocked(window.showInputBox).mock.calls.find(([options]) => (options as any)?.title === title);
+  return call?.[0];
 }
 
 function isRepoPathPickItems(items: unknown): items is Array<{ pickKind?: string; repoPath?: string }> {
@@ -190,6 +204,149 @@ describe('StartWorkAction', () => {
         'worktree', 'add', path.join('/mock', 'workspace-vendor-ABC-123-ABC-123'), 'vendor/ABC-123',
       ]);
       expect(memento.update).toHaveBeenCalledWith('repoPath:Vendor Repo', '/mock/workspace');
+    });
+
+    it('prompts for issue branch name and worktree path when promptForNames is enabled', async () => {
+      const customWorktreePath = path.join('/mock', 'custom-worktree');
+      vi.mocked(window.showInputBox).mockImplementation(async (options: any) => {
+        if (options?.prompt?.includes('base branch')) {
+          return 'origin/dev';
+        }
+        if (options?.title === 'DevDocket: Branch name') {
+          return 'team/custom-branch';
+        }
+        if (options?.title === 'DevDocket: Worktree path') {
+          return customWorktreePath;
+        }
+        return options?.value;
+      });
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(inputBoxOptions('DevDocket: Branch name')).toEqual(expect.objectContaining({
+        value: 'issue123',
+        valueSelection: [0, 'issue123'.length],
+      }));
+      expect(inputBoxOptions('DevDocket: Worktree path')).toEqual(expect.objectContaining({
+        value: path.join('/mock', 'workspace-team-custom-branch-item-1'),
+      }));
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toEqual([
+        ['branch', '--list', 'team/custom-branch'],
+        ['branch', 'team/custom-branch', 'origin/dev'],
+        ['worktree', 'add', customWorktreePath, 'team/custom-branch'],
+      ]);
+    });
+
+    it('uses issue branch name and worktree path silently when promptForNames is disabled', async () => {
+      setPromptForNames(false);
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(inputBoxOptions('DevDocket: Branch name')).toBeUndefined();
+      expect(inputBoxOptions('DevDocket: Worktree path')).toBeUndefined();
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toEqual([
+        ['branch', '--list', 'issue123'],
+        ['branch', 'issue123', 'origin/dev'],
+        ['worktree', 'add', path.join('/mock', 'workspace-issue123-item-1'), 'issue123'],
+      ]);
+    });
+
+    it('validates prompted branch names synchronously', async () => {
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      const validateInput = inputBoxOptions('DevDocket: Branch name').validateInput;
+      expect(validateInput('')).toBe('Branch name is required.');
+      expect(validateInput('-bad')).toContain('valid git ref');
+      expect(validateInput('bad..branch')).toContain('valid git ref');
+      expect(validateInput('bad branch')).toContain('valid git ref');
+      expect(validateInput('bad\nbranch')).toContain('valid git ref');
+      expect(validateInput('feature/good-branch')).toBeUndefined();
+    });
+
+    it('validates prompted worktree paths synchronously', async () => {
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      const validateInput = inputBoxOptions('DevDocket: Worktree path').validateInput;
+      const outsideTarget = path.join(path.parse(process.cwd()).root, 'devdocket-test-worktrees', 'target');
+      const outsideParent = path.dirname(outsideTarget);
+      expect(validateInput('relative-worktree')).toBe('Worktree path must be absolute.');
+
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      expect(validateInput(outsideTarget)).toContain('does not exist');
+
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => path.resolve(p.toString()) === path.resolve(outsideParent));
+      expect(validateInput(outsideTarget)).toBeUndefined();
+
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => {
+        const resolved = path.resolve(p.toString());
+        return resolved === path.resolve(outsideParent) || resolved === path.resolve(outsideTarget);
+      });
+      expect(validateInput(outsideTarget)).toContain('already exists');
+
+      const nestedTarget = path.join('/mock', 'workspace', 'nested-parent', 'target');
+      const nestedParent = path.dirname(nestedTarget);
+      vi.mocked(fs.existsSync).mockImplementation((p: any) => path.resolve(p.toString()) === path.resolve(nestedParent));
+      expect(validateInput(nestedTarget)).toBe('Worktree parent directory must not be inside the source repository.');
+    });
+
+    it('aborts without side effects when the branch-name prompt is cancelled', async () => {
+      vi.mocked(window.showInputBox).mockImplementation(async (options: any) => {
+        if (options?.prompt?.includes('base branch')) {
+          return 'origin/dev';
+        }
+        if (options?.title === 'DevDocket: Branch name') {
+          return undefined;
+        }
+        return options?.value;
+      });
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(execFile).not.toHaveBeenCalled();
+      expect(window.withProgress).not.toHaveBeenCalled();
+    });
+
+    it('aborts without side effects when the worktree-path prompt is cancelled', async () => {
+      vi.mocked(window.showInputBox).mockImplementation(async (options: any) => {
+        if (options?.prompt?.includes('base branch')) {
+          return 'origin/dev';
+        }
+        if (options?.title === 'DevDocket: Worktree path') {
+          return undefined;
+        }
+        return options?.value;
+      });
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(execFile).not.toHaveBeenCalled();
+      expect(window.withProgress).not.toHaveBeenCalled();
     });
 
     it('offers cached and git workspace folders before paste and browse choices', async () => {
@@ -331,6 +488,86 @@ describe('StartWorkAction', () => {
         ['rev-parse', '--verify', 'refs/heads/feature/topic'],
         ['worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic-item-1'), 'origin/feature/topic'],
       ]);
+    });
+
+    it('prompts for PR worktree path but not branch name when promptForNames is enabled', async () => {
+      mockNoLocalBranch();
+      const customWorktreePath = path.join('/mock', 'custom-pr-worktree');
+      vi.mocked(window.showInputBox).mockImplementation(async (options: any) => {
+        if (options?.title === 'DevDocket: Worktree path') {
+          return customWorktreePath;
+        }
+        return options?.value;
+      });
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'pr', cloneUrl: 'https://example.com/acme/repo.git', ref: 'feature/topic', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(inputBoxOptions('DevDocket: Branch name')).toBeUndefined();
+      expect(inputBoxOptions('DevDocket: Worktree path')).toEqual(expect.objectContaining({
+        value: path.join('/mock', 'workspace-feature-topic-item-1'),
+      }));
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
+        'worktree', 'add', '-b', 'feature/topic', customWorktreePath, 'origin/feature/topic',
+      ]);
+    });
+
+    it('uses PR worktree path silently when promptForNames is disabled', async () => {
+      setPromptForNames(false);
+      mockNoLocalBranch();
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'pr', cloneUrl: 'https://example.com/acme/repo.git', ref: 'feature/topic', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(inputBoxOptions('DevDocket: Branch name')).toBeUndefined();
+      expect(inputBoxOptions('DevDocket: Worktree path')).toBeUndefined();
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual([
+        'worktree', 'add', '-b', 'feature/topic', path.join('/mock', 'workspace-feature-topic-item-1'), 'origin/feature/topic',
+      ]);
+    });
+
+    it('prompts for issue checkout branch name but skips worktree path', async () => {
+      mockQuickPicks('/mock/workspace', 'checkout');
+      vi.mocked(window.showInputBox).mockImplementation(async (options: any) => {
+        if (options?.prompt?.includes('base branch')) {
+          return 'origin/dev';
+        }
+        if (options?.title === 'DevDocket: Branch name') {
+          return 'custom-checkout';
+        }
+        return options?.value;
+      });
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(inputBoxOptions('DevDocket: Branch name')).toBeDefined();
+      expect(inputBoxOptions('DevDocket: Worktree path')).toBeUndefined();
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual(['checkout', '-b', 'custom-checkout', 'origin/dev']);
+    });
+
+    it('skips branch-name and worktree-path prompts for PR checkout', async () => {
+      mockQuickPicks('/mock/workspace', 'checkout');
+      mockNoLocalBranch();
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'pr', cloneUrl: 'https://example.com/acme/repo.git', ref: 'feature/topic', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(inputBoxOptions('DevDocket: Branch name')).toBeUndefined();
+      expect(inputBoxOptions('DevDocket: Worktree path')).toBeUndefined();
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual(['checkout', '-b', 'feature/topic', '--track', 'origin/feature/topic']);
     });
 
     it('normalizes fully-qualified PR head refs before fetching and checking out', async () => {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -619,7 +619,7 @@ describe('StartWorkAction', () => {
       }));
     });
 
-    it('falls back to the local repo and ref slug when no work item number is derivable', async () => {
+    it('falls back to the local repo, ref slug, and stable identity when no work item number is derivable', async () => {
       mockNoLocalBranch();
       const item = createWorkItem({ externalId: 'work-item' });
       const { action } = createAction(discovered('provider', 'work-item', {
@@ -628,9 +628,35 @@ describe('StartWorkAction', () => {
 
       await action.run(item);
 
-      expect(inputBoxOptions('DevDocket: Worktree path')).toEqual(expect.objectContaining({
-        value: path.join('/mock', 'workspace-feature-topic'),
-      }));
+      const defaultPath = inputBoxOptions('DevDocket: Worktree path')?.value;
+      expect(path.basename(defaultPath)).toMatch(/^workspace-feature-topic-[a-z0-9]{6}$/);
+    });
+
+    it('keeps fallback worktree paths distinct for different work items with the same ref', async () => {
+      setPromptForNames(false);
+      mockNoLocalBranch();
+      const gitWork = {
+        kind: 'pr' as const,
+        cloneUrl: 'https://example.com/acme/repo.git',
+        ref: 'feature/topic',
+        repoLabel: undefined,
+      };
+      const { action } = createAction({
+        ...discovered('provider', 'work-a', gitWork),
+        ...discovered('provider', 'work-b', gitWork),
+      });
+
+      await action.run(createWorkItem({ id: 'wc-test-a', externalId: 'work-a' }));
+      await action.run(createWorkItem({ id: 'wc-test-b', externalId: 'work-b' }));
+
+      const worktreePaths = vi.mocked(execFile).mock.calls
+        .map(call => call[1])
+        .filter(args => args[0] === 'worktree' && args[1] === 'add')
+        .map(args => args[4]);
+      expect(worktreePaths).toHaveLength(2);
+      expect(path.basename(worktreePaths[0])).toMatch(/^workspace-feature-topic-[a-z0-9]{6}$/);
+      expect(path.basename(worktreePaths[1])).toMatch(/^workspace-feature-topic-[a-z0-9]{6}$/);
+      expect(worktreePaths[0]).not.toEqual(worktreePaths[1]);
     });
 
     it('prompts for issue checkout branch name but skips worktree path', async () => {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -294,6 +294,7 @@ describe('StartWorkAction', () => {
 
       vi.mocked(fs.existsSync).mockImplementation((p: any) => path.resolve(p.toString()) === path.resolve(outsideParent));
       expect(validateInput(outsideTarget)).toBeUndefined();
+      expect(validateInput(`  ${outsideTarget}  `)).toBeUndefined();
 
       vi.mocked(fs.existsSync).mockImplementation((p: any) => {
         const resolved = path.resolve(p.toString());


### PR DESCRIPTION
## Summary

- Add `devdocket.startGitWork.promptForNames` with default `true`
- Prompt for issue branch names, PR local branch names, and worktree paths with validated defaults
- Default worktree directories now prefer source repo + issue/PR number (for example, `install-scripts-pr-692`)
- Document the setting and add Start Git Work prompt/default coverage

Closes #569

## Validation

- `npm run build && npm run test`
- `superpowers:code-reviewer` clean
- Copilot PR review clean
