### PR TITLE
Customize Changesets changelog generator (drop Thanks line; add PR title)

### DIFF
--- a/.changeset/changelog-format.mjs
+++ b/.changeset/changelog-format.mjs
@@ -1,0 +1,117 @@
+/**
+ * Custom Changesets changelog generator for the devdocket monorepo.
+ *
+ * Differs from the default `@changesets/changelog-github` in two ways:
+ *   1. The "Thanks @user!" attribution is omitted.
+ *   2. The PR link text is `#N PR Title` instead of just `#N`, so the PR's
+ *      subject is visible inline in the CHANGELOG and the auto-generated
+ *      GitHub Release notes that the publish workflows derive from it.
+ *
+ * The output otherwise mirrors @changesets/changelog-github: a PR link,
+ * an abbreviated commit link, and the changeset summary, separated by
+ * dashes.
+ *
+ * GitHub API calls (commit -> PR lookup, PR -> title) need a token to
+ * avoid the 60/hr anonymous rate limit. The publish workflow provides
+ * `GITHUB_TOKEN` automatically; for local runs of `npx changeset version`
+ * without a token, the formatter gracefully falls back to a PR-less line.
+ */
+
+const repoSlug = 'devdocket/devdocket';
+const [owner, repoName] = repoSlug.split('/');
+
+/**
+ * GitHub PR titles can contain Markdown-significant characters that would
+ * break or confuse the surrounding link syntax. Escape the subset that
+ * actually matters inside a `[link text](url)` construct, plus newlines
+ * which would split the line.
+ */
+function escapeLinkText(text) {
+  return String(text)
+    .replace(/\\/g, '\\\\')
+    .replace(/\]/g, '\\]')
+    .replace(/\r?\n/g, ' ')
+    .trim();
+}
+
+async function fetchJson(url) {
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'User-Agent': `${owner}-changesets-changelog`,
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+
+  const response = await fetch(url, { headers });
+  if (!response.ok) {
+    return null;
+  }
+  return response.json();
+}
+
+async function lookupPullRequestForCommit(sha) {
+  if (!sha) return null;
+  const data = await fetchJson(
+    `https://api.github.com/repos/${repoSlug}/commits/${sha}/pulls`,
+  );
+  if (!Array.isArray(data) || data.length === 0) {
+    return null;
+  }
+  // A commit can appear in multiple PRs (e.g. backports). Prefer the merged
+  // PR closest to the integration into dev — the first MERGED entry in the
+  // list, or the first entry overall as a fallback.
+  return data.find((pr) => pr.merged_at) ?? data[0];
+}
+
+function commitLink(sha) {
+  if (!sha) return '';
+  const short = sha.slice(0, 7);
+  return `[\`${short}\`](https://github.com/${repoSlug}/commit/${sha})`;
+}
+
+function prLink(pr) {
+  const title = escapeLinkText(pr.title);
+  return `[#${pr.number} ${title}](https://github.com/${repoSlug}/pull/${pr.number})`;
+}
+
+const changelogFunctions = {
+  async getReleaseLine(changeset, _type, _changelogOpts) {
+    const summary = changeset.summary.trim();
+    const pr = await lookupPullRequestForCommit(changeset.commit);
+    const linkParts = [];
+    if (pr) {
+      linkParts.push(prLink(pr));
+    }
+    const commit = commitLink(changeset.commit);
+    if (commit) {
+      linkParts.push(commit);
+    }
+
+    const prefix = linkParts.length > 0 ? `${linkParts.join(' ')} - ` : '';
+    return `\n\n- ${prefix}${summary}`;
+  },
+
+  async getDependencyReleaseLine(changesets, dependenciesUpdated, _changelogOpts) {
+    if (dependenciesUpdated.length === 0) {
+      return '';
+    }
+
+    const commitShas = changesets
+      .map((c) => c.commit)
+      .filter(Boolean);
+    const commitMarkdown = commitShas.length > 0
+      ? ` [${commitShas.map(commitLink).join(', ')}]`
+      : '';
+
+    const updatedLines = dependenciesUpdated
+      .map((dep) => `  - ${dep.name}@${dep.newVersion}`)
+      .join('\n');
+
+    return `\n\n- Updated dependencies${commitMarkdown}:\n${updatedLines}`;
+  },
+};
+
+export default changelogFunctions;

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "devdocket/devdocket" }],
+  "changelog": "./changelog-format.mjs",
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@changesets/changelog-github": "^0.6.0",
         "@changesets/cli": "^2.31.0"
       }
     },
