### PR TITLE
Introduce versioned schema for work-started activity detail

### DIFF
--- a/.github/instructions/start-git-work.instructions.md
+++ b/.github/instructions/start-git-work.instructions.md
@@ -40,6 +40,20 @@ await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-sta
 
 To read the detail elsewhere, use `decodeWorkStartedDetail` from the same module. It handles current `v: 1` payloads, accepts legacy unversioned entries for backward compatibility, and warns (returning `undefined`) for unknown schema versions.
 
-Cleanup operations log `'cleanup'` or `'cleanup-dismissed'` entries. The activity log is the source of truth for branch/worktree associations — do not add metadata fields to WorkItem.
+### Rendering in the editor
 
-**Bumping the schema:** if the payload shape needs to change, introduce a new `WorkStartedDetailV2` interface, update the encoder to write `v: 2`, and update the decoder to recognise both versions. The editor's `packages/core/src/webview/editor/components/ActivityLog.tsx` also reads these entries to render them — its `KNOWN_WORK_STARTED_DETAIL_VERSION` and field set must be updated in the same change. Renaming or removing existing fields without a version bump silently breaks cleanup for every pre-existing activity entry.
+The `'work-started'` schema is private to this extension — the core extension does not parse it. The editor displays each entry by calling a renderer that we register at activation:
+
+```ts
+api.registerActivityDetailRenderer?.('work-started', renderWorkStartedActivityDetail);
+```
+
+`renderWorkStartedActivityDetail` (also in `workStartedDetail.ts`) decodes the v1 payload and returns an `ActivityDetailRender` shape that the core sends to the editor webview as-is. If the renderer returns `undefined` (for an undecodable / unknown-version entry), the core falls back to rendering the raw `detail` string as plain text.
+
+### Other activity types
+
+Cleanup operations log `'cleanup'` or `'cleanup-dismissed'` entries with plain-text `detail` (or no detail). They don't need a renderer because the raw text is already display-ready. The activity log is the source of truth for branch/worktree associations — do not add metadata fields to WorkItem.
+
+### Bumping the schema
+
+If the payload shape needs to change, introduce a new `WorkStartedDetailV2` interface, update the encoder to write `v: 2`, and update the decoder to recognise both versions. Update `renderWorkStartedActivityDetail` to render the new fields. All of this lives inside `workStartedDetail.ts`; the core extension does not need to be touched. Renaming or removing existing fields without a version bump silently breaks cleanup for every pre-existing activity entry.

