### PR TITLE
Complete Marketplace metadata for extensions

### DIFF
--- a/.changeset/marketplace-metadata.md
+++ b/.changeset/marketplace-metadata.md
@@ -1,0 +1,9 @@
+---
+"devdocket": patch
+"devdocket-github": patch
+"devdocket-ado": patch
+"devdocket-start-git-work": patch
+"devdocket-ai-reviewer": patch
+---
+
+Complete Marketplace metadata for each publishable extension: add `repository`, `bugs`, `homepage`, `keywords`, `galleryBanner`, `preview: true`, and reassign `categories` from `Other` to descriptive Marketplace categories so listings show working repo/issues/learn-more links, brand-colored headers, a Preview badge, and surface under category filters.

--- a/packages/ado/package.json
+++ b/packages/ado/package.json
@@ -9,8 +9,33 @@
     "vscode": "^1.92.0"
   },
   "categories": [
+    "SCM Providers",
+    "Azure",
     "Other"
   ],
+  "keywords": [
+    "azure devops",
+    "ado",
+    "work items",
+    "pull requests",
+    "pipelines",
+    "devdocket",
+    "provider"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/devdocket/devdocket.git",
+    "directory": "packages/ado"
+  },
+  "bugs": {
+    "url": "https://github.com/devdocket/devdocket/issues"
+  },
+  "homepage": "https://github.com/devdocket/devdocket#readme",
+  "galleryBanner": {
+    "color": "#1F2937",
+    "theme": "dark"
+  },
+  "preview": true,
   "extensionDependencies": [
     "devdocket.devdocket"
   ],

--- a/packages/ai-reviewer/package.json
+++ b/packages/ai-reviewer/package.json
@@ -9,8 +9,35 @@
     "vscode": "^1.96.0"
   },
   "categories": [
-    "Other"
+    "AI",
+    "Chat",
+    "SCM Providers"
   ],
+  "keywords": [
+    "ai",
+    "code review",
+    "pull request",
+    "github",
+    "azure devops",
+    "copilot",
+    "walkthrough",
+    "chat participant",
+    "devdocket"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/devdocket/devdocket.git",
+    "directory": "packages/ai-reviewer"
+  },
+  "bugs": {
+    "url": "https://github.com/devdocket/devdocket/issues"
+  },
+  "homepage": "https://github.com/devdocket/devdocket#readme",
+  "galleryBanner": {
+    "color": "#1F2937",
+    "theme": "dark"
+  },
+  "preview": true,
   "extensionDependencies": [
     "devdocket.devdocket"
   ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,8 +9,35 @@
     "vscode": "^1.92.0"
   },
   "categories": [
+    "SCM Providers",
     "Other"
   ],
+  "keywords": [
+    "work items",
+    "tasks",
+    "todo",
+    "github",
+    "azure devops",
+    "pull requests",
+    "issues",
+    "productivity",
+    "hub",
+    "inbox"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/devdocket/devdocket.git",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/devdocket/devdocket/issues"
+  },
+  "homepage": "https://github.com/devdocket/devdocket#readme",
+  "galleryBanner": {
+    "color": "#1F2937",
+    "theme": "dark"
+  },
+  "preview": true,
   "activationEvents": [
     "onView:devdocket.main",
     "onWebviewPanel:devdocket.editItem",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -9,8 +9,33 @@
     "vscode": "^1.92.0"
   },
   "categories": [
+    "SCM Providers",
     "Other"
   ],
+  "keywords": [
+    "github",
+    "pull requests",
+    "issues",
+    "code review",
+    "notifications",
+    "devdocket",
+    "actions",
+    "provider"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/devdocket/devdocket.git",
+    "directory": "packages/github"
+  },
+  "bugs": {
+    "url": "https://github.com/devdocket/devdocket/issues"
+  },
+  "homepage": "https://github.com/devdocket/devdocket#readme",
+  "galleryBanner": {
+    "color": "#1F2937",
+    "theme": "dark"
+  },
+  "preview": true,
   "extensionDependencies": [
     "devdocket.devdocket"
   ],

--- a/packages/start-git-work/package.json
+++ b/packages/start-git-work/package.json
@@ -9,8 +9,31 @@
     "vscode": "^1.92.0"
   },
   "categories": [
+    "SCM Providers",
     "Other"
   ],
+  "keywords": [
+    "git",
+    "worktree",
+    "branch",
+    "git workflow",
+    "devdocket",
+    "action"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/devdocket/devdocket.git",
+    "directory": "packages/start-git-work"
+  },
+  "bugs": {
+    "url": "https://github.com/devdocket/devdocket/issues"
+  },
+  "homepage": "https://github.com/devdocket/devdocket#readme",
+  "galleryBanner": {
+    "color": "#1F2937",
+    "theme": "dark"
+  },
+  "preview": true,
   "extensionDependencies": [
     "devdocket.devdocket"
   ],


### PR DESCRIPTION
## Summary

- Add Marketplace metadata to all five publishable extension `package.json` files: `repository`, `bugs`, `homepage`, `keywords`, `galleryBanner`, and `preview: true`.
- Reassign `categories` from `Other` to descriptive, valid Marketplace categories per extension.
- Add a changeset for the user-facing Marketplace listing improvements.

Closes #602

## Validation

- `npm run build`
- `npm run test`
- `npx @vscode/vsce package --no-dependencies --allow-missing-repository` in `packages/core` (packaged successfully; only pre-existing missing LICENSE warning)
