### PR TITLE
Show loading state when sidebar opens before providers are ready

### DIFF
--- a/.changeset/sidebar-loading-state.md
+++ b/.changeset/sidebar-loading-state.md
@@ -1,0 +1,5 @@
+---
+"devdocket": patch
+---
+
+Show a loading indicator when the sidebar opens before providers complete their initial refresh, instead of showing an empty state.

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -960,6 +960,7 @@ describe('MainViewProvider', () => {
   });
 
   it('resends loading state when the sidebar webview is resolved again while providers are still loading', () => {
+    vi.useFakeTimers();
     const registry = createProviderRegistry({});
     registry.setLoading(true);
     const provider = createProvider(
@@ -975,6 +976,7 @@ describe('MainViewProvider', () => {
 
     provider.resolveWebviewView(secondView.view, {} as any, {} as any);
     expect(secondView.webview.postMessage).toHaveBeenCalledWith({ type: 'setLoading', loading: true });
+    provider.dispose();
   });
 
   it('retries refresh when providers have no items and none have refreshed successfully yet', () => {

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -132,6 +132,8 @@ function createProviderRegistry(
     getProviderItems: vi.fn((providerId: string) => discovered.get(providerId) ?? []),
     getProviderLabel: vi.fn((providerId: string) => labels[providerId] ?? providerId),
     getProviderHealth: vi.fn((providerId: string) => health[providerId] ?? { status: 'healthy' }),
+    get loading() { return false; },
+    get hasProviders() { return discovered.size > 0; },
   };
 }
 
@@ -919,5 +921,48 @@ describe('MainViewProvider', () => {
     expect(mockView.webview.postMessage).toHaveBeenCalledTimes(2);
     expect(findPostedMessage(mockView, 'updateItems')).toBeDefined();
     expect(findPostedMessage(mockView, 'updateSources')).toBeDefined();
+  });
+
+  it('sends loading state when providers are still loading on sidebar open', async () => {
+    vi.useFakeTimers();
+    const registry = createProviderRegistry({});
+    // Simulate providers still loading
+    Object.defineProperty(registry, 'loading', { get: () => true });
+    const provider = createProvider(
+      createMockWorkGraph([]),
+      registry,
+      createStateStore(),
+    );
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+
+    // setLoading(true) should be sent immediately (not debounced)
+    expect(mockView.webview.postMessage).toHaveBeenCalledWith({ type: 'setLoading', loading: true });
+
+    // After debounce fires, setLoading(false) should be sent (providers are "loaded" by the time refresh runs)
+    Object.defineProperty(registry, 'loading', { get: () => false });
+    await vi.advanceTimersByTimeAsync(50);
+
+    const messages = mockView.webview.postMessage.mock.calls.map((c: any) => c[0]);
+    expect(messages.some((m: any) => m.type === 'setLoading' && m.loading === false)).toBe(true);
+    expect(messages.some((m: any) => m.type === 'updateItems')).toBe(true);
+  });
+
+  it('does not send loading state when providers are already loaded', async () => {
+    vi.useFakeTimers();
+    const provider = createProvider(
+      createMockWorkGraph([]),
+      createProviderRegistry({}),
+      createStateStore(),
+    );
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+
+    // No setLoading sent before debounce fires
+    expect(mockView.webview.postMessage).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'setLoading' }),
+    );
   });
 });

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -956,6 +956,24 @@ describe('MainViewProvider', () => {
     expect(messages.some((m: any) => m.type === 'setLoading' && m.loading === false)).toBe(true);
   });
 
