### PR TITLE
Split docs into README / CONTRIBUTING.md / RELEASING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,8 @@ Key rules:
 
 This repo uses [Changesets](https://github.com/changesets/changesets) for per-package versioning, changelog generation, and automated VS Code Marketplace / GitHub Packages publishing. **Every PR that changes user-facing behavior of a publishable package MUST include a `.changeset/*.md` file** describing the change.
 
+> Maintainers operating the release pipeline (reviewing/merging Version Packages PRs, approving publish runs, recovering from failures, setting up infrastructure) should refer to [RELEASING.md](RELEASING.md). This section covers only the contributor/agent task of producing the `.changeset/*.md` file.
+
 ### When a changeset is required
 
 **Required** for any change to one of the following packages that is user-facing — a new feature, bug fix, behavior change, performance improvement, deprecation, or API change:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,131 @@
+# Contributing to DevDocket
+
+Thanks for your interest in contributing! This guide covers setting up a dev environment, the day-to-day build/test loop, and the conventions DevDocket follows for branches, commits, and pull requests.
+
+For exhaustive agent-targeted conventions (testing patterns, storage contract, view conventions, etc.), see [AGENTS.md](AGENTS.md). For the maintainer-side release pipeline, see [RELEASING.md](RELEASING.md).
+
+## Prerequisites
+
+- [Node.js](https://nodejs.org/) **22.x** (the CI uses `actions/setup-node@v4` with `node-version: 22`)
+- [VS Code](https://code.visualstudio.com/) **1.92.0** or later (1.96.0+ if you want to work on `packages/ai-reviewer`)
+- [Git](https://git-scm.com/)
+
+## Quick start
+
+```bash
+git clone https://github.com/devdocket/devdocket.git
+cd devdocket
+npm install
+npm run build
+npm run test
+```
+
+Then press **F5** inside VS Code to launch the Extension Development Host with DevDocket loaded.
+
+## Repository layout
+
+DevDocket is a monorepo with five VS Code extensions and one shared library:
+
+```
+packages/
+├── core/              # The hub extension (UI, lifecycle, plugin API)
+├── github/            # GitHub issues, mentions, PR reviews, my-PRs + Actions and PR watcher
+├── ado/               # Azure DevOps work items, PR reviews, my-PRs + Pipelines and PR watcher
+├── start-git-work/    # Branch + worktree action
+├── ai-reviewer/       # AI code review action
+└── shared/            # Shared library (BaseProvider, utilities) — published as @devdocket/shared
+```
+
+See the [Extension API documentation](docs/extension-api.md) for the contracts between `core` and the provider/action extensions.
+
+## Building and testing
+
+All commands run from the repo root unless noted.
+
+| Command | What it does |
+|---------|--------------|
+| `npm run build` | Build every package (shared first, then the rest in parallel) |
+| `npm run build:prod` | Production build (minified) |
+| `npm run test` | Run vitest for every package |
+| `npm run lint` | Run import-boundary check + per-package lint |
+| `npm run check-boundaries` | Validate that packages don't import across forbidden boundaries |
+
+For a single package, scope to its workspace:
+
+```bash
+cd packages/core
+npm run build      # build just this package
+npm run test       # test just this package
+npm run watch      # rebuild on save
+```
+
+To run a single test file:
+
+```bash
+cd packages/core
+npx vitest run src/test/workGraph.test.ts
+```
+
+## Branching and pull request conventions
+
+- **Default branch is `dev`.** All feature branches branch *from* `dev` and PR back *to* `dev`. The `main` branch is bot-owned and tracks the latest release — do not push to it directly.
+- **Use git worktrees** for feature branches instead of `git checkout`-ing in your main clone. This keeps the main working tree on `dev` and avoids disrupting other in-flight work.
+
+  ```bash
+  git worktree add ../devdocket-my-feature -b my-feature dev
+  cd ../devdocket-my-feature
+  # ... work ...
+  # After merge:
+  git worktree remove ../devdocket-my-feature
+  ```
+
+- **Use merge commits, not rebase,** when syncing with `dev`: `git merge origin/dev` (not `git rebase origin/dev`). Preserves history and avoids force-push issues.
+- **Commit messages and PR titles** should describe the change, not the issue. Never include the issue number in either — references go in the PR description (`Closes #N`).
+- **Include a `.changeset/*.md` file** when your PR changes user-facing behavior of a publishable package. See [Releases & Changesets in AGENTS.md](AGENTS.md#releases--changesets) for the format, exact package names to use, and when a changeset is and isn't required.
+
+## Building a `.vsix` for local install
+
+If you want to install your build into your own VS Code (not just the Extension Development Host):
+
+```bash
+cd packages/core            # or packages/github, packages/ado, etc.
+npx @vscode/vsce package
+```
+
+This produces a `.vsix` file you can install via **Extensions → ⋯ → Install from VSIX…** in VS Code.
+
+## Regenerating the status-bar icon font
+
+Only needed when the logomark SVG changes:
+
+```bash
+npm run build:icons -w devdocket
+```
+
+This converts `packages/core/resources/devdocket-logo-mono.svg` into the checked-in `packages/core/resources/devdocket-icons.woff` glyph used by the VS Code status bar.
+
+## Code conventions
+
+DevDocket has a substantial set of repository-specific conventions covering storage contracts, view patterns, testing practices, the extension API surface, etc. They're documented exhaustively in [AGENTS.md](AGENTS.md) and the topic-specific files under `.github/instructions/`. Before opening a PR with non-trivial changes, skim AGENTS.md to make sure your change aligns with how the rest of the codebase is structured.
+
+## Submitting a pull request
+
+1. Make sure tests pass: `npm run test`
+2. Make sure the build succeeds: `npm run build`
+3. Make sure linting passes: `npm run lint`
+4. Push your branch and open a PR against `dev`:
+
+   ```bash
+   gh pr create --base dev
+   ```
+
+5. Request review from `copilot-pull-request-reviewer` (or wait for a maintainer to add it).
+6. Address feedback. Each round of review feedback should be addressed in its own commit (no force-pushes) so reviewers can see what changed.
+
+## For maintainers
+
+See [RELEASING.md](RELEASING.md) for the release process, Changesets workflow, and operations playbook.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the project's [MIT license](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thanks for your interest in contributing! This guide covers setting up a dev environment, the day-to-day build/test loop, and the conventions DevDocket follows for branches, commits, and pull requests.
 
-For exhaustive agent-targeted conventions (testing patterns, storage contract, view conventions, etc.), see [AGENTS.md](AGENTS.md). For the maintainer-side release pipeline, see [RELEASING.md](RELEASING.md).
+For the comprehensive list of code conventions used throughout the codebase (testing patterns, storage contract, view conventions, etc.), see [AGENTS.md](AGENTS.md). For the maintainer-side release pipeline, see [RELEASING.md](RELEASING.md).
 
 ## Prerequisites
 
@@ -68,7 +68,7 @@ npx vitest run src/test/workGraph.test.ts
 
 ## Branching and pull request conventions
 
-- **Default branch is `dev`.** All feature branches branch *from* `dev` and PR back *to* `dev`. The `main` branch is bot-owned and tracks the latest release — do not push to it directly.
+- **Default branch is `dev`.** All feature branches branch *from* `dev` and PR back *to* `dev`. The `main` branch is managed by the release pipeline and tracks the latest released state — do not push to it directly.
 - **Use git worktrees** for feature branches instead of `git checkout`-ing in your main clone. This keeps the main working tree on `dev` and avoids disrupting other in-flight work.
 
   ```bash
@@ -119,7 +119,7 @@ DevDocket has a substantial set of repository-specific conventions covering stor
    gh pr create --base dev
    ```
 
-5. Request review from `copilot-pull-request-reviewer` (or wait for a maintainer to add it).
+5. Wait for a maintainer to review.
 6. Address feedback. Each round of review feedback should be addressed in its own commit (no force-pushes) so reviewers can see what changed.
 
 ## For maintainers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,16 +69,6 @@ npx vitest run src/test/workGraph.test.ts
 ## Branching and pull request conventions
 
 - **Default branch is `dev`.** All feature branches branch *from* `dev` and PR back *to* `dev`. The `main` branch is managed by the release pipeline and tracks the latest released state — do not push to it directly.
-- **Use git worktrees** for feature branches instead of `git checkout`-ing in your main clone. This keeps the main working tree on `dev` and avoids disrupting other in-flight work.
-
-  ```bash
-  git worktree add ../devdocket-my-feature -b my-feature dev
-  cd ../devdocket-my-feature
-  # ... work ...
-  # After merge:
-  git worktree remove ../devdocket-my-feature
-  ```
-
 - **Use merge commits, not rebase,** when syncing with `dev`: `git merge origin/dev` (not `git rebase origin/dev`). Preserves history and avoids force-push issues.
 - **Commit messages and PR titles** should describe the change, not the issue. Never include the issue number in either — references go in the PR description (`Closes #N`).
 - **Include a `.changeset/*.md` file** when your PR changes user-facing behavior of a publishable package. See [Releases & Changesets in AGENTS.md](AGENTS.md#releases--changesets) for the format, exact package names to use, and when a changeset is and isn't required.

--- a/README.md
+++ b/README.md
@@ -42,34 +42,7 @@ For detailed view behavior, keyboard shortcuts, and configuration options, see t
 
 DevDocket's core, provider, and git-worktree extensions require VS Code 1.92.0 or later. The AI reviewer extension requires VS Code 1.96.0 or later.
 
-DevDocket is not yet available on the VS Code Marketplace. To run it, build from source:
-
-1. **Clone the repository:**
-   ```bash
-   git clone https://github.com/devdocket/devdocket.git
-   cd devdocket
-   ```
-
-2. **Install dependencies and build:**
-   ```bash
-   npm install
-   npm run build
-   ```
-
-3. **Run in VS Code** — open the repo in VS Code and press **F5** to launch the Extension Development Host with DevDocket loaded.
-
-4. **Package for local install** (optional):
-   ```bash
-   cd packages/core
-   npx @vscode/vsce package
-   ```
-   Run this from each extension folder you want to package (e.g., `packages/core`, `packages/github`). This produces a `.vsix` file you can install via **Extensions → ⋯ → Install from VSIX…** in VS Code.
-
-5. **Regenerate the status-bar icon font** (only when the logomark changes):
-   ```bash
-   npm run build:icons -w devdocket
-   ```
-   This converts `packages/core/resources/devdocket-logo-mono.svg` into the checked-in `packages/core/resources/devdocket-icons.woff` glyph used by VS Code status bar icons.
+> ⚠️ **Pre-release:** DevDocket is not yet available on the VS Code Marketplace. To run it today, build from source — see [CONTRIBUTING.md](CONTRIBUTING.md#quick-start).
 
 ## Plugin Ecosystem
 
@@ -91,20 +64,6 @@ DevDocket is extensible with two types of plugins:
 
 To build your own provider or action, see the [Extension API documentation](docs/extension-api.md).
 
-## Architecture
-
-DevDocket is a monorepo with five VS Code extensions and a shared library:
-
-```
-packages/
-├── core/              # The hub extension (UI, lifecycle, plugin API)
-├── github/            # GitHub issues, mentions, PR reviews, my-PRs + Actions and PR watcher
-├── ado/               # Azure DevOps work items, PR reviews, my-PRs + Pipelines and PR watcher
-├── start-git-work/    # Branch + worktree action
-├── ai-reviewer/       # AI code review action
-└── shared/            # Shared library (BaseProvider, utilities)
-```
-
 ## Documentation
 
 | Document | Description |
@@ -112,18 +71,8 @@ packages/
 | [UX Guide](docs/ux-guide.md) | Views, data flow, configuration, keyboard shortcuts |
 | [Extension API](docs/extension-api.md) | Provider and action contracts, interfaces, examples |
 | [Provider Discovery](docs/provider-discovery.md) | What causes items to appear in each provider |
-
-## Contributing
-
-1. Fork the repository and create a branch from `dev`.
-2. Install dependencies: `npm install`
-3. Build all packages: `npm run build`
-4. Run tests: `npm run test`
-5. Open a pull request targeting the `dev` branch.
-
-The default branch is **`dev`** — all work should be based from and merged back to `dev`.
-
-**Maintainers:** see [RELEASING.md](RELEASING.md) for the release process, Changesets workflow, and infrastructure setup.
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Dev environment setup, build/test, branching conventions, PR workflow |
+| [RELEASING.md](RELEASING.md) | Maintainer guide for the Changesets workflow and publish pipeline |
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ packages/
 
 The default branch is **`dev`** — all work should be based from and merged back to `dev`.
 
+**Maintainers:** see [RELEASING.md](RELEASING.md) for the release process, Changesets workflow, and infrastructure setup.
+
 ## License
 
 [MIT](LICENSE) © Matt Thalman

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -6,7 +6,7 @@ For the contributor / agent perspective on how to add a `.changeset/*.md` file t
 
 ## Overview
 
-DevDocket uses [Changesets](https://github.com/changesets/changesets) for per-package versioning and an automated tag-driven publish pipeline. Once the underlying infrastructure is configured (see [One-time setup](#one-time-setup)), the maintainer's day-to-day responsibility is to:
+DevDocket uses [Changesets](https://github.com/changesets/changesets) for per-package versioning and an automated tag-driven publish pipeline. The maintainer's day-to-day responsibility is to:
 
 1. Review and merge PRs that contain a `.changeset/*.md` file describing their user-facing change.
 2. Periodically review and merge the **Version Packages** PR that the Changesets bot keeps up to date on `dev`.
@@ -92,7 +92,7 @@ The moment that PR merges, the publish path of `changesets.yml` runs:
 
 ### 4. Approve each per-package publish (if you enabled required reviewers)
 
-Each tag push triggers a separate publish workflow run. If you configured **Required reviewers** on the `marketplace-publish` GitHub Environment (recommended — see [Environment setup](#github-environment-marketplace-publish)), each extension publish workflow pauses at the Azure login step waiting for an approval click.
+Each tag push triggers a separate publish workflow run. If you configured **Required reviewers** on the `marketplace-publish` GitHub Environment (recommended), each extension publish workflow pauses at the Azure login step waiting for an approval click.
 
 Approve each one in the GitHub Actions UI:
 
@@ -114,16 +114,6 @@ After the cascade settles, verify:
 | `git tag -l '*-v*' --sort=-v:refname` (local) | New tags exist for every bumped package |
 
 ## Common scenarios
-
-### Bootstrap release (first time only)
-
-Before any package has been published, run a one-time "Initial public release" PR:
-
-1. Set every `packages/*/package.json` `version` field to `0.0.0` directly (this is the **only** time direct version editing is permitted).
-2. Add `.changeset/initial-release.md` with `minor` bumps for all six publishable packages and a description like `Initial public release.`
-3. Merge. The Version PR will bump everything `0.0.0 → 0.1.0` (or use `major` if you want to start at `1.0.0`).
-
-After this PR ships, version edits go exclusively through changesets.
 
 ### Routine release
 
@@ -147,77 +137,6 @@ This is uncommon but supported. In the Version Packages PR's diff:
 4. Merge.
 
 The Changesets bot will then re-open a new Version Packages PR containing the changes you removed, ready for the next release.
-
-## One-time setup
-
-Before the first release can succeed, the maintainer must configure several pieces of infrastructure. None of these are automatable through PRs — they all live in external service UIs (Azure Portal, Marketplace, GitHub Settings).
-
-### Changesets GitHub App
-
-**Why:** Tag pushes made with the default `GITHUB_TOKEN` don't trigger downstream workflows (GitHub blocks this to prevent loops). The publish step needs to push tags that trigger `publish-*.yml`, so it uses a GitHub App's installation token instead.
-
-**Steps:**
-
-1. Create the App at https://github.com/organizations/devdocket/settings/apps/new
-   - **Name:** `devdocket-changesets-bot`
-   - **Homepage URL:** `https://github.com/devdocket/devdocket`
-   - **Webhook → Active:** unchecked
-   - **Repository permissions:**
-     - **Contents:** Read & write
-     - **Pull requests:** Read & write
-     - **Workflows:** Read & write
-     - **Metadata:** Read-only (default)
-   - **Where can this GitHub App be installed?:** Only on this account
-2. Generate a private key (settings page → Private keys → Generate a private key) — a `.pem` file downloads.
-3. Note the App ID (top of the settings page, numeric).
-4. Install the App on `devdocket/devdocket` (settings page → Install App → select repo).
-5. Add repository secrets at https://github.com/devdocket/devdocket/settings/secrets/actions:
-   - `CHANGESETS_APP_ID` — the numeric App ID
-   - `CHANGESETS_APP_PRIVATE_KEY` — the full `.pem` contents, including `-----BEGIN…` and `-----END…` lines
-6. Add the App to `main` branch protection bypass at https://github.com/devdocket/devdocket/settings/branches — edit the `main` rule → add `devdocket-changesets-bot` to the bypass / push-allow list. (The publish script does `git push origin main`, which branch protection would otherwise block.)
-
-### Entra ID app for VS Code Marketplace publishing
-
-**Why:** PAT-based marketplace authentication is being deprecated by Microsoft (global PATs decommissioned Dec 1, 2026 — see https://aka.ms/GlobalPATDeprecation). The reusable publish workflow (`_publish-vscode-extension.yml`) uses Microsoft Entra ID via GitHub Actions OIDC instead — no long-lived secrets.
-
-**Steps:**
-
-1. Create an Entra ID **App registration** at https://portal.azure.com → Microsoft Entra ID → App registrations → New registration.
-   - **Name:** `devdocket-vsce-publish`
-   - **Supported account types:** Accounts in this organizational directory only
-   - **Redirect URI:** leave blank
-2. Add a **federated credential** (App's Certificates & secrets → Federated credentials → Add credential):
-   - **Federated credential scenario:** GitHub Actions deploying Azure resources
-   - **Issuer:** `https://token.actions.githubusercontent.com`
-   - **Subject identifier:** `repo:devdocket/devdocket:environment:marketplace-publish`
-   - **Audience:** `api://AzureADTokenExchange`
-3. Add the App's service principal as a member of the `devdocket` Marketplace publisher at https://marketplace.visualstudio.com/manage/publishers/devdocket with **Contributor** role (or higher). The portal accepts the SP by its Application (client) ID.
-4. Add repository variables at https://github.com/devdocket/devdocket/settings/variables/actions:
-   - `AZURE_PUBLISH_CLIENT_ID` — the App's Application (client) ID
-   - `AZURE_PUBLISH_TENANT_ID` — the Directory (tenant) ID
-
-These are variables, not secrets, because they're identifiers (not credentials). The actual auth token is minted on-demand by GitHub OIDC and expires in minutes.
-
-### GitHub Environment `marketplace-publish`
-
-**Why:** The federated credential subject in step 2 above includes `environment:marketplace-publish` — Entra ID will only mint a token for workflow runs that are scoped to that environment. This is the security chokepoint that controls who can publish.
-
-**Steps at https://github.com/devdocket/devdocket/settings/environments:**
-
-1. Create environment named exactly `marketplace-publish` (the publish workflows hardcode this name).
-2. **Required reviewers (strongly recommended):** add at least one maintainer. Each per-package publish run will pause for an approval click — your last line of defense against an unintended release.
-3. **Deployment branches and tags (recommended):** restrict to tag patterns matching the release tag prefixes:
-   - `shared-v*`
-   - `core-v*`
-   - `github-v*`
-   - `ado-v*`
-   - `start-git-work-v*`
-   - `ai-reviewer-v*`
-   This prevents any branch / arbitrary tag from acquiring the publish identity, even if a workflow was accidentally configured to use the environment.
-
-### GitHub Packages (for `@devdocket/shared`)
-
-`publish-shared.yml` uses the auto-issued `GITHUB_TOKEN` with `packages: write` permission — no extra setup needed. It publishes to https://npm.pkg.github.com under the `@devdocket` scope.
 
 ## Troubleshooting
 
@@ -264,7 +183,7 @@ Common causes:
 
 - **`.changeset/config.json` validation error.** If `ignore`, `linked`, `fixed`, etc. reference packages not in `workspaces`, `npx changeset version` throws. Fix the config, push to `dev`, the workflow re-runs.
 - **No `.changeset/*.md` files were present** (only `config.json` and `README.md`). The workflow correctly took the publish path instead — see next item.
-- **`CHANGELOG.md` missing for a package with a publish workflow.** Pre-fix-#591 behavior. The bootstrap fix in #591 makes the script warn and skip instead of throwing.
+- **`CHANGELOG.md` missing for a package with a publish workflow.** Fixed in #591 — the script now warns and skips instead of throwing.
 
 ### The bot couldn't push tags
 
@@ -312,7 +231,7 @@ The App ID stays the same; in-flight workflow runs continue with the old key unt
 
 If you need to retire the federated credential (e.g., suspected compromise of the App):
 
-1. Add a new App + federated credential following [Entra ID app setup](#entra-id-app-for-vs-code-marketplace-publishing).
+1. Register a new Entra ID App with a federated credential whose subject is `repo:devdocket/devdocket:environment:marketplace-publish`.
 2. Add the new SP as a Marketplace publisher member.
 3. Update repository variables `AZURE_PUBLISH_CLIENT_ID` and `AZURE_PUBLISH_TENANT_ID` to point at the new App.
 4. Remove the old SP from the Marketplace publisher.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,351 @@
+# DevDocket Release Process
+
+This document is the maintainer's guide to the DevDocket release pipeline. It covers how releases are produced, what the maintainer is expected to do, how to set up the underlying infrastructure, and how to recover from common failures.
+
+For the contributor / agent perspective on how to add a `.changeset/*.md` file to a PR, see the **Releases & Changesets** section of [AGENTS.md](AGENTS.md#releases--changesets). This document picks up where that one stops — it focuses on the maintainer-side operations.
+
+## Overview
+
+DevDocket uses [Changesets](https://github.com/changesets/changesets) for per-package versioning and an automated tag-driven publish pipeline. Once the underlying infrastructure is configured (see [One-time setup](#one-time-setup)), the maintainer's day-to-day responsibility is to:
+
+1. Review and merge PRs that contain a `.changeset/*.md` file describing their user-facing change.
+2. Periodically review and merge the **Version Packages** PR that the Changesets bot keeps up to date on `dev`.
+3. Optionally approve each per-package publish run via the `marketplace-publish` GitHub Environment.
+
+That's it. Version numbers, changelogs, git tags, marketplace publishes, and GitHub Releases are all produced automatically from those actions.
+
+## Pipeline at a glance
+
+```
+Contributor PR (with .changeset/*.md) merges to dev
+        │
+        ▼ (push to dev)
+.github/workflows/changesets.yml runs
+        │
+        ▼ (uses changesets/action@v1)
+Are there pending .changeset/*.md files?
+        │
+        ├── YES ── npx changeset version  ─►  Opens / updates the "Version Packages" PR against dev
+        │                                       (bumps package.json versions, writes CHANGELOG.md
+        │                                        entries, deletes consumed .changeset/*.md files)
+        │
+        └── NO ──── node scripts/create-release-tags.mjs
+                        │
+                        ▼
+                    Fast-forward main to dev's HEAD
+                    Create release tags on main (e.g., core-v0.1.0, shared-v0.1.0)
+                    Push main + tags via the Changesets GitHub App
+                        │
+                        ▼ (each tag push triggers ONE workflow)
+                    publish-shared.yml          → @devdocket/shared to GitHub Packages
+                    publish-core.yml            ┐
+                    publish-github.yml          │
+                    publish-ado.yml             ├─► VS Code Marketplace (gated by
+                    publish-start-git-work.yml  │   marketplace-publish environment)
+                    publish-ai-reviewer.yml     ┘
+                        │
+                        ▼
+                    GitHub Release created per tag with the matching CHANGELOG entry
+```
+
+## Day-to-day maintainer workflow
+
+### 1. Review incoming PRs for changesets
+
+When reviewing a PR, check that the PR includes a `.changeset/*.md` file **if and only if** the change affects user-facing behavior of a publishable package. The AGENTS.md `## Releases & Changesets` section is the canonical guide on what counts; the short version is:
+
+- **Required:** new features, bug fixes, behavior changes, performance improvements, deprecations, API changes to any of the six publishable packages.
+- **Not required:** docs, CI / workflow changes, scripts under `scripts/`, pure refactors, test-only changes, internal-only changes invisible to consumers.
+
+A CI check emits a non-blocking warning on PRs missing a changeset. The warning is fine for legitimately changeset-less PRs — don't reject the PR just because the warning is there.
+
+When a PR's changeset describes the change incorrectly (wrong packages, wrong bump type, misleading summary), ask the author to fix it before merging. Once merged, the changeset content becomes the changelog entry verbatim.
+
+### 2. Watch for the Version Packages PR
+
+Within ~1 minute of merging any PR that contained a `.changeset/*.md` file, the Changesets bot opens (or updates) a single open PR titled **"Version Packages"** against `dev`. There is always at most one such PR open at a time.
+
+Its diff shows you **exactly what will publish** if you merge it:
+
+- New version numbers in each affected `packages/*/package.json`
+- New entries in each affected `packages/*/CHANGELOG.md`
+- Deletion of the consumed `.changeset/*.md` files
+
+You don't have to merge it immediately. The bot keeps refreshing the PR every time another `.changeset/*.md` lands on `dev`. **Treat the Version PR as a release candidate that accumulates pending changes until you're ready to ship.**
+
+### 3. Cutting a release
+
+When you're ready to release everything in the current Version Packages PR:
+
+1. **Review the diff one more time.** Look for:
+   - Version bumps that look wrong (e.g., a `minor` for what should be a `major`)
+   - CHANGELOG entries that read poorly or expose internal implementation details that shouldn't be in a public changelog
+   - Missing entries you expected to see (means a contributor forgot a changeset — usually fixable before merging by landing the missing changeset on `dev`, which refreshes the Version PR)
+2. **Optionally amend the PR directly** — you can edit changelog text, adjust version bumps in `package.json`, or remove a package's entries entirely if you don't want it to ship in this release. The bot won't fight you; it only refreshes the PR when new `.changeset/*.md` files appear on `dev`.
+3. **Merge the Version PR** (squash merge is fine; the merge commit is what publishes).
+
+The moment that PR merges, the publish path of `changesets.yml` runs:
+
+- `main` is fast-forwarded to `dev`'s HEAD (the script aborts if `main` has diverged — see [Recovery](#recovery)).
+- One git tag per bumped package is created on `main` (e.g., `core-v0.1.0`, `shared-v0.1.0`).
+- The Changesets GitHub App pushes `main` + tags. (The default `GITHUB_TOKEN` won't work here because tag pushes made with it don't trigger downstream workflows.)
+
+### 4. Approve each per-package publish (if you enabled required reviewers)
+
+Each tag push triggers a separate publish workflow run. If you configured **Required reviewers** on the `marketplace-publish` GitHub Environment (recommended — see [Environment setup](#github-environment-marketplace-publish)), each extension publish workflow pauses at the Azure login step waiting for an approval click.
+
+Approve each one in the GitHub Actions UI:
+
+- https://github.com/devdocket/devdocket/actions
+
+Each run takes ~2–4 minutes from approval to a live marketplace listing. The six workflows run in parallel — you can approve them all in quick succession without serializing.
+
+`@devdocket/shared` is the exception: it publishes to GitHub Packages, doesn't use the `marketplace-publish` environment, and doesn't need approval — it publishes immediately on its tag push.
+
+### 5. Verify the release
+
+After the cascade settles, verify:
+
+| Where | What to check |
+|-------|---------------|
+| https://marketplace.visualstudio.com/manage/publishers/devdocket | Each of the 5 extensions shows the new version in its listing |
+| https://github.com/devdocket/devdocket/packages | `@devdocket/shared` shows the new version |
+| https://github.com/devdocket/devdocket/releases | One GitHub Release per bumped package, with the CHANGELOG entry as the release notes |
+| `git tag -l '*-v*' --sort=-v:refname` (local) | New tags exist for every bumped package |
+
+## Common scenarios
+
+### Bootstrap release (first time only)
+
+Before any package has been published, run a one-time "Initial public release" PR:
+
+1. Set every `packages/*/package.json` `version` field to `0.0.0` directly (this is the **only** time direct version editing is permitted).
+2. Add `.changeset/initial-release.md` with `minor` bumps for all six publishable packages and a description like `Initial public release.`
+3. Merge. The Version PR will bump everything `0.0.0 → 0.1.0` (or use `major` if you want to start at `1.0.0`).
+
+After this PR ships, version edits go exclusively through changesets.
+
+### Routine release
+
+The 99% case: contributors land changesets with their PRs over the course of a few days/weeks. You watch the Version PR's diff grow. When the pending changes feel like "enough for a release", merge it. Approve each publish run in the Actions UI. Done.
+
+### Hotfix release (single-package urgent fix)
+
+1. Land a feature PR with a `.changeset/*.md` that bumps only the affected package with `patch`.
+2. Merge the resulting Version Packages PR immediately (don't wait to batch with other pending changesets).
+3. Approve the affected publish workflow.
+
+If other changesets are pending but you only want to ship the hotfix, you can edit the Version Packages PR directly to remove the other packages' entries before merging.
+
+### Shipping a subset of pending changesets
+
+This is uncommon but supported. In the Version Packages PR's diff:
+
+1. Delete the `CHANGELOG.md` and `package.json` version updates for the packages you don't want to ship.
+2. Delete the corresponding `.changeset/*.md` deletions (which restores those changesets on `dev`).
+3. Commit those edits to the Version PR branch.
+4. Merge.
+
+The Changesets bot will then re-open a new Version Packages PR containing the changes you removed, ready for the next release.
+
+## One-time setup
+
+Before the first release can succeed, the maintainer must configure several pieces of infrastructure. None of these are automatable through PRs — they all live in external service UIs (Azure Portal, Marketplace, GitHub Settings).
+
+### Changesets GitHub App
+
+**Why:** Tag pushes made with the default `GITHUB_TOKEN` don't trigger downstream workflows (GitHub blocks this to prevent loops). The publish step needs to push tags that trigger `publish-*.yml`, so it uses a GitHub App's installation token instead.
+
+**Steps:**
+
+1. Create the App at https://github.com/organizations/devdocket/settings/apps/new
+   - **Name:** `devdocket-changesets-bot`
+   - **Homepage URL:** `https://github.com/devdocket/devdocket`
+   - **Webhook → Active:** unchecked
+   - **Repository permissions:**
+     - **Contents:** Read & write
+     - **Pull requests:** Read & write
+     - **Workflows:** Read & write
+     - **Metadata:** Read-only (default)
+   - **Where can this GitHub App be installed?:** Only on this account
+2. Generate a private key (settings page → Private keys → Generate a private key) — a `.pem` file downloads.
+3. Note the App ID (top of the settings page, numeric).
+4. Install the App on `devdocket/devdocket` (settings page → Install App → select repo).
+5. Add repository secrets at https://github.com/devdocket/devdocket/settings/secrets/actions:
+   - `CHANGESETS_APP_ID` — the numeric App ID
+   - `CHANGESETS_APP_PRIVATE_KEY` — the full `.pem` contents, including `-----BEGIN…` and `-----END…` lines
+6. Add the App to `main` branch protection bypass at https://github.com/devdocket/devdocket/settings/branches — edit the `main` rule → add `devdocket-changesets-bot` to the bypass / push-allow list. (The publish script does `git push origin main`, which branch protection would otherwise block.)
+
+### Entra ID app for VS Code Marketplace publishing
+
+**Why:** PAT-based marketplace authentication is being deprecated by Microsoft (global PATs decommissioned Dec 1, 2026 — see https://aka.ms/GlobalPATDeprecation). The reusable publish workflow (`_publish-vscode-extension.yml`) uses Microsoft Entra ID via GitHub Actions OIDC instead — no long-lived secrets.
+
+**Steps:**
+
+1. Create an Entra ID **App registration** at https://portal.azure.com → Microsoft Entra ID → App registrations → New registration.
+   - **Name:** `devdocket-vsce-publish`
+   - **Supported account types:** Accounts in this organizational directory only
+   - **Redirect URI:** leave blank
+2. Add a **federated credential** (App's Certificates & secrets → Federated credentials → Add credential):
+   - **Federated credential scenario:** GitHub Actions deploying Azure resources
+   - **Issuer:** `https://token.actions.githubusercontent.com`
+   - **Subject identifier:** `repo:devdocket/devdocket:environment:marketplace-publish`
+   - **Audience:** `api://AzureADTokenExchange`
+3. Add the App's service principal as a member of the `devdocket` Marketplace publisher at https://marketplace.visualstudio.com/manage/publishers/devdocket with **Contributor** role (or higher). The portal accepts the SP by its Application (client) ID.
+4. Add repository variables at https://github.com/devdocket/devdocket/settings/variables/actions:
+   - `AZURE_PUBLISH_CLIENT_ID` — the App's Application (client) ID
+   - `AZURE_PUBLISH_TENANT_ID` — the Directory (tenant) ID
+
+These are variables, not secrets, because they're identifiers (not credentials). The actual auth token is minted on-demand by GitHub OIDC and expires in minutes.
+
+### GitHub Environment `marketplace-publish`
+
+**Why:** The federated credential subject in step 2 above includes `environment:marketplace-publish` — Entra ID will only mint a token for workflow runs that are scoped to that environment. This is the security chokepoint that controls who can publish.
+
+**Steps at https://github.com/devdocket/devdocket/settings/environments:**
+
+1. Create environment named exactly `marketplace-publish` (the publish workflows hardcode this name).
+2. **Required reviewers (strongly recommended):** add at least one maintainer. Each per-package publish run will pause for an approval click — your last line of defense against an unintended release.
+3. **Deployment branches and tags (recommended):** restrict to tag patterns matching the release tag prefixes:
+   - `shared-v*`
+   - `core-v*`
+   - `github-v*`
+   - `ado-v*`
+   - `start-git-work-v*`
+   - `ai-reviewer-v*`
+   This prevents any branch / arbitrary tag from acquiring the publish identity, even if a workflow was accidentally configured to use the environment.
+
+### GitHub Packages (for `@devdocket/shared`)
+
+`publish-shared.yml` uses the auto-issued `GITHUB_TOKEN` with `packages: write` permission — no extra setup needed. It publishes to https://npm.pkg.github.com under the `@devdocket` scope.
+
+## Troubleshooting
+
+### "Cannot fast-forward main to dev"
+
+Reported by `scripts/create-release-tags.mjs`. Means someone (or something) pushed directly to `main` since the last release, so `main` is no longer a strict ancestor of `dev`.
+
+**Recovery:**
+
+```bash
+git fetch origin
+git checkout main
+git pull --ff-only origin main
+# Inspect the divergence:
+git log --oneline origin/dev..main
+```
+
+Decide whether the `main`-only commits need to be preserved (rare — `main` should be effectively a mirror of released `dev`):
+
+- **Discard them:** `git reset --hard origin/dev && git push --force-with-lease origin main`. The next release will succeed.
+- **Preserve them:** merge `main` into `dev` (`git checkout dev && git merge main --no-ff && git push origin dev`). After that lands, the next push to `dev` will re-run the workflow and ff-merge will succeed because `main` is now reachable from `dev`.
+
+This shouldn't happen if you treat `main` as bot-owned (no direct human pushes). It's worth tightening `main` branch protection to disallow direct pushes from everyone except the Changesets App.
+
+### A publish workflow failed
+
+Click into the failed run at https://github.com/devdocket/devdocket/actions. Common causes:
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `azure/login` step fails with `AADSTS700213` or "no matching federated credential" | Federated credential subject mismatch or environment not set | Verify FC subject is exactly `repo:devdocket/devdocket:environment:marketplace-publish` |
+| `vsce publish` fails with 401/403 | SP not added as Marketplace publisher member, or wrong role | Add SP as Contributor at https://marketplace.visualstudio.com/manage/publishers/devdocket |
+| `vsce publish` succeeds but listing doesn't update | VS Marketplace indexing lag (rare, usually ≤5min) | Wait |
+| `gh release create` fails | `contents: write` permission missing or release already exists | Check workflow `permissions:` block; releases with the same tag conflict |
+| Build / test step fails | Code regression slipped through CI (shouldn't happen — `npm run test` runs in CI on every PR) | Fix on `dev`, ship a new release |
+
+**Recovery for a failed publish:** click **Re-run failed jobs** in the Actions UI after fixing the underlying issue. The tag already exists, so the workflow picks up where it left off. Other packages' publishes (which succeeded) are unaffected — each runs in its own independent workflow.
+
+### Version Packages PR didn't appear
+
+The merge to `dev` ran the Changesets workflow but no Version PR was opened. Check the workflow logs at https://github.com/devdocket/devdocket/actions/workflows/changesets.yml.
+
+Common causes:
+
+- **`.changeset/config.json` validation error.** If `ignore`, `linked`, `fixed`, etc. reference packages not in `workspaces`, `npx changeset version` throws. Fix the config, push to `dev`, the workflow re-runs.
+- **No `.changeset/*.md` files were present** (only `config.json` and `README.md`). The workflow correctly took the publish path instead — see next item.
+- **`CHANGELOG.md` missing for a package with a publish workflow.** Pre-fix-#591 behavior. The bootstrap fix in #591 makes the script warn and skip instead of throwing.
+
+### The bot couldn't push tags
+
+Symptom: `changesets.yml` succeeds, but no `publish-*.yml` workflows fire. Verify:
+
+- `CHANGESETS_APP_ID` and `CHANGESETS_APP_PRIVATE_KEY` repository secrets are set.
+- The Changesets App is installed on `devdocket/devdocket`.
+- The App has `contents: write`, `pull-requests: write`, `workflows: write` repository permissions.
+- The App is in the `main` branch protection bypass list.
+
+## Recovery
+
+### Publishing the wrong version
+
+The Marketplace does **not** allow un-publishing a version. You can only publish a new version that supersedes it.
+
+If you released a broken version:
+
+1. Land the fix on `dev` (with a `patch` changeset).
+2. Merge the Version PR ASAP to ship the corrected version.
+3. The broken version remains in the Marketplace's version history but won't be installed by new users (the latest is always preferred).
+
+For truly catastrophic releases (security leak, broken installs), contact Marketplace support to deprecate the version: https://aka.ms/vsmarketplace-support.
+
+### Deleting a tag created by mistake
+
+```bash
+git push --delete origin shared-v0.1.0
+git tag -d shared-v0.1.0
+```
+
+This deletes the tag but **does not** un-publish anything that the tag's workflow already shipped. The corresponding GitHub Release also remains (delete it separately at https://github.com/devdocket/devdocket/releases).
+
+### Rotating the Changesets GitHub App private key
+
+If `CHANGESETS_APP_PRIVATE_KEY` is leaked or expiring:
+
+1. Generate a new private key on the App's settings page → Private keys → Generate.
+2. Update the `CHANGESETS_APP_PRIVATE_KEY` repo secret with the new `.pem` contents.
+3. **Revoke the old private key** on the App settings page.
+
+The App ID stays the same; in-flight workflow runs continue with the old key until they finish.
+
+### Rotating Entra ID federated credential
+
+If you need to retire the federated credential (e.g., suspected compromise of the App):
+
+1. Add a new App + federated credential following [Entra ID app setup](#entra-id-app-for-vs-code-marketplace-publishing).
+2. Add the new SP as a Marketplace publisher member.
+3. Update repository variables `AZURE_PUBLISH_CLIENT_ID` and `AZURE_PUBLISH_TENANT_ID` to point at the new App.
+4. Remove the old SP from the Marketplace publisher.
+5. Delete the old App (App settings → Manage → Delete).
+
+No code change is required — the workflow just reads the variables.
+
+## Adding a new publishable package
+
+If a future package (e.g., `packages/foo`) becomes publishable to the Marketplace:
+
+1. **Pick a tag prefix** (e.g., `foo-v`) and add it to the `tagPrefixes` map in `scripts/create-release-tags.mjs`.
+2. **Create `.github/workflows/publish-foo.yml`** mirroring the existing publish-*.yml files:
+   - Trigger: `push: tags: ['foo-v*']`
+   - Calls `./.github/workflows/_publish-vscode-extension.yml` with `package-directory: packages/foo`, `package-title: <human title>`, `tag-prefix: foo-v`
+   - Grants `permissions: contents: write, id-token: write`
+3. **Add the new tag pattern (`foo-v*`) to the `marketplace-publish` environment's deployment-tag restrictions.**
+4. **Add an entry for `foo` to the publish package list in [AGENTS.md](../AGENTS.md#releases--changesets).**
+5. Land a `.changeset/*.md` for `packages/foo` and let the next release cut its first published version.
+
+No federated credential changes needed — the environment-based subject covers any workflow scoped to `marketplace-publish`.
+
+## Reference
+
+| File / location | What it does |
+|-----------------|--------------|
+| `.changeset/config.json` | Changesets configuration (changelog format, base branch, internal dependency policy) |
+| `.changeset/*.md` | Pending change descriptions waiting to ship in the next Version Packages PR |
+| `packages/*/CHANGELOG.md` | Per-package changelog — written by `changeset version`, never edited manually |
+| `.github/workflows/changesets.yml` | Triggers on push to `dev`; opens Version PR or runs publish script |
+| `scripts/create-release-tags.mjs` | The publish script — ff-merges main, creates tags, pushes |
+| `scripts/extract-changelog.mjs` | Helper that reads the latest CHANGELOG entry for a release's notes |
+| `.github/workflows/_publish-vscode-extension.yml` | Reusable workflow that builds, packages, OIDC-authenticates, and publishes one extension |
+| `.github/workflows/publish-*.yml` | Per-package tag-triggered wrappers around the reusable workflow |
+| `.github/workflows/publish-shared.yml` | The shared library's GitHub Packages publish (separate path from the extensions) |
+| `AGENTS.md` § Releases & Changesets | The contributor/agent-side rules for adding changesets to PRs |


### PR DESCRIPTION
## Summary

Restructure the project's documentation into the three GitHub conventional root-level files:

- **`CONTRIBUTING.md`** (new) — canonical entry point for new contributors. Covers prerequisites, quick start, repo layout, build/test commands, branching and PR conventions, `.vsix` packaging, the icon font script, and pointers to `AGENTS.md` (deeper conventions) and `RELEASING.md` (maintainer pipeline).
- **`RELEASING.md`** (already in this PR; now slimmed) — maintainer ops guide for the Changesets pipeline. Focused on day-to-day operations, common scenarios, troubleshooting, recovery, and rotating credentials. The Bootstrap-release scenario and One-time-setup sections have been removed (the bootstrap is a one-off historical step, and the infrastructure setup is captured in the originating PR descriptions).
- **`README.md`** — slimmed. The multi-step build-from-source instructions and architecture diagram are moved to `CONTRIBUTING.md`; the Installation section now points readers there with a "pre-release" notice. The Documentation table gains rows for `CONTRIBUTING.md` and `RELEASING.md`.

## Why

The previous README mixed three audiences (users, contributors, maintainers) into one document. Splitting them by audience makes each doc easier to maintain and navigate, and aligns with GitHub's well-known file conventions (CONTRIBUTING.md, SECURITY.md, etc.).

## What stays where

| Audience | Document | Contents |
|----------|----------|----------|
| **Users** | `README.md` | What DevDocket is, why it exists, the user workflow, installation pointer, included plugin overview |
| **Contributors** | `CONTRIBUTING.md` | Dev env setup, build/test, branching, `.vsix` packaging, icon font script, PR workflow |
| **Maintainers** | `RELEASING.md` | Day-to-day release operations, common scenarios, troubleshooting, recovery, credential rotation |
| **Agents** | `AGENTS.md` | Exhaustive conventions (storage, views, testing, API surface, Changeset format, etc.) |

`AGENTS.md` is intentionally not touched in this PR — it remains the canonical comprehensive convention doc that `CONTRIBUTING.md` and `RELEASING.md` link out to.

## Validation

- Docs-only change. Per `AGENTS.md` ("Documentation changes do not need to be linted, built or tested"), no build/test needed.
- All internal links use relative paths and were sanity-checked.
- All anchor links (`#section-name`) verified against current section headings after the RELEASING.md trim.
- README, CONTRIBUTING, and RELEASING all cross-link consistently.

## Notes for maintainers

No changeset added — the `AGENTS.md` `## Releases & Changesets` section classifies documentation-only changes as not requiring one.
