### PR TITLE
Normalize Marketplace displayName across extensions

### DIFF
--- a/.changeset/normalize-display-names.md
+++ b/.changeset/normalize-display-names.md
@@ -1,0 +1,7 @@
+---
+"devdocket": patch
+"devdocket-ado": patch
+"devdocket-ai-reviewer": patch
+---
+
+Normalize Marketplace `displayName` across extensions to a consistent `DevDocket <Suffix>` pattern with a plain space separator. Rename `DevDocket — Azure DevOps` to `DevDocket Azure DevOps` and `DevDocket — AI Actions` to `DevDocket AI Reviewer` (the latter also aligns the display name with the package name `devdocket-ai-reviewer` and accurately describes the extension). Output channel names, configuration section titles, user-visible warning messages, and the Azure DevOps walkthrough instruction are updated to match.

--- a/packages/ado/package.json
+++ b/packages/ado/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devdocket-ado",
-  "displayName": "DevDocket — Azure DevOps",
+  "displayName": "DevDocket Azure DevOps",
   "description": "Azure DevOps provider for DevDocket — discovers assigned work items and PR reviews.",
   "version": "0.1.0",
   "publisher": "devdocket",

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -199,7 +199,7 @@ export class AdoWorkItemProvider extends BaseProvider {
         ? `Failed to fetch work items from ${failures[0]}`
         : `Failed to fetch work items from ${failures.length} sources`;
       if (isUserTriggered) {
-        void vscode.window.showWarningMessage(`DevDocket ADO: ${message}`);
+        void vscode.window.showWarningMessage(`DevDocket Azure DevOps: ${message}`);
       }
       logger.warn(message);
     }

