### PR TITLE
Improve startup experience for new users and standardize "recognized" spelling

### DIFF
--- a/.changeset/improve-new-user-onboarding.md
+++ b/.changeset/improve-new-user-onboarding.md
@@ -1,0 +1,5 @@
+---
+"devdocket": minor
+---
+
+Improve the new-user startup experience. The **My Work** tab now shows the same friendly onboarding empty state as the **Sources** tab — both empty states now offer "Create Work Item", "Browse Provider Extensions", and "Open Walkthrough" buttons — instead of a bare "No items yet" placeholder on My Work. The walkthrough's extensions link and the new button both open the Extensions view filtered to the DevDocket publisher. The "No provider recognized this URL" error (spelling updated from the previous British form) now includes a "Browse Provider Extensions" action that opens the same filtered view, and a new `devdocket.browseProviderExtensions` command is registered.

--- a/.github/instructions/start-git-work.instructions.md
+++ b/.github/instructions/start-git-work.instructions.md
@@ -56,4 +56,4 @@ Cleanup operations log `'cleanup'` or `'cleanup-dismissed'` entries with plain-t
 
 ### Bumping the schema
 
-If the payload shape needs to change, introduce a new `WorkStartedDetailV2` interface, update the encoder to write `v: 2`, and update the decoder to recognise both versions. Update `renderWorkStartedActivityDetail` to render the new fields. All of this lives inside `workStartedDetail.ts`; the core extension does not need to be touched. Renaming or removing existing fields without a version bump silently breaks cleanup for every pre-existing activity entry.
+If the payload shape needs to change, introduce a new `WorkStartedDetailV2` interface, update the encoder to write `v: 2`, and update the decoder to recognize both versions. Update `renderWorkStartedActivityDetail` to render the new fields. All of this lives inside `workStartedDetail.ts`; the core extension does not need to be touched. Renaming or removing existing fields without a version bump silently breaks cleanup for every pre-existing activity entry.

