### PR TITLE
Mark 0.x GitHub Releases as prerelease automatically

### DIFF
--- a/.github/workflows/_publish-vscode-extension.yml
+++ b/.github/workflows/_publish-vscode-extension.yml
@@ -114,6 +114,12 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" --title "$PACKAGE_TITLE $TAG_VERSION" --notes-file release-notes.md
+        run: |
+          PRERELEASE_FLAG=""
+          MAJOR_VERSION=$(printf '%s' "$TAG_VERSION" | cut -d. -f1)
+          if [ "$MAJOR_VERSION" = "0" ] || printf '%s' "$TAG_VERSION" | grep -q '-'; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          gh release create "$GITHUB_REF_NAME" $PRERELEASE_FLAG --title "$PACKAGE_TITLE $TAG_VERSION" --notes-file release-notes.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-shared.yml
+++ b/.github/workflows/publish-shared.yml
@@ -61,6 +61,13 @@ jobs:
           rm -f "$error_log"
 
       - name: Create GitHub Release
-        run: gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+        run: |
+          PRERELEASE_FLAG=""
+          TAG_VERSION="${GITHUB_REF_NAME#shared-v}"
+          MAJOR_VERSION=$(printf '%s' "$TAG_VERSION" | cut -d. -f1)
+          if [ "$MAJOR_VERSION" = "0" ] || printf '%s' "$TAG_VERSION" | grep -q '-'; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          gh release create "$GITHUB_REF_NAME" $PRERELEASE_FLAG --title "$GITHUB_REF_NAME" --notes-file release-notes.md
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -46,6 +46,7 @@ Are there pending .changeset/*.md files?
                         │
                         ▼
                     GitHub Release created per tag with the matching CHANGELOG entry
+                    (marked as a pre-release for any 0.x or `1.0.0-rc.1` style version)
 ```
 
 ## Day-to-day maintainer workflow


### PR DESCRIPTION
## Summary

Auto-marks GitHub Releases as **pre-release** whenever the tagged version is pre-1.0 (major version `0`) or carries a SemVer pre-release suffix (e.g. `1.0.0-rc.1`).

Companion change to the manual prerelease flag-flip just performed on the existing 0.1.0 / 0.1.1 releases. Without this, the next Changesets-driven release cycle would publish stable releases again and a maintainer would have to flip them manually each time.

## Changes

- `.github/workflows/_publish-vscode-extension.yml` — the `Create GitHub Release` step now computes a `PRERELEASE_FLAG` based on `TAG_VERSION` (already set earlier in the workflow) and passes it to `gh release create`.
- `.github/workflows/publish-shared.yml` — same logic, parsing `TAG_VERSION` from `GITHUB_REF_NAME` (`shared-v…`).
- `RELEASING.md` — documents the auto-detected prerelease behavior in the release pipeline diagram.

## Detection rule

```
PRERELEASE if MAJOR(TAG_VERSION) == 0  OR  TAG_VERSION contains "-"
STABLE     otherwise
```

This means every release continues to be flagged prerelease automatically until someone cuts `1.0.0`, then stable releases ship without any further workflow edits.

## No changeset

CI / workflow change only — no user-visible behavior change in any publishable package.

## Validation

Workflow YAML is the only changed code; nothing locally testable. The next Changesets release will exercise it end-to-end.
