### PR TITLE
Use extension displayName as CHANGELOG.md H1 heading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@changesets/changelog-github": "^0.6.0",
         "@changesets/cli": "^2.31.0"
       }
     },
@@ -93,18 +92,6 @@
       "license": "MIT",
       "dependencies": {
         "@changesets/types": "^6.1.0"
-      }
-    },
-    "node_modules/@changesets/changelog-github": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.6.0.tgz",
-      "integrity": "sha512-wA2/y4hR/A1K411cCT75rz0d46Iezxp1WYRFoFJDIUpkQ6oDBAIUiU7BZkDCmYgz0NBl94X1lgcZO+mHoiHnFg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@changesets/get-github-info": "^0.8.0",
-        "@changesets/types": "^6.1.0",
-        "dotenv": "^8.1.0"
       }
     },
     "node_modules/@changesets/cli": {
@@ -193,17 +180,6 @@
         "@manypkg/get-packages": "^1.1.3",
         "picocolors": "^1.1.0",
         "semver": "^7.5.3"
-      }
-    },
-    "node_modules/@changesets/get-github-info": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.8.0.tgz",
-      "integrity": "sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dataloader": "^1.4.0",
-        "node-fetch": "^2.5.0"
       }
     },
     "node_modules/@changesets/get-release-plan": {
@@ -2184,13 +2160,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/dataloader": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
-      "integrity": "sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2393,16 +2362,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/dotenv": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
-      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/dunder-proto": {
@@ -4307,52 +4266,6 @@
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -6673,7 +6586,7 @@
     },
     "packages/ado": {
       "name": "devdocket-ado",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*"
@@ -7109,7 +7022,7 @@
     },
     "packages/ai-reviewer": {
       "name": "devdocket-ai-reviewer",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*"
@@ -7545,7 +7458,7 @@
     },
     "packages/core": {
       "name": "devdocket",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*",
@@ -8681,7 +8594,7 @@
     },
     "packages/github": {
       "name": "devdocket-github",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*",
@@ -9127,7 +9040,7 @@
     },
     "packages/start-git-work": {
       "name": "devdocket-start-git-work",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*"

--- a/packages/ado/CHANGELOG.md
+++ b/packages/ado/CHANGELOG.md
@@ -1,4 +1,4 @@
-# devdocket-ado
+# DevDocket Azure DevOps
 
 ## 0.1.1
 

--- a/packages/ai-reviewer/CHANGELOG.md
+++ b/packages/ai-reviewer/CHANGELOG.md
@@ -1,4 +1,4 @@
-# devdocket-ai-reviewer
+# DevDocket AI Reviewer
 
 ## 0.1.1
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# devdocket
+# DevDocket
 
 ## 0.1.1
 

--- a/packages/github/CHANGELOG.md
+++ b/packages/github/CHANGELOG.md
@@ -1,4 +1,4 @@
-# devdocket-github
+# DevDocket GitHub
 
 ## 0.1.1
 

--- a/packages/start-git-work/CHANGELOG.md
+++ b/packages/start-git-work/CHANGELOG.md
@@ -1,4 +1,4 @@
-# devdocket-start-git-work
+# DevDocket Start Git Work
 
 ## 0.1.1
 


### PR DESCRIPTION
## Summary

The Marketplace's Changelog tab renders `CHANGELOG.md` from the published `.vsix`. Changesets initializes each CHANGELOG.md with `# {pkg.name}`, which gave the 5 publishable extensions developer-flavored H1s (`# devdocket-start-git-work`, `# devdocket-ai-reviewer`, …) instead of the user-facing brand names.

Rewrite the H1 of each publishable extension's `CHANGELOG.md` to use the extension's `displayName`.

## Before / After

| Package | Before | After |
|---|---|---|
| `core` | `# devdocket` | `# DevDocket` |
| `github` | `# devdocket-github` | `# DevDocket GitHub` |
| `ado` | `# devdocket-ado` | `# DevDocket Azure DevOps` |
| `start-git-work` | `# devdocket-start-git-work` | `# DevDocket Start Git Work` |
| `ai-reviewer` | `# devdocket-ai-reviewer` | `# DevDocket AI Reviewer` |
| `shared` | `# @devdocket/shared` | `# @devdocket/shared` (unchanged — npm, not Marketplace) |

`@devdocket/shared` is intentionally left as-is since it publishes to GitHub Packages, where the npm package name is the conventional display.

## Why one-time edits are enough

Changesets only writes the `# {pkg.name}` H1 when CHANGELOG.md does **not** yet exist. On every subsequent `changeset version` run it just prepends a new `## X.Y.Z` section and leaves the H1 alone. So this one-time fix sticks.

If a new publishable extension is added later, its initial CHANGELOG.md will get the npm-name H1 and need a one-line follow-up edit — easy to spot in the resulting Version Packages PR review.

## No changeset

Documentation-style change to CHANGELOG.md heading lines only — no behavior change in any publishable package.