+  it('resends loading state when the sidebar webview is resolved again while providers are still loading', () => {
+    const registry = createProviderRegistry({});
+    registry.setLoading(true);
+    const provider = createProvider(
+      createMockWorkGraph([]),
+      registry,
+      createStateStore(),
+    );
+    const firstView = createMockWebviewView();
+    const secondView = createMockWebviewView();
+
+    provider.resolveWebviewView(firstView.view, {} as any, {} as any);
+    expect(firstView.webview.postMessage).toHaveBeenCalledWith({ type: 'setLoading', loading: true });
+
+    provider.resolveWebviewView(secondView.view, {} as any, {} as any);
+    expect(secondView.webview.postMessage).toHaveBeenCalledWith({ type: 'setLoading', loading: true });
+  });
+
   it('does not send loading state when providers are already loaded', async () => {
     vi.useFakeTimers();
     const provider = createProvider(

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -1028,5 +1028,6 @@ describe('MainViewProvider', () => {
     expect(mockView.webview.postMessage).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'setLoading' }),
     );
+    provider.dispose();
   });
 });

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -948,6 +948,7 @@ describe('MainViewProvider', () => {
     await vi.advanceTimersByTimeAsync(50);
 
     let messages = mockView.webview.postMessage.mock.calls.map((c: any) => c[0]);
+    expect(messages.filter((m: any) => m.type === 'setLoading' && m.loading === true)).toHaveLength(2);
     expect(messages.some((m: any) => m.type === 'setLoading' && m.loading === false)).toBe(false);
     expect(messages.some((m: any) => m.type === 'updateItems')).toBe(true);
 

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -978,6 +978,7 @@ describe('MainViewProvider', () => {
   });
 
   it('retries refresh when providers have no items and none have refreshed successfully yet', () => {
+    vi.useFakeTimers();
     const registry = createProviderRegistry({ github: [] });
     const provider = createProvider(
       createMockWorkGraph([]),
@@ -989,9 +990,11 @@ describe('MainViewProvider', () => {
     provider.resolveWebviewView(mockView.view, {} as any, {} as any);
 
     expect(registry.refreshAll).toHaveBeenCalledTimes(1);
+    provider.dispose();
   });
 
   it('does not retry refresh when providers previously refreshed successfully with no items', () => {
+    vi.useFakeTimers();
     const registry = createProviderRegistry({ github: [] }, {}, {
       github: { status: 'healthy', lastRefreshTime: new Date('2024-01-02T03:04:05Z') },
     });
@@ -1005,6 +1008,7 @@ describe('MainViewProvider', () => {
     provider.resolveWebviewView(mockView.view, {} as any, {} as any);
 
     expect(registry.refreshAll).not.toHaveBeenCalled();
+    provider.dispose();
   });
 
   it('does not send loading state when providers are already loaded', async () => {

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -124,17 +124,20 @@ function createMockWorkGraph(initialItems: WorkItem[] = []) {
 function createProviderRegistry(
   itemsByProvider: Record<string, TestProviderItem[]>,
   labels: Record<string, string> = {},
-  health: Record<string, { status: string }> = {},
+  initialHealth: Record<string, { status: string; lastRefreshTime?: Date }> = {},
 ) {
   const discovered = new Map<string, TestProviderItem[]>(Object.entries(itemsByProvider));
+  const health = new Map(Object.entries(initialHealth));
   let loading = false;
   return {
     getAllProviderItems: vi.fn(() => discovered),
     getProviderItems: vi.fn((providerId: string) => discovered.get(providerId) ?? []),
     getProviderLabel: vi.fn((providerId: string) => labels[providerId] ?? providerId),
-    getProviderHealth: vi.fn((providerId: string) => health[providerId] ?? { status: 'healthy' }),
+    getProviderHealth: vi.fn((providerId: string) => health.get(providerId) ?? { status: 'unknown' }),
+    refreshAll: vi.fn(async () => undefined),
     get loading() { return loading; },
     setLoading(value: boolean) { loading = value; },
+    setHealth(providerId: string, value: { status: string; lastRefreshTime?: Date }) { health.set(providerId, value); },
     get hasProviders() { return discovered.size > 0; },
   };
 }
@@ -972,6 +975,36 @@ describe('MainViewProvider', () => {
 
     provider.resolveWebviewView(secondView.view, {} as any, {} as any);
     expect(secondView.webview.postMessage).toHaveBeenCalledWith({ type: 'setLoading', loading: true });
+  });
+
+  it('retries refresh when providers have no items and none have refreshed successfully yet', () => {
+    const registry = createProviderRegistry({ github: [] });
+    const provider = createProvider(
+      createMockWorkGraph([]),
+      registry,
+      createStateStore(),
+    );
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+
+    expect(registry.refreshAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry refresh when providers previously refreshed successfully with no items', () => {
+    const registry = createProviderRegistry({ github: [] }, {}, {
+      github: { status: 'healthy', lastRefreshTime: new Date('2024-01-02T03:04:05Z') },
+    });
+    const provider = createProvider(
+      createMockWorkGraph([]),
+      registry,
+      createStateStore(),
+    );
+    const mockView = createMockWebviewView();
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+
+    expect(registry.refreshAll).not.toHaveBeenCalled();
   });
 
   it('does not send loading state when providers are already loaded', async () => {

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -127,12 +127,14 @@ function createProviderRegistry(
   health: Record<string, { status: string }> = {},
 ) {
   const discovered = new Map<string, TestProviderItem[]>(Object.entries(itemsByProvider));
+  let loading = false;
   return {
     getAllProviderItems: vi.fn(() => discovered),
     getProviderItems: vi.fn((providerId: string) => discovered.get(providerId) ?? []),
     getProviderLabel: vi.fn((providerId: string) => labels[providerId] ?? providerId),
     getProviderHealth: vi.fn((providerId: string) => health[providerId] ?? { status: 'healthy' }),
-    get loading() { return false; },
+    get loading() { return loading; },
+    setLoading(value: boolean) { loading = value; },
     get hasProviders() { return discovered.size > 0; },
   };
 }
@@ -925,11 +927,10 @@ describe('MainViewProvider', () => {
     expect(findPostedMessage(mockView, 'updateSources')).toBeDefined();
   });
 
-  it('sends loading state when providers are still loading on sidebar open', async () => {
+  it('keeps loading state active until providers finish their initial refresh', async () => {
     vi.useFakeTimers();
     const registry = createProviderRegistry({});
-    // Simulate providers still loading
-    Object.defineProperty(registry, 'loading', { get: () => true });
+    registry.setLoading(true);
     const provider = createProvider(
       createMockWorkGraph([]),
       registry,
@@ -939,16 +940,20 @@ describe('MainViewProvider', () => {
 
     provider.resolveWebviewView(mockView.view, {} as any, {} as any);
 
-    // setLoading(true) should be sent immediately (not debounced)
     expect(mockView.webview.postMessage).toHaveBeenCalledWith({ type: 'setLoading', loading: true });
 
-    // After debounce fires, setLoading(false) should be sent (providers are "loaded" by the time refresh runs)
-    Object.defineProperty(registry, 'loading', { get: () => false });
     await vi.advanceTimersByTimeAsync(50);
 
-    const messages = mockView.webview.postMessage.mock.calls.map((c: any) => c[0]);
-    expect(messages.some((m: any) => m.type === 'setLoading' && m.loading === false)).toBe(true);
+    let messages = mockView.webview.postMessage.mock.calls.map((c: any) => c[0]);
+    expect(messages.some((m: any) => m.type === 'setLoading' && m.loading === false)).toBe(false);
     expect(messages.some((m: any) => m.type === 'updateItems')).toBe(true);
+
+    registry.setLoading(false);
+    provider.scheduleRefresh('discovered');
+    await vi.advanceTimersByTimeAsync(50);
+
+    messages = mockView.webview.postMessage.mock.calls.map((c: any) => c[0]);
+    expect(messages.some((m: any) => m.type === 'setLoading' && m.loading === false)).toBe(true);
   });
 
   it('does not send loading state when providers are already loaded', async () => {

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -7,6 +7,7 @@ export type ExtensionMessage =
   | { type: 'updateSources'; providers: SourceProviderData[] }
   | { type: 'selectItem'; itemId: string }
   | { type: 'toggleSearch' }
+  | { type: 'setLoading'; loading: boolean }
   | { type: 'updateWatches'; watches: WatchData[] }
   | { type: 'updateWatchPanel'; prWatches: PRWatchData[]; runWatches: RunWatchData[] }
   | { type: 'updateEditorItem'; item: EditorItemData }

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -76,6 +76,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     _token: vscode.CancellationToken,
   ): void {
     this.view = webviewView;
+    this.loadingSent = false;
 
     webviewView.webview.options = {
       enableScripts: true,

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -45,6 +45,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
   private refreshTimer?: ReturnType<typeof setTimeout>;
   private pendingRefreshReasons = new Set<RefreshReason>();
   private disposed = false;
+  private loadingSent = false;
 
   constructor(
     private readonly extensionUri: vscode.Uri,
@@ -86,6 +87,14 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       void this.handleMessage(message);
     });
 
+    // Send loading state if providers are registered but haven't completed
+    // their initial refresh yet. This shows a "Loading providers…" message
+    // instead of the empty/onboarding state while data is being fetched.
+    if (this.providerRegistry.loading) {
+      void webviewView.webview.postMessage({ type: 'setLoading', loading: true });
+      this.loadingSent = true;
+    }
+
     this.scheduleRefresh('discovered');
   }
 
@@ -116,6 +125,12 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
   private refresh(reasons: ReadonlySet<RefreshReason>): void {
     if (!this.view) {
       return;
+    }
+
+    // Clear loading indicator once providers have data
+    if (this.loadingSent && (reasons.has('discovered') || reasons.has('health'))) {
+      void this.view.webview.postMessage({ type: 'setLoading', loading: false });
+      this.loadingSent = false;
     }
 
     const allProviderItems = this.providerRegistry.getAllProviderItems();

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -94,6 +94,21 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     this.syncLoadingState();
 
     this.scheduleRefresh('discovered');
+
+    // If providers are registered but none have emitted items yet (e.g. a
+    // fresh VS Code instance where the initial refresh timed out or auth
+    // wasn't available), trigger a full user-level refresh so providers
+    // re-authenticate and fetch data. Without this, background refreshes
+    // may silently skip (createIfNone: false returns no session) and the
+    // sidebar stays permanently empty.
+    if (this.providerRegistry.hasProviders && !this.providerRegistry.loading) {
+      const allItems = this.providerRegistry.getAllProviderItems();
+      const hasAnyItems = Array.from(allItems.values()).some(items => items.length > 0);
+      if (!hasAnyItems) {
+        logger.debug('Sidebar opened with registered providers but no items — triggering refresh');
+        void this.providerRegistry.refreshAll();
+      }
+    }
   }
 
   scheduleRefresh(reason: RefreshReason): void {

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -95,20 +95,32 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
 
     this.scheduleRefresh('discovered');
 
-    // If providers are registered but none have emitted items yet (e.g. a
-    // fresh VS Code instance where the initial refresh timed out or auth
-    // wasn't available), trigger a full user-level refresh so providers
-    // re-authenticate and fetch data. Without this, background refreshes
-    // may silently skip (createIfNone: false returns no session) and the
-    // sidebar stays permanently empty.
-    if (this.providerRegistry.hasProviders && !this.providerRegistry.loading) {
-      const allItems = this.providerRegistry.getAllProviderItems();
-      const hasAnyItems = Array.from(allItems.values()).some(items => items.length > 0);
-      if (!hasAnyItems) {
-        logger.debug('Sidebar opened with registered providers but no items — triggering refresh');
-        void this.providerRegistry.refreshAll();
-      }
+    // If providers are registered, no items are visible, and at least one
+    // provider has never completed a successful refresh (e.g. a fresh VS Code
+    // instance where the initial refresh timed out or auth wasn't available),
+    // trigger a full user-level refresh so providers re-authenticate and fetch
+    // data. This avoids retrying on every sidebar open for users who
+    // legitimately have zero discoverable items.
+    if (this.shouldRetryEmptySidebarRefresh()) {
+      logger.debug('Sidebar opened before providers completed a successful refresh — triggering refresh');
+      void this.providerRegistry.refreshAll();
     }
+  }
+
+  private shouldRetryEmptySidebarRefresh(): boolean {
+    if (!this.providerRegistry.hasProviders || this.providerRegistry.loading) {
+      return false;
+    }
+
+    const allItems = this.providerRegistry.getAllProviderItems();
+    const hasAnyItems = Array.from(allItems.values()).some(items => items.length > 0);
+    if (hasAnyItems) {
+      return false;
+    }
+
+    return Array.from(allItems.keys()).some(
+      providerId => this.providerRegistry.getProviderHealth(providerId).lastRefreshTime === undefined,
+    );
   }
 
   scheduleRefresh(reason: RefreshReason): void {

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -87,13 +87,10 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       void this.handleMessage(message);
     });
 
-    // Send loading state if providers are registered but haven't completed
-    // their initial refresh yet. This shows a "Loading providers…" message
-    // instead of the empty/onboarding state while data is being fetched.
-    if (this.providerRegistry.loading) {
-      void webviewView.webview.postMessage({ type: 'setLoading', loading: true });
-      this.loadingSent = true;
-    }
+    // Sync loading state immediately so the sidebar shows a loading
+    // placeholder instead of the empty/onboarding state while providers are
+    // still completing their initial refresh.
+    this.syncLoadingState();
 
     this.scheduleRefresh('discovered');
   }
@@ -122,16 +119,26 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     void this.view?.webview.postMessage({ type: 'toggleSearch' });
   }
 
+  private syncLoadingState(): void {
+    if (!this.view) {
+      return;
+    }
+
+    const loading = this.providerRegistry.loading;
+    if (loading === this.loadingSent) {
+      return;
+    }
+
+    void this.view.webview.postMessage({ type: 'setLoading', loading });
+    this.loadingSent = loading;
+  }
+
   private refresh(reasons: ReadonlySet<RefreshReason>): void {
     if (!this.view) {
       return;
     }
 
-    // Clear loading indicator once providers have data
-    if (this.loadingSent && (reasons.has('discovered') || reasons.has('health'))) {
-      void this.view.webview.postMessage({ type: 'setLoading', loading: false });
-      this.loadingSent = false;
-    }
+    this.syncLoadingState();
 
     const allProviderItems = this.providerRegistry.getAllProviderItems();
     const relatedItemsIndex = buildRelatedItemsIndex(this.providerRegistry, this.workGraph, allProviderItems);

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -46,6 +46,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
   private pendingRefreshReasons = new Set<RefreshReason>();
   private disposed = false;
   private loadingSent = false;
+  private forceLoadingSyncOnNextRefresh = false;
 
   constructor(
     private readonly extensionUri: vscode.Uri,
@@ -77,6 +78,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
   ): void {
     this.view = webviewView;
     this.loadingSent = false;
+    this.forceLoadingSyncOnNextRefresh = this.providerRegistry.loading;
 
     webviewView.webview.options = {
       enableScripts: true,
@@ -147,13 +149,13 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     void this.view?.webview.postMessage({ type: 'toggleSearch' });
   }
 
-  private syncLoadingState(): void {
+  private syncLoadingState(force = false): void {
     if (!this.view) {
       return;
     }
 
     const loading = this.providerRegistry.loading;
-    if (loading === this.loadingSent) {
+    if (!force && loading === this.loadingSent) {
       return;
     }
 
@@ -166,7 +168,9 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       return;
     }
 
-    this.syncLoadingState();
+    const forceLoadingSync = this.forceLoadingSyncOnNextRefresh;
+    this.forceLoadingSyncOnNextRefresh = false;
+    this.syncLoadingState(forceLoadingSync);
 
     const allProviderItems = this.providerRegistry.getAllProviderItems();
     const relatedItemsIndex = buildRelatedItemsIndex(this.providerRegistry, this.workGraph, allProviderItems);

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -21,6 +21,7 @@ export function App() {
   const [tiers, setTiers] = useState<TierData[]>([]);
   const [sources, setSources] = useState<SourceProviderData[]>([]);
   const [hasReceivedItems, setHasReceivedItems] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [selectedItemId, setSelectedItemId] = useState<string | null>(null);
   const [queries, setQueries] = useState<TabQueries>(emptyQueries);
   const [appliedQueries, setAppliedQueries] = useState<TabQueries>(emptyQueries);
@@ -113,11 +114,15 @@ export function App() {
           }
           previousTiersRef.current = nextTiers;
           setHasReceivedItems(true);
+          setIsLoading(false);
           setTiers(nextTiers);
           break;
         }
         case 'updateSources':
           setSources(msg.providers);
+          break;
+        case 'setLoading':
+          setIsLoading(msg.loading);
           break;
         case 'selectItem':
           setSelectedItemId(msg.itemId);
@@ -276,6 +281,8 @@ export function App() {
             ) : null}
             {isMyWorkFilterActive && myWorkVisibleCount === 0 ? (
               <NoMatches query={myWorkQuery} onClear={() => clearQuery('myWork')} />
+            ) : !isMyWorkFilterActive && isLoading ? (
+              <div class="empty-state" role="status">Loading providers…</div>
             ) : !isMyWorkFilterActive && !hasReceivedItems ? (
               <div class="empty-state">No items yet</div>
             ) : !isMyWorkFilterActive && tiers.every(tier => tier.items.length === 0) ? (

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -51,6 +51,8 @@ export function App() {
   const visibleSources = filteredSources?.providers ?? sources;
   const myWorkVisibleCount = getTierItemCount(visibleTiers);
   const sourcesVisibleCount = getProviderItemCount(visibleSources);
+  const hasMyWorkItems = tiers.some(tier => tier.items.length > 0);
+  const showLoadingPlaceholder = isLoading && !hasMyWorkItems;
   const myWorkSearchBoxVisible = isSearchBoxEffectivelyVisible('myWork', searchBoxVisible, queries, appliedQueries);
   const sourcesSearchBoxVisible = isSearchBoxEffectivelyVisible('sources', searchBoxVisible, queries, appliedQueries);
 
@@ -280,7 +282,7 @@ export function App() {
             ) : null}
             {isMyWorkFilterActive && myWorkVisibleCount === 0 ? (
               <NoMatches query={myWorkQuery} onClear={() => clearQuery('myWork')} />
-            ) : !isMyWorkFilterActive && isLoading ? (
+            ) : !isMyWorkFilterActive && showLoadingPlaceholder ? (
               <div class="empty-state" role="status">Loading providers…</div>
             ) : !isMyWorkFilterActive && tiersLoaded && tiers.every(tier => tier.items.length === 0) ? (
               <EmptyMyWork />

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -113,7 +113,6 @@ export function App() {
             announce(buildLiveAnnouncement(previousTiers, nextTiers));
           }
           previousTiersRef.current = nextTiers;
-          setIsLoading(false);
           setTiers(nextTiers);
           setTiersLoaded(true);
           break;


### PR DESCRIPTION
## Summary
- send an explicit loading-state message when the sidebar opens before providers finish their initial refresh
- show a "Loading providers…" placeholder in the sidebar instead of the empty/onboarding state during that initial load
- trigger a full provider `refreshAll()` when the sidebar opens with registered providers but no items yet so a first-open notification flow repopulates the sidebar immediately
- add coverage for the sidebar loading-state and empty-provider refresh paths, plus a patch changeset for the core extension

## Testing
- npm run build
- npm run test

Closes #624