### PR TITLE
Initialize package versions for first Changesets release

### DIFF
--- a/.changeset/initial-release.md
+++ b/.changeset/initial-release.md
@@ -1,0 +1,10 @@
+---
+"@devdocket/shared": minor
+"devdocket": minor
+"devdocket-github": minor
+"devdocket-ado": minor
+"devdocket-start-git-work": minor
+"devdocket-ai-reviewer": minor
+---
+
+Initial public release.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6673,7 +6673,7 @@
     },
     "packages/ado": {
       "name": "devdocket-ado",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*"
@@ -7109,7 +7109,7 @@
     },
     "packages/ai-reviewer": {
       "name": "devdocket-ai-reviewer",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*"
@@ -7545,7 +7545,7 @@
     },
     "packages/core": {
       "name": "devdocket",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*",
@@ -8681,7 +8681,7 @@
     },
     "packages/github": {
       "name": "devdocket-github",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*",
@@ -9118,7 +9118,7 @@
     },
     "packages/shared": {
       "name": "@devdocket/shared",
-      "version": "1.0.0",
+      "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.3.0",
@@ -9127,7 +9127,7 @@
     },
     "packages/start-git-work": {
       "name": "devdocket-start-git-work",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*"

--- a/packages/ado/package.json
+++ b/packages/ado/package.json
@@ -2,7 +2,7 @@
   "name": "devdocket-ado",
   "displayName": "DevDocket — Azure DevOps",
   "description": "Azure DevOps provider for DevDocket — discovers assigned work items and PR reviews.",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "publisher": "devdocket",
   "license": "MIT",
   "engines": {

--- a/packages/ai-reviewer/package.json
+++ b/packages/ai-reviewer/package.json
@@ -2,7 +2,7 @@
   "name": "devdocket-ai-reviewer",
   "displayName": "DevDocket — AI Actions",
   "description": "AI-powered code review and PR walkthrough actions for DevDocket",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "publisher": "devdocket",
   "license": "MIT",
   "engines": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "devdocket",
   "displayName": "DevDocket",
   "description": "A central hub for managing work across pull requests, issues, investigations, and follow-ups.",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "publisher": "devdocket",
   "license": "MIT",
   "engines": {

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -2,7 +2,7 @@
   "name": "devdocket-github",
   "displayName": "DevDocket GitHub",
   "description": "GitHub provider for DevDocket — discovers assigned issues, PR reviews, and authored PRs with status tracking.",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "publisher": "devdocket",
   "license": "MIT",
   "engines": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devdocket/shared",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "Shared types, base classes, and utilities for DevDocket extensions",
   "license": "MIT",
   "repository": {

--- a/packages/start-git-work/package.json
+++ b/packages/start-git-work/package.json
@@ -2,7 +2,7 @@
   "name": "devdocket-start-git-work",
   "displayName": "DevDocket Start Git Work",
   "description": "Start Git Work action for DevDocket — creates git branches and worktrees for GitHub and Azure DevOps work items.",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "publisher": "devdocket",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
## Summary

One-time bootstrap PR to set up the initial Changesets-managed release. Resets every publishable package's version to `0.0.0` and adds an `initial-release.md` changeset that bumps each one to `0.1.0`.

## Why a direct `package.json` version edit?

Normally agents must never edit `package.json` `version` fields directly — `AGENTS.md` is explicit about that. This PR is the documented exception:

- No version of any package has ever been published. The current `version` field values are arbitrary placeholders that never correspond to anything in the marketplace or any registry.
- Letting the first Changesets release land at "previous + bump" produces awkward starting versions (extensions at `0.2.0`, shared at `1.1.0`, with phantom `0.1.0` / `1.0.0` versions implied by the bump arithmetic but never published).
- Setting everything to `0.0.0` first lets the first release land cleanly at `0.1.0` across all packages.

After this PR + the resulting Version Packages PR merge, the rule reverts: all future version changes flow exclusively through `.changeset/*.md` files.

## What changes

| Package | Before | After this PR | After Version PR merges |
|---------|--------|---------------|-------------------------|
| `@devdocket/shared` | `1.0.0` | `0.0.0` | `0.1.0` |
| `devdocket` (core) | `0.1.0` | `0.0.0` | `0.1.0` |
| `devdocket-github` | `0.1.0` | `0.0.0` | `0.1.0` |
| `devdocket-ado` | `0.1.0` | `0.0.0` | `0.1.0` |
| `devdocket-start-git-work` | `0.1.0` | `0.0.0` | `0.1.0` |
| `devdocket-ai-reviewer` | `0.1.0` | `0.0.0` | `0.1.0` |

Plus a new `.changeset/initial-release.md`:

```md
---
"@devdocket/shared": minor
"devdocket": minor
"devdocket-github": minor
"devdocket-ado": minor
"devdocket-start-git-work": minor
"devdocket-ai-reviewer": minor
---

Initial public release.
```

And the corresponding 6-line update to `package-lock.json` (npm re-syncs the workspace version fields when `npm install` runs).

## Validation

- `npm install` — succeeded; lockfile diff is the expected 6 workspace `version` field updates.
- `npm run build` — all 6 packages build cleanly.
- `npm run test` — full suite passes (931 core, 446 github, 232 ado, 232 ai-reviewer, 222 shared, 85 start-git-work).
- Verified there are no `dependencies` entries pinning to specific inter-package versions — every extension declares `"@devdocket/shared": "*"`, so the version reset doesn't break anything.

## What happens after this PR merges

1. Push to `dev` triggers the Changesets workflow.
2. Bot detects `.changeset/initial-release.md` and opens a **Version Packages** PR against `dev` that:
   - Bumps every `package.json` from `0.0.0` to `0.1.0`
   - Writes a new `CHANGELOG.md` to each `packages/*` with the "Initial public release." entry
   - Deletes `.changeset/initial-release.md` (consumed)
3. Reviewing the Version PR's diff is the chance to sanity-check the planned release before shipping.
4. Merging the Version PR triggers the full release cascade: `main` fast-forwards to `dev`, six release tags get pushed (`shared-v0.1.0`, `core-v0.1.0`, etc.), and each `publish-*.yml` workflow fires in parallel — publishing five extensions to the VS Code Marketplace and `@devdocket/shared` to GitHub Packages, with six corresponding GitHub Releases.

## Notes for maintainers

This PR itself does NOT need approval at the `marketplace-publish` environment — no publish happens here, just version bootstrapping. The environment approval (if you configured required reviewers) only kicks in when the Version Packages PR merges and the per-package publish workflows actually start running.
