### PR TITLE
Drop invalid 'devdocket-monorepo' entry from Changesets ignore list

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "restricted",
   "baseBranch": "dev",
   "updateInternalDependencies": "patch",
-  "ignore": ["devdocket-monorepo"]
+  "ignore": []
 }


### PR DESCRIPTION
## Summary

Drop the `"devdocket-monorepo"` entry from `.changeset/config.json`'s `ignore` array. `@changesets/cli@2.31.0` validates that every entry in `ignore` matches a known workspace package and throws `ValidationError` otherwise.

## The bug

The Changesets workflow run that fired after PR #593 (initial-release bootstrap) merged into `dev` failed at the `npx changeset version` step:

> The package or glob expression "devdocket-monorepo" is specified in the `ignore` option but it is not found in the project.

Failed run: https://github.com/devdocket/devdocket/actions/runs/26071799293

The root `package.json` (`name: "devdocket-monorepo"`) is private and is NOT listed in the npm `workspaces` array (which only points at `packages/*`). Changesets only manages packages reachable via `workspaces`, so it never sees the root — making the `ignore` entry refer to a non-existent package.

## The fix

Remove `"devdocket-monorepo"` from the `ignore` array (leave as `[]` for explicitness):

```diff
-  "ignore": ["devdocket-monorepo"]
+  "ignore": []
```

No behavioral change — the root was already invisible to Changesets. This just lets `changeset version` run without erroring.

## Validation

Ran `npx --yes @changesets/cli status` locally against the modified config:

```
Packages to be bumped at minor:
- @devdocket/shared
- devdocket
- devdocket-github
- devdocket-ado
- devdocket-start-git-work
- devdocket-ai-reviewer
```

Matches the expected outcome from `.changeset/initial-release.md` queued by PR #593.

## What happens after this PR merges

1. Push to `dev` triggers the Changesets workflow.
2. The `changeset version` step now succeeds and produces the **Version Packages** PR bumping every package from `0.0.0` → `0.1.0`.
3. Review and merge that Version PR to trigger the full release cascade as documented in AGENTS.md.

## Notes for maintainers

No changeset added for this PR — the new AGENTS.md guidance classifies changes to `.changeset/config.json` as not requiring a changeset.