--- a/docs/provider-api.md
+++ b/docs/provider-api.md
@@ -352,7 +352,7 @@ class JiraProvider implements DevDocketProvider {
 - **`refresh()` is called by DevDocket** — It is invoked automatically when the provider is registered for initial discovery. It must be safe to call multiple times. DevDocket passes a `CancellationToken` and enforces a refresh timeout; providers should check `token.isCancellationRequested` before and during long-running operations.
 - **`externalId` must be unique per provider** — DevDocket uses the combination of `providerId + externalId` to track inbox state. Use a stable identifier like `owner/repo#123` or `PROJECT/TICKET-42`.
 - **`group` is optional** — When set, items with the same group value are nested under a folder node in the Sources tab and surfaced as a small annotation below the title on each item card.
-- **`resolveUrl()` is optional** — Implement it to let users create work items by pasting a URL (e.g. from a browser). When the user runs the "Create Item from URL" command, DevDocket asks each registered provider to resolve the URL. The first provider that returns a `ResolvedItem` wins. If your provider doesn't recognise the URL, return `undefined`.
+- **`resolveUrl()` is optional** — Implement it to let users create work items by pasting a URL (e.g. from a browser). When the user runs the "Create Item from URL" command, DevDocket asks each registered provider to resolve the URL. The first provider that returns a `ResolvedItem` wins. If your provider doesn't recognize the URL, return `undefined`.
 - **`getClosedItems()` is optional** — Implement it to enable auto-completion of work items when their linked external item is closed or merged. After each provider refresh, DevDocket collects all work items in the WorkGraph linked to your provider (including manually-imported items) and calls `getClosedItems()` with their external IDs. Return the subset that are closed, merged, or completed. Providers without this method fall back to **disappearance detection** — if a previously-discovered item is absent from the next refresh, it is assumed closed. The disappearance fallback cannot cover manually-imported items since the provider never discovered them. Auto-completion is controlled by the `devDocket.autoCompleteOnClose` setting (default: `true`).
 - **Emit the full set every time** — Each `onDidDiscoverItems` emission replaces all previously known items for that provider. Emit everything currently relevant, not just deltas.
 
@@ -695,7 +695,7 @@ interface DevDocketProvider {
   /**
    * Attempt to resolve a URL into an item this provider can manage.
    * Return a ResolvedItem if the URL matches a pattern your provider
-   * owns (e.g. a GitHub issue URL), or undefined if not recognised.
+   * owns (e.g. a GitHub issue URL), or undefined if not recognized.
    * Optional — providers that don't support URL import omit this.
    *
    * @param url - The raw URL entered by the user.
@@ -721,7 +721,7 @@ interface DevDocketProvider {
 
 ### `ResolvedItem`
 
-Returned by `resolveUrl()` when a provider recognises a URL. Contains enough detail for DevDocket to create a work item.
+Returned by `resolveUrl()` when a provider recognizes a URL. Contains enough detail for DevDocket to create a work item.
 
 ```ts
 interface ResolvedItem {

--- a/packages/core/media/walkthroughs/providers.md
+++ b/packages/core/media/walkthroughs/providers.md
@@ -13,7 +13,7 @@ Discovers:
 Each item shows badges in the editor for upstream state (Open / Closed) and PR review status (Approved / Changes requested / etc.) so you can prioritize at a glance.
 
 **Setup:**
-1. Install the **DevDocket GitHub** extension (if not already installed)
+1. Install the **DevDocket GitHub** extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=devdocket.devdocket-github)
 2. Authenticate with GitHub when prompted
 3. Configure which repositories to watch via settings
 
@@ -24,7 +24,7 @@ Discovers:
 - Pull requests you authored
 
 **Setup:**
-1. Install the **DevDocket Azure DevOps** extension
+1. Install the **DevDocket Azure DevOps** extension from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=devdocket.devdocket-ado)
 2. Configure your organization and project
 3. Authenticate when prompted
 
@@ -32,4 +32,4 @@ Discovers:
 
 **Tip:** Once a provider is connected, browse everything it knows about under the **Sources** tab of the DevDocket sidebar — even items that haven't surfaced in your Incoming tier yet.
 
-[Open Extensions](command:workbench.view.extensions)
+[Browse DevDocket Extensions](command:devdocket.browseProviderExtensions)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -415,6 +415,11 @@
         "category": "DevDocket"
       },
       {
+        "command": "devdocket.browseProviderExtensions",
+        "title": "Browse Provider Extensions",
+        "category": "DevDocket"
+      },
+      {
         "command": "devdocket.toggleSearch",
         "title": "Toggle Search",
         "category": "DevDocket",

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -63,6 +63,23 @@ function formatItemTitle(item: { group?: string; title: string }): string {
 
 // isSafeUrl is imported from ../utils/url.
 
+/**
+ * Label for the notification action button that opens the VS Code Extensions
+ * view filtered to DevDocket-published extensions. Shared between the action
+ * registration and the post-await `if (action === ...)` check so they cannot
+ * drift apart silently.
+ */
+const BROWSE_PROVIDER_EXTENSIONS_ACTION = 'Browse Provider Extensions';
+
+/**
+ * Open the VS Code Extensions view filtered to extensions published by the
+ * "devdocket" publisher. Used by the URL-import error notification and by
+ * onboarding empty states so new users can discover provider extensions.
+ */
+async function browseProviderExtensions(): Promise<void> {
+  await vscode.commands.executeCommand('workbench.extensions.search', '@publisher:"devdocket"');
+}
+
 /** Log the error and show a user-facing message. */
 function handleCommandError(context: string, err: unknown): void {
   logger.error(context, err);
@@ -347,7 +364,13 @@ async function handleCreateItemFromUrl(
   }
 
   if (!details) {
-    void vscode.window.showErrorMessage('DevDocket: No provider recognised this URL');
+    const action = await vscode.window.showErrorMessage(
+      'DevDocket: No provider recognized this URL',
+      BROWSE_PROVIDER_EXTENSIONS_ACTION,
+    );
+    if (action === BROWSE_PROVIDER_EXTENSIONS_ACTION) {
+      await browseProviderExtensions();
+    }
     return;
   }
 
@@ -820,6 +843,8 @@ export function registerCommands(
           false,
         ),
       )),
+    vscode.commands.registerCommand('devdocket.browseProviderExtensions',
+      wrapCommand('Failed to open Extensions view', () => browseProviderExtensions())),
     vscode.commands.registerCommand('devdocket.createItem',
       wrapCommand('Failed to create item', () => handleCreateItem(context, workGraph, providerRegistry, labelCache, editorPanelDependencies))),
     vscode.commands.registerCommand('devdocket.createItemFromUrl',

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -278,7 +278,7 @@ export class ProviderRegistry {
 
   /**
    * Ask each registered provider to resolve a URL.
-   * Returns the first successful result, or `undefined` if no provider recognises the URL.
+   * Returns the first successful result, or `undefined` if no provider recognizes the URL.
    */
   async resolveUrl(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined> {
     for (const provider of this.providers.values()) {
@@ -288,7 +288,7 @@ export class ProviderRegistry {
         if (result) { return { ...result, providerId: provider.id }; }
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') { throw error; }
-        // Provider recognised the URL but failed (e.g. 404, auth error) — surface to user
+        // Provider recognized the URL but failed (e.g. 404, auth error) — surface to user
         logger.warn(`Provider ${provider.id} failed to resolve URL`, error);
         throw error;
       }

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -232,6 +232,7 @@ describe('registerCommands', () => {
       'devdocket.addActivity',
       'devdocket.watchUrl',
       'devdocket.showWatchesQuickPick',
+      'devdocket.browseProviderExtensions',
     ];
     for (const cmd of expected) {
       expect(commandHandlers.has(cmd), `missing command: ${cmd}`).toBe(true);
@@ -302,6 +303,19 @@ describe('registerCommands', () => {
       await invoke('devdocket.showWatchesQuickPick');
 
       expect(watchPanelProvider.open).toHaveBeenCalled();
+    });
+  });
+
+  // ── browseProviderExtensions ─────────────────────────────────────
+
+  describe('devdocket.browseProviderExtensions', () => {
+    it('opens the Extensions view filtered to the devdocket publisher', async () => {
+      await invoke('devdocket.browseProviderExtensions');
+
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        'workbench.extensions.search',
+        '@publisher:"devdocket"',
+      );
     });
   });
 
@@ -397,14 +411,28 @@ describe('registerCommands', () => {
       );
     });
 
-    it('shows error when no provider recognises the URL', async () => {
+    it('shows error when no provider recognizes the URL', async () => {
       providerRegistry.resolveUrl.mockResolvedValue(undefined);
       (vscode.window.showInputBox as Mock).mockResolvedValue('https://invalid.com/something');
+      (vscode.window.showErrorMessage as Mock).mockResolvedValue(undefined);
       await invoke('devdocket.createItemFromUrl');
 
       expect(workGraph.createItem).not.toHaveBeenCalled();
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: No provider recognised this URL',
+        'DevDocket: No provider recognized this URL',
+        'Browse Provider Extensions',
+      );
+    });
+
+    it('opens the Extensions view filtered by publisher when user clicks Browse Provider Extensions', async () => {
+      providerRegistry.resolveUrl.mockResolvedValue(undefined);
+      (vscode.window.showInputBox as Mock).mockResolvedValue('https://invalid.com/something');
+      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Browse Provider Extensions');
+      await invoke('devdocket.createItemFromUrl');
+
+      expect(vscode.commands.executeCommand).toHaveBeenCalledWith(
+        'workbench.extensions.search',
+        '@publisher:"devdocket"',
       );
     });
 

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -851,9 +851,11 @@ describe('MainViewProvider', () => {
 
     await mockView.simulateMessage({ type: 'createItem' });
     await mockView.simulateMessage({ type: 'openWalkthrough' });
+    await mockView.simulateMessage({ type: 'browseProviderExtensions' });
 
     expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.createItem');
     expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.openWalkthrough');
+    expect(vscode.commands.executeCommand).toHaveBeenCalledWith('devdocket.browseProviderExtensions');
   });
 
   it('handles reorderItems messages through the webview message switch', async () => {

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -24,6 +24,7 @@ export type WebviewMessage =
   | { type: 'reorderItems'; itemIds: string[] }
   | { type: 'createItem' }
   | { type: 'openWalkthrough' }
+  | { type: 'browseProviderExtensions' }
   | { type: 'clearHistory' }
   | { type: 'runAction'; itemId: string }
   | { type: 'openWatches' }

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -535,6 +535,9 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       case 'openWalkthrough':
         await vscode.commands.executeCommand('devdocket.openWalkthrough');
         break;
+      case 'browseProviderExtensions':
+        await vscode.commands.executeCommand('devdocket.browseProviderExtensions');
+        break;
       case 'clearHistory':
         await vscode.commands.executeCommand('devdocket.clearHistory');
         break;

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -19,8 +19,8 @@ import {
 export function App() {
   const [activeTab, setActiveTab] = useState<SidebarTab>('myWork');
   const [tiers, setTiers] = useState<TierData[]>([]);
+  const [tiersLoaded, setTiersLoaded] = useState(false);
   const [sources, setSources] = useState<SourceProviderData[]>([]);
-  const [hasReceivedItems, setHasReceivedItems] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const [queries, setQueries] = useState<TabQueries>(emptyQueries);
   const [appliedQueries, setAppliedQueries] = useState<TabQueries>(emptyQueries);
@@ -112,8 +112,8 @@ export function App() {
             announce(buildLiveAnnouncement(previousTiers, nextTiers));
           }
           previousTiersRef.current = nextTiers;
-          setHasReceivedItems(true);
           setTiers(nextTiers);
+          setTiersLoaded(true);
           break;
         }
         case 'updateSources':
@@ -276,9 +276,7 @@ export function App() {
             ) : null}
             {isMyWorkFilterActive && myWorkVisibleCount === 0 ? (
               <NoMatches query={myWorkQuery} onClear={() => clearQuery('myWork')} />
-            ) : !isMyWorkFilterActive && !hasReceivedItems ? (
-              <div class="empty-state">No items yet</div>
-            ) : !isMyWorkFilterActive && tiers.every(tier => tier.items.length === 0) ? (
+            ) : !isMyWorkFilterActive && tiersLoaded && tiers.every(tier => tier.items.length === 0) ? (
               <EmptyMyWork />
             ) : (
               <div class="tiers">

--- a/packages/core/src/webview/sidebar/components/OnboardingEmptyState.tsx
+++ b/packages/core/src/webview/sidebar/components/OnboardingEmptyState.tsx
@@ -21,6 +21,13 @@ export function OnboardingEmptyState({ description, titleId }: OnboardingEmptySt
         <button
           type="button"
           class="onboarding-empty-state-button onboarding-empty-state-button-secondary"
+          onClick={() => postMessage({ type: 'browseProviderExtensions' })}
+        >
+          Browse Provider Extensions
+        </button>
+        <button
+          type="button"
+          class="onboarding-empty-state-button onboarding-empty-state-button-secondary"
           onClick={() => postMessage({ type: 'openWalkthrough' })}
         >
           Open Walkthrough

--- a/packages/shared/src/apiTypes.ts
+++ b/packages/shared/src/apiTypes.ts
@@ -96,7 +96,7 @@ export interface DevDocketProvider {
    * Providers that support URL import should parse the URL and, if it
    * matches a pattern they own (e.g. a GitHub issue URL), fetch the
    * item details and return a {@link ResolvedItem}. Return `undefined`
-   * if the URL is not recognised by this provider.
+   * if the URL is not recognized by this provider.
    *
    * @param url - The raw URL entered by the user.
    * @param signal - Optional abort signal for cancellation.

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -187,7 +187,7 @@ export interface ProviderBadge {
 }
 
 /**
- * Result returned by a provider's `resolveUrl` method when it recognises a URL.
+ * Result returned by a provider's `resolveUrl` method when it recognizes a URL.
  * Contains enough detail for the core extension to create a work item.
  */
 export interface ResolvedItem {

--- a/packages/start-git-work/src/workStartedDetail.ts
+++ b/packages/start-git-work/src/workStartedDetail.ts
@@ -12,7 +12,7 @@ import type { ActivityDetailRender } from '@devdocket/shared';
  * the shape is treated as a stable, versioned contract rather
  * than a free-form string. Any change to the payload shape
  * MUST bump the version (e.g. introduce `WorkStartedDetailV2`)
- * and update {@link decodeWorkStartedDetail} to recognise the
+ * and update {@link decodeWorkStartedDetail} to recognize the
  * new version alongside the old one.
  *
  * `repoPath` is required: every write site has a known repo,
@@ -78,7 +78,7 @@ export function encodeWorkStartedDetail(input: Readonly<WorkStartedDetailInput>)
  *   payloads of the same shape. This preserves the cleanup
  *   prompt for activity logs created prior to this change.
  * - Logs a warning and returns `undefined` for entries whose
- *   `v` is present but unrecognised. This makes future
+ *   `v` is present but unrecognized. This makes future
  *   schema mismatches visible in the logs instead of
  *   silently downgrading cleanup to a no-op.
  * - Returns `undefined` when the payload is missing the


### PR DESCRIPTION
## Summary

Improves the startup experience for new users — especially those who installed only the **Core** extension and haven't added any provider extensions yet — and fixes a small en-GB/en-US spelling inconsistency along the way.

## Changes

### Sidebar onboarding parity (My Work ↔ Sources)

- The **My Work** tab no longer shows a bare `No items yet` placeholder. It now renders the same friendly `OnboardingEmptyState` that the **Sources** tab already uses.
- That shared empty state now exposes a third button — **Browse Provider Extensions** — alongside *Create Work Item* and *Open Walkthrough*. Both tabs benefit from this, since installing a provider extension is the natural next step on either side.
- To avoid the onboarding empty state flashing for *existing* users on every sidebar open, `App.tsx` tracks a `tiersLoaded` flag and only renders the empty state once the first `updateItems` message has arrived.

### Marketplace linking

- New `devdocket.browseProviderExtensions` command runs `workbench.extensions.search` with `@publisher:"devdocket"`, which is the actual VS Code search syntax for the lowercase `devdocket` publisher ID.
- The walkthrough (`media/walkthroughs/providers.md`) now:
  - links each provider setup step directly to its Marketplace page, and
  - replaces the generic `[Open Extensions]` link with `[Browse DevDocket Extensions]` pointing at the new command.
- The "No provider recognized this URL" error notification gained a **Browse Provider Extensions** action that opens the same filtered Extensions view.

### Spelling

Renamed all `recognis*` → `recogniz*` across error strings, JSDoc, code comments, `docs/provider-api.md`, and `.github/instructions/start-git-work.instructions.md`. Verified with `rg -i recognis` returning no matches.

## Tests

- Added test for the new `devdocket.browseProviderExtensions` command, asserting it invokes `workbench.extensions.search` with `@publisher:"devdocket"`.
- Added test that clicking **Browse Provider Extensions** on the URL-import error triggers the search command.
- Added the new command to the `registers all expected commands` list.
- Updated the renamed error-message test.
- Extended `mainViewProvider.test.ts` onboarding-message coverage to include the new `browseProviderExtensions` webview message.

Full suite: 2,182 tests pass across all packages.

## Changeset

`.changeset/improve-new-user-onboarding.md` — `devdocket: minor`. The shared and start-git-work edits are comment/doc-only so they don't warrant changeset entries.

## API surface

No public API surface changes. The new variant added to `WebviewMessage` lives in `packages/core/src/views/mainTypes.ts`, which is internal extension↔webview plumbing (not in the API surface list per `.github/instructions/api-surface.instructions.md`).
