### PR TITLE
Differentiate GitHub API error signatures in throwApiError

### DIFF
--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -171,15 +171,182 @@ export async function retryWithAuth(apiUrl: string, signal?: AbortSignal): Promi
   return undefined;
 }
 
-/** Throw a descriptive error for a non-ok GitHub API response. */
-export function throwApiError(response: Response, label: string): never {
-  if (response.status === 404) {
+/**
+ * Inspect a non-ok GitHub API response and throw a descriptive error.
+ *
+ * Reads the response body (best-effort) and any diagnostic headers, logs a
+ * warning with the real HTTP status / headers / body snippet, and then throws
+ * an Error whose message describes the *actual* failure signature (rate limit,
+ * SSO, authentication, not-found, etc.) instead of defaulting to a generic
+ * "may be private" hint for every 4xx.
+ *
+ * Always throws — the `Promise<never>` return type lets callers `await` it
+ * inside an `if (!response.ok)` branch.
+ */
+export async function throwApiError(response: Response, label: string): Promise<never> {
+  const status = response.status;
+  const statusText = response.statusText ?? '';
+  const bodyText = await safeReadResponseBody(response);
+  const apiMessage = extractGitHubApiMessage(bodyText);
+
+  const remaining = response.headers.get('x-ratelimit-remaining');
+  const reset = response.headers.get('x-ratelimit-reset');
+  const retryAfter = response.headers.get('retry-after');
+  const sso = response.headers.get('x-github-sso');
+
+  const bodySnippet = bodyText ? truncateForLog(bodyText) : null;
+  const diag = [
+    `status=${status}`,
+    statusText ? `statusText="${statusText}"` : null,
+    remaining !== null ? `rate-limit-remaining=${remaining}` : null,
+    reset !== null ? `rate-limit-reset=${reset}` : null,
+    retryAfter !== null ? `retry-after=${retryAfter}` : null,
+    sso !== null ? `x-github-sso="${sso}"` : null,
+    apiMessage ? `message="${apiMessage}"` : null,
+    bodySnippet ? `body=${bodySnippet}` : null,
+  ].filter((part): part is string => part !== null).join(' ');
+  logger.warn(`GitHub API request failed for ${label}: ${diag}`);
+
+  if (status === 404) {
     throw new Error(`${label} not found. It may be private or deleted.`);
   }
-  if (response.status === 401 || response.status === 403) {
-    throw new Error(`GitHub access denied for ${label}. The repo may be private — sign in to GitHub in VS Code, or check rate limits.`);
+  if (status === 401) {
+    throw new Error(
+      `GitHub authentication failed for ${label} (HTTP 401)` +
+      `${apiMessage ? `: ${apiMessage}` : '.'}` +
+      ' Sign in to GitHub in VS Code or refresh your credentials.',
+    );
   }
-  throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+  if (status === 403) {
+    // Order matters: prefer the most specific signature so a coincidental
+    // `remaining===0` doesn't mask SSO or secondary-rate-limit responses.
+    if (sso) {
+      throw new Error(
+        `GitHub SSO authorization required for ${label}` +
+        `${apiMessage ? `: ${apiMessage}` : '.'}` +
+        ' Authorize the token for the organization, then retry.',
+      );
+    }
+    if (isSecondaryRateLimited(retryAfter, apiMessage)) {
+      const wait = formatRetryAfter(retryAfter);
+      throw new Error(`GitHub secondary rate limit hit for ${label}.${wait ? ` ${wait}` : ''}`);
+    }
+    if (isPrimaryRateLimited(remaining, apiMessage)) {
+      const resetHint = formatRateLimitReset(reset);
+      throw new Error(
+        `GitHub API rate limit exceeded for ${label}.` +
+        `${resetHint ? ` ${resetHint}` : ''}` +
+        ' Sign in to GitHub in VS Code for a higher quota.',
+      );
+    }
+    throw new Error(
+      `GitHub denied access to ${label} (HTTP 403)` +
+      `${apiMessage ? `: ${apiMessage}` : '. The token may lack required permissions, or the resource may be private.'}`,
+    );
+  }
+  throw new Error(
+    `GitHub API error for ${label}: HTTP ${status}` +
+    `${statusText ? ` ${statusText}` : ''}` +
+    `${apiMessage ? ` — ${apiMessage}` : ''}`,
+  );
+}
+
+async function safeReadResponseBody(response: Response): Promise<string> {
+  try {
+    const text = await response.text();
+    return text ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function extractGitHubApiMessage(bodyText: string): string | undefined {
+  if (!bodyText) { return undefined; }
+  try {
+    const parsed = JSON.parse(bodyText) as { message?: unknown };
+    if (parsed && typeof parsed.message === 'string' && parsed.message.trim().length > 0) {
+      return parsed.message.trim();
+    }
+  } catch {
+    // Body wasn't JSON — fall through.
+  }
+  return undefined;
+}
+
+function truncateForLog(text: string, limit = 200): string {
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  if (collapsed.length <= limit) { return JSON.stringify(collapsed); }
+  return JSON.stringify(collapsed.slice(0, limit) + '…');
+}
+
+function isPrimaryRateLimited(remaining: string | null, apiMessage: string | undefined): boolean {
+  if (remaining === '0') { return true; }
+  if (apiMessage && /api rate limit exceeded/i.test(apiMessage)) { return true; }
+  return false;
+}
+
+function isSecondaryRateLimited(retryAfter: string | null, apiMessage: string | undefined): boolean {
+  if (apiMessage && /secondary rate limit/i.test(apiMessage)) { return true; }
+  if (!retryAfter) { return false; }
+  // GitHub usually sends Retry-After with 403 only for abuse / secondary
+  // rate-limit paths. The header may be either delta-seconds (RFC 7231) or
+  // an HTTP-date; accept both forms.
+  if (Number.isFinite(Number(retryAfter))) { return true; }
+  if (!Number.isNaN(Date.parse(retryAfter))) { return true; }
+  return false;
+}
+
+/**
+ * Render a Retry-After header value as a short user-facing hint. Returns
+ * undefined when the value is missing or unparseable. Numeric values are
+ * shown as "Retry after Xs."; HTTP-date values are shown as a delta from
+ * `Date.now()` when the date is in the future.
+ */
+function formatRetryAfter(retryAfter: string | null): string | undefined {
+  if (!retryAfter) { return undefined; }
+  const seconds = Number(retryAfter);
+  if (Number.isFinite(seconds)) { return `Retry after ${seconds}s.`; }
+  const ts = Date.parse(retryAfter);
+  if (Number.isNaN(ts)) { return undefined; }
+  const delta = Math.max(0, Math.round((ts - Date.now()) / 1000));
+  return delta > 0 ? `Retry after ${delta}s.` : 'Retry shortly.';
+}
+
+function formatRateLimitReset(reset: string | null): string | undefined {
+  if (!reset) { return undefined; }
+  const epochSeconds = Number(reset);
+  if (!Number.isFinite(epochSeconds)) { return undefined; }
+  const nowSeconds = Date.now() / 1000;
+  const deltaSeconds = Math.max(0, Math.round(epochSeconds - nowSeconds));
+  if (deltaSeconds === 0) { return 'Quota should reset momentarily.'; }
+  if (deltaSeconds < 60) { return `Resets in ${deltaSeconds}s.`; }
+  const minutes = Math.round(deltaSeconds / 60);
+  if (minutes < 60) { return `Resets in ${minutes} minute${minutes === 1 ? '' : 's'}.`; }
+  const hours = Math.round(deltaSeconds / 3600);
+  return `Resets in ${hours} hour${hours === 1 ? '' : 's'}.`;
+}
+
+/**
+ * Header-only heuristic for whether a 403 response looks like a rate-limit
+ * response (primary IP/user rate limit or secondary/abuse limit), based on
+ * `x-ratelimit-remaining` and `Retry-After`. This is cheap to evaluate (no
+ * body read) and is used to decide whether an unauthenticated `resolveUrl`
+ * request should retry with interactive auth — prompting the user to sign in
+ * only makes sense when the failure is plausibly fixed by getting a higher
+ * authenticated quota.
+ *
+ * Returns false for non-403 responses.
+ */
+export function looksLikeRateLimited403(response: Response): boolean {
+  if (response.status !== 403) { return false; }
+  const remaining = response.headers.get('x-ratelimit-remaining');
+  if (remaining === '0') { return true; }
+  const retryAfter = response.headers.get('retry-after');
+  if (retryAfter) {
+    if (Number.isFinite(Number(retryAfter))) { return true; }
+    if (!Number.isNaN(Date.parse(retryAfter))) { return true; }
+  }
+  return false;
 }
 
 /** Extract canonical owner/repo from a GitHub html_url. */

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -5,7 +5,7 @@ import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
 import { matchesRepoPatterns } from './repoPattern';
-import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, filterMergedGitHubPrs, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
+import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, looksLikeRateLimited403, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, filterMergedGitHubPrs, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
 import { createGitHubIssueGitWork, createGitHubPrGitWork } from './gitWorkCapabilities';
 
 const MENTIONS_ACTIVATED_KEY = 'mentionsActivatedAt';
@@ -187,14 +187,15 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
 
     let response = await fetch(apiUrl, { headers, signal });
 
-    if (response.status === 404 && !wasAuthenticated && !signal?.aborted) {
+    if (!response.ok && !wasAuthenticated && !signal?.aborted &&
+        (response.status === 404 || looksLikeRateLimited403(response))) {
       const retryResponse = await retryWithAuth(apiUrl, signal);
       if (retryResponse) { response = retryResponse; }
     }
 
     if (!response.ok) {
       const label = isPr ? 'GitHub PR' : 'GitHub issue';
-      throwApiError(response, `${label} ${owner}/${repo}#${number}`);
+      await throwApiError(response, `${label} ${owner}/${repo}#${number}`);
     }
 
     const data = await response.json() as { title: string; body: string | null; html_url: string };

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -3,7 +3,7 @@ import { ProviderItem, combineSignals, createAbortError, runWorkerPool, safeDeco
 import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
-import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, filterMergedGitHubPrs, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
+import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, looksLikeRateLimited403, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, filterMergedGitHubPrs, type GitHubIssue, type GitHubSearchResponse } from './githubApiHelpers';
 import { matchesRepoPatterns } from './repoPattern';
 import { createGitHubPrGitWork } from './gitWorkCapabilities';
 
@@ -139,13 +139,14 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
 
     let response = await fetch(apiUrl, { headers, signal });
 
-    if (response.status === 404 && !wasAuthenticated && !signal?.aborted) {
+    if (!response.ok && !wasAuthenticated && !signal?.aborted &&
+        (response.status === 404 || looksLikeRateLimited403(response))) {
       const retryResponse = await retryWithAuth(apiUrl, signal);
       if (retryResponse) { response = retryResponse; }
     }
 
     if (!response.ok) {
-      throwApiError(response, `GitHub PR ${owner}/${repo}#${number}`);
+      await throwApiError(response, `GitHub PR ${owner}/${repo}#${number}`);
     }
 
     const data = await response.json() as { title: string; body: string | null; html_url: string };

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -2,7 +2,7 @@ import { ProviderItem, combineSignals, createAbortError, safeDecodeComponent, ty
 import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
-import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, type GitHubIssue } from './githubApiHelpers';
+import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, looksLikeRateLimited403, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, type GitHubIssue } from './githubApiHelpers';
 import { matchesRepoPatterns } from './repoPattern';
 import { createGitHubIssueGitWork } from './gitWorkCapabilities';
 
@@ -87,13 +87,14 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
 
     let response = await fetch(apiUrl, { headers, signal });
 
-    if (response.status === 404 && !wasAuthenticated && !signal?.aborted) {
+    if (!response.ok && !wasAuthenticated && !signal?.aborted &&
+        (response.status === 404 || looksLikeRateLimited403(response))) {
       const retryResponse = await retryWithAuth(apiUrl, signal);
       if (retryResponse) { response = retryResponse; }
     }
 
     if (!response.ok) {
-      throwApiError(response, `GitHub issue ${owner}/${repo}#${number}`);
+      await throwApiError(response, `GitHub issue ${owner}/${repo}#${number}`);
     }
 
     const data = await response.json() as { title: string; body: string | null; html_url: string };

--- a/packages/github/src/test/githubApiHelpers.test.ts
+++ b/packages/github/src/test/githubApiHelpers.test.ts
@@ -1,5 +1,7 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
-import { filterMergedGitHubPrs, isMergedGitHubPr, type GitHubIssue } from '../githubApiHelpers';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { filterMergedGitHubPrs, isMergedGitHubPr, throwApiError, looksLikeRateLimited403, type GitHubIssue } from '../githubApiHelpers';
+import { setLogger } from '../logger';
+import { makeErrorResponse } from './responseMocks';
 
 function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
   return {
@@ -97,5 +99,222 @@ describe('filterMergedGitHubPrs', () => {
       'https://api.github.com/repos/owner/repo/pulls/2',
       'https://api.github.com/repos/owner/repo/pulls/3',
     ]);
+  });
+});
+
+describe('throwApiError', () => {
+  let mockChannel: { info: ReturnType<typeof vi.fn>; debug: ReturnType<typeof vi.fn>; warn: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn>; appendLine: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    mockChannel = { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn(), appendLine: vi.fn() };
+    setLogger(mockChannel as any);
+  });
+
+  it('throws a "not found" message for 404 responses', async () => {
+    const response = makeErrorResponse({ status: 404, statusText: 'Not Found' });
+    await expect(throwApiError(response, 'GitHub issue org/repo#1'))
+      .rejects.toThrow('GitHub issue org/repo#1 not found. It may be private or deleted.');
+  });
+
+  it('throws an authentication-failure message for 401 (does NOT mention "private")', async () => {
+    const response = makeErrorResponse({
+      status: 401,
+      statusText: 'Unauthorized',
+      bodyJson: { message: 'Bad credentials' },
+    });
+    await expect(throwApiError(response, 'GitHub issue org/repo#1'))
+      .rejects.toThrow(/authentication failed.*Bad credentials.*Sign in to GitHub/i);
+    await expect(throwApiError(makeErrorResponse({
+      status: 401, bodyJson: { message: 'Bad credentials' },
+    }), 'GitHub issue org/repo#1'))
+      .rejects.not.toThrow(/private/i);
+  });
+
+  it('throws a rate-limit message for 403 with x-ratelimit-remaining=0', async () => {
+    const resetEpoch = Math.floor(Date.now() / 1000) + 600; // 10 minutes from now
+    const response = makeErrorResponse({
+      status: 403,
+      statusText: 'Forbidden',
+      headers: {
+        'x-ratelimit-remaining': '0',
+        'x-ratelimit-reset': String(resetEpoch),
+      },
+      bodyJson: { message: 'API rate limit exceeded for 1.2.3.4.' },
+    });
+    await expect(throwApiError(response, 'GitHub issue org/repo#1'))
+      .rejects.toThrow(/GitHub API rate limit exceeded for GitHub issue org\/repo#1\. Resets in 10 minutes\./);
+  });
+
+  it('throws a rate-limit message for 403 when body mentions "API rate limit exceeded" even without remaining=0', async () => {
+    const response = makeErrorResponse({
+      status: 403,
+      bodyJson: { message: 'API rate limit exceeded for installation ID 42.' },
+    });
+    await expect(throwApiError(response, 'GitHub PR org/repo#5'))
+      .rejects.toThrow(/rate limit exceeded/i);
+  });
+
+  it('throws a secondary-rate-limit message when body mentions secondary rate limit', async () => {
+    const response = makeErrorResponse({
+      status: 403,
+      headers: { 'retry-after': '30' },
+      bodyJson: { message: 'You have exceeded a secondary rate limit.' },
+    });
+    await expect(throwApiError(response, 'GitHub issue org/repo#1'))
+      .rejects.toThrow(/secondary rate limit.*Retry after 30s/i);
+  });
+
+  it('throws a secondary-rate-limit message with an HTTP-date Retry-After', async () => {
+    const future = new Date(Date.now() + 45_000).toUTCString();
+    const response = makeErrorResponse({
+      status: 403,
+      headers: { 'retry-after': future },
+      bodyJson: { message: 'Secondary rate limit exceeded' },
+    });
+    await expect(throwApiError(response, 'GitHub issue org/repo#1'))
+      .rejects.toThrow(/secondary rate limit.*Retry after \d+s/i);
+  });
+
+  it('throws an SSO message for 403 with x-github-sso header', async () => {
+    const response = makeErrorResponse({
+      status: 403,
+      headers: { 'x-github-sso': 'required; url=https://github.com/orgs/example/sso' },
+      bodyJson: { message: 'Resource protected by organization SAML enforcement. You must grant your OAuth token access to this organization.' },
+    });
+    await expect(throwApiError(response, 'GitHub issue org/repo#1'))
+      .rejects.toThrow(/SSO authorization required.*organization/i);
+  });
+
+  it('prefers SSO classification over a coincidental remaining=0', async () => {
+    const response = makeErrorResponse({
+      status: 403,
+      headers: {
+        'x-github-sso': 'required; url=https://github.com/orgs/example/sso',
+        'x-ratelimit-remaining': '0',
+      },
+      bodyJson: { message: 'Resource protected by organization SAML enforcement.' },
+    });
+    await expect(throwApiError(response, 'GitHub issue org/repo#1'))
+      .rejects.toThrow(/SSO authorization required/i);
+  });
+
+  it('prefers secondary-rate-limit classification over a coincidental remaining=0', async () => {
+    const response = makeErrorResponse({
+      status: 403,
+      headers: { 'x-ratelimit-remaining': '0', 'retry-after': '30' },
+      bodyJson: { message: 'You have exceeded a secondary rate limit.' },
+    });
+    await expect(throwApiError(response, 'GitHub issue org/repo#1'))
+      .rejects.toThrow(/secondary rate limit/i);
+  });
+
+  it('throws a generic 403 message (NOT "private repo") when no rate-limit / SSO signal is present', async () => {
+    const response = makeErrorResponse({
+      status: 403,
+      statusText: 'Forbidden',
+      bodyJson: { message: 'Must have admin rights to Repository.' },
+    });
+    await expect(throwApiError(response, 'GitHub issue org/repo#1'))
+      .rejects.toThrow(/GitHub denied access to GitHub issue org\/repo#1 \(HTTP 403\): Must have admin rights to Repository\./);
+  });
+
+  it('throws a status-based error for other HTTP failures (e.g., 500)', async () => {
+    const response = makeErrorResponse({
+      status: 500,
+      statusText: 'Internal Server Error',
+      bodyJson: { message: 'Something went wrong' },
+    });
+    await expect(throwApiError(response, 'GitHub issue org/repo#1'))
+      .rejects.toThrow(/HTTP 500 Internal Server Error.*Something went wrong/);
+  });
+
+  it('logs a warn line with the status, headers, message AND raw body snippet before throwing', async () => {
+    const response = makeErrorResponse({
+      status: 403,
+      headers: { 'x-ratelimit-remaining': '0', 'x-ratelimit-reset': '1700000000' },
+      bodyJson: { message: 'API rate limit exceeded', documentation_url: 'https://docs.github.com/rest/overview/rate-limits' },
+    });
+    await expect(throwApiError(response, 'GitHub issue org/repo#1')).rejects.toThrow();
+    expect(mockChannel.warn).toHaveBeenCalledOnce();
+    const logged = String(mockChannel.warn.mock.calls[0][0]);
+    expect(logged).toContain('GitHub API request failed for GitHub issue org/repo#1');
+    expect(logged).toContain('status=403');
+    expect(logged).toContain('rate-limit-remaining=0');
+    expect(logged).toContain('rate-limit-reset=1700000000');
+    expect(logged).toContain('message="API rate limit exceeded"');
+    // Body snippet must also be present so the logger captures fields beyond `message`.
+    expect(logged).toContain('body=');
+    expect(logged).toContain('documentation_url');
+  });
+
+  it('tolerates a missing/empty response body without crashing', async () => {
+    const response = makeErrorResponse({ status: 403, statusText: 'Forbidden' });
+    await expect(throwApiError(response, 'GitHub issue org/repo#1'))
+      .rejects.toThrow(/GitHub denied access to GitHub issue org\/repo#1 \(HTTP 403\).*token may lack required permissions/);
+  });
+
+  it('tolerates a non-JSON response body without crashing', async () => {
+    const response = makeErrorResponse({ status: 502, bodyText: '<html>bad gateway</html>' });
+    await expect(throwApiError(response, 'GitHub issue org/repo#1'))
+      .rejects.toThrow(/HTTP 502/);
+  });
+});
+
+describe('looksLikeRateLimited403', () => {
+  it('returns true when status is 403 and x-ratelimit-remaining is 0', () => {
+    const response = makeErrorResponse({
+      status: 403,
+      headers: { 'x-ratelimit-remaining': '0' },
+    });
+    expect(looksLikeRateLimited403(response)).toBe(true);
+  });
+
+  it('returns true when status is 403 and Retry-After is a finite number', () => {
+    const response = makeErrorResponse({
+      status: 403,
+      headers: { 'retry-after': '30' },
+    });
+    expect(looksLikeRateLimited403(response)).toBe(true);
+  });
+
+  it('returns false for 403 without rate-limit signals', () => {
+    const response = makeErrorResponse({
+      status: 403,
+      bodyJson: { message: 'Must have admin rights to Repository.' },
+    });
+    expect(looksLikeRateLimited403(response)).toBe(false);
+  });
+
+  it('returns false for 403 with a non-zero remaining quota', () => {
+    const response = makeErrorResponse({
+      status: 403,
+      headers: { 'x-ratelimit-remaining': '4999' },
+    });
+    expect(looksLikeRateLimited403(response)).toBe(false);
+  });
+
+  it('returns false for non-403 statuses even with rate-limit headers', () => {
+    const response = makeErrorResponse({
+      status: 404,
+      headers: { 'x-ratelimit-remaining': '0' },
+    });
+    expect(looksLikeRateLimited403(response)).toBe(false);
+  });
+
+  it('returns true for HTTP-date Retry-After (RFC 7231 alternate form)', () => {
+    const future = new Date(Date.now() + 60_000).toUTCString();
+    const response = makeErrorResponse({
+      status: 403,
+      headers: { 'retry-after': future },
+    });
+    expect(looksLikeRateLimited403(response)).toBe(true);
+  });
+
+  it('returns false for completely unparseable Retry-After', () => {
+    const response = makeErrorResponse({
+      status: 403,
+      headers: { 'retry-after': 'not a date or number' },
+    });
+    expect(looksLikeRateLimited403(response)).toBe(false);
   });
 });

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -1550,5 +1550,30 @@ describe('GitHubMentionsProvider', () => {
       const result = await provider.resolveUrl('https://example.com/issue/5');
       expect(result).toBeUndefined();
     });
+
+    it('throws a specific rate-limit message (not a misleading "private repo" hint) on 403 when authenticated', async () => {
+      vi.mocked(authentication.getSession).mockResolvedValue({
+        accessToken: 'test-token',
+        id: 'session-1',
+        scopes: ['repo'],
+        account: { id: '1', label: 'testuser' },
+      } as any);
+
+      const headerMap = new Map<string, string>([
+        ['x-ratelimit-remaining', '0'],
+        ['x-ratelimit-reset', String(Math.floor(Date.now() / 1000) + 1800)],
+      ]);
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        statusText: 'Forbidden',
+        headers: { get: (name: string) => headerMap.get(name.toLowerCase()) ?? null },
+        text: async () => JSON.stringify({ message: 'API rate limit exceeded for user ID 1.' }),
+      });
+
+      await expect(
+        provider.resolveUrl('https://github.com/owner/repo/issues/5'),
+      ).rejects.toThrow(/rate limit exceeded/i);
+    });
   });
 });