@@ -93,18 +92,6 @@
       "license": "MIT",
       "dependencies": {
         "@changesets/types": "^6.1.0"
-      }
-    },
-    "node_modules/@changesets/changelog-github": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.6.0.tgz",
-      "integrity": "sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@changesets/get-github-info": "^0.8.0",
-        "@changesets/types": "^6.1.0",
-        "dotenv": "^8.1.0"
       }
     },
     "node_modules/@changesets/cli": {
@@ -193,17 +180,6 @@
         "@manypkg/get-packages": "^1.1.3",
         "picocolors": "^1.1.0",
         "semver": "^7.5.3"
-      }
-    },
-    "node_modules/@changesets/get-github-info": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.8.0.tgz",
-      "integrity": "sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dataloader": "^1.4.0",
-        "node-fetch": "^2.5.0"
       }
     },
     "node_modules/@changesets/get-release-plan": {
@@ -2184,13 +2160,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/dataloader": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
-      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2393,16 +2362,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/dunder-proto": {
@@ -4307,52 +4266,6 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -6673,7 +6586,7 @@
     },
     "packages/ado": {
       "name": "devdocket-ado",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*"
@@ -7109,7 +7022,7 @@
     },
     "packages/ai-reviewer": {
       "name": "devdocket-ai-reviewer",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*"
@@ -7545,7 +7458,7 @@
     },
     "packages/core": {
       "name": "devdocket",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*",
@@ -8681,7 +8594,7 @@
     },
     "packages/github": {
       "name": "devdocket-github",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*",
@@ -9127,7 +9040,7 @@
     },
     "packages/start-git-work": {
       "name": "devdocket-start-git-work",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "version-packages": "changeset version"
   },
   "devDependencies": {
-    "@changesets/changelog-github": "^0.6.0",
     "@changesets/cli": "^2.31.0"
   }
 }


### PR DESCRIPTION
## Summary

Replaces `@changesets/changelog-github` with a small custom generator at `.changeset/changelog-format.mjs`, and points `.changeset/config.json` at it.

## Format changes

Two intentional differences from the default generator:

1. **No "Thanks @user!" attribution.** Every entry is the author's own contribution by definition; the noise is removed.
2. **PR link includes the PR title** — `[#603 Add Marketplace READMEs](...)` instead of just `[#603](...)`. PR subjects now show up inline both in CHANGELOG.md and in the auto-generated GitHub Release notes that `_publish-vscode-extension.yml` derives from them.

Dependency-bump release lines (`- Updated dependencies [...]:`) keep the same shape as before.

## Before / After

**Before:**

```md
- [#604](https://github.com/devdocket/devdocket/pull/604) [`35c88ed`](.../commit/35c88ed) Thanks [@mthalman](https://github.com/mthalman)! - Add a 128×128 Marketplace icon to each publishable extension…
```

**After:**

```md
- [#604 Add Marketplace icons for extensions](https://github.com/devdocket/devdocket/pull/604) [`35c88ed`](.../commit/35c88ed) - Add a 128×128 Marketplace icon to each publishable extension…
```

## Implementation notes

- The generator uses Node's built-in `fetch` (Node 22 in CI). PR titles come from `GET /repos/{owner}/{repo}/commits/{sha}/pulls`, authenticated with `GITHUB_TOKEN` to avoid the 60/hr anonymous rate limit.
- Local `npx changeset version` without a token gracefully falls back to a commit-only line (no exception, just no PR link).
- PR titles are escaped (`]`, `\\`, newlines) so unusual titles don't break the surrounding `[link](url)` markdown.
- A commit that appears in multiple PRs (e.g., backports) prefers the merged PR.
- Existing CHANGELOG.md entries are left as-is; only **new** version entries from the next Changesets release onward will use the new format.

## Dependency cleanup

Removes `@changesets/changelog-github` from `devDependencies` since the new generator replaces it entirely. `package-lock.json` regenerated accordingly.

## Validation

Tested locally with a throwaway changeset:

- `npx changeset version` ran successfully against the new generator.
- The generated entry produced the expected `- … - summary` format with no "Thanks" line.
- A direct invocation against a real merged-PR commit (`29d3039` → #606) produced the desired output: `[#606 Normalize Marketplace displayName across extensions](…)`.
- `npm run build` and `npm run test` both pass.

## No changeset

`.changeset/config.json` and changelog tooling changes are explicitly listed as "not required" in AGENTS.md's Changesets section.
