### PR TITLE
Rename Changesets bot secrets with CHANGESETS_ prefix

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -16,8 +16,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.CHANGESETS_APP_ID }}
+          private-key: ${{ secrets.CHANGESETS_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - uses: actions/checkout@v4
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary

Update `.github/workflows/changesets.yml` to reference `CHANGESETS_APP_ID` and `CHANGESETS_APP_PRIVATE_KEY`, matching the prefixed secret names configured in the repository.

The previous generic `APP_ID` / `APP_PRIVATE_KEY` names risked collision with other future GitHub App integrations (e.g., a separate app for issue triage, release notes, etc.). Prefixing with `CHANGESETS_` makes the secret's purpose explicit and keeps the namespace clean.

## Validation

- Workflow YAML parsed with Python/PyYAML
- `npx --yes prettier --write .github/workflows/changesets.yml` (prettier normalized one unrelated quote style)
- The failing Changesets workflow run (https://github.com/devdocket/devdocket/actions/runs/26070242077) should succeed on re-run once this PR is merged, because both repository secrets `CHANGESETS_APP_ID` and `CHANGESETS_APP_PRIVATE_KEY` are now configured.

## Notes for maintainers

No other files reference the old `APP_ID` / `APP_PRIVATE_KEY` names — verified with `grep -rn '\bAPP_ID\b|\bAPP_PRIVATE_KEY\b' .`.
