### PR TITLE
Warn instead of throw for missing CHANGELOG in release tag script

### DIFF
--- a/scripts/create-release-tags.mjs
+++ b/scripts/create-release-tags.mjs
@@ -48,8 +48,13 @@ function packageShouldBeTagged(packageDirectory, version) {
   const packageHasPublishWorkflow = hasPublishWorkflow(packageDirectory);
 
   if (!existsSync(changelogPath)) {
+    // CHANGELOG.md is created by `changeset version` on the first release. Its
+    // absence means the package has never been versioned through Changesets yet
+    // (bootstrap state, or a newly added package). Skip without failing; a future
+    // run that includes a real changeset for this package will create the
+    // changelog, and the package can be tagged then.
     if (packageHasPublishWorkflow) {
-      throw new Error(`Cannot determine release status for ${packageDirectory}: missing CHANGELOG.md at ${changelogPath}`);
+      console.warn(`Skipping ${packageDirectory}: no CHANGELOG.md yet (package has not been versioned through Changesets).`);
     }
 
     return false;
@@ -59,21 +64,13 @@ function packageShouldBeTagged(packageDirectory, version) {
     const latestEntry = extractLatestChangelogEntry(changelogPath);
 
     if (typeof latestEntry.version !== 'string' || latestEntry.version.length === 0) {
-      if (packageHasPublishWorkflow) {
-        throw new Error('latest changelog entry is missing a readable version');
-      }
-
+      console.warn(`Skipping ${packageDirectory}: latest CHANGELOG.md entry is missing a readable version.`);
       return false;
     }
 
     return latestEntry.version === version;
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-
-    if (packageHasPublishWorkflow) {
-      throw new Error(`Cannot determine release status for ${packageDirectory}: ${message}`);
-    }
-
     console.warn(`Skipping ${packageDirectory}: ${message}`);
     return false;
   }


### PR DESCRIPTION
## Summary

Fix `scripts/create-release-tags.mjs` to handle the bootstrap state cleanly instead of throwing.

## The bug

When the Changesets workflow ran on `dev` after PR #452/#552 landed (https://github.com/devdocket/devdocket/actions/runs/26070896245), it failed at the publish step:

```
Error: Cannot determine release status for shared: missing CHANGELOG.md at /home/runner/work/devdocket/devdocket/packages/shared/CHANGELOG.md
    at packageShouldBeTagged (file:///home/runner/work/devdocket/devdocket/scripts/create-release-tags.mjs:52:13)
```

The script threw whenever a package with a publish workflow had no `CHANGELOG.md`. In the bootstrap state — before the first `changeset version` ever runs — none of the packages have a `CHANGELOG.md`, so the very first push to `dev` after adopting Changesets always failed.

The same throwing behavior also blocked tag creation for healthy packages whenever any one package was misconfigured (e.g., corrupted changelog).

## The fix

Treat "no CHANGELOG.md" and "unreadable latest changelog entry" as "nothing to release for this package" and log a warning instead of throwing. The script now:

- Skips packages with no `CHANGELOG.md` (bootstrap state, or newly added unreleased package) — emits a warning if the package has a publish workflow so accidental deletions are still visible in logs.
- Skips packages with an unreadable / version-less latest changelog entry — same warning behavior.
- Continues processing remaining packages and exits 0 if no candidates were found (the existing "No release candidates detected." path).

When the next push to `dev` includes a real `.changeset/*.md`, the Changesets action will open a Version Packages PR. Merging that PR creates the `CHANGELOG.md` files for the affected packages, and the next run of this script will correctly tag them.

## Validation

- Inlined the new `packageShouldBeTagged` logic against the current bootstrap state (no `CHANGELOG.md` for any of the 6 publishable packages, all 6 `publish-*.yml` workflows present) and confirmed:
  ```
  Skipping shared: no CHANGELOG.md yet (package has not been versioned through Changesets).
  Skipping core: no CHANGELOG.md yet (...).
  Skipping github: no CHANGELOG.md yet (...).
  Skipping ado: no CHANGELOG.md yet (...).
  Skipping start-git-work: no CHANGELOG.md yet (...).
  Skipping ai-reviewer: no CHANGELOG.md yet (...).
  Release candidates: NONE (would exit 0)
  ```
- The main control flow at the bottom of the script already prints `No release candidates detected.` and exits 0 when `releaseCandidates.length === 0`, so the workflow run will succeed cleanly.

## Notes for maintainers

After this PR merges, the failing Changesets workflow run will succeed automatically on the next push to `dev`. No further manual intervention needed — release tag creation will resume on the first real `.changeset/*.md` that lands.