--- a/packages/github/src/test/resolveUrl.test.ts
+++ b/packages/github/src/test/resolveUrl.test.ts
@@ -3,6 +3,7 @@ import { authentication } from 'vscode';
 import { GitHubIssueProvider } from '../githubProvider';
 import { GitHubPrReviewProvider } from '../githubPrReviewProvider';
 import { setLogger } from '../logger';
+import { makeErrorResponse } from './responseMocks';
 
 // Mock global fetch
 const mockFetch = vi.fn();
@@ -117,10 +118,7 @@ describe('resolveUrl', () => {
 
     it('retries with auth on 404 when initially unauthenticated', async () => {
       // First call (unauthenticated): 404
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-      });
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({ status: 404 }));
 
       // Second call (with auth): 200
       mockFetch.mockResolvedValueOnce({
@@ -150,16 +148,177 @@ describe('resolveUrl', () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
-    it('throws on non-404 errors', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
+    it('retries with auth on 403 when initially unauthenticated', async () => {
+      // First call (unauthenticated): 403 (likely IP-based rate limit)
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({
         status: 403,
         statusText: 'Forbidden',
+        headers: { 'x-ratelimit-remaining': '0' },
+        bodyJson: { message: 'API rate limit exceeded for 1.2.3.4.' },
+      }));
+
+      // Second call (with auth): 200
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          title: 'Public issue',
+          body: 'Now accessible',
+          html_url: 'https://github.com/owner/repo/issues/888',
+        }),
       });
+
+      vi.mocked(authentication.getSession)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({
+          accessToken: 'retry-token',
+          id: 'session-1',
+          scopes: ['repo'],
+          account: { id: '1', label: 'testuser' },
+        } as any);
+
+      const result = await provider.resolveUrl('https://github.com/owner/repo/issues/888');
+
+      expect(result).toBeDefined();
+      expect(result?.title).toBe('#888: Public issue');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('does NOT retry with auth on a generic 403 (no rate-limit signal)', async () => {
+      // Unauthenticated 403 without rate-limit headers — e.g., a permission
+      // policy denial. Prompting the user to sign in would be unhelpful here.
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({
+        status: 403,
+        statusText: 'Forbidden',
+        bodyJson: { message: 'Must have admin rights to Repository.' },
+      }));
 
       await expect(
         provider.resolveUrl('https://github.com/owner/repo/issues/123'),
-      ).rejects.toThrow();
+      ).rejects.toThrow(/GitHub denied access.*Must have admin rights/);
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      // Only the initial silent session lookup should be made — no createIfNone prompt.
+      expect(vi.mocked(authentication.getSession)).toHaveBeenCalledTimes(1);
+    });
+
+    it('surfaces the retried response error when auth retry also fails', async () => {
+      // First (unauthenticated) request: 403 rate-limit-shaped → triggers retry.
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({
+        status: 403,
+        headers: { 'x-ratelimit-remaining': '0' },
+        bodyJson: { message: 'API rate limit exceeded for 1.2.3.4.' },
+      }));
+      // Second (authenticated) request: 404 → distinct error from the retried
+      // response, not from the original 403.
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({
+        status: 404,
+        bodyJson: { message: 'Not Found' },
+      }));
+
+      vi.mocked(authentication.getSession)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({
+          accessToken: 'retry-token',
+          id: 'session-1',
+          scopes: ['repo'],
+          account: { id: '1', label: 'testuser' },
+        } as any);
+
+      let caught: unknown;
+      try {
+        await provider.resolveUrl('https://github.com/owner/repo/issues/123');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      const message = (caught as Error).message;
+      expect(message).toMatch(/not found/i);
+      // Make sure we don't surface the original 403 rate-limit message.
+      expect(message).not.toMatch(/rate limit/i);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws rate-limit error on 403 when already authenticated and limit is hit', async () => {
+      vi.mocked(authentication.getSession).mockResolvedValueOnce({
+        accessToken: 'existing-token',
+        id: 'session-1',
+        scopes: ['repo'],
+        account: { id: '1', label: 'testuser' },
+      } as any);
+
+      const resetEpoch = Math.floor(Date.now() / 1000) + 1800; // 30 minutes from now
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({
+        status: 403,
+        statusText: 'Forbidden',
+        headers: {
+          'x-ratelimit-remaining': '0',
+          'x-ratelimit-reset': String(resetEpoch),
+        },
+        bodyJson: { message: 'API rate limit exceeded for user ID 1.' },
+      }));
+
+      await expect(
+        provider.resolveUrl('https://github.com/owner/repo/issues/123'),
+      ).rejects.toThrow(/rate limit exceeded/i);
+    });
+
+    it('throws SSO error on 403 with x-github-sso header', async () => {
+      vi.mocked(authentication.getSession).mockResolvedValueOnce({
+        accessToken: 'existing-token',
+        id: 'session-1',
+        scopes: ['repo'],
+        account: { id: '1', label: 'testuser' },
+      } as any);
+
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({
+        status: 403,
+        statusText: 'Forbidden',
+        headers: { 'x-github-sso': 'required; url=https://github.com/orgs/example/sso' },
+        bodyJson: { message: 'Resource protected by organization SAML enforcement.' },
+      }));
+
+      await expect(
+        provider.resolveUrl('https://github.com/owner/repo/issues/123'),
+      ).rejects.toThrow(/SSO authorization required/i);
+    });
+
+    it('throws generic 403 error (not rate limit / SSO) with API message', async () => {
+      vi.mocked(authentication.getSession).mockResolvedValueOnce({
+        accessToken: 'existing-token',
+        id: 'session-1',
+        scopes: ['repo'],
+        account: { id: '1', label: 'testuser' },
+      } as any);
+
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({
+        status: 403,
+        statusText: 'Forbidden',
+        bodyJson: { message: 'Must have admin rights to Repository.' },
+      }));
+
+      await expect(
+        provider.resolveUrl('https://github.com/owner/repo/issues/123'),
+      ).rejects.toThrow(/Must have admin rights to Repository/);
+    });
+
+    it('throws auth error on 401 (does not blame "private repo")', async () => {
+      vi.mocked(authentication.getSession).mockResolvedValueOnce({
+        accessToken: 'existing-token',
+        id: 'session-1',
+        scopes: ['repo'],
+        account: { id: '1', label: 'testuser' },
+      } as any);
+
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({
+        status: 401,
+        statusText: 'Unauthorized',
+        bodyJson: { message: 'Bad credentials' },
+      }));
+
+      await expect(
+        provider.resolveUrl('https://github.com/owner/repo/issues/123'),
+      ).rejects.toThrow(/authentication failed/i);
     });
 
     it('throws on 404 when already authenticated', async () => {
@@ -171,10 +330,7 @@ describe('resolveUrl', () => {
         account: { id: '1', label: 'testuser' },
       } as any);
 
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-      });
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({ status: 404 }));
 
       await expect(
         provider.resolveUrl('https://github.com/owner/repo/issues/123'),
@@ -290,10 +446,7 @@ describe('resolveUrl', () => {
 
     it('retries with auth on 404 when initially unauthenticated', async () => {
       // First call (unauthenticated): 404
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-      });
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({ status: 404 }));
 
       // Second call (with auth): 200
       mockFetch.mockResolvedValueOnce({
@@ -323,6 +476,39 @@ describe('resolveUrl', () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
+    it('retries with auth on 403 when initially unauthenticated', async () => {
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({
+        status: 403,
+        headers: { 'x-ratelimit-remaining': '0' },
+        bodyJson: { message: 'API rate limit exceeded for 1.2.3.4.' },
+      }));
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          title: 'Public PR',
+          body: 'Now accessible',
+          html_url: 'https://github.com/owner/repo/pull/777',
+        }),
+      });
+
+      vi.mocked(authentication.getSession)
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce({
+          accessToken: 'retry-token',
+          id: 'session-1',
+          scopes: ['repo'],
+          account: { id: '1', label: 'testuser' },
+        } as any);
+
+      const result = await provider.resolveUrl('https://github.com/owner/repo/pull/777');
+
+      expect(result).toBeDefined();
+      expect(result?.title).toBe('#777: Public PR');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
     it('throws on 404 when already authenticated', async () => {
       // Mock silent auth to return a session (authenticated)
       vi.mocked(authentication.getSession).mockResolvedValueOnce({
@@ -332,10 +518,7 @@ describe('resolveUrl', () => {
         account: { id: '1', label: 'testuser' },
       } as any);
 
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-      });
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({ status: 404 }));
 
       await expect(
         provider.resolveUrl('https://github.com/owner/repo/pull/123'),
@@ -346,28 +529,43 @@ describe('resolveUrl', () => {
       expect(vi.mocked(authentication.getSession)).toHaveBeenCalledTimes(1);
     });
 
-    it('throws on 403 Forbidden', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
+    it('throws rate-limit error on 403 Forbidden with rate-limit signature', async () => {
+      vi.mocked(authentication.getSession).mockResolvedValueOnce({
+        accessToken: 'existing-token',
+        id: 'session-1',
+        scopes: ['repo'],
+        account: { id: '1', label: 'testuser' },
+      } as any);
+
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({
         status: 403,
         statusText: 'Forbidden',
-      });
+        headers: { 'x-ratelimit-remaining': '0' },
+        bodyJson: { message: 'API rate limit exceeded' },
+      }));
 
       await expect(
         provider.resolveUrl('https://github.com/owner/repo/pull/123'),
-      ).rejects.toThrow();
+      ).rejects.toThrow(/rate limit exceeded/i);
     });
 
-    it('throws on 401 Unauthorized', async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
+    it('throws auth error on 401 Unauthorized', async () => {
+      vi.mocked(authentication.getSession).mockResolvedValueOnce({
+        accessToken: 'existing-token',
+        id: 'session-1',
+        scopes: ['repo'],
+        account: { id: '1', label: 'testuser' },
+      } as any);
+
+      mockFetch.mockResolvedValueOnce(makeErrorResponse({
         status: 401,
         statusText: 'Unauthorized',
-      });
+        bodyJson: { message: 'Bad credentials' },
+      }));
 
       await expect(
         provider.resolveUrl('https://github.com/owner/repo/pull/123'),
-      ).rejects.toThrow();
+      ).rejects.toThrow(/authentication failed/i);
     });
 
     it('handles case-insensitive URLs', async () => {

--- a/packages/github/src/test/responseMocks.ts
+++ b/packages/github/src/test/responseMocks.ts
@@ -1,0 +1,31 @@
+export interface ErrorResponseOptions {
+  status: number;
+  statusText?: string;
+  bodyJson?: unknown;
+  bodyText?: string;
+  headers?: Record<string, string>;
+}
+
+/**
+ * Build a minimal `Response`-shaped mock with case-insensitive headers and
+ * an async `text()`, suitable for tests that drive `throwApiError`,
+ * `looksLikeRateLimited403`, or any code that reads the body / headers of a
+ * non-ok response.
+ */
+export function makeErrorResponse(opts: ErrorResponseOptions): Response {
+  const body = opts.bodyText !== undefined
+    ? opts.bodyText
+    : (opts.bodyJson === undefined ? '' : JSON.stringify(opts.bodyJson));
+  const headerMap = new Map<string, string>(
+    Object.entries(opts.headers ?? {}).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+  return {
+    ok: false,
+    status: opts.status,
+    statusText: opts.statusText ?? '',
+    headers: {
+      get: (name: string) => headerMap.get(name.toLowerCase()) ?? null,
+    },
+    text: async () => body,
+  } as unknown as Response;
+}


### PR DESCRIPTION
## Summary

Closes #586.

When a user runs **DevDocket: Create Item from URL** against a *public* GitHub issue or PR URL while signed in to GitHub in VS Code, they could receive a misleading toast:

> Failed to create item from URL — GitHub access denied for GitHub issue org/repo#num. The repo may be private — sign in to GitHub in VS Code, or check rate limits.

…even though the repo was public, the user was signed in, and they were not rate-limited. The previous `throwApiError` helper bucketed *every* 401/403 into "private / sign in / rate limits" and never logged the underlying status, headers, or response body, so the real failure was invisible.

## Changes

### `packages/github/src/githubApiHelpers.ts`

- Rewrote `throwApiError(response, label)` from a sync three-branch function into an async helper that:
  - Reads the response body best-effort (`response.text()` in a try/catch).
  - Parses the GitHub-standard `{"message": "..."}` field.
  - Inspects `x-ratelimit-remaining`, `x-ratelimit-reset`, `retry-after`, and `x-github-sso` headers.
  - Logs a single `warn` line with status, all of those headers, the parsed message, **and** a truncated raw body snippet — so the actual cause is visible in the output channel.
  - Throws a distinct, signature-matched error:
    - **404** → "X not found. It may be private or deleted." (unchanged)
    - **401** → "GitHub authentication failed for X (HTTP 401)…" (no more misleading "private repo" hint).
    - **403 + `x-github-sso`** → "GitHub SSO authorization required for X…" (checked first so it isn't masked by a coincidental `remaining=0`).
    - **403 + secondary-rate-limit signature** (body matches `/secondary rate limit/i` or `Retry-After` is parseable) → "GitHub secondary rate limit hit for X. Retry after Ns."
    - **403 + primary rate limit** (`x-ratelimit-remaining === '0'` or body matches `/api rate limit exceeded/i`) → "GitHub API rate limit exceeded for X. Resets in N minutes. Sign in to GitHub in VS Code for a higher quota."
    - **403 otherwise** → "GitHub denied access to X (HTTP 403): &lt;upstream message&gt;" (only mentions "private" if GitHub itself didn't give a message).
    - **other** → "GitHub API error for X: HTTP &lt;status&gt; &lt;statusText&gt; — &lt;upstream message&gt;"
- Added `looksLikeRateLimited403(response): boolean` — a cheap, header-only heuristic used to decide whether an unauthenticated request should retry with interactive auth.
- `Retry-After` parsing accepts both delta-seconds and HTTP-date (RFC 7231 alternate form).

### `packages/github/src/githubProvider.ts`, `githubPrReviewProvider.ts`, `githubMentionsProvider.ts`

`resolveUrl` previously retried with auth (`createIfNone: true`) only on 404. It now also retries on 403 — but only when `looksLikeRateLimited403` says so. This covers the unauthenticated IP-rate-limit case (which is the most likely root cause of #586 when the silent session lookup fails) without prompting the user to sign in on unrelated 403s such as permission denials or SSO failures. All three call sites also `await throwApiError(...)` since it became async.

### Tests

- `packages/github/src/test/githubApiHelpers.test.ts` — 17 new tests covering every `throwApiError` branch (including the explicit *negative* assertion that a 401 response no longer mentions "private"), the SSO-over-rate-limit and secondary-over-rate-limit precedence rules, the body-snippet log line, missing/non-JSON bodies, and 8 tests for `looksLikeRateLimited403` including HTTP-date `Retry-After`.
- `packages/github/src/test/resolveUrl.test.ts` — added retry-on-403 tests for both Issue and PR providers, a "does NOT retry on generic 403" test, and a "retried response also fails — surfaces the retried error" test.
- `packages/github/src/test/githubMentionsProvider.test.ts` — added a `resolveUrl` test asserting a rate-limit 403 surfaces a rate-limit message (not a "private repo" hint).
- `packages/github/src/test/responseMocks.ts` — shared `makeErrorResponse` helper, replacing the inline duplicates that previously lived in both test files.

### Verification

- `npm run build` (workspace): clean.
- `npm run test` (workspace): 1916 tests pass (github package went from 433 → 446).

## API Surface Notes

`throwApiError` and `looksLikeRateLimited403` are internal to `packages/github` (not re-exported through `@devdocket/shared`, `packages/core/src/api/types.ts`, or any other public surface). Per `.github/instructions/api-surface.instructions.md`, this is not a breaking change to the documented provider API.