--- a/packages/ado/src/baseAdoPrProvider.ts
+++ b/packages/ado/src/baseAdoPrProvider.ts
@@ -231,7 +231,7 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
     if (messages.length > 0) {
       const message = `${this.logLabel} errors: ${messages.join('; ')}`;
       if (isUserTriggered) {
-        void vscode.window.showWarningMessage(`DevDocket ADO: ${message}`);
+        void vscode.window.showWarningMessage(`DevDocket Azure DevOps: ${message}`);
       }
       logger.warn(message);
     }

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -20,11 +20,11 @@ function showAdoProjectsSettingsWarning(message: string): void {
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  const log = vscode.window.createOutputChannel('DevDocket ADO', { log: true });
+  const log = vscode.window.createOutputChannel('DevDocket Azure DevOps', { log: true });
   context.subscriptions.push(log);
   setLogger(log);
 
-  log.info('DevDocket ADO activating...');
+  log.info('DevDocket Azure DevOps activating...');
 
   const coreExtension = vscode.extensions.getExtension('devdocket.devdocket');
   if (!coreExtension) {
@@ -75,7 +75,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         logger.info('All devDocketAdo.projects entries are invalid — entries must be "org" or "org/project"');
         if (!orgWarningShown) {
           showAdoProjectsSettingsWarning(
-            'DevDocket ADO: All devDocketAdo.projects entries are invalid. Each entry must be "org" or "org/project".',
+            'DevDocket Azure DevOps: All devDocketAdo.projects entries are invalid. Each entry must be "org" or "org/project".',
           );
           orgWarningShown = true;
         }
@@ -83,7 +83,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         logger.info('No organizations configured — set devDocketAdo.projects to enable ADO providers');
         if (!orgWarningShown) {
           showAdoProjectsSettingsWarning(
-            'DevDocket ADO: No Azure DevOps organizations configured. Add entries to devDocketAdo.projects (e.g. "myorg" or "myorg/myproject").',
+            'DevDocket Azure DevOps: No Azure DevOps organizations configured. Add entries to devDocketAdo.projects (e.g. "myorg" or "myorg/myproject").',
           );
           orgWarningShown = true;
         }
@@ -138,7 +138,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
   );
 
-  logger.info('DevDocket ADO activated');
+  logger.info('DevDocket Azure DevOps activated');
 }
 
 export function deactivate(): void {

--- a/packages/ado/src/test/__mocks__/vscode.ts
+++ b/packages/ado/src/test/__mocks__/vscode.ts
@@ -64,7 +64,7 @@ const window = {
     show: vi.fn(),
     hide: vi.fn(),
     dispose: vi.fn(),
-    name: 'DevDocket ADO',
+    name: 'DevDocket Azure DevOps',
     replace: vi.fn(),
     logLevel: 2,
     onDidChangeLogLevel: vi.fn(),

--- a/packages/ado/src/test/adoMyPrsProvider.test.ts
+++ b/packages/ado/src/test/adoMyPrsProvider.test.ts
@@ -215,7 +215,7 @@ describe('AdoMyPrsProvider', () => {
       }),
     ]);
     expect(window.showWarningMessage).toHaveBeenCalledWith(
-      'DevDocket ADO: My PRs errors: failed to fetch from myorg/ProjectB',
+      'DevDocket Azure DevOps: My PRs errors: failed to fetch from myorg/ProjectB',
     );
     expect(
       mockChannel.error.mock.calls.some(

--- a/packages/ado/src/test/extension.test.ts
+++ b/packages/ado/src/test/extension.test.ts
@@ -295,7 +295,7 @@ describe('extension activation', () => {
   it('creates an output channel', async () => {
     await activate(mockContext);
 
-    expect(window.createOutputChannel).toHaveBeenCalledWith('DevDocket ADO', { log: true });
+    expect(window.createOutputChannel).toHaveBeenCalledWith('DevDocket Azure DevOps', { log: true });
     expect(disposables.length).toBeGreaterThan(0);
   });
 

--- a/packages/ai-reviewer/package.json
+++ b/packages/ai-reviewer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "devdocket-ai-reviewer",
-  "displayName": "DevDocket — AI Actions",
+  "displayName": "DevDocket AI Reviewer",
   "description": "AI-powered code review and PR walkthrough actions for DevDocket",
   "version": "0.1.0",
   "publisher": "devdocket",
@@ -213,7 +213,7 @@
     ],
     "configuration": [
       {
-        "title": "DevDocket AI Actions",
+        "title": "DevDocket AI Reviewer",
         "properties": {
           "devDocketAiReview.customPromptPath": {
             "type": "string",

--- a/packages/ai-reviewer/src/extension.ts
+++ b/packages/ai-reviewer/src/extension.ts
@@ -7,7 +7,7 @@ import { registerAllTools } from './tools';
 import type { DevDocketApi } from './types';
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
-  const log = vscode.window.createOutputChannel('DevDocket AI Review', { log: true });
+  const log = vscode.window.createOutputChannel('DevDocket AI Reviewer', { log: true });
   context.subscriptions.push(log);
 
   log.info('Activating DevDocket AI Reviewer extension');

--- a/packages/ai-reviewer/src/test/__mocks__/vscode.ts
+++ b/packages/ai-reviewer/src/test/__mocks__/vscode.ts
@@ -70,7 +70,7 @@ const mockLogOutputChannel = {
   show: vi.fn(),
   hide: vi.fn(),
   dispose: vi.fn(),
-  name: 'DevDocket AI Review',
+  name: 'DevDocket AI Reviewer',
   logLevel: 2,
   onDidChangeLogLevel: vi.fn(),
   replace: vi.fn(),

--- a/packages/core/media/walkthroughs/providers.md
+++ b/packages/core/media/walkthroughs/providers.md
@@ -24,7 +24,7 @@ Discovers:
 - Pull requests you authored
 
 **Setup:**
-1. Install the **DevDocket ADO** extension
+1. Install the **DevDocket Azure DevOps** extension
 2. Configure your organization and project
 3. Authenticate when prompted
 


### PR DESCRIPTION
## Summary

Normalizes the Marketplace `displayName` across the 5 publishable extensions to a consistent `DevDocket <Suffix>` pattern with a plain space separator (matching the Marketplace convention used by GitHub/Azure extension families).

| Package | Before | After |
|---|---|---|
| `core` | `DevDocket` | `DevDocket` (unchanged) |
| `github` | `DevDocket GitHub` | `DevDocket GitHub` (unchanged) |
| `ado` | `DevDocket — Azure DevOps` | **`DevDocket Azure DevOps`** |
| `start-git-work` | `DevDocket Start Git Work` | `DevDocket Start Git Work` (unchanged) |
| `ai-reviewer` | `DevDocket — AI Actions` | **`DevDocket AI Reviewer`** |

The AI reviewer rename also aligns the display name with the package name (`devdocket-ai-reviewer`) and accurately describes what the extension does. "AI Actions" was a generic category that did not match the actual feature set.

## User-visible strings updated to match

- Output channel names: `DevDocket ADO` → `DevDocket Azure DevOps`, `DevDocket AI Review` → `DevDocket AI Reviewer`
- VS Code Settings UI configuration section titles
- Warning and info log messages prefixed with the provider name
- The Azure DevOps walkthrough step in the core extension (`Install the DevDocket ADO extension` → `Install the DevDocket Azure DevOps extension`)

## Out of scope

Marketplace READMEs (added in #603) and the root `README.md` / `docs/provider-discovery.md` still reference the old display names. Those will be updated in a follow-up so this PR stays focused on the user-visible product names. Both Marketplace publish workflows (`publish-ado.yml`, `publish-ai-reviewer.yml`) already use the new names, so no changes needed there.

## Validation

- `npm run build` — passed
- `npm run test` — passed (all packages)

## Changeset

Included as a `patch` bump for `devdocket`, `devdocket-ado`, `devdocket-ai-reviewer`.