--- a/.github/instructions/start-git-work.instructions.md
+++ b/.github/instructions/start-git-work.instructions.md
@@ -29,4 +29,17 @@ env: {
 
 ## Activity Log Integration
 
-When creating branches/worktrees, log via `devdocket.addActivity` with type `'work-started'` and a JSON detail string containing `{ branchName, worktreePath, repoPath }`. Cleanup operations log `'cleanup'` or `'cleanup-dismissed'` entries. The activity log is the source of truth for branch/worktree associations — do not add metadata fields to WorkItem.
+When creating branches/worktrees, log via `devdocket.addActivity` with type `'work-started'` and a JSON detail string built with the **`encodeWorkStartedDetail` helper** from `./workStartedDetail`. Never call `JSON.stringify` directly on an ad-hoc shape — the helper stamps a version tag so future readers (e.g. `gitCleanup.ts`) can detect schema mismatches instead of silently degrading.
+
+```ts
+import { encodeWorkStartedDetail } from './workStartedDetail';
+
+const detail = encodeWorkStartedDetail({ branchName, worktreePath, repoPath });
+await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-started', detail);
+```
+
+To read the detail elsewhere, use `decodeWorkStartedDetail` from the same module. It handles current `v: 1` payloads, accepts legacy unversioned entries for backward compatibility, and warns (returning `undefined`) for unknown schema versions.
+
+Cleanup operations log `'cleanup'` or `'cleanup-dismissed'` entries. The activity log is the source of truth for branch/worktree associations — do not add metadata fields to WorkItem.
+
+**Bumping the schema:** if the payload shape needs to change, introduce a new `WorkStartedDetailV2` interface, update the encoder to write `v: 2`, and update the decoder to recognise both versions. The editor's `packages/core/src/webview/editor/components/ActivityLog.tsx` also reads these entries to render them — its `KNOWN_WORK_STARTED_DETAIL_VERSION` and field set must be updated in the same change. Renaming or removing existing fields without a version bump silently breaks cleanup for every pre-existing activity entry.

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -98,7 +98,27 @@ interface DevDocketApi {
 
   /** Optional accessor for live provider data, used by actions that need capabilities. */
   getProviderItem?(providerId: string, externalId: string): ProviderItem | undefined;
+
+  /**
+   * Optional: register a renderer that converts an activity log entry's
+   * raw `detail` string into a display-ready representation for the
+   * editor. Use this when your extension writes structured `detail`
+   * payloads (e.g. JSON) that the core extension should not be coupled to.
+   * See "Activity log rendering" below.
+   */
+  registerActivityDetailRenderer?(
+    type: ActivityType,
+    render: (detail: string | undefined) => ActivityDetailRender | undefined,
+  ): vscode.Disposable;
 }
+```
+
+`ActivityDetailRender` is one of:
+
+```ts
+type ActivityDetailRender =
+  | { kind: 'text'; text: string }
+  | { kind: 'fields'; rows: ReadonlyArray<{ label: string; value: string }> };
 ```
 
 Both methods return a `vscode.Disposable`. Push it into `context.subscriptions` so VS Code cleans up on deactivation.
@@ -474,6 +494,30 @@ Items transition through these states as the user interacts with them in the UI.
 | `Archived` | **Done** | Archived items (rendered alongside Done items). |
 
 Action authors should use this mapping when implementing `canRun()` — for example, an action that only applies to active work should target `InProgress` and `Paused`.
+
+## Activity log rendering
+
+Activity log entries carry a free-form `detail` string. Extensions that write structured payloads (e.g. JSON encoded with their own schema) should register a renderer so the core extension can display the entry without parsing the schema itself. This keeps the core decoupled from extension-private schemas — only the writer extension knows the shape.
+
+```ts
+api.registerActivityDetailRenderer?.('work-started', (raw) => {
+  const decoded = decodeMyDetail(raw);
+  if (!decoded) {
+    return undefined; // falls back to plain-text rendering of `raw`
+  }
+  return {
+    kind: 'fields',
+    rows: [
+      { label: 'Branch', value: decoded.branchName },
+      { label: 'Repo', value: decoded.repoPath },
+    ],
+  };
+});
+```
+
+The renderer must be synchronous and return a JSON-serialisable shape (since the result is sent to the editor webview). Returning `undefined`, or throwing, causes the core to fall back to plain-text rendering of the raw `detail`. Only one renderer may be registered per activity type. The disposable should be pushed into `context.subscriptions` so the renderer is removed when the extension deactivates.
+
+If the extension does not register a renderer for an activity type, the raw `detail` string is rendered verbatim — this is appropriate for simple human-readable details such as `"New → InProgress"` for `'state-changed'` entries.
 
 ## Limits and Security
 

--- a/packages/core/src/api/devDocketApi.ts
+++ b/packages/core/src/api/devDocketApi.ts
@@ -1,9 +1,10 @@
-import { DevDocketApi, DevDocketProvider, DevDocketAction, DevDocketRunWatcher, DevDocketPRWatcher, Disposable, type ActivityType, type StateTransitionEvent } from './types';
+import { DevDocketApi, DevDocketProvider, DevDocketAction, DevDocketRunWatcher, DevDocketPRWatcher, Disposable, type ActivityType, type ActivityDetailRenderer, type StateTransitionEvent } from './types';
 import type { Event } from '@devdocket/shared';
 import { ProviderRegistry } from '../services/providerRegistry';
 import { ActionRegistry } from '../services/actionRegistry';
 import { WatcherRegistry } from '../services/watcherRegistry';
 import { PRWatcherRegistry } from '../services/prWatcherRegistry';
+import { ActivityDetailRendererRegistry } from '../services/activityDetailRendererRegistry';
 import { WorkGraph } from '../services/workGraph';
 
 export class DevDocketApiImpl implements DevDocketApi {
@@ -15,6 +16,7 @@ export class DevDocketApiImpl implements DevDocketApi {
     private readonly watcherRegistry: WatcherRegistry,
     private readonly prWatcherRegistry: PRWatcherRegistry,
     private readonly workGraph: WorkGraph,
+    private readonly activityDetailRendererRegistry: ActivityDetailRendererRegistry,
   ) {
     this.onDidTransitionState = workGraph.onDidTransitionState;
   }
@@ -41,5 +43,9 @@ export class DevDocketApiImpl implements DevDocketApi {
 
   async addActivity(itemId: string, type: ActivityType, detail?: string): Promise<void> {
     return this.workGraph.addActivity(itemId, type, detail);
+  }
+
+  registerActivityDetailRenderer(type: ActivityType, render: ActivityDetailRenderer): Disposable {
+    return this.activityDetailRendererRegistry.register(type, render);
   }
 }

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -2,4 +2,4 @@
 // existing intra-core imports (e.g. `from '../api/types'`).
 export type { Disposable, Event, ProviderItem, ProviderItemAuthor, ProviderItemCapabilities, GitWorkInfo, ProviderBadge, RelatedItemRef, ResolvedItem, DevDocketRunWatcher, DevDocketPRWatcher } from '@devdocket/shared';
 export type { ActivityLogEntry, ActivityType } from '@devdocket/shared';
-export type { StateTransitionEvent, DevDocketProvider, DevDocketAction, DevDocketApi } from '@devdocket/shared';
+export type { StateTransitionEvent, DevDocketProvider, DevDocketAction, DevDocketApi, ActivityDetailRender, ActivityDetailRenderer } from '@devdocket/shared';

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -11,6 +11,7 @@ import { WorkGraph } from './services/workGraph';
 import { ProviderRegistry } from './services/providerRegistry';
 import { checkAutoComplete, showAutoCompleteNotification } from './services/autoComplete';
 import { ActionRegistry } from './services/actionRegistry';
+import { ActivityDetailRendererRegistry } from './services/activityDetailRendererRegistry';
 import { WatcherRegistry } from './services/watcherRegistry';
 import { PRWatcherRegistry } from './services/prWatcherRegistry';
 import { WatcherService } from './services/watcherService';
@@ -474,11 +475,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     },
   );
   const ar = new ActionRegistry();
+  const adrr = new ActivityDetailRendererRegistry();
   const wr = new WatcherRegistry(logger);
   const pwr = new PRWatcherRegistry(logger);
   const watchStore = new WatchStore(context.globalState);
   const ws = new WatcherService(wr, pwr, watchStore, logger);
-  const api = new DevDocketApiImpl(pr, ar, wr, pwr, wg);
+  const api = new DevDocketApiImpl(pr, ar, wr, pwr, wg, adrr);
   logger.info(`Store + service init took ${Math.round(performance.now() - initStart)}ms`);
 
   const watchPanelProvider = new WatchPanelProvider(context.extensionUri, ws, wg, pr);
@@ -550,6 +552,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     actionRegistry: ar,
     stateStore: ss,
     watcherService: ws,
+    activityDetailRendererRegistry: adrr,
   };
 
   // Panel managers must be first: editor disposal flushes pending saves via

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -587,6 +587,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     { dispose: () => pwr.dispose() },
     { dispose: () => pr.dispose() },
     { dispose: () => ar.dispose() },
+    { dispose: () => adrr.dispose() },
   );
 
   const commandRegStart = performance.now();

--- a/packages/core/src/services/activityDetailRendererRegistry.ts
+++ b/packages/core/src/services/activityDetailRendererRegistry.ts
@@ -1,0 +1,69 @@
+import * as vscode from 'vscode';
+import type { ActivityType, ActivityDetailRender, ActivityDetailRenderer } from '../api/types';
+import { logger } from './logger';
+
+/**
+ * Registry for {@link ActivityDetailRenderer} functions keyed by
+ * {@link ActivityType}.
+ *
+ * Extensions register a renderer for activity types whose `detail`
+ * payload they own (typically a structured JSON blob). When the
+ * editor webview is built, the core extension calls
+ * {@link render} on each activity entry; if a renderer is registered
+ * for that type, its output is sent to the webview alongside the raw
+ * detail string. The webview prefers the rendered representation
+ * when present and falls back to plain text otherwise.
+ *
+ * This keeps the core extension free of any knowledge of the
+ * `detail` schema owned by other extensions.
+ */
+export class ActivityDetailRendererRegistry {
+  private readonly renderers = new Map<ActivityType, ActivityDetailRenderer>();
+
+  /**
+   * Register a renderer for an activity type.
+   *
+   * @throws If a renderer is already registered for {@link type}.
+   */
+  register(type: ActivityType, renderer: ActivityDetailRenderer): vscode.Disposable {
+    if (this.renderers.has(type)) {
+      throw new Error(`Activity detail renderer already registered for type: ${type}`);
+    }
+    this.renderers.set(type, renderer);
+    logger.warn(`Registered activity detail renderer for type: ${type}`);
+    let disposed = false;
+    return new vscode.Disposable(() => {
+      if (disposed) {
+        return;
+      }
+      disposed = true;
+      if (this.renderers.get(type) === renderer) {
+        this.renderers.delete(type);
+      }
+    });
+  }
+
+  /**
+   * Invoke the renderer for {@link type} on {@link detail}.
+   *
+   * Returns `undefined` when no renderer is registered, the renderer
+   * returns `undefined`, or the renderer throws. Renderer exceptions
+   * are caught and logged so a buggy renderer cannot break the editor.
+   */
+  render(type: ActivityType, detail: string | undefined): ActivityDetailRender | undefined {
+    const renderer = this.renderers.get(type);
+    if (!renderer) {
+      return undefined;
+    }
+    try {
+      return renderer(detail);
+    } catch (err) {
+      logger.warn(`Activity detail renderer for type "${type}" threw; falling back to plain text`, err);
+      return undefined;
+    }
+  }
+
+  dispose(): void {
+    this.renderers.clear();
+  }
+}

--- a/packages/core/src/services/activityDetailRendererRegistry.ts
+++ b/packages/core/src/services/activityDetailRendererRegistry.ts
@@ -19,6 +19,15 @@ import { logger } from './logger';
  */
 export class ActivityDetailRendererRegistry {
   private readonly renderers = new Map<ActivityType, ActivityDetailRenderer>();
+  private readonly _onDidChange = new vscode.EventEmitter<void>();
+  /**
+   * Fires after a renderer is registered or unregistered. Open editor
+   * panels subscribe to this so they can re-render their activity log
+   * once a relevant renderer becomes available — this matters when an
+   * editor opens before the provider extension that owns the renderer
+   * has finished activating.
+   */
+  readonly onDidChange: vscode.Event<void> = this._onDidChange.event;
 
   /**
    * Register a renderer for an activity type.
@@ -30,7 +39,8 @@ export class ActivityDetailRendererRegistry {
       throw new Error(`Activity detail renderer already registered for type: ${type}`);
     }
     this.renderers.set(type, renderer);
-    logger.warn(`Registered activity detail renderer for type: ${type}`);
+    logger.info(`Registered activity detail renderer for type: ${type}`);
+    this._onDidChange.fire();
     let disposed = false;
     return new vscode.Disposable(() => {
       if (disposed) {
@@ -39,6 +49,7 @@ export class ActivityDetailRendererRegistry {
       disposed = true;
       if (this.renderers.get(type) === renderer) {
         this.renderers.delete(type);
+        this._onDidChange.fire();
       }
     });
   }
@@ -65,5 +76,6 @@ export class ActivityDetailRendererRegistry {
 
   dispose(): void {
     this.renderers.clear();
+    this._onDidChange.dispose();
   }
 }

--- a/packages/core/src/services/activityDetailRendererRegistry.ts
+++ b/packages/core/src/services/activityDetailRendererRegistry.ts
@@ -63,12 +63,14 @@ export class ActivityDetailRendererRegistry {
    * exceptions are caught and logged so a buggy renderer cannot break
    * the editor.
    *
-   * Output is also shape-validated: the rendered value is sent to the
-   * editor webview via `postMessage` (which uses structured clone),
-   * so a renderer that returns a non-serialisable value would
-   * otherwise crash the editor update. Validation rejects unknown
-   * `kind` values, non-string fields, and missing `rows`, all of
-   * which would either fail structured-clone or render garbage.
+   * Output is shape-validated AND normalised: only the known fields of
+   * the discriminated union are copied into the returned value. The
+   * rendered value is sent to the editor webview via `postMessage`
+   * (which uses structured clone), so a renderer that returns extra
+   * non-cloneable properties (e.g. functions, BigInt, cyclic refs)
+   * alongside the expected shape would otherwise crash the editor
+   * update. Normalisation drops every property the contract does not
+   * promise, guaranteeing the result is safe to post.
    */
   render(type: ActivityType, detail: string | undefined): ActivityDetailRender | undefined {
     const renderer = this.renderers.get(type);
@@ -85,11 +87,12 @@ export class ActivityDetailRendererRegistry {
     if (result === undefined) {
       return undefined;
     }
-    if (!isValidActivityDetailRender(result)) {
+    const normalised = normaliseActivityDetailRender(result);
+    if (!normalised) {
       logger.warn(`Activity detail renderer for type "${type}" returned an invalid shape; falling back to plain text`);
       return undefined;
     }
-    return result;
+    return normalised;
   }
 
   dispose(): void {
@@ -98,26 +101,43 @@ export class ActivityDetailRendererRegistry {
   }
 }
 
-function isValidActivityDetailRender(value: unknown): value is ActivityDetailRender {
+/**
+ * Validate {@link value} against the {@link ActivityDetailRender} contract
+ * AND return a freshly-constructed copy containing only the contract
+ * fields. Returns `undefined` if the value is not a valid render.
+ *
+ * Constructing a new object is intentional — see the JSDoc on
+ * {@link ActivityDetailRendererRegistry.render} for why extra properties
+ * on the renderer's return value must be stripped before crossing the
+ * webview boundary.
+ */
+function normaliseActivityDetailRender(value: unknown): ActivityDetailRender | undefined {
   if (!value || typeof value !== 'object') {
-    return false;
+    return undefined;
   }
-  const obj = value as { kind?: unknown };
+  const obj = value as { kind?: unknown; text?: unknown; rows?: unknown };
   if (obj.kind === 'text') {
-    return typeof (value as { text?: unknown }).text === 'string';
+    if (typeof obj.text !== 'string') {
+      return undefined;
+    }
+    return { kind: 'text', text: obj.text };
   }
   if (obj.kind === 'fields') {
-    const rows = (value as { rows?: unknown }).rows;
-    if (!Array.isArray(rows)) {
-      return false;
+    if (!Array.isArray(obj.rows)) {
+      return undefined;
     }
-    return rows.every(row => {
+    const rows: Array<{ label: string; value: string }> = [];
+    for (const row of obj.rows) {
       if (!row || typeof row !== 'object') {
-        return false;
+        return undefined;
       }
       const r = row as { label?: unknown; value?: unknown };
-      return typeof r.label === 'string' && typeof r.value === 'string';
-    });
+      if (typeof r.label !== 'string' || typeof r.value !== 'string') {
+        return undefined;
+      }
+      rows.push({ label: r.label, value: r.value });
+    }
+    return { kind: 'fields', rows };
   }
-  return false;
+  return undefined;
 }

--- a/packages/core/src/services/activityDetailRendererRegistry.ts
+++ b/packages/core/src/services/activityDetailRendererRegistry.ts
@@ -58,24 +58,66 @@ export class ActivityDetailRendererRegistry {
    * Invoke the renderer for {@link type} on {@link detail}.
    *
    * Returns `undefined` when no renderer is registered, the renderer
-   * returns `undefined`, or the renderer throws. Renderer exceptions
-   * are caught and logged so a buggy renderer cannot break the editor.
+   * returns `undefined` or a shape that doesn't match
+   * {@link ActivityDetailRender}, or the renderer throws. Renderer
+   * exceptions are caught and logged so a buggy renderer cannot break
+   * the editor.
+   *
+   * Output is also shape-validated: the rendered value is sent to the
+   * editor webview via `postMessage` (which uses structured clone),
+   * so a renderer that returns a non-serialisable value would
+   * otherwise crash the editor update. Validation rejects unknown
+   * `kind` values, non-string fields, and missing `rows`, all of
+   * which would either fail structured-clone or render garbage.
    */
   render(type: ActivityType, detail: string | undefined): ActivityDetailRender | undefined {
     const renderer = this.renderers.get(type);
     if (!renderer) {
       return undefined;
     }
+    let result: ActivityDetailRender | undefined;
     try {
-      return renderer(detail);
+      result = renderer(detail);
     } catch (err) {
       logger.warn(`Activity detail renderer for type "${type}" threw; falling back to plain text`, err);
       return undefined;
     }
+    if (result === undefined) {
+      return undefined;
+    }
+    if (!isValidActivityDetailRender(result)) {
+      logger.warn(`Activity detail renderer for type "${type}" returned an invalid shape; falling back to plain text`);
+      return undefined;
+    }
+    return result;
   }
 
   dispose(): void {
     this.renderers.clear();
     this._onDidChange.dispose();
   }
+}
+
+function isValidActivityDetailRender(value: unknown): value is ActivityDetailRender {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const obj = value as { kind?: unknown };
+  if (obj.kind === 'text') {
+    return typeof (value as { text?: unknown }).text === 'string';
+  }
+  if (obj.kind === 'fields') {
+    const rows = (value as { rows?: unknown }).rows;
+    if (!Array.isArray(rows)) {
+      return false;
+    }
+    return rows.every(row => {
+      if (!row || typeof row !== 'object') {
+        return false;
+      }
+      const r = row as { label?: unknown; value?: unknown };
+      return typeof r.label === 'string' && typeof r.value === 'string';
+    });
+  }
+  return false;
 }

--- a/packages/core/src/test/activityDetailRendererRegistry.test.ts
+++ b/packages/core/src/test/activityDetailRendererRegistry.test.ts
@@ -121,5 +121,37 @@ describe('ActivityDetailRendererRegistry', () => {
       registry.register('work-started', () => bad as unknown as ReturnType<Parameters<typeof registry.register>[1]>);
       expect(registry.render('work-started', '')).toBeUndefined();
     });
+
+    it('strips extra properties from text renders', () => {
+      registry.register('work-started', () => ({
+        kind: 'text',
+        text: 'ok',
+        nope: () => 1,
+        extra: Symbol('not cloneable'),
+      } as unknown as ReturnType<Parameters<typeof registry.register>[1]>));
+      const result = registry.render('work-started', '');
+      expect(result).toEqual({ kind: 'text', text: 'ok' });
+      expect(Object.keys(result!)).toEqual(['kind', 'text']);
+    });
+
+    it('strips extra properties from fields renders and from each row', () => {
+      registry.register('work-started', () => ({
+        kind: 'fields',
+        rows: [
+          { label: 'L', value: 'V', extra: () => 1 },
+          { label: 'L2', value: 'V2', another: Symbol('x') },
+        ],
+        extraTopLevel: 'should be dropped',
+      } as unknown as ReturnType<Parameters<typeof registry.register>[1]>));
+      const result = registry.render('work-started', '');
+      expect(result).toEqual({
+        kind: 'fields',
+        rows: [{ label: 'L', value: 'V' }, { label: 'L2', value: 'V2' }],
+      });
+      expect(Object.keys(result!)).toEqual(['kind', 'rows']);
+      for (const row of (result as { rows: Array<Record<string, unknown>> }).rows) {
+        expect(Object.keys(row)).toEqual(['label', 'value']);
+      }
+    });
   });
 });

--- a/packages/core/src/test/activityDetailRendererRegistry.test.ts
+++ b/packages/core/src/test/activityDetailRendererRegistry.test.ts
@@ -87,4 +87,39 @@ describe('ActivityDetailRendererRegistry', () => {
     disposable.dispose();
     expect(listener).toHaveBeenCalledTimes(2);
   });
+
+  describe('output shape validation', () => {
+    it('accepts a valid text render', () => {
+      registry.register('work-started', () => ({ kind: 'text', text: 'ok' }));
+      expect(registry.render('work-started', '')).toEqual({ kind: 'text', text: 'ok' });
+    });
+
+    it('accepts a valid fields render', () => {
+      registry.register('work-started', () => ({
+        kind: 'fields',
+        rows: [{ label: 'L', value: 'V' }, { label: 'L2', value: 'V2' }],
+      }));
+      expect(registry.render('work-started', '')).toEqual({
+        kind: 'fields',
+        rows: [{ label: 'L', value: 'V' }, { label: 'L2', value: 'V2' }],
+      });
+    });
+
+    it.each([
+      ['unknown kind', { kind: 'wat', text: 'x' }],
+      ['text without string text', { kind: 'text', text: 42 }],
+      ['fields without rows array', { kind: 'fields', rows: 'nope' }],
+      ['fields with non-string label', { kind: 'fields', rows: [{ label: 42, value: 'v' }] }],
+      ['fields with non-string value', { kind: 'fields', rows: [{ label: 'l', value: null }] }],
+      ['fields with non-object row', { kind: 'fields', rows: ['not an object'] }],
+      ['null', null],
+      ['array', []],
+      ['string', 'not a render'],
+      ['number', 42],
+      ['function', () => undefined],
+    ])('rejects %s and returns undefined', (_label, bad) => {
+      registry.register('work-started', () => bad as unknown as ReturnType<Parameters<typeof registry.register>[1]>);
+      expect(registry.render('work-started', '')).toBeUndefined();
+    });
+  });
 });

--- a/packages/core/src/test/activityDetailRendererRegistry.test.ts
+++ b/packages/core/src/test/activityDetailRendererRegistry.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../services/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { ActivityDetailRendererRegistry } from '../services/activityDetailRendererRegistry';
+
+describe('ActivityDetailRendererRegistry', () => {
+  let registry: ActivityDetailRendererRegistry;
+
+  beforeEach(() => {
+    registry = new ActivityDetailRendererRegistry();
+  });
+
+  it('returns undefined when no renderer is registered', () => {
+    expect(registry.render('work-started', 'anything')).toBeUndefined();
+  });
+
+  it('invokes the registered renderer and returns its result', () => {
+    const renderer = vi.fn().mockReturnValue({ kind: 'text', text: 'pretty' });
+    registry.register('work-started', renderer);
+    const result = registry.render('work-started', '{"x":1}');
+    expect(renderer).toHaveBeenCalledWith('{"x":1}');
+    expect(result).toEqual({ kind: 'text', text: 'pretty' });
+  });
+
+  it('throws when registering a second renderer for the same type', () => {
+    registry.register('work-started', () => undefined);
+    expect(() => registry.register('work-started', () => undefined)).toThrow(/already registered/);
+  });
+
+  it('allows re-registering after the previous registration is disposed', () => {
+    const first = registry.register('work-started', () => ({ kind: 'text', text: 'first' }));
+    first.dispose();
+    registry.register('work-started', () => ({ kind: 'text', text: 'second' }));
+    expect(registry.render('work-started', undefined)).toEqual({ kind: 'text', text: 'second' });
+  });
+
+  it('dispose only removes the renderer when it is still the active one', () => {
+    const first = registry.register('work-started', () => ({ kind: 'text', text: 'first' }));
+    first.dispose();
+    const secondRenderer = () => ({ kind: 'text' as const, text: 'second' });
+    registry.register('work-started', secondRenderer);
+    // Disposing the (already-disposed) first registration is a no-op.
+    first.dispose();
+    expect(registry.render('work-started', undefined)).toEqual({ kind: 'text', text: 'second' });
+  });
+
+  it('returns undefined and does not throw when the renderer throws', () => {
+    registry.register('work-started', () => { throw new Error('boom'); });
+    expect(registry.render('work-started', 'anything')).toBeUndefined();
+  });
+
+  it('passes undefined detail through to the renderer', () => {
+    const renderer = vi.fn().mockReturnValue(undefined);
+    registry.register('work-started', renderer);
+    expect(registry.render('work-started', undefined)).toBeUndefined();
+    expect(renderer).toHaveBeenCalledWith(undefined);
+  });
+
+  it('dispose() clears all registrations', () => {
+    registry.register('work-started', () => ({ kind: 'text', text: 'a' }));
+    registry.register('cleanup', () => ({ kind: 'text', text: 'b' }));
+    registry.dispose();
+    expect(registry.render('work-started', '')).toBeUndefined();
+    expect(registry.render('cleanup', '')).toBeUndefined();
+  });
+});

--- a/packages/core/src/test/activityDetailRendererRegistry.test.ts
+++ b/packages/core/src/test/activityDetailRendererRegistry.test.ts
@@ -71,4 +71,20 @@ describe('ActivityDetailRendererRegistry', () => {
     expect(registry.render('work-started', '')).toBeUndefined();
     expect(registry.render('cleanup', '')).toBeUndefined();
   });
+
+  it('fires onDidChange when a renderer is registered and unregistered', () => {
+    const listener = vi.fn();
+    registry.onDidChange(listener);
+    expect(listener).not.toHaveBeenCalled();
+
+    const disposable = registry.register('work-started', () => undefined);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    disposable.dispose();
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    // Disposing an already-disposed registration is a no-op (no extra event).
+    disposable.dispose();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
 });

--- a/packages/core/src/test/activityLog.test.ts
+++ b/packages/core/src/test/activityLog.test.ts
@@ -3,11 +3,13 @@ import { h, render } from 'preact';
 import { act } from 'preact/test-utils';
 import { afterEach, describe, expect, it } from 'vitest';
 import { ActivityLog } from '../webview/editor/components/ActivityLog';
+import type { ActivityDetailRender } from '../api/types';
 
 interface TestActivityEntry {
   timestamp: number;
   type: string;
   detail?: string;
+  displayDetail?: ActivityDetailRender;
 }
 
 describe('ActivityLog', () => {
@@ -21,15 +23,19 @@ describe('ActivityLog', () => {
     }
   });
 
-  it('renders work-started JSON detail as labelled fields', () => {
+  it('renders displayDetail.fields as a labelled definition list', () => {
     renderActivityLog([{
       timestamp: Date.now(),
       type: 'work-started',
-      detail: JSON.stringify({
-        branchName: 'feature/activity-renderer',
-        worktreePath: 'C:\\repos\\devdocket-activity-renderer',
-        repoPath: 'C:\\repos\\devdocket',
-      }),
+      detail: 'raw payload (should not be rendered)',
+      displayDetail: {
+        kind: 'fields',
+        rows: [
+          { label: 'Branch', value: 'feature/activity-renderer' },
+          { label: 'Worktree', value: 'C:\\repos\\devdocket-activity-renderer' },
+          { label: 'Repo', value: 'C:\\repos\\devdocket' },
+        ],
+      },
     }]);
 
     expandActivityLog();
@@ -44,8 +50,23 @@ describe('ActivityLog', () => {
     expect(detail!.textContent).toContain('C:\\repos\\devdocket');
   });
 
-  it('falls back to raw detail when work-started JSON is invalid', () => {
-    const rawDetail = '{"branchName":';
+  it('renders displayDetail.text in place of the raw detail', () => {
+    renderActivityLog([{
+      timestamp: Date.now(),
+      type: 'work-started',
+      detail: 'ignored raw payload',
+      displayDetail: { kind: 'text', text: 'pretty text from renderer' },
+    }]);
+
+    expandActivityLog();
+
+    const detail = container!.querySelector('.activity-entry-detail');
+    expect(detail).toBeInstanceOf(HTMLSpanElement);
+    expect(detail!.textContent).toBe('pretty text from renderer');
+  });
+
+  it('falls back to raw detail when no displayDetail is provided', () => {
+    const rawDetail = '{"branchName": "feature/x"}';
     renderActivityLog([{ timestamp: Date.now(), type: 'work-started', detail: rawDetail }]);
 
     expandActivityLog();
@@ -55,7 +76,7 @@ describe('ActivityLog', () => {
     expect(detail!.textContent).toBe(rawDetail);
   });
 
-  it('renders other activity type details verbatim', () => {
+  it('renders plain detail strings verbatim', () => {
     renderActivityLog([{ timestamp: Date.now(), type: 'state-changed', detail: 'New → InProgress' }]);
 
     expandActivityLog();
@@ -65,31 +86,13 @@ describe('ActivityLog', () => {
     expect(detail!.textContent).toBe('New → InProgress');
   });
 
-  it('renders v1 work-started detail as labelled fields', () => {
-    renderActivityLog([{
-      timestamp: Date.now(),
-      type: 'work-started',
-      detail: JSON.stringify({ v: 1, branchName: 'feature/x', repoPath: '/r' }),
-    }]);
+  it('renders nothing for the detail slot when both detail and displayDetail are absent', () => {
+    renderActivityLog([{ timestamp: Date.now(), type: 'created' }]);
 
     expandActivityLog();
 
-    const detail = container!.querySelector('.activity-entry-detail--structured');
-    expect(detail).toBeInstanceOf(HTMLDListElement);
-    expect(detail!.textContent).toContain('feature/x');
-  });
-
-  it('falls back to raw detail for unknown work-started schema version', () => {
-    const raw = JSON.stringify({ v: 99, branchName: 'feature/x', repoPath: '/r' });
-    renderActivityLog([{ timestamp: Date.now(), type: 'work-started', detail: raw }]);
-
-    expandActivityLog();
-
-    const structured = container!.querySelector('.activity-entry-detail--structured');
-    expect(structured).toBeNull();
-    const plain = container!.querySelector('.activity-entry-detail');
-    expect(plain).toBeInstanceOf(HTMLSpanElement);
-    expect(plain!.textContent).toBe(raw);
+    const detail = container!.querySelector('.activity-entry-detail');
+    expect(detail).toBeNull();
   });
 
   function renderActivityLog(entries: TestActivityEntry[]) {

--- a/packages/core/src/test/activityLog.test.ts
+++ b/packages/core/src/test/activityLog.test.ts
@@ -65,6 +65,33 @@ describe('ActivityLog', () => {
     expect(detail!.textContent).toBe('New → InProgress');
   });
 
+  it('renders v1 work-started detail as labelled fields', () => {
+    renderActivityLog([{
+      timestamp: Date.now(),
+      type: 'work-started',
+      detail: JSON.stringify({ v: 1, branchName: 'feature/x', repoPath: '/r' }),
+    }]);
+
+    expandActivityLog();
+
+    const detail = container!.querySelector('.activity-entry-detail--structured');
+    expect(detail).toBeInstanceOf(HTMLDListElement);
+    expect(detail!.textContent).toContain('feature/x');
+  });
+
+  it('falls back to raw detail for unknown work-started schema version', () => {
+    const raw = JSON.stringify({ v: 99, branchName: 'feature/x', repoPath: '/r' });
+    renderActivityLog([{ timestamp: Date.now(), type: 'work-started', detail: raw }]);
+
+    expandActivityLog();
+
+    const structured = container!.querySelector('.activity-entry-detail--structured');
+    expect(structured).toBeNull();
+    const plain = container!.querySelector('.activity-entry-detail');
+    expect(plain).toBeInstanceOf(HTMLSpanElement);
+    expect(plain!.textContent).toBe(raw);
+  });
+
   function renderActivityLog(entries: TestActivityEntry[]) {
     container = document.createElement('div');
     document.body.appendChild(container);

--- a/packages/core/src/test/devDocketApi.test.ts
+++ b/packages/core/src/test/devDocketApi.test.ts
@@ -2,6 +2,7 @@ import { DevDocketApiImpl } from '../api/devDocketApi';
 import { DevDocketProvider, DevDocketAction, ProviderItem } from '../api/types';
 import { ProviderRegistry } from '../services/providerRegistry';
 import { ActionRegistry } from '../services/actionRegistry';
+import { ActivityDetailRendererRegistry } from '../services/activityDetailRendererRegistry';
 import { WatcherRegistry } from '../services/watcherRegistry';
 import { PRWatcherRegistry } from '../services/prWatcherRegistry';
 import { WorkGraph } from '../services/workGraph';
@@ -70,6 +71,7 @@ describe('DevDocketApiImpl', () => {
   let watcherRegistry: WatcherRegistry;
   let prWatcherRegistry: PRWatcherRegistry;
   let workGraph: WorkGraph;
+  let activityDetailRendererRegistry: ActivityDetailRendererRegistry;
 
   beforeEach(async () => {
     const stateStore = createMockStateStore();
@@ -79,7 +81,8 @@ describe('DevDocketApiImpl', () => {
     prWatcherRegistry = new PRWatcherRegistry({ info: vi.fn(), warn: vi.fn() });
     workGraph = new WorkGraph(createMockStore());
     await workGraph.load();
-    api = new DevDocketApiImpl(providerRegistry, actionRegistry, watcherRegistry, prWatcherRegistry, workGraph);
+    activityDetailRendererRegistry = new ActivityDetailRendererRegistry();
+    api = new DevDocketApiImpl(providerRegistry, actionRegistry, watcherRegistry, prWatcherRegistry, workGraph, activityDetailRendererRegistry);
   });
 
   describe('registerProvider', () => {
@@ -252,6 +255,21 @@ describe('DevDocketApiImpl', () => {
       disposable.dispose();
 
       expect(prWatcherRegistry.get('test-pr-watcher')).toBeUndefined();
+    });
+  });
+
+  describe('registerActivityDetailRenderer', () => {
+    it('delegates to ActivityDetailRendererRegistry.register and returns a Disposable', () => {
+      const renderer = vi.fn().mockReturnValue({ kind: 'text', text: 'pretty' });
+      const spy = vi.spyOn(activityDetailRendererRegistry, 'register');
+
+      const disposable = api.registerActivityDetailRenderer('work-started', renderer);
+
+      expect(spy).toHaveBeenCalledWith('work-started', renderer);
+      expect(activityDetailRendererRegistry.render('work-started', '{}')).toEqual({ kind: 'text', text: 'pretty' });
+
+      disposable.dispose();
+      expect(activityDetailRendererRegistry.render('work-started', '{}')).toBeUndefined();
     });
   });
 

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -1,4 +1,5 @@
 import type { RunConclusion } from '@devdocket/shared';
+import type { ActivityDetailRender } from '../api/types';
 import type { ResolvedRelatedItem } from './relatedItemTypes';
 
 export type ExtensionMessage =
@@ -88,6 +89,21 @@ export interface EditorCIWatchData {
   totalFailing: number;
 }
 
+/** A single activity log entry as serialised for the editor webview. */
+export interface EditorActivityLogEntry {
+  timestamp: number;
+  type: string;
+  /** Raw `detail` string written by the producer. */
+  detail?: string;
+  /**
+   * Pre-rendered display representation produced by an
+   * extension-registered renderer. When present, the webview renders
+   * this in place of {@link detail}. Otherwise the webview falls
+   * back to plain-text rendering of {@link detail}.
+   */
+  displayDetail?: ActivityDetailRender;
+}
+
 export interface EditorItemData {
   id: string;
   title: string;
@@ -105,7 +121,7 @@ export interface EditorItemData {
   isProviderManaged: boolean;
   validTransitions: string[];
   hasActions: boolean;
-  activityLog: Array<{ timestamp: number; type: string; detail?: string }>;
+  activityLog: EditorActivityLogEntry[];
   relatedItems: ResolvedRelatedItem[];
   ciWatch?: EditorCIWatchData;
   isIncoming?: boolean;

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -3,6 +3,7 @@ import * as crypto from 'node:crypto';
 import type { ProviderItem } from '../api/types';
 import { WorkItem, WorkItemInput, WorkItemState } from '../models/workItem';
 import { ActionRegistry } from '../services/actionRegistry';
+import { ActivityDetailRendererRegistry } from '../services/activityDetailRendererRegistry';
 import { ProviderRegistry } from '../services/providerRegistry';
 import { buildRelatedItemsIndex, resolveRelatedItemsFor, type RelatedItemsIndex } from '../services/relatedItems';
 import { VALID_TRANSITIONS, WorkGraph } from '../services/workGraph';
@@ -59,6 +60,7 @@ export interface WorkItemEditorPanelDependencies {
   actionRegistry: ActionRegistry;
   stateStore: InboxStateStore;
   watcherService?: WatcherService;
+  activityDetailRendererRegistry?: ActivityDetailRendererRegistry;
 }
 
 export class WorkItemEditorPanel {
@@ -72,6 +74,7 @@ export class WorkItemEditorPanel {
   private readonly actionRegistry: ActionRegistry;
   private readonly stateStore: InboxStateStore;
   private readonly watcherService?: WatcherService;
+  private readonly activityDetailRendererRegistry?: ActivityDetailRendererRegistry;
   private readonly extensionUri: vscode.Uri;
   private disposed = false;
   private htmlInitialized = false;
@@ -176,6 +179,7 @@ export class WorkItemEditorPanel {
       dependencies.actionRegistry,
       dependencies.stateStore,
       dependencies.watcherService,
+      dependencies.activityDetailRendererRegistry,
       context.extensionUri,
       providerLabel,
     );
@@ -203,6 +207,7 @@ export class WorkItemEditorPanel {
     actionRegistry: ActionRegistry,
     stateStore: InboxStateStore,
     watcherService: WatcherService | undefined,
+    activityDetailRendererRegistry: ActivityDetailRendererRegistry | undefined,
     extensionUri: vscode.Uri,
     private providerLabel?: string,
   ) {
@@ -214,6 +219,7 @@ export class WorkItemEditorPanel {
     this.actionRegistry = actionRegistry;
     this.stateStore = stateStore;
     this.watcherService = watcherService;
+    this.activityDetailRendererRegistry = activityDetailRendererRegistry;
     this.extensionUri = extensionUri;
 
     this.update();
@@ -483,7 +489,12 @@ export class WorkItemEditorPanel {
       isProviderManaged: this.isProviderManaged(item),
       validTransitions: Array.from(VALID_TRANSITIONS.get(item.state) ?? []),
       hasActions: this.actionRegistry.hasActionsFor(item),
-      activityLog: item.activityLog ?? [],
+      activityLog: (item.activityLog ?? []).map(entry => ({
+        timestamp: entry.timestamp,
+        type: entry.type,
+        detail: entry.detail,
+        displayDetail: this.activityDetailRendererRegistry?.render(entry.type, entry.detail),
+      })),
       relatedItems: resolveRelatedItemsFor(item, this.providerRegistry, this.workGraph, relatedItemsIndex),
       ciWatch: this.buildCIWatchData(item),
       isIncoming: false,

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -86,6 +86,7 @@ export class WorkItemEditorPanel {
   private readonly providerRegSub: vscode.Disposable;
   private readonly providerChangeSub: vscode.Disposable;
   private readonly actionRegistrySub: vscode.Disposable;
+  private readonly activityRendererSub?: vscode.Disposable;
   private readonly watcherSubscriptions: vscode.Disposable[] = [];
   private lastDisplayedTitle: string | undefined;
   private lastDisplayedUrl: string | undefined;
@@ -240,6 +241,15 @@ export class WorkItemEditorPanel {
       this.update();
     });
 
+    if (this.activityDetailRendererRegistry) {
+      // Re-render when an activity detail renderer is added or removed —
+      // this covers the case where this editor opened before a provider
+      // extension finished activating and registering its renderer.
+      this.activityRendererSub = this.activityDetailRendererRegistry.onDidChange(() => {
+        this.update();
+      });
+    }
+
     const activeWatcherService = this.watcherService;
     if (activeWatcherService) {
       this.watcherSubscriptions.push(
@@ -315,6 +325,7 @@ export class WorkItemEditorPanel {
         this.providerRegSub.dispose();
         this.providerChangeSub.dispose();
         this.actionRegistrySub.dispose();
+        this.activityRendererSub?.dispose();
         this.disposeWatcherSubscriptions();
       }
     });
@@ -618,6 +629,7 @@ export class WorkItemEditorPanel {
       this.providerRegSub.dispose();
       this.providerChangeSub.dispose();
       this.actionRegistrySub.dispose();
+      this.activityRendererSub?.dispose();
       this.disposeWatcherSubscriptions();
       this.panel.dispose();
     }

--- a/packages/core/src/webview/editor/components/ActivityLog.tsx
+++ b/packages/core/src/webview/editor/components/ActivityLog.tsx
@@ -38,7 +38,7 @@ export function ActivityLog({ entries }: ActivityLogProps) {
             <div class="activity-entry" key={`${entry.timestamp}-${entry.type}-${index}`}>
               <div class="activity-entry-main">
                 <span class="activity-entry-type">{activityTypeLabel(entry.type)}</span>
-                {renderActivityDetail(entry)}
+                {renderActivityDetail(entry, index)}
               </div>
               <span class="activity-entry-time">{formatRelativeTime(entry.timestamp)}</span>
             </div>
@@ -49,9 +49,9 @@ export function ActivityLog({ entries }: ActivityLogProps) {
   );
 }
 
-function renderActivityDetail(entry: EditorActivityLogEntry): VNode | null {
+function renderActivityDetail(entry: EditorActivityLogEntry, entryIndex: number): VNode | null {
   if (entry.displayDetail) {
-    return renderDisplayDetail(entry.displayDetail);
+    return renderDisplayDetail(entry.displayDetail, entryIndex);
   }
   if (entry.detail) {
     return renderPlainActivityDetail(entry.detail);
@@ -59,11 +59,11 @@ function renderActivityDetail(entry: EditorActivityLogEntry): VNode | null {
   return null;
 }
 
-function renderDisplayDetail(display: ActivityDetailRender): VNode {
+function renderDisplayDetail(display: ActivityDetailRender, entryIndex: number): VNode {
   if (display.kind === 'fields') {
     return (
       <dl class="activity-entry-detail activity-entry-detail--structured">
-        {display.rows.map(row => renderDetailRow(row.label, row.value))}
+        {display.rows.map((row, rowIndex) => renderDetailRow(row.label, row.value, entryIndex, rowIndex))}
       </dl>
     );
   }
@@ -74,9 +74,11 @@ function renderPlainActivityDetail(detail: string): VNode {
   return <span class="activity-entry-detail">{detail}</span>;
 }
 
-function renderDetailRow(label: string, value: string): VNode {
+function renderDetailRow(label: string, value: string, entryIndex: number, rowIndex: number): VNode {
+  // Include both indices so duplicate labels (rare but possible — the API
+  // does not require row labels to be unique) cannot collide on the Preact key.
   return (
-    <div class="activity-detail-row" key={label}>
+    <div class="activity-detail-row" key={`${entryIndex}-${rowIndex}-${label}`}>
       <dt class="activity-detail-label">{label}:</dt>
       <dd class="activity-detail-value">{value}</dd>
     </div>

--- a/packages/core/src/webview/editor/components/ActivityLog.tsx
+++ b/packages/core/src/webview/editor/components/ActivityLog.tsx
@@ -1,7 +1,7 @@
 import type { VNode } from 'preact';
 import { useState } from 'preact/hooks';
 import { formatRelativeTime } from '../../shared/timeUtils';
-import type { EditorItemData } from '../../shared/types';
+import type { ActivityDetailRender, EditorActivityLogEntry, EditorItemData } from '../../shared/types';
 import { activityTypeLabel } from '../editorUtils';
 
 interface ActivityLogProps {
@@ -38,7 +38,7 @@ export function ActivityLog({ entries }: ActivityLogProps) {
             <div class="activity-entry" key={`${entry.timestamp}-${entry.type}-${index}`}>
               <div class="activity-entry-main">
                 <span class="activity-entry-type">{activityTypeLabel(entry.type)}</span>
-                {entry.detail ? renderActivityDetail(entry.type, entry.detail) : null}
+                {renderActivityDetail(entry)}
               </div>
               <span class="activity-entry-time">{formatRelativeTime(entry.timestamp)}</span>
             </div>
@@ -49,81 +49,29 @@ export function ActivityLog({ entries }: ActivityLogProps) {
   );
 }
 
-type ActivityDetailRenderer = (detail: string) => VNode;
+function renderActivityDetail(entry: EditorActivityLogEntry): VNode | null {
+  if (entry.displayDetail) {
+    return renderDisplayDetail(entry.displayDetail);
+  }
+  if (entry.detail) {
+    return renderPlainActivityDetail(entry.detail);
+  }
+  return null;
+}
 
-const activityDetailRenderers: Partial<Record<string, ActivityDetailRenderer>> = {
-  'work-started': renderWorkStartedDetail,
-};
-
-function renderActivityDetail(type: string, detail: string): VNode {
-  const renderer = activityDetailRenderers[type] ?? renderPlainActivityDetail;
-  return renderer(detail);
+function renderDisplayDetail(display: ActivityDetailRender): VNode {
+  if (display.kind === 'fields') {
+    return (
+      <dl class="activity-entry-detail activity-entry-detail--structured">
+        {display.rows.map(row => renderDetailRow(row.label, row.value))}
+      </dl>
+    );
+  }
+  return renderPlainActivityDetail(display.text);
 }
 
 function renderPlainActivityDetail(detail: string): VNode {
   return <span class="activity-entry-detail">{detail}</span>;
-}
-
-interface WorkStartedDetail {
-  branchName?: string;
-  worktreePath?: string;
-  repoPath?: string;
-}
-
-/**
- * Parse the `'work-started'` activity entry detail for rendering.
- *
- * Must stay in lockstep with the schema owned by
- * `packages/start-git-work/src/workStartedDetail.ts`. When that schema
- * bumps to V2, this version check (and the rendered fields) must be
- * updated in the same change. Unknown versions fall through to the
- * plain JSON rendering so the user still sees the raw payload.
- */
-const KNOWN_WORK_STARTED_DETAIL_VERSION = 1;
-
-function parseWorkStartedDetail(raw: string): WorkStartedDetail | undefined {
-  try {
-    const parsed = JSON.parse(raw) as unknown;
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return undefined;
-    }
-
-    const values = parsed as Record<string, unknown>;
-
-    if (values.v !== undefined && values.v !== KNOWN_WORK_STARTED_DETAIL_VERSION) {
-      return undefined;
-    }
-
-    const detail: WorkStartedDetail = {};
-    if (typeof values.branchName === 'string') {
-      detail.branchName = values.branchName;
-    }
-    if (typeof values.worktreePath === 'string') {
-      detail.worktreePath = values.worktreePath;
-    }
-    if (typeof values.repoPath === 'string') {
-      detail.repoPath = values.repoPath;
-    }
-
-    return detail.branchName || detail.worktreePath || detail.repoPath ? detail : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function renderWorkStartedDetail(raw: string): VNode {
-  const detail = parseWorkStartedDetail(raw);
-  if (!detail) {
-    return renderPlainActivityDetail(raw);
-  }
-
-  return (
-    <dl class="activity-entry-detail activity-entry-detail--structured">
-      {detail.branchName ? renderDetailRow('Branch', detail.branchName) : null}
-      {detail.worktreePath ? renderDetailRow('Worktree', detail.worktreePath) : null}
-      {detail.repoPath ? renderDetailRow('Repo', detail.repoPath) : null}
-    </dl>
-  );
 }
 
 function renderDetailRow(label: string, value: string): VNode {

--- a/packages/core/src/webview/editor/components/ActivityLog.tsx
+++ b/packages/core/src/webview/editor/components/ActivityLog.tsx
@@ -70,6 +70,17 @@ interface WorkStartedDetail {
   repoPath?: string;
 }
 
+/**
+ * Parse the `'work-started'` activity entry detail for rendering.
+ *
+ * Must stay in lockstep with the schema owned by
+ * `packages/start-git-work/src/workStartedDetail.ts`. When that schema
+ * bumps to V2, this version check (and the rendered fields) must be
+ * updated in the same change. Unknown versions fall through to the
+ * plain JSON rendering so the user still sees the raw payload.
+ */
+const KNOWN_WORK_STARTED_DETAIL_VERSION = 1;
+
 function parseWorkStartedDetail(raw: string): WorkStartedDetail | undefined {
   try {
     const parsed = JSON.parse(raw) as unknown;
@@ -78,6 +89,11 @@ function parseWorkStartedDetail(raw: string): WorkStartedDetail | undefined {
     }
 
     const values = parsed as Record<string, unknown>;
+
+    if (values.v !== undefined && values.v !== KNOWN_WORK_STARTED_DETAIL_VERSION) {
+      return undefined;
+    }
+
     const detail: WorkStartedDetail = {};
     if (typeof values.branchName === 'string') {
       detail.branchName = values.branchName;

--- a/packages/core/src/webview/shared/types.ts
+++ b/packages/core/src/webview/shared/types.ts
@@ -1,5 +1,6 @@
 export type {
   BadgeData,
+  EditorActivityLogEntry,
   EditorCIWatchData,
   EditorItemData,
   ExtensionMessage,
@@ -14,3 +15,4 @@ export type {
   WatchData,
   WebviewMessage,
 } from '../../views/mainTypes';
+export type { ActivityDetailRender } from '../../api/types';

--- a/packages/shared/src/apiTypes.ts
+++ b/packages/shared/src/apiTypes.ts
@@ -4,6 +4,36 @@ import type { Disposable, Event, ProviderItem, ResolvedItem } from './baseProvid
 import type { WorkItem, ActivityType } from './workItem';
 
 /**
+ * Rendered representation of an activity log entry's `detail` field,
+ * returned by an {@link ActivityDetailRenderer}.
+ *
+ * The shape is plain JSON so it can be serialised across the webview
+ * boundary.
+ *
+ * - `text` — a single string rendered verbatim where the raw detail
+ *   would otherwise appear.
+ * - `fields` — an ordered set of label/value rows rendered as a
+ *   definition list. Use this for structured payloads that benefit
+ *   from labelled per-field display.
+ */
+export type ActivityDetailRender =
+  | { readonly kind: 'text'; readonly text: string }
+  | { readonly kind: 'fields'; readonly rows: ReadonlyArray<{ readonly label: string; readonly value: string }> };
+
+/**
+ * Renders the `detail` payload of an activity log entry into a
+ * display-ready representation. Called by the core extension when
+ * serialising activity entries for the editor webview.
+ *
+ * Extensions that write structured `detail` payloads (e.g. JSON) own
+ * the schema and should register a renderer so the core extension can
+ * display the data without parsing the schema itself. Returning
+ * `undefined` (or throwing) falls back to the default rendering, which
+ * shows the raw `detail` string verbatim.
+ */
+export type ActivityDetailRenderer = (detail: string | undefined) => ActivityDetailRender | undefined;
+
+/**
  * Event payload emitted when a work item changes lifecycle state.
  *
  * The {@link oldState} and {@link newState} fields are plain strings (e.g.
@@ -206,6 +236,26 @@ export interface DevDocketApi {
    * @param detail - Optional human-readable detail string.
    */
   addActivity?(itemId: string, type: ActivityType, detail?: string): Promise<void>;
+  /**
+   * Register a renderer that converts an activity log entry's raw
+   * `detail` string into a display-ready representation.
+   *
+   * Extensions that write structured `detail` payloads (e.g. JSON
+   * encoded by the writer) should register a renderer for their
+   * activity types so the core extension can render entries without
+   * having to understand the writer's schema. The core extension
+   * always falls back to plain-text rendering of the raw `detail`
+   * when no renderer is registered or the renderer returns
+   * `undefined`.
+   *
+   * Only one renderer may be registered per activity type. Attempting
+   * to register a second renderer for the same type throws.
+   *
+   * @param type - The activity type this renderer handles.
+   * @param render - The rendering function.
+   * @returns A {@link Disposable} that unregisters the renderer.
+   */
+  registerActivityDetailRenderer?(type: ActivityType, render: ActivityDetailRenderer): Disposable;
   /**
    * Register a PR watcher for tracking pull request pipelines.
    *

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,4 +14,4 @@ export { combineSignals, createAbortError } from './signalUtils';
 export { runWorkerPool, runWorkerPoolSettled } from './concurrency';
 export { WorkItemState } from './workItem';
 export type { WorkItem, WorkItemInput, ActivityLogEntry, ActivityType } from './workItem';
-export type { DevDocketProvider, DevDocketAction, DevDocketApi, StateTransitionEvent } from './apiTypes';
+export type { DevDocketProvider, DevDocketAction, DevDocketApi, StateTransitionEvent, ActivityDetailRender, ActivityDetailRenderer } from './apiTypes';

--- a/packages/start-git-work/src/extension.ts
+++ b/packages/start-git-work/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { StartWorkAction } from './startWorkAction';
 import { promptGitCleanup } from './gitCleanup';
+import { renderWorkStartedActivityDetail } from './workStartedDetail';
 import { logger, setLogger } from './logger';
 import type { StateTransitionEvent, ActivityType, DevDocketApi } from '@devdocket/shared';
 
@@ -30,6 +31,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   );
   const actionDisposable = api.registerAction(startWorkAction);
   context.subscriptions.push(actionDisposable);
+
+  // Register the activity-detail renderer for our 'work-started' entries.
+  // The core extension uses this to render entries without parsing the
+  // schema itself, keeping the cross-package contract one-directional
+  // (we own the schema, the encoder, the decoder, and the renderer).
+  if (typeof api.registerActivityDetailRenderer === 'function') {
+    try {
+      const rendererDisposable = api.registerActivityDetailRenderer('work-started', renderWorkStartedActivityDetail);
+      context.subscriptions.push(rendererDisposable);
+    } catch (err) {
+      logger.warn('Failed to register work-started activity detail renderer', err);
+    }
+  }
 
   // Listen for Done transitions to prompt for branch/worktree cleanup
   if (typeof api.onDidTransitionState === 'function') {

--- a/packages/start-git-work/src/gitCleanup.ts
+++ b/packages/start-git-work/src/gitCleanup.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs/promises';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { logger } from './logger';
+import { decodeWorkStartedDetail, type WorkStartedDetail } from './workStartedDetail';
 import type { WorkItem, ActivityType } from '@devdocket/shared';
 
 const execFileAsync = promisify(execFile);
@@ -17,19 +18,12 @@ async function pathExists(p: string): Promise<boolean> {
   }
 }
 
-/** Structured data stored in the detail field of a 'work-started' activity entry. */
-interface WorkStartedData {
-  branchName?: string;
-  worktreePath?: string;
-  repoPath?: string;
-}
-
 /**
  * Extract branch/worktree/repo info from the item's activity log.
  * Finds the most recent 'work-started' entry, then checks whether a
  * 'cleanup-dismissed' entry exists after it (which suppresses prompting).
  */
-function getWorkStartedInfo(item: Readonly<WorkItem>): WorkStartedData | undefined {
+function getWorkStartedInfo(item: Readonly<WorkItem>): WorkStartedDetail | undefined {
   const log = item.activityLog;
   if (!log || log.length === 0) {
     return undefined;
@@ -54,25 +48,7 @@ function getWorkStartedInfo(item: Readonly<WorkItem>): WorkStartedData | undefin
     }
   }
 
-  const detail = log[lastStartedIdx].detail;
-  if (!detail) {
-    return undefined;
-  }
-
-  try {
-    const parsed = JSON.parse(detail) as Record<string, unknown>;
-    if (typeof parsed !== 'object' || parsed === null) {
-      return undefined;
-    }
-    return {
-      branchName: typeof parsed.branchName === 'string' ? parsed.branchName : undefined,
-      worktreePath: typeof parsed.worktreePath === 'string' ? parsed.worktreePath : undefined,
-      repoPath: typeof parsed.repoPath === 'string' ? parsed.repoPath : undefined,
-    };
-  } catch {
-    logger.warn('Failed to parse work-started activity detail');
-    return undefined;
-  }
+  return decodeWorkStartedDetail(log[lastStartedIdx].detail);
 }
 
 interface CleanupState {

--- a/packages/start-git-work/src/gitCleanup.ts
+++ b/packages/start-git-work/src/gitCleanup.ts
@@ -69,11 +69,6 @@ async function checkCleanupState(item: Readonly<WorkItem>): Promise<CleanupState
     return undefined;
   }
 
-  if (!info.repoPath) {
-    logger.warn('Cannot check cleanup state: repoPath is missing');
-    return undefined;
-  }
-
   const repoPath = info.repoPath;
   if (!await pathExists(path.join(repoPath, '.git'))) {
     logger.warn('Skipping cleanup: repoPath is not a valid git repo');

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -5,6 +5,7 @@ import * as path from 'path';
 import * as fs from 'fs';
 import { logger } from './logger';
 import { WorkItemState, type ProviderItem, type GitWorkInfo, type WorkItem, type DevDocketAction } from '@devdocket/shared';
+import { encodeWorkStartedDetail } from './workStartedDetail';
 
 const execFileAsync = promisify(execFile);
 
@@ -310,7 +311,7 @@ export class StartWorkAction implements DevDocketAction {
     logger.info(`Created worktree at ${worktreePath}`);
 
     try {
-      const detail = JSON.stringify({ branchName, worktreePath, repoPath });
+      const detail = encodeWorkStartedDetail({ branchName, worktreePath, repoPath });
       await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-started', detail);
     } catch (activityErr) {
       logger.error('Failed to log work-started activity', activityErr);
@@ -344,7 +345,7 @@ export class StartWorkAction implements DevDocketAction {
     logger.info(`Starting work: checked out new branch ${branchName}`);
 
     try {
-      const detail = JSON.stringify({ branchName, repoPath });
+      const detail = encodeWorkStartedDetail({ branchName, repoPath });
       await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-started', detail);
     } catch (activityErr) {
       logger.error('Failed to log work-started activity', activityErr);
@@ -566,7 +567,7 @@ export class StartWorkAction implements DevDocketAction {
     try {
       // Only include branchName when this action created the branch, so cleanup
       // won't accidentally delete a pre-existing user branch.
-      const detail = JSON.stringify({
+      const detail = encodeWorkStartedDetail({
         ...(createdBranch ? { branchName } : {}),
         worktreePath,
         repoPath,
@@ -644,7 +645,7 @@ export class StartWorkAction implements DevDocketAction {
     try {
       // Only include branchName when this action created the branch, so cleanup
       // won't accidentally delete a pre-existing user branch.
-      const detail = JSON.stringify({
+      const detail = encodeWorkStartedDetail({
         ...(createdBranch ? { branchName } : {}),
         repoPath,
       });

--- a/packages/start-git-work/src/test/gitCleanup.test.ts
+++ b/packages/start-git-work/src/test/gitCleanup.test.ts
@@ -30,6 +30,10 @@ import { execFile } from 'child_process';
 import { promptGitCleanup } from '../gitCleanup';
 
 function workStartedEntry(data: { branchName?: string; worktreePath?: string; repoPath?: string }) {
+  return { timestamp: Date.now(), type: 'work-started', detail: JSON.stringify({ v: 1, ...data }) };
+}
+
+function legacyWorkStartedEntry(data: { branchName?: string; worktreePath?: string; repoPath?: string }) {
   return { timestamp: Date.now(), type: 'work-started', detail: JSON.stringify(data) };
 }
 
@@ -132,5 +136,33 @@ describe('promptGitCleanup', () => {
     await promptGitCleanup(createItem({
       activityLog: [workStartedEntry({ branchName: 'feature/x', repoPath: '/repos/main' })],
     }), addActivity);
+  });
+
+  it('still prompts for legacy entries without a version tag', async () => {
+    (fs.access as Mock).mockResolvedValue(undefined);
+    (execFile as unknown as Mock).mockResolvedValueOnce({ stdout: '', stderr: '' });
+    (vscode.window.showInformationMessage as Mock).mockResolvedValue('Yes');
+    (execFile as unknown as Mock).mockResolvedValueOnce({ stdout: '', stderr: '' });
+
+    await promptGitCleanup(createItem({
+      activityLog: [legacyWorkStartedEntry({ branchName: 'feature/x', repoPath: '/repos/main' })],
+    }), addActivity);
+
+    expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+      expect.stringContaining('branch "feature/x"'), 'Yes', 'No',
+    );
+    expect(addActivity).toHaveBeenCalledWith('wc-test-1', 'cleanup', 'Removed branch feature/x');
+  });
+
+  it('does not prompt when the entry has an unknown schema version', async () => {
+    const unknownVersion = {
+      timestamp: Date.now(),
+      type: 'work-started',
+      detail: JSON.stringify({ v: 99, branchName: 'feature/x', repoPath: '/repos/main' }),
+    };
+
+    await promptGitCleanup(createItem({ activityLog: [unknownVersion] }), addActivity);
+
+    expect(vscode.window.showInformationMessage).not.toHaveBeenCalled();
   });
 });

--- a/packages/start-git-work/src/test/gitCleanup.test.ts
+++ b/packages/start-git-work/src/test/gitCleanup.test.ts
@@ -28,9 +28,10 @@ vi.mock('../logger', () => ({
 import * as fs from 'fs/promises';
 import { execFile } from 'child_process';
 import { promptGitCleanup } from '../gitCleanup';
+import { encodeWorkStartedDetail } from '../workStartedDetail';
 
-function workStartedEntry(data: { branchName?: string; worktreePath?: string; repoPath?: string }) {
-  return { timestamp: Date.now(), type: 'work-started', detail: JSON.stringify({ v: 1, ...data }) };
+function workStartedEntry(data: { repoPath: string; branchName?: string; worktreePath?: string }) {
+  return { timestamp: Date.now(), type: 'work-started', detail: encodeWorkStartedDetail(data) };
 }
 
 function legacyWorkStartedEntry(data: { branchName?: string; worktreePath?: string; repoPath?: string }) {

--- a/packages/start-git-work/src/test/workStartedDetail.test.ts
+++ b/packages/start-git-work/src/test/workStartedDetail.test.ts
@@ -12,6 +12,7 @@ import { logger } from '../logger';
 import {
   encodeWorkStartedDetail,
   decodeWorkStartedDetail,
+  renderWorkStartedActivityDetail,
   WORK_STARTED_DETAIL_VERSION,
 } from '../workStartedDetail';
 
@@ -105,6 +106,49 @@ describe('decodeWorkStartedDetail', () => {
   it('returns undefined when repoPath has a non-string value', () => {
     const nonStringRepoPath = JSON.stringify({ v: 1, repoPath: 42, branchName: 'b' });
     expect(decodeWorkStartedDetail(nonStringRepoPath)).toBeUndefined();
+  });
+});
+
+describe('renderWorkStartedActivityDetail', () => {
+  it('renders all known fields as labelled rows', () => {
+    const encoded = encodeWorkStartedDetail({
+      branchName: 'feature/x',
+      worktreePath: '/path/to/worktree',
+      repoPath: '/path/to/repo',
+    });
+    expect(renderWorkStartedActivityDetail(encoded)).toEqual({
+      kind: 'fields',
+      rows: [
+        { label: 'Branch', value: 'feature/x' },
+        { label: 'Worktree', value: '/path/to/worktree' },
+        { label: 'Repo', value: '/path/to/repo' },
+      ],
+    });
+  });
+
+  it('omits rows whose underlying field is absent', () => {
+    const encoded = encodeWorkStartedDetail({ repoPath: '/path/to/repo' });
+    expect(renderWorkStartedActivityDetail(encoded)).toEqual({
+      kind: 'fields',
+      rows: [{ label: 'Repo', value: '/path/to/repo' }],
+    });
+  });
+
+  it('returns undefined for undecodable detail (lets core fall back to plain text)', () => {
+    expect(renderWorkStartedActivityDetail(undefined)).toBeUndefined();
+    expect(renderWorkStartedActivityDetail('not json')).toBeUndefined();
+    expect(renderWorkStartedActivityDetail(JSON.stringify({ v: 99 }))).toBeUndefined();
+  });
+
+  it('renders legacy unversioned entries (backward compatibility)', () => {
+    const legacy = JSON.stringify({ branchName: 'feature/x', repoPath: '/r' });
+    expect(renderWorkStartedActivityDetail(legacy)).toEqual({
+      kind: 'fields',
+      rows: [
+        { label: 'Branch', value: 'feature/x' },
+        { label: 'Repo', value: '/r' },
+      ],
+    });
   });
 });
 

--- a/packages/start-git-work/src/test/workStartedDetail.test.ts
+++ b/packages/start-git-work/src/test/workStartedDetail.test.ts
@@ -96,16 +96,19 @@ describe('decodeWorkStartedDetail', () => {
   it('returns undefined for v1 payloads missing required repoPath', () => {
     const noRepoPath = JSON.stringify({ v: 1, branchName: 'feature/x', worktreePath: '/w' });
     expect(decodeWorkStartedDetail(noRepoPath)).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('missing a string "repoPath"'));
   });
 
   it('returns undefined for legacy unversioned payloads missing repoPath', () => {
     const legacyNoRepoPath = JSON.stringify({ branchName: 'feature/x', worktreePath: '/w' });
     expect(decodeWorkStartedDetail(legacyNoRepoPath)).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('missing a string "repoPath"'));
   });
 
   it('returns undefined when repoPath has a non-string value', () => {
     const nonStringRepoPath = JSON.stringify({ v: 1, repoPath: 42, branchName: 'b' });
     expect(decodeWorkStartedDetail(nonStringRepoPath)).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('missing a string "repoPath"'));
   });
 });
 

--- a/packages/start-git-work/src/test/workStartedDetail.test.ts
+++ b/packages/start-git-work/src/test/workStartedDetail.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { logger } from '../logger';
+import {
+  encodeWorkStartedDetail,
+  decodeWorkStartedDetail,
+  WORK_STARTED_DETAIL_VERSION,
+} from '../workStartedDetail';
+
+describe('encodeWorkStartedDetail', () => {
+  it('stamps the current schema version', () => {
+    const encoded = encodeWorkStartedDetail({ branchName: 'feature/x', repoPath: '/r' });
+    const parsed = JSON.parse(encoded);
+    expect(parsed.v).toBe(WORK_STARTED_DETAIL_VERSION);
+    expect(parsed.branchName).toBe('feature/x');
+    expect(parsed.repoPath).toBe('/r');
+  });
+
+  it('omits undefined optional fields', () => {
+    const encoded = encodeWorkStartedDetail({ repoPath: '/r' });
+    const parsed = JSON.parse(encoded);
+    expect(parsed).not.toHaveProperty('branchName');
+    expect(parsed).not.toHaveProperty('worktreePath');
+    expect(parsed.repoPath).toBe('/r');
+  });
+
+  it('round-trips through decode', () => {
+    const original = { branchName: 'b', worktreePath: '/w', repoPath: '/r' };
+    const decoded = decodeWorkStartedDetail(encodeWorkStartedDetail(original));
+    expect(decoded).toEqual({ v: 1, ...original });
+  });
+});
+
+describe('decodeWorkStartedDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns undefined for missing detail', () => {
+    expect(decodeWorkStartedDetail(undefined)).toBeUndefined();
+    expect(decodeWorkStartedDetail('')).toBeUndefined();
+  });
+
+  it('returns undefined and warns for malformed JSON', () => {
+    expect(decodeWorkStartedDetail('not json')).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Failed to parse'));
+  });
+
+  it('returns undefined for non-object payloads', () => {
+    expect(decodeWorkStartedDetail(JSON.stringify('a string'))).toBeUndefined();
+    expect(decodeWorkStartedDetail(JSON.stringify(42))).toBeUndefined();
+    expect(decodeWorkStartedDetail(JSON.stringify(null))).toBeUndefined();
+    expect(decodeWorkStartedDetail(JSON.stringify(['a']))).toBeUndefined();
+  });
+
+  it('accepts legacy unversioned payloads (no v field)', () => {
+    const legacy = JSON.stringify({ branchName: 'feature/x', worktreePath: '/w', repoPath: '/r' });
+    const decoded = decodeWorkStartedDetail(legacy);
+    expect(decoded).toEqual({ v: 1, branchName: 'feature/x', worktreePath: '/w', repoPath: '/r' });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('parses current v1 payloads', () => {
+    const v1 = JSON.stringify({ v: 1, branchName: 'b', repoPath: '/r' });
+    const decoded = decodeWorkStartedDetail(v1);
+    expect(decoded).toEqual({ v: 1, branchName: 'b', repoPath: '/r' });
+  });
+
+  it('returns undefined and warns for unknown version', () => {
+    const future = JSON.stringify({ v: 2, branchName: 'b', repoPath: '/r' });
+    expect(decodeWorkStartedDetail(future)).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Unknown work-started activity detail version'));
+  });
+
+  it('drops non-string field values silently', () => {
+    const mixed = JSON.stringify({ v: 1, branchName: 42, worktreePath: null, repoPath: '/r' });
+    const decoded = decodeWorkStartedDetail(mixed);
+    expect(decoded).toEqual({ v: 1, repoPath: '/r' });
+  });
+
+  it('treats a string version "1" as unknown (strict equality)', () => {
+    const stringVersion = JSON.stringify({ v: '1', branchName: 'b', repoPath: '/r' });
+    expect(decodeWorkStartedDetail(stringVersion)).toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Unknown work-started activity detail version'));
+  });
+});
+
+describe('encodeWorkStartedDetail (extra invariants)', () => {
+  it('round-trips when only repoPath is set', () => {
+    const encoded = encodeWorkStartedDetail({ repoPath: '/r' });
+    expect(decodeWorkStartedDetail(encoded)).toEqual({ v: 1, repoPath: '/r' });
+  });
+
+  it('always stamps v: 1 even if the caller tries to pass v', () => {
+    // Compile-time `Omit<…, 'v'>` blocks this; the cast simulates a runtime
+    // refactor that loosens the type. The encoder must still write v: 1.
+    const encoded = encodeWorkStartedDetail({ repoPath: '/r', v: 99 } as unknown as Parameters<typeof encodeWorkStartedDetail>[0]);
+    expect(JSON.parse(encoded).v).toBe(1);
+  });
+});

--- a/packages/start-git-work/src/test/workStartedDetail.test.ts
+++ b/packages/start-git-work/src/test/workStartedDetail.test.ts
@@ -91,6 +91,21 @@ describe('decodeWorkStartedDetail', () => {
     expect(decodeWorkStartedDetail(stringVersion)).toBeUndefined();
     expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('Unknown work-started activity detail version'));
   });
+
+  it('returns undefined for v1 payloads missing required repoPath', () => {
+    const noRepoPath = JSON.stringify({ v: 1, branchName: 'feature/x', worktreePath: '/w' });
+    expect(decodeWorkStartedDetail(noRepoPath)).toBeUndefined();
+  });
+
+  it('returns undefined for legacy unversioned payloads missing repoPath', () => {
+    const legacyNoRepoPath = JSON.stringify({ branchName: 'feature/x', worktreePath: '/w' });
+    expect(decodeWorkStartedDetail(legacyNoRepoPath)).toBeUndefined();
+  });
+
+  it('returns undefined when repoPath has a non-string value', () => {
+    const nonStringRepoPath = JSON.stringify({ v: 1, repoPath: 42, branchName: 'b' });
+    expect(decodeWorkStartedDetail(nonStringRepoPath)).toBeUndefined();
+  });
 });
 
 describe('encodeWorkStartedDetail (extra invariants)', () => {

--- a/packages/start-git-work/src/workStartedDetail.ts
+++ b/packages/start-git-work/src/workStartedDetail.ts
@@ -1,0 +1,131 @@
+import { logger } from './logger';
+
+/**
+ * Versioned schema for the `detail` field of a `'work-started'`
+ * activity log entry written by this extension.
+ *
+ * The activity log is the source of truth for branch/worktree
+ * associations (see AGENTS.md). Because the cleanup flow in
+ * {@link ./gitCleanup} reads these entries by exact field name
+ * — potentially weeks or months after the entry was written —
+ * the shape is treated as a stable, versioned contract rather
+ * than a free-form string. Any change to the payload shape
+ * MUST bump the version (e.g. introduce `WorkStartedDetailV2`)
+ * and update {@link decodeWorkStartedDetail} to recognise the
+ * new version alongside the old one.
+ *
+ * All fields except `v` are optional because the writer omits
+ * fields it cannot safely act on later (e.g. `branchName` is
+ * omitted for PR flows when the action did not create the
+ * branch, so cleanup will not delete a pre-existing user
+ * branch).
+ */
+export interface WorkStartedDetailV1 {
+  /** Schema version. */
+  v: 1;
+  /** Branch name created by the action, if any. */
+  branchName?: string;
+  /** Absolute filesystem path of the worktree created by the action, if any. */
+  worktreePath?: string;
+  /** Absolute filesystem path of the repository the action operated on. */
+  repoPath?: string;
+}
+
+/** Input accepted by {@link encodeWorkStartedDetail} — the version tag is supplied by the encoder.
+ *
+ * `repoPath` is required because every code path in {@link ../startWorkAction}
+ * has a known repo to record, and {@link decodeWorkStartedDetail} consumers
+ * (e.g. cleanup) cannot act on an entry without it. `branchName` /
+ * `worktreePath` stay optional: the PR flows intentionally omit `branchName`
+ * when the action did not create the branch, and the checkout flows have no
+ * worktree.
+ */
+export type WorkStartedDetailInput = Omit<WorkStartedDetailV1, 'v' | 'repoPath'> & { repoPath: string };
+
+/** Decoded payload returned by {@link decodeWorkStartedDetail}.
+ *
+ * Always the latest known shape. When a future `WorkStartedDetailV2` is
+ * introduced, {@link decodeWorkStartedDetail} is responsible for upgrading
+ * older versions in place so callers can keep targeting a single type.
+ */
+export type WorkStartedDetail = WorkStartedDetailV1;
+
+/** Current schema version emitted by {@link encodeWorkStartedDetail}. */
+export const WORK_STARTED_DETAIL_VERSION = 1 as const;
+
+/**
+ * Encode a typed payload as the JSON string stored in the
+ * `'work-started'` activity log entry's `detail` field.
+ *
+ * Always stamps the current schema version, so older readers
+ * that lack version awareness still observe the legacy field
+ * names at the top level.
+ */
+export function encodeWorkStartedDetail(input: Readonly<WorkStartedDetailInput>): string {
+  const payload: WorkStartedDetailV1 = { v: WORK_STARTED_DETAIL_VERSION };
+  if (input.branchName !== undefined) {
+    payload.branchName = input.branchName;
+  }
+  if (input.worktreePath !== undefined) {
+    payload.worktreePath = input.worktreePath;
+  }
+  if (input.repoPath !== undefined) {
+    payload.repoPath = input.repoPath;
+  }
+  return JSON.stringify(payload);
+}
+
+/**
+ * Decode a `'work-started'` activity log entry's `detail` field.
+ *
+ * - Returns `undefined` for missing, empty, malformed, or
+ *   non-object JSON — callers should treat this as "no
+ *   actionable info" rather than a hard error.
+ * - Accepts entries written before the version tag existed
+ *   (i.e. with no `v` field) by treating them as legacy
+ *   payloads of the same shape. This preserves the cleanup
+ *   prompt for activity logs created prior to this change.
+ * - Logs a warning and returns `undefined` for entries whose
+ *   `v` is present but unrecognised. This makes future
+ *   schema mismatches visible in the logs instead of
+ *   silently downgrading cleanup to a no-op.
+ */
+export function decodeWorkStartedDetail(detail: string | undefined): WorkStartedDetail | undefined {
+  if (!detail) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(detail);
+  } catch {
+    logger.warn('Failed to parse work-started activity detail as JSON');
+    return undefined;
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return undefined;
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const version = obj.v;
+
+  if (version !== undefined && version !== WORK_STARTED_DETAIL_VERSION) {
+    // Single-version check today; expand to a `switch (version)` per-version
+    // parser when V2 lands so each version can upgrade in place.
+    logger.warn(`Unknown work-started activity detail version: ${String(version)}; cleanup will be skipped for this entry.`);
+    return undefined;
+  }
+
+  const result: WorkStartedDetailV1 = { v: WORK_STARTED_DETAIL_VERSION };
+  if (typeof obj.branchName === 'string') {
+    result.branchName = obj.branchName;
+  }
+  if (typeof obj.worktreePath === 'string') {
+    result.worktreePath = obj.worktreePath;
+  }
+  if (typeof obj.repoPath === 'string') {
+    result.repoPath = obj.repoPath;
+  }
+  return result;
+}

--- a/packages/start-git-work/src/workStartedDetail.ts
+++ b/packages/start-git-work/src/workStartedDetail.ts
@@ -14,33 +14,27 @@ import { logger } from './logger';
  * and update {@link decodeWorkStartedDetail} to recognise the
  * new version alongside the old one.
  *
- * All fields except `v` are optional because the writer omits
- * fields it cannot safely act on later (e.g. `branchName` is
- * omitted for PR flows when the action did not create the
- * branch, so cleanup will not delete a pre-existing user
- * branch).
+ * `repoPath` is required: every write site has a known repo,
+ * and downstream cleanup cannot act on an entry without one.
+ * The decoder enforces this and rejects v1 payloads missing it.
+ * `branchName` / `worktreePath` stay optional because the PR
+ * flows intentionally omit `branchName` when the action did not
+ * create the branch (so cleanup will not delete a pre-existing
+ * user branch), and the checkout flows have no worktree.
  */
 export interface WorkStartedDetailV1 {
   /** Schema version. */
   v: 1;
+  /** Absolute filesystem path of the repository the action operated on. */
+  repoPath: string;
   /** Branch name created by the action, if any. */
   branchName?: string;
   /** Absolute filesystem path of the worktree created by the action, if any. */
   worktreePath?: string;
-  /** Absolute filesystem path of the repository the action operated on. */
-  repoPath?: string;
 }
 
-/** Input accepted by {@link encodeWorkStartedDetail} — the version tag is supplied by the encoder.
- *
- * `repoPath` is required because every code path in {@link ./startWorkAction}
- * has a known repo to record, and {@link decodeWorkStartedDetail} consumers
- * (e.g. cleanup) cannot act on an entry without it. `branchName` /
- * `worktreePath` stay optional: the PR flows intentionally omit `branchName`
- * when the action did not create the branch, and the checkout flows have no
- * worktree.
- */
-export type WorkStartedDetailInput = Omit<WorkStartedDetailV1, 'v' | 'repoPath'> & { repoPath: string };
+/** Input accepted by {@link encodeWorkStartedDetail} — the version tag is supplied by the encoder. */
+export type WorkStartedDetailInput = Omit<WorkStartedDetailV1, 'v'>;
 
 /** Decoded payload returned by {@link decodeWorkStartedDetail}.
  *
@@ -62,15 +56,12 @@ export const WORK_STARTED_DETAIL_VERSION = 1 as const;
  * names at the top level.
  */
 export function encodeWorkStartedDetail(input: Readonly<WorkStartedDetailInput>): string {
-  const payload: WorkStartedDetailV1 = { v: WORK_STARTED_DETAIL_VERSION };
+  const payload: WorkStartedDetailV1 = { v: WORK_STARTED_DETAIL_VERSION, repoPath: input.repoPath };
   if (input.branchName !== undefined) {
     payload.branchName = input.branchName;
   }
   if (input.worktreePath !== undefined) {
     payload.worktreePath = input.worktreePath;
-  }
-  if (input.repoPath !== undefined) {
-    payload.repoPath = input.repoPath;
   }
   return JSON.stringify(payload);
 }
@@ -89,6 +80,9 @@ export function encodeWorkStartedDetail(input: Readonly<WorkStartedDetailInput>)
  *   `v` is present but unrecognised. This makes future
  *   schema mismatches visible in the logs instead of
  *   silently downgrading cleanup to a no-op.
+ * - Returns `undefined` when the payload is missing the
+ *   required `repoPath` field, since callers cannot act on
+ *   an entry without it.
  */
 export function decodeWorkStartedDetail(detail: string | undefined): WorkStartedDetail | undefined {
   if (!detail) {
@@ -117,15 +111,16 @@ export function decodeWorkStartedDetail(detail: string | undefined): WorkStarted
     return undefined;
   }
 
-  const result: WorkStartedDetailV1 = { v: WORK_STARTED_DETAIL_VERSION };
+  if (typeof obj.repoPath !== 'string') {
+    return undefined;
+  }
+
+  const result: WorkStartedDetailV1 = { v: WORK_STARTED_DETAIL_VERSION, repoPath: obj.repoPath };
   if (typeof obj.branchName === 'string') {
     result.branchName = obj.branchName;
   }
   if (typeof obj.worktreePath === 'string') {
     result.worktreePath = obj.worktreePath;
-  }
-  if (typeof obj.repoPath === 'string') {
-    result.repoPath = obj.repoPath;
   }
   return result;
 }

--- a/packages/start-git-work/src/workStartedDetail.ts
+++ b/packages/start-git-work/src/workStartedDetail.ts
@@ -1,4 +1,5 @@
 import { logger } from './logger';
+import type { ActivityDetailRender } from '@devdocket/shared';
 
 /**
  * Versioned schema for the `detail` field of a `'work-started'`
@@ -123,4 +124,31 @@ export function decodeWorkStartedDetail(detail: string | undefined): WorkStarted
     result.worktreePath = obj.worktreePath;
   }
   return result;
+}
+
+/**
+ * Render a `'work-started'` activity entry's `detail` payload into a
+ * display-ready representation for the editor's activity log.
+ *
+ * Registered with the core extension via
+ * `DevDocketApi.registerActivityDetailRenderer('work-started', ...)`
+ * so that the core extension does not need to understand the v1
+ * schema. Returns `undefined` when the detail cannot be decoded,
+ * which causes the core to fall back to plain-text rendering of
+ * the raw `detail` string.
+ */
+export function renderWorkStartedActivityDetail(detail: string | undefined): ActivityDetailRender | undefined {
+  const decoded = decodeWorkStartedDetail(detail);
+  if (!decoded) {
+    return undefined;
+  }
+  const rows: Array<{ label: string; value: string }> = [];
+  if (decoded.branchName) {
+    rows.push({ label: 'Branch', value: decoded.branchName });
+  }
+  if (decoded.worktreePath) {
+    rows.push({ label: 'Worktree', value: decoded.worktreePath });
+  }
+  rows.push({ label: 'Repo', value: decoded.repoPath });
+  return { kind: 'fields', rows };
 }

--- a/packages/start-git-work/src/workStartedDetail.ts
+++ b/packages/start-git-work/src/workStartedDetail.ts
@@ -113,6 +113,10 @@ export function decodeWorkStartedDetail(detail: string | undefined): WorkStarted
   }
 
   if (typeof obj.repoPath !== 'string') {
+    // Missing/invalid repoPath is the most common producer bug because the
+    // type system already requires it on the encoder input — surfacing a
+    // warning makes it easier to diagnose silent cleanup no-ops.
+    logger.warn(`work-started activity detail is missing a string "repoPath" (version=${version === undefined ? 'legacy' : String(version)}); cleanup will be skipped for this entry.`);
     return undefined;
   }
 

--- a/packages/start-git-work/src/workStartedDetail.ts
+++ b/packages/start-git-work/src/workStartedDetail.ts
@@ -33,7 +33,7 @@ export interface WorkStartedDetailV1 {
 
 /** Input accepted by {@link encodeWorkStartedDetail} — the version tag is supplied by the encoder.
  *
- * `repoPath` is required because every code path in {@link ../startWorkAction}
+ * `repoPath` is required because every code path in {@link ./startWorkAction}
  * has a known repo to record, and {@link decodeWorkStartedDetail} consumers
  * (e.g. cleanup) cannot act on an entry without it. `branchName` /
  * `worktreePath` stay optional: the PR flows intentionally omit `branchName`


### PR DESCRIPTION
Closes #581.

## Problem

The `'work-started'` activity log entry's `detail` field was used as an inter-module JSON contract between three sites: `startWorkAction.ts` (writer), `gitCleanup.ts` (reader for branch/worktree cleanup), and the editor's `ActivityLog.tsx` (reader for labelled-field rendering). The shape was untagged and undocumented — renaming any field would compile, ship, and silently break cleanup for every pre-existing activity entry. Cleanup failures were invisible because the optional-field code paths skipped silently.

## Fix

Two parts:

### 1. Versioned schema for the cleanup payload

`packages/start-git-work/src/workStartedDetail.ts` introduces:

- `WorkStartedDetailV1` interface with a `v: 1` discriminator and a required `repoPath` (every call site supplies it; cleanup cannot act without it).
- `encodeWorkStartedDetail()` always stamps the current version and writes `repoPath` unconditionally.
- `decodeWorkStartedDetail()` accepts legacy unversioned entries (backward compatible with logs created before this change), parses v1, logs a warning + returns `undefined` for unknown versions, and rejects entries missing the required `repoPath`.

All four `JSON.stringify({...})` sites in `startWorkAction.ts` now use the encoder; `gitCleanup.ts` uses the decoder.

### 2. Editor rendering moved to the schema owner (core extension isolation)

The first round of this PR had the editor webview parse the v1 payload in `ActivityLog.tsx`. That violated the AGENTS.md "Core extension isolation" rule — `core` had to know the schema owned by `start-git-work`, so a future bump in `start-git-work` would have forced a matching change in `core`.

Introduce a new optional `DevDocketApi.registerActivityDetailRenderer(type, renderFn)` so extensions that own an activity type's `detail` schema can also own its display:

```ts
type ActivityDetailRender =
  | { kind: 'text'; text: string }
  | { kind: 'fields'; rows: ReadonlyArray<{ label: string; value: string }> };
```

- `ActivityDetailRendererRegistry` (new core service) keeps the type → renderer mapping. Throws on duplicate registration (schema owner is unique); buggy renderers are caught and treated as "no render". Fires `onDidChange` so open editor panels re-render when a renderer comes online — covers the case where the editor opens before `start-git-work.activate()` finishes.
- `WorkItemEditorPanel.buildEditorItemData()` invokes the registry per activity entry and ships the rendered shape to the webview as `displayDetail`.
- `ActivityLog.tsx` is now schema-agnostic: renders `displayDetail` if present (text → `<span>`, fields → `<dl>`), otherwise falls back to plain `detail`.
- `start-git-work.activate()` registers `renderWorkStartedActivityDetail`, which decodes the v1 payload into `{ kind: 'fields', rows: [...] }`. Returns `undefined` for undecodable / unknown-version entries, so core falls back to plain text.

Result: `start-git-work` now owns the schema, the encoder, the decoder, AND the display rendering. `core` no longer knows anything about the `'work-started'` payload shape.

## API surface (additive)

- `@devdocket/shared`: new exported types `ActivityDetailRender`, `ActivityDetailRenderer`; new optional `registerActivityDetailRenderer?` on `DevDocketApi`.
- `packages/core/src/api/types.ts` re-exports the new types.

No breaking changes — all additions are optional / new symbols.

## Docs

- `docs/extension-api.md` documents the new API method, the `ActivityDetailRender` shape, and the renderer contract under a new "Activity log rendering" section.
- `.github/instructions/start-git-work.instructions.md` replaces the prior "must update both files in lockstep" warning with the new ownership story.

## Tests

- `workStartedDetail.test.ts` (20 tests): round-trip, current v1, legacy unversioned, unknown numeric/string version, malformed JSON, non-object payloads, missing/non-string `repoPath`, field-type coercion, encoder ignores caller-supplied `v`, `repoPath`-only round-trip, and the renderer's field/legacy/undefined behavior.
- `gitCleanup.test.ts` (+2): legacy entries still prompt; unknown-version entries do not prompt.
- `activityDetailRendererRegistry.test.ts` (9 tests): register / render / throws on duplicate / re-register after dispose / no-op on double-dispose / swallows renderer errors / `onDidChange` fires correctly / dispose clears all.
- `activityLog.test.ts` (5 tests, rewritten): renders fields, renders text, falls back to raw `detail`, renders plain types verbatim, renders nothing when both fields are absent.
- `devDocketApi.test.ts`: new delegation test for `registerActivityDetailRenderer`.

Full monorepo test suite passes (43 core, 21 github, 16 ado, 16 ai-reviewer, 6 shared, 3 start-git-work test files).
