### PR TITLE
Throttle provider refreshes in unfocused windows

### DIFF
--- a/.changeset/focus-gating-623.md
+++ b/.changeset/focus-gating-623.md
@@ -3,4 +3,4 @@
 "devdocket": patch
 ---
 
-Add focus-aware refresh gating so background provider refreshes are skipped when the VS Code window is unfocused, reducing redundant API calls across multiple windows.
+Throttle background provider refreshes when the VS Code window is unfocused so background windows still poll for new notifications while reducing redundant API calls across multiple windows.

--- a/.changeset/focus-gating-623.md
+++ b/.changeset/focus-gating-623.md
@@ -1,0 +1,6 @@
+---
+"@devdocket/shared": minor
+"devdocket": patch
+---
+
+Add focus-aware refresh gating so background provider refreshes are skipped when the VS Code window is unfocused, reducing redundant API calls across multiple windows.

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -107,6 +107,7 @@ export class AdoWorkItemProvider extends BaseProvider {
       }
 
       await this.fetchAndPublishWorkItems(session.accessToken, true, abortController.signal);
+      this.markRefreshSuccess();
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
         logger.debug('ADO work items fetch aborted due to cancellation');

--- a/packages/ado/src/baseAdoPrProvider.ts
+++ b/packages/ado/src/baseAdoPrProvider.ts
@@ -102,6 +102,7 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
       }
 
       await this.fetchAndPublishPrs(session.accessToken, true, session.account.id, abortController.signal);
+      this.markRefreshSuccess();
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError' && abortController.signal.aborted && token?.isCancellationRequested) {
         logger.debug(`ADO ${this.logLabel} fetch aborted due to cancellation`);

--- a/packages/ado/src/test/adoPrReviewProvider.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.test.ts
@@ -696,18 +696,18 @@ describe('AdoPrReviewProvider', () => {
     expect(listener).toHaveBeenCalledWith([]);
   });
 
-  it('startPeriodicRefresh schedules a repeating timer', () => {
+  it('startPeriodicRefresh schedules a repeating timer', async () => {
     vi.useFakeTimers();
 
-    const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
+    const refreshSpy = vi.spyOn(provider as any, 'doBackgroundRefresh').mockResolvedValue(undefined);
     provider.startPeriodicRefresh(60);
 
     expect(refreshSpy).not.toHaveBeenCalled();
 
-    vi.advanceTimersByTime(60_000);
+    await vi.advanceTimersByTimeAsync(60_000);
     expect(refreshSpy).toHaveBeenCalledTimes(1);
 
-    vi.advanceTimersByTime(60_000);
+    await vi.advanceTimersByTimeAsync(61_000);
     expect(refreshSpy).toHaveBeenCalledTimes(2);
 
     vi.useRealTimers();

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -382,18 +382,18 @@ describe('AdoWorkItemProvider', () => {
     expect(listener).toHaveBeenCalledWith([]);
   });
 
-  it('startPeriodicRefresh schedules a repeating timer', () => {
+  it('startPeriodicRefresh schedules a repeating timer', async () => {
     vi.useFakeTimers();
 
-    const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
+    const refreshSpy = vi.spyOn(provider as any, 'doBackgroundRefresh').mockResolvedValue(undefined);
     provider.startPeriodicRefresh(60);
 
     expect(refreshSpy).not.toHaveBeenCalled();
 
-    vi.advanceTimersByTime(60_000);
+    await vi.advanceTimersByTimeAsync(60_000);
     expect(refreshSpy).toHaveBeenCalledTimes(1);
 
-    vi.advanceTimersByTime(60_000);
+    await vi.advanceTimersByTimeAsync(61_000);
     expect(refreshSpy).toHaveBeenCalledTimes(2);
 
     vi.useRealTimers();

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -492,8 +492,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   };
   pr.setWindowState(windowState);
   context.subscriptions.push(
-    windowStateEmitter,
     vscode.window.onDidChangeWindowState(state => windowStateEmitter.fire(state.focused)),
+    windowStateEmitter,
   );
 
   // Cross-window state propagation for work-item and inbox/read-state stores.

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { runWorkerPool, type PRIdentifier } from '@devdocket/shared';
+import { runWorkerPool, type PRIdentifier, type WindowStateProvider } from '@devdocket/shared';
 import { DevDocketApi } from './api/types';
 import { DevDocketApiImpl } from './api/devDocketApi';
 import { JsonTaskStore } from './storage/jsonTaskStore';
@@ -482,6 +482,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const ws = new WatcherService(wr, pwr, watchStore, logger);
   const api = new DevDocketApiImpl(pr, ar, wr, pwr, wg, adrr);
   logger.info(`Store + service init took ${Math.round(performance.now() - initStart)}ms`);
+
+  // Wire window focus state so providers skip background refreshes when unfocused
+  const windowStateEmitter = new vscode.EventEmitter<boolean>();
+  const windowState: WindowStateProvider = {
+    get isFocused() { return vscode.window.state.focused; },
+    onDidChangeFocus: windowStateEmitter.event,
+  };
+  pr.setWindowState(windowState);
+  context.subscriptions.push(
+    windowStateEmitter,
+    vscode.window.onDidChangeWindowState(state => windowStateEmitter.fire(state.focused)),
+  );
 
   const watchPanelProvider = new WatchPanelProvider(context.extensionUri, ws, wg, pr);
 

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -130,7 +130,11 @@ export class ProviderRegistry {
 
   private applyWindowState(provider: DevDocketProvider): void {
     if (this._windowState && isWindowStateAwareProvider(provider)) {
-      provider.setWindowState(this._windowState);
+      try {
+        provider.setWindowState(this._windowState);
+      } catch (error) {
+        logger.warn(`Provider ${provider.id} rejected window state updates`, error);
+      }
     }
   }
 

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -33,7 +33,11 @@ function isActiveWorkItemState(state: WorkItemState | undefined): boolean {
 }
 
 interface WindowStateAwareProvider {
-  setWindowState(windowState: WindowStateProvider): void;
+  setWindowState(windowState: WindowStateProvider): void | PromiseLike<void>;
+}
+
+function isPromiseLike<T>(value: unknown): value is PromiseLike<T> {
+  return typeof value === 'object' && value !== null && typeof (value as PromiseLike<T>).then === 'function';
 }
 
 function isWindowStateAwareProvider(provider: DevDocketProvider): provider is DevDocketProvider & WindowStateAwareProvider {
@@ -131,7 +135,12 @@ export class ProviderRegistry {
   private applyWindowState(provider: DevDocketProvider): void {
     if (this._windowState && isWindowStateAwareProvider(provider)) {
       try {
-        provider.setWindowState(this._windowState);
+        const result = provider.setWindowState(this._windowState);
+        if (isPromiseLike<void>(result)) {
+          void Promise.resolve(result).catch((error: unknown) => {
+            logger.warn(`Provider ${provider.id} rejected window state updates`, error);
+          });
+        }
       } catch (error) {
         logger.warn(`Provider ${provider.id} rejected window state updates`, error);
       }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -32,6 +32,14 @@ function isActiveWorkItemState(state: WorkItemState | undefined): boolean {
   return state === WorkItemState.New || state === WorkItemState.InProgress || state === WorkItemState.Paused;
 }
 
+interface WindowStateAwareProvider {
+  setWindowState(windowState: WindowStateProvider): void;
+}
+
+function isWindowStateAwareProvider(provider: DevDocketProvider): provider is DevDocketProvider & WindowStateAwareProvider {
+  return typeof (provider as Partial<WindowStateAwareProvider>).setWindowState === 'function';
+}
+
 /**
  * Central registry for {@link DevDocketProvider} instances.
  *
@@ -121,8 +129,8 @@ export class ProviderRegistry {
   }
 
   private applyWindowState(provider: DevDocketProvider): void {
-    if (this._windowState && typeof (provider as any).setWindowState === 'function') {
-      (provider as any).setWindowState(this._windowState);
+    if (this._windowState && isWindowStateAwareProvider(provider)) {
+      provider.setWindowState(this._windowState);
     }
   }
 

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { DevDocketProvider, ProviderItem, type ResolvedItem } from '../api/types';
+import type { WindowStateProvider } from '@devdocket/shared';
 import { InboxStateStore, InboxState } from '../storage/inboxStateStore';
 import { ProviderLabelCache } from '../storage/providerLabelCache';
 import { logger } from './logger';
@@ -87,6 +88,7 @@ export class ProviderRegistry {
    */
   private readonly _handleQueues = new Map<string, Promise<void>>();
   private _disposed = false;
+  private _windowState: WindowStateProvider | undefined;
 
   /** Whether any provider is currently performing its initial refresh. */
   get loading(): boolean {
@@ -107,6 +109,24 @@ export class ProviderRegistry {
   ) {}
 
   /**
+   * Sets the window state provider for focus-aware refresh gating.
+   * Providers that extend BaseProvider (and expose setWindowState) will
+   * skip background refreshes when the window is unfocused.
+   */
+  setWindowState(windowState: WindowStateProvider): void {
+    this._windowState = windowState;
+    for (const provider of this.providers.values()) {
+      this.applyWindowState(provider);
+    }
+  }
+
+  private applyWindowState(provider: DevDocketProvider): void {
+    if (this._windowState && typeof (provider as any).setWindowState === 'function') {
+      (provider as any).setWindowState(this._windowState);
+    }
+  }
+
+  /**
    * Register a provider and trigger its initial refresh.
    *
    * The provider's {@link DevDocketProvider.onDidDiscoverItems} event is
@@ -122,6 +142,7 @@ export class ProviderRegistry {
     }
 
     this.providers.set(provider.id, provider);
+    this.applyWindowState(provider);
     if (this.labelCache) {
       void this.labelCache.set(provider.id, provider.label).catch(err => {
         logger.debug(`Failed to cache provider label for provider ${provider.id} (label: ${provider.label})`, err);

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -121,9 +121,9 @@ export class ProviderRegistry {
   ) {}
 
   /**
-   * Sets the window state provider for focus-aware refresh gating.
+   * Sets the window state provider for focus-aware refresh throttling.
    * Providers that extend BaseProvider (and expose setWindowState) will
-   * skip background refreshes when the window is unfocused.
+   * slow background refreshes when the window is unfocused.
    */
   setWindowState(windowState: WindowStateProvider): void {
     this._windowState = windowState;

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -115,6 +115,8 @@ const window = {
     onDidChangeLogLevel: vi.fn(),
   })),
   createStatusBarItem: vi.fn((alignment?: number, priority?: number) => new MockStatusBarItem()),
+  state: { focused: true },
+  onDidChangeWindowState: vi.fn(() => ({ dispose: vi.fn() })),
 };
 
 const commands = {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -173,6 +173,21 @@ describe('ProviderRegistry', () => {
     expect(() => registry.register(provider)).not.toThrow();
   });
 
+  it('logs and ignores errors from window-state-aware providers', () => {
+    const provider = {
+      ...createMockProvider('throws-window-state'),
+      setWindowState: vi.fn(() => {
+        throw new Error('window state failed');
+      }),
+    };
+    const warnSpy = vi.spyOn(logger, 'warn');
+
+    registry.register(provider);
+
+    expect(() => registry.setWindowState(createMockWindowState(false))).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith('Provider throws-window-state rejected window state updates', expect.any(Error));
+  });
+
   it('returns undefined from getProvider for unknown id', () => {
     expect(registry.getProvider('nonexistent')).toBeUndefined();
   });

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { CancellationTokenSource, EventEmitter } from 'vscode';
 import { DevDocketProvider, ProviderItem } from '../api/types';
+import type { WindowStateProvider } from '@devdocket/shared';
 import { WorkGraph } from '../services/workGraph';
 import { ProviderRegistry } from '../services/providerRegistry';
 import { logger } from '../services/logger';
@@ -75,6 +76,13 @@ function createMockProvider(id: string): DevDocketProvider & { fireItems: (items
   };
 }
 
+function createMockWindowState(isFocused = true): WindowStateProvider {
+  return {
+    isFocused,
+    onDidChangeFocus: vi.fn(() => ({ dispose: vi.fn() })),
+  };
+}
+
 describe('ProviderRegistry', () => {
   let store: ITaskStore;
   let graph: WorkGraph;
@@ -113,6 +121,35 @@ describe('ProviderRegistry', () => {
     expect(provider.refresh).toHaveBeenCalledTimes(1);
   });
 
+  it('applies window state to already registered providers that support it', () => {
+    const provider = {
+      ...createMockProvider('window-aware'),
+      setWindowState: vi.fn(),
+    };
+    registry.register(provider);
+    provider.setWindowState.mockClear();
+    const windowState = createMockWindowState(false);
+
+    registry.setWindowState(windowState);
+
+    expect(provider.setWindowState).toHaveBeenCalledOnce();
+    expect(provider.setWindowState).toHaveBeenCalledWith(windowState);
+  });
+
+  it('applies window state to newly registered providers after state is set', () => {
+    const windowState = createMockWindowState(false);
+    registry.setWindowState(windowState);
+    const provider = {
+      ...createMockProvider('late-window-aware'),
+      setWindowState: vi.fn(),
+    };
+
+    registry.register(provider);
+
+    expect(provider.setWindowState).toHaveBeenCalledOnce();
+    expect(provider.setWindowState).toHaveBeenCalledWith(windowState);
+  });
+
   it('removes the provider when the returned Disposable is disposed', () => {
     const provider = createMockProvider('removable');
     const disposable = registry.register(provider);
@@ -127,6 +164,13 @@ describe('ProviderRegistry', () => {
     registry.register(provider);
 
     expect(registry.getProvider('findme')).toBe(provider);
+  });
+
+  it('does not try to apply window state to providers that do not support it', () => {
+    const provider = createMockProvider('not-window-aware');
+    registry.setWindowState(createMockWindowState(false));
+
+    expect(() => registry.register(provider)).not.toThrow();
   });
 
   it('returns undefined from getProvider for unknown id', () => {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -184,8 +184,12 @@ describe('ProviderRegistry', () => {
 
     registry.register(provider);
 
-    expect(() => registry.setWindowState(createMockWindowState(false))).not.toThrow();
-    expect(warnSpy).toHaveBeenCalledWith('Provider throws-window-state rejected window state updates', expect.any(Error));
+    try {
+      expect(() => registry.setWindowState(createMockWindowState(false))).not.toThrow();
+      expect(warnSpy).toHaveBeenCalledWith('Provider throws-window-state rejected window state updates', expect.any(Error));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('logs and ignores async errors from window-state-aware providers', async () => {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -188,6 +188,23 @@ describe('ProviderRegistry', () => {
     expect(warnSpy).toHaveBeenCalledWith('Provider throws-window-state rejected window state updates', expect.any(Error));
   });
 
+  it('logs and ignores async errors from window-state-aware providers', async () => {
+    const provider = {
+      ...createMockProvider('async-window-state'),
+      setWindowState: vi.fn(async () => {
+        throw new Error('async window state failed');
+      }),
+    };
+    const warnSpy = vi.spyOn(logger, 'warn');
+
+    registry.register(provider);
+
+    expect(() => registry.setWindowState(createMockWindowState(false))).not.toThrow();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(warnSpy).toHaveBeenCalledWith('Provider async-window-state rejected window state updates', expect.any(Error));
+  });
+
   it('returns undefined from getProvider for unknown id', () => {
     expect(registry.getProvider('nonexistent')).toBeUndefined();
   });

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -203,10 +203,14 @@ describe('ProviderRegistry', () => {
 
     registry.register(provider);
 
-    expect(() => registry.setWindowState(createMockWindowState(false))).not.toThrow();
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    try {
+      expect(() => registry.setWindowState(createMockWindowState(false))).not.toThrow();
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(warnSpy).toHaveBeenCalledWith('Provider async-window-state rejected window state updates', expect.any(Error));
+      expect(warnSpy).toHaveBeenCalledWith('Provider async-window-state rejected window state updates', expect.any(Error));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('returns undefined from getProvider for unknown id', () => {

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -64,6 +64,7 @@ export abstract class BaseGitHubProvider extends BaseProvider {
       }
 
       await this.fetchAndPublish(session.accessToken, true, abortController.signal);
+      this.markRefreshSuccess();
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError' && abortController.signal.aborted && token?.isCancellationRequested) {
         logger.debug(`${this.label} fetch aborted due to cancellation`);

--- a/packages/github/src/test/githubPrReviewProvider.error.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.error.test.ts
@@ -327,7 +327,7 @@ describe('GitHubPrReviewProvider — error handling', () => {
       vi.useFakeTimers();
 
       let callCount = 0;
-      const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockImplementation(async () => {
+      const refreshSpy = vi.spyOn(provider as any, 'doBackgroundRefresh').mockImplementation(async () => {
         callCount++;
         if (callCount === 1) {
           throw new Error('transient failure');
@@ -336,12 +336,10 @@ describe('GitHubPrReviewProvider — error handling', () => {
 
       provider.startPeriodicRefresh(60);
 
-      vi.advanceTimersByTime(60_000);
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(60_000);
       expect(refreshSpy).toHaveBeenCalledTimes(1);
 
-      vi.advanceTimersByTime(60_000);
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(61_000);
       expect(refreshSpy).toHaveBeenCalledTimes(2);
     });
 
@@ -349,7 +347,7 @@ describe('GitHubPrReviewProvider — error handling', () => {
       vi.useFakeTimers();
 
       let callCount = 0;
-      const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockImplementation(async () => {
+      const refreshSpy = vi.spyOn(provider as any, 'doBackgroundRefresh').mockImplementation(async () => {
         callCount++;
         if (callCount === 1) {
           throw new Error('Auth unavailable');
@@ -358,12 +356,10 @@ describe('GitHubPrReviewProvider — error handling', () => {
 
       provider.startPeriodicRefresh(60);
 
-      vi.advanceTimersByTime(60_000);
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(60_000);
       expect(refreshSpy).toHaveBeenCalledTimes(1);
 
-      vi.advanceTimersByTime(60_000);
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(61_000);
       expect(refreshSpy).toHaveBeenCalledTimes(2);
     });
   });

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -383,18 +383,18 @@ describe('GitHubPrReviewProvider', () => {
     expect(listener).toHaveBeenCalledWith([]);
   });
 
-  it('startPeriodicRefresh schedules a repeating timer', () => {
+  it('startPeriodicRefresh schedules a repeating timer', async () => {
     vi.useFakeTimers();
 
-    const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue(undefined);
+    const refreshSpy = vi.spyOn(provider as any, 'doBackgroundRefresh').mockResolvedValue(undefined);
     provider.startPeriodicRefresh(60);
 
     expect(refreshSpy).not.toHaveBeenCalled();
 
-    vi.advanceTimersByTime(60_000);
+    await vi.advanceTimersByTimeAsync(60_000);
     expect(refreshSpy).toHaveBeenCalledTimes(1);
 
-    vi.advanceTimersByTime(60_000);
+    await vi.advanceTimersByTimeAsync(61_000);
     expect(refreshSpy).toHaveBeenCalledTimes(2);
 
     vi.useRealTimers();

--- a/packages/github/src/test/githubProvider.error.test.ts
+++ b/packages/github/src/test/githubProvider.error.test.ts
@@ -346,7 +346,7 @@ describe('GitHubIssueProvider — error handling', () => {
       // First tick: fetch rejects
       // Second tick: fetch succeeds
       let callCount = 0;
-      const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockImplementation(async () => {
+      const refreshSpy = vi.spyOn(provider as any, 'doBackgroundRefresh').mockImplementation(async () => {
         callCount++;
         if (callCount === 1) {
           throw new Error('transient failure');
@@ -355,13 +355,10 @@ describe('GitHubIssueProvider — error handling', () => {
 
       provider.startPeriodicRefresh(60);
 
-      vi.advanceTimersByTime(60_000);
-      // Timer's .catch() swallows the error; timer still alive
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(60_000);
       expect(refreshSpy).toHaveBeenCalledTimes(1);
 
-      vi.advanceTimersByTime(60_000);
-      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(61_000);
       expect(refreshSpy).toHaveBeenCalledTimes(2);
     });
 

--- a/packages/github/src/test/githubProvider.test.ts
+++ b/packages/github/src/test/githubProvider.test.ts
@@ -341,20 +341,19 @@ describe('GitHubIssueProvider', () => {
     expect(logged).toBe(true);
   });
 
-  it('startPeriodicRefresh schedules a repeating timer', () => {
+  it('startPeriodicRefresh schedules a repeating timer', async () => {
     vi.useFakeTimers();
 
-    // Spy on the private refreshInBackground method that's called by the timer
-    const refreshSpy = vi.spyOn(provider as any, 'refreshInBackground').mockResolvedValue();
+    const refreshSpy = vi.spyOn(provider as any, 'doBackgroundRefresh').mockResolvedValue();
     provider.startPeriodicRefresh(60);
 
     // No immediate call — only on interval
     expect(refreshSpy).not.toHaveBeenCalled();
 
-    vi.advanceTimersByTime(60_000);
+    await vi.advanceTimersByTimeAsync(60_000);
     expect(refreshSpy).toHaveBeenCalledTimes(1);
 
-    vi.advanceTimersByTime(60_000);
+    await vi.advanceTimersByTimeAsync(61_000);
     expect(refreshSpy).toHaveBeenCalledTimes(2);
 
     vi.useRealTimers();

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -244,6 +244,10 @@ export abstract class BaseProvider {
   /** Optional error handler for background refresh failures. Override to add logging. */
   protected onBackgroundRefreshError: (error: unknown) => void = () => {};
 
+  protected markRefreshSuccess(): void {
+    this._lastRefreshTime = Date.now();
+  }
+
   private handleBackgroundRefreshError(error: unknown): void {
     try {
       this.onBackgroundRefreshError(error);
@@ -369,7 +373,7 @@ export abstract class BaseProvider {
     this._isRefreshing = true;
     try {
       await this.doBackgroundRefresh();
-      this._lastRefreshTime = Date.now();
+      this.markRefreshSuccess();
     } finally {
       this._isRefreshing = false;
     }

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -259,9 +259,7 @@ export abstract class BaseProvider {
         this.handleBackgroundRefreshError(error);
       })
       .finally(() => {
-        if (!this._isRefreshing) {
-          this.scheduleNextPeriodicRefresh();
-        }
+        this.scheduleNextPeriodicRefresh();
       });
   }
 
@@ -290,7 +288,11 @@ export abstract class BaseProvider {
     const delayMs = Math.max(requiredIntervalMs - elapsedMs, 0);
     this.refreshTimer = setTimeout(() => {
       this.refreshTimer = undefined;
-      if (this._disposed || this._isRefreshing) {
+      if (this._disposed) {
+        return;
+      }
+      if (this._isRefreshing) {
+        this.scheduleNextPeriodicRefresh();
         return;
       }
       this.triggerPeriodicRefresh();
@@ -328,13 +330,9 @@ export abstract class BaseProvider {
       if (focused) {
         this.refreshOnFocusIfStale();
       }
-      if (!this._isRefreshing) {
-        this.scheduleNextPeriodicRefresh();
-      }
-    });
-    if (!this._isRefreshing) {
       this.scheduleNextPeriodicRefresh();
-    }
+    });
+    this.scheduleNextPeriodicRefresh();
   }
 
   startPeriodicRefresh(intervalSeconds: number): void {
@@ -372,9 +370,7 @@ export abstract class BaseProvider {
       await this.doBackgroundRefresh();
       this._lastRefreshTime = Date.now();
     } finally {
-      this._lastRefreshAttemptTime = Date.now();
       this._isRefreshing = false;
-      this.scheduleNextPeriodicRefresh();
     }
   }
 

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -232,12 +232,24 @@ export abstract class BaseProvider {
 
   private _windowState: WindowStateProvider | undefined;
   private _windowStateSub: Disposable | undefined;
-  private _refreshIntervalMs = 0;
-  private _lastRefreshTime = 0;
   private _overdueRefresh = false;
 
   /** Optional error handler for background refresh failures. Override to add logging. */
   protected onBackgroundRefreshError: (error: unknown) => void = () => {};
+
+  private triggerOverdueRefresh(): void {
+    if (this._disposed || !this._overdueRefresh || this._isRefreshing || !this._windowState?.isFocused) {
+      return;
+    }
+    this._overdueRefresh = false;
+    this.refreshInBackground().catch((error: unknown) => {
+      try {
+        this.onBackgroundRefreshError(error);
+      } catch {
+        // Prevent handler errors from becoming unhandled rejections
+      }
+    });
+  }
 
   constructor(emitter: EventEmitterLike<ProviderItem[]>) {
     this._onDidDiscoverItems = emitter;
@@ -250,18 +262,14 @@ export abstract class BaseProvider {
    * if one was skipped while unfocused.
    */
   setWindowState(provider: WindowStateProvider): void {
+    if (this._disposed) {
+      return;
+    }
     this._windowStateSub?.dispose();
     this._windowState = provider;
     this._windowStateSub = provider.onDidChangeFocus((focused) => {
-      if (focused && this._overdueRefresh && !this._disposed) {
-        this._overdueRefresh = false;
-        this.refreshInBackground().catch((error: unknown) => {
-          try {
-            this.onBackgroundRefreshError(error);
-          } catch {
-            // Prevent handler errors from becoming unhandled rejections
-          }
-        });
+      if (focused) {
+        this.triggerOverdueRefresh();
       }
     });
   }
@@ -276,7 +284,6 @@ export abstract class BaseProvider {
       return;
     }
     const clampedInterval = Math.max(interval, 60);
-    this._refreshIntervalMs = clampedInterval * 1000;
     this.refreshTimer = setInterval(() => {
       if (this._windowState && !this._windowState.isFocused) {
         this._overdueRefresh = true;
@@ -289,7 +296,7 @@ export abstract class BaseProvider {
           // Prevent handler errors from becoming unhandled rejections
         }
       });
-    }, this._refreshIntervalMs);
+    }, clampedInterval * 1000);
   }
 
   stopPeriodicRefresh(): void {
@@ -308,9 +315,9 @@ export abstract class BaseProvider {
     this._isRefreshing = true;
     try {
       await this.doBackgroundRefresh();
-      this._lastRefreshTime = Date.now();
     } finally {
       this._isRefreshing = false;
+      this.triggerOverdueRefresh();
     }
   }
 

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -199,6 +199,18 @@ export interface ResolvedItem {
   providerId: string;
 }
 
+/**
+ * Abstraction over window focus state, allowing BaseProvider to gate
+ * background refreshes without depending on the vscode module.
+ * The core extension provides the concrete implementation.
+ */
+export interface WindowStateProvider {
+  /** Whether the window is currently focused. */
+  readonly isFocused: boolean;
+  /** Fires when focus state changes. */
+  readonly onDidChangeFocus: Event<boolean>;
+}
+
 /** Matches the subset of vscode.EventEmitter used by providers. */
 export interface EventEmitterLike<T> {
   event: Event<T>;
@@ -218,12 +230,40 @@ export abstract class BaseProvider {
   protected _isRefreshing = false;
   private _disposed = false;
 
+  private _windowState: WindowStateProvider | undefined;
+  private _windowStateSub: Disposable | undefined;
+  private _refreshIntervalMs = 0;
+  private _lastRefreshTime = 0;
+  private _overdueRefresh = false;
+
   /** Optional error handler for background refresh failures. Override to add logging. */
   protected onBackgroundRefreshError: (error: unknown) => void = () => {};
 
   constructor(emitter: EventEmitterLike<ProviderItem[]>) {
     this._onDidDiscoverItems = emitter;
     this.onDidDiscoverItems = emitter.event;
+  }
+
+  /**
+   * Provides window focus state so background refreshes are skipped when
+   * the window is unfocused. On focus gain, an immediate refresh is triggered
+   * if one was skipped while unfocused.
+   */
+  setWindowState(provider: WindowStateProvider): void {
+    this._windowStateSub?.dispose();
+    this._windowState = provider;
+    this._windowStateSub = provider.onDidChangeFocus((focused) => {
+      if (focused && this._overdueRefresh && !this._disposed) {
+        this._overdueRefresh = false;
+        this.refreshInBackground().catch((error: unknown) => {
+          try {
+            this.onBackgroundRefreshError(error);
+          } catch {
+            // Prevent handler errors from becoming unhandled rejections
+          }
+        });
+      }
+    });
   }
 
   startPeriodicRefresh(intervalSeconds: number): void {
@@ -236,7 +276,12 @@ export abstract class BaseProvider {
       return;
     }
     const clampedInterval = Math.max(interval, 60);
+    this._refreshIntervalMs = clampedInterval * 1000;
     this.refreshTimer = setInterval(() => {
+      if (this._windowState && !this._windowState.isFocused) {
+        this._overdueRefresh = true;
+        return;
+      }
       this.refreshInBackground().catch((error: unknown) => {
         try {
           this.onBackgroundRefreshError(error);
@@ -244,7 +289,7 @@ export abstract class BaseProvider {
           // Prevent handler errors from becoming unhandled rejections
         }
       });
-    }, clampedInterval * 1000);
+    }, this._refreshIntervalMs);
   }
 
   stopPeriodicRefresh(): void {
@@ -252,6 +297,7 @@ export abstract class BaseProvider {
       clearInterval(this.refreshTimer);
       this.refreshTimer = undefined;
     }
+    this._overdueRefresh = false;
   }
 
   /** Runs a background refresh with a concurrency guard to prevent overlapping calls. */
@@ -262,6 +308,7 @@ export abstract class BaseProvider {
     this._isRefreshing = true;
     try {
       await this.doBackgroundRefresh();
+      this._lastRefreshTime = Date.now();
     } finally {
       this._isRefreshing = false;
     }
@@ -278,6 +325,7 @@ export abstract class BaseProvider {
     }
     this._disposed = true;
     this.stopPeriodicRefresh();
+    this._windowStateSub?.dispose();
     this._onDidDiscoverItems.dispose();
   }
 }

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -223,32 +223,50 @@ export interface EventEmitterLike<T> {
  * Owns the EventEmitter lifecycle, refresh timer, concurrency guard, and dispose logic.
  */
 export abstract class BaseProvider {
+  /** Multiplier for the unfocused-window polling interval. Matches the pattern
+   *  used by Microsoft's vscode-pull-request-github extension (2min focused,
+   *  5min unfocused = 2.5x). */
+  private static readonly UNFOCUSED_INTERVAL_MULTIPLIER = 2.5;
+  private static readonly REFRESH_TOLERANCE_MS = 1000;
+
   protected readonly _onDidDiscoverItems: EventEmitterLike<ProviderItem[]>;
   readonly onDidDiscoverItems: Event<ProviderItem[]>;
 
   private refreshTimer: ReturnType<typeof setInterval> | undefined;
+  private periodicRefreshIntervalMs: number | undefined;
+  private _lastRefreshTime = 0;
   protected _isRefreshing = false;
   private _disposed = false;
 
   private _windowState: WindowStateProvider | undefined;
   private _windowStateSub: Disposable | undefined;
-  private _overdueRefresh = false;
 
   /** Optional error handler for background refresh failures. Override to add logging. */
   protected onBackgroundRefreshError: (error: unknown) => void = () => {};
 
-  private triggerOverdueRefresh(): void {
-    if (this._disposed || !this._overdueRefresh || this._isRefreshing || !this._windowState?.isFocused) {
+  private handleBackgroundRefreshError(error: unknown): void {
+    try {
+      this.onBackgroundRefreshError(error);
+    } catch {
+      // Prevent handler errors from becoming unhandled rejections
+    }
+  }
+
+  private triggerPeriodicRefresh(): void {
+    this.refreshInBackground().catch((error: unknown) => {
+      this.handleBackgroundRefreshError(error);
+    });
+  }
+
+  private refreshOnFocusIfStale(): void {
+    const focusedIntervalMs = this.periodicRefreshIntervalMs;
+    if (this._disposed || !focusedIntervalMs || this._isRefreshing || !this._windowState?.isFocused) {
       return;
     }
-    this._overdueRefresh = false;
-    this.refreshInBackground().catch((error: unknown) => {
-      try {
-        this.onBackgroundRefreshError(error);
-      } catch {
-        // Prevent handler errors from becoming unhandled rejections
-      }
-    });
+    if (Date.now() - this._lastRefreshTime <= focusedIntervalMs) {
+      return;
+    }
+    this.triggerPeriodicRefresh();
   }
 
   constructor(emitter: EventEmitterLike<ProviderItem[]>) {
@@ -257,9 +275,9 @@ export abstract class BaseProvider {
   }
 
   /**
-   * Provides window focus state so background refreshes are skipped when
+   * Provides window focus state so background refreshes can be throttled when
    * the window is unfocused. On focus gain, an immediate refresh is triggered
-   * if one was skipped while unfocused.
+   * when the focused polling interval has already elapsed.
    */
   setWindowState(provider: WindowStateProvider): void {
     if (this._disposed) {
@@ -269,10 +287,9 @@ export abstract class BaseProvider {
     this._windowState = provider;
     this._windowStateSub = provider.onDidChangeFocus((focused) => {
       if (focused) {
-        this.triggerOverdueRefresh();
+        this.refreshOnFocusIfStale();
       }
     });
-    this.triggerOverdueRefresh();
   }
 
   startPeriodicRefresh(intervalSeconds: number): void {
@@ -285,19 +302,18 @@ export abstract class BaseProvider {
       return;
     }
     const clampedInterval = Math.max(interval, 60);
+    const focusedIntervalMs = clampedInterval * 1000;
+    this.periodicRefreshIntervalMs = focusedIntervalMs;
+    this._lastRefreshTime = Date.now();
     this.refreshTimer = setInterval(() => {
-      if (this._windowState && !this._windowState.isFocused) {
-        this._overdueRefresh = true;
+      const requiredIntervalMs = this._windowState?.isFocused === false
+        ? focusedIntervalMs * BaseProvider.UNFOCUSED_INTERVAL_MULTIPLIER
+        : focusedIntervalMs;
+      if (Date.now() - this._lastRefreshTime < requiredIntervalMs - BaseProvider.REFRESH_TOLERANCE_MS) {
         return;
       }
-      this.refreshInBackground().catch((error: unknown) => {
-        try {
-          this.onBackgroundRefreshError(error);
-        } catch {
-          // Prevent handler errors from becoming unhandled rejections
-        }
-      });
-    }, clampedInterval * 1000);
+      this.triggerPeriodicRefresh();
+    }, focusedIntervalMs);
   }
 
   stopPeriodicRefresh(): void {
@@ -305,7 +321,7 @@ export abstract class BaseProvider {
       clearInterval(this.refreshTimer);
       this.refreshTimer = undefined;
     }
-    this._overdueRefresh = false;
+    this.periodicRefreshIntervalMs = undefined;
   }
 
   /** Runs a background refresh with a concurrency guard to prevent overlapping calls. */
@@ -316,9 +332,9 @@ export abstract class BaseProvider {
     this._isRefreshing = true;
     try {
       await this.doBackgroundRefresh();
+      this._lastRefreshTime = Date.now();
     } finally {
       this._isRefreshing = false;
-      this.triggerOverdueRefresh();
     }
   }
 

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -227,14 +227,14 @@ export abstract class BaseProvider {
    *  used by Microsoft's vscode-pull-request-github extension (2min focused,
    *  5min unfocused = 2.5x). */
   private static readonly UNFOCUSED_INTERVAL_MULTIPLIER = 2.5;
-  private static readonly REFRESH_TOLERANCE_MS = 1000;
 
   protected readonly _onDidDiscoverItems: EventEmitterLike<ProviderItem[]>;
   readonly onDidDiscoverItems: Event<ProviderItem[]>;
 
-  private refreshTimer: ReturnType<typeof setInterval> | undefined;
+  private refreshTimer: ReturnType<typeof setTimeout> | undefined;
   private periodicRefreshIntervalMs: number | undefined;
   private _lastRefreshTime = 0;
+  private _lastRefreshAttemptTime = 0;
   protected _isRefreshing = false;
   private _disposed = false;
 
@@ -256,6 +256,38 @@ export abstract class BaseProvider {
     this.refreshInBackground().catch((error: unknown) => {
       this.handleBackgroundRefreshError(error);
     });
+  }
+
+  private getRequiredRefreshIntervalMs(): number | undefined {
+    const focusedIntervalMs = this.periodicRefreshIntervalMs;
+    if (!focusedIntervalMs) {
+      return undefined;
+    }
+    return this._windowState?.isFocused === false
+      ? focusedIntervalMs * BaseProvider.UNFOCUSED_INTERVAL_MULTIPLIER
+      : focusedIntervalMs;
+  }
+
+  private scheduleNextPeriodicRefresh(): void {
+    if (this._disposed) {
+      return;
+    }
+    const requiredIntervalMs = this.getRequiredRefreshIntervalMs();
+    if (!requiredIntervalMs) {
+      return;
+    }
+    if (this.refreshTimer) {
+      clearTimeout(this.refreshTimer);
+    }
+    const elapsedMs = Date.now() - this._lastRefreshAttemptTime;
+    const delayMs = Math.max(requiredIntervalMs - elapsedMs, 0);
+    this.refreshTimer = setTimeout(() => {
+      this.refreshTimer = undefined;
+      if (this._disposed || this._isRefreshing) {
+        return;
+      }
+      this.triggerPeriodicRefresh();
+    }, delayMs);
   }
 
   private refreshOnFocusIfStale(): void {
@@ -289,7 +321,13 @@ export abstract class BaseProvider {
       if (focused) {
         this.refreshOnFocusIfStale();
       }
+      if (!this._isRefreshing) {
+        this.scheduleNextPeriodicRefresh();
+      }
     });
+    if (!this._isRefreshing) {
+      this.scheduleNextPeriodicRefresh();
+    }
   }
 
   startPeriodicRefresh(intervalSeconds: number): void {
@@ -302,23 +340,16 @@ export abstract class BaseProvider {
       return;
     }
     const clampedInterval = Math.max(interval, 60);
-    const focusedIntervalMs = clampedInterval * 1000;
-    this.periodicRefreshIntervalMs = focusedIntervalMs;
-    this._lastRefreshTime = Date.now();
-    this.refreshTimer = setInterval(() => {
-      const requiredIntervalMs = this._windowState?.isFocused === false
-        ? focusedIntervalMs * BaseProvider.UNFOCUSED_INTERVAL_MULTIPLIER
-        : focusedIntervalMs;
-      if (Date.now() - this._lastRefreshTime < requiredIntervalMs - BaseProvider.REFRESH_TOLERANCE_MS) {
-        return;
-      }
-      this.triggerPeriodicRefresh();
-    }, focusedIntervalMs);
+    const startTime = Date.now();
+    this.periodicRefreshIntervalMs = clampedInterval * 1000;
+    this._lastRefreshTime = startTime;
+    this._lastRefreshAttemptTime = startTime;
+    this.scheduleNextPeriodicRefresh();
   }
 
   stopPeriodicRefresh(): void {
     if (this.refreshTimer) {
-      clearInterval(this.refreshTimer);
+      clearTimeout(this.refreshTimer);
       this.refreshTimer = undefined;
     }
     this.periodicRefreshIntervalMs = undefined;
@@ -334,7 +365,9 @@ export abstract class BaseProvider {
       await this.doBackgroundRefresh();
       this._lastRefreshTime = Date.now();
     } finally {
+      this._lastRefreshAttemptTime = Date.now();
       this._isRefreshing = false;
+      this.scheduleNextPeriodicRefresh();
     }
   }
 

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -285,7 +285,8 @@ export abstract class BaseProvider {
       clearTimeout(this.refreshTimer);
     }
     const elapsedMs = Date.now() - this._lastRefreshAttemptTime;
-    const delayMs = Math.max(requiredIntervalMs - elapsedMs, 0);
+    const intervalsElapsed = Math.floor(elapsedMs / requiredIntervalMs) + 1;
+    const delayMs = (intervalsElapsed * requiredIntervalMs) - elapsedMs;
     this.refreshTimer = setTimeout(() => {
       this.refreshTimer = undefined;
       if (this._disposed) {

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -253,9 +253,16 @@ export abstract class BaseProvider {
   }
 
   private triggerPeriodicRefresh(): void {
-    this.refreshInBackground().catch((error: unknown) => {
-      this.handleBackgroundRefreshError(error);
-    });
+    this._lastRefreshAttemptTime = Date.now();
+    this.refreshInBackground()
+      .catch((error: unknown) => {
+        this.handleBackgroundRefreshError(error);
+      })
+      .finally(() => {
+        if (!this._isRefreshing) {
+          this.scheduleNextPeriodicRefresh();
+        }
+      });
   }
 
   private getRequiredRefreshIntervalMs(): number | undefined {

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -272,6 +272,7 @@ export abstract class BaseProvider {
         this.triggerOverdueRefresh();
       }
     });
+    this.triggerOverdueRefresh();
   }
 
   startPeriodicRefresh(intervalSeconds: number): void {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -5,7 +5,7 @@
 export { createLoggerService, LogLevel, resolveLogLevel, serializeArg } from './logger';
 export type { Logger, LogOutput, LoggerService } from './logger';
 export { BaseProvider } from './baseProvider';
-export type { ProviderItem, ProviderItemAuthor, ProviderItemCapabilities, Disposable, Event, EventEmitterLike, GitWorkInfo, ProviderBadge, RelatedItemRef, ResolvedItem } from './baseProvider';
+export type { ProviderItem, ProviderItemAuthor, ProviderItemCapabilities, Disposable, Event, EventEmitterLike, GitWorkInfo, ProviderBadge, RelatedItemRef, ResolvedItem, WindowStateProvider } from './baseProvider';
 export { isValidUrlSegment, isValidGitHubRepo, isValidRepoSlug, sanitizeUrlSegment, safeDecodeComponent } from './urlValidation';
 export { validateRefreshInterval } from './refreshInterval';
 export type { DevDocketRunWatcher, RunIdentifier, RunStatus, JobStatus, RunState, RunConclusion, CancellationTokenLike } from './runWatcher';

--- a/packages/shared/src/test/baseProvider.test.ts
+++ b/packages/shared/src/test/baseProvider.test.ts
@@ -398,90 +398,8 @@ describe('BaseProvider', () => {
     });
   });
 
-  describe('focus gating via setWindowState', () => {
-    it('skips timer-fired refresh when window is unfocused', async () => {
-      const provider = new TestProvider(createMockEmitter());
-      const { state } = createMockWindowState(false);
-      provider.setWindowState(state);
-
-      provider.startPeriodicRefresh(60);
-      await vi.advanceTimersByTimeAsync(60_000);
-      expect(provider.backgroundRefreshCalls).toBe(0);
-
-      // Second tick still skipped
-      await vi.advanceTimersByTimeAsync(60_000);
-      expect(provider.backgroundRefreshCalls).toBe(0);
-
-      provider.dispose();
-    });
-
-    it('refreshes immediately on focus gain when overdue', async () => {
-      const provider = new TestProvider(createMockEmitter());
-      const { state, setFocused } = createMockWindowState(false);
-      provider.setWindowState(state);
-
-      provider.startPeriodicRefresh(60);
-
-      // Timer fires while unfocused — skipped
-      await vi.advanceTimersByTimeAsync(60_000);
-      expect(provider.backgroundRefreshCalls).toBe(0);
-
-      // Gaining focus triggers the overdue refresh
-      setFocused(true);
-      // Allow the async refresh to settle
-      await vi.advanceTimersByTimeAsync(0);
-      expect(provider.backgroundRefreshCalls).toBe(1);
-
-      provider.dispose();
-    });
-
-    it('runs an overdue refresh after an in-flight refresh completes', async () => {
-      const provider = new TestProvider(createMockEmitter());
-      const { state, setFocused } = createMockWindowState(false);
-      provider.setWindowState(state);
-
-      let resolveGate!: () => void;
-      provider.refreshGate = {
-        promise: new Promise<void>(r => { resolveGate = r; }),
-        resolve: () => resolveGate(),
-      };
-
-      provider.startPeriodicRefresh(60);
-      await vi.advanceTimersByTimeAsync(60_000);
-      expect(provider.backgroundRefreshCalls).toBe(0);
-
-      const firstRefresh = provider.refreshInBackground();
-      expect(provider.backgroundRefreshCalls).toBe(1);
-
-      setFocused(true);
-      await vi.advanceTimersByTimeAsync(0);
-      expect(provider.backgroundRefreshCalls).toBe(1);
-
-      resolveGate();
-      await firstRefresh;
-      await vi.advanceTimersByTimeAsync(0);
-      expect(provider.backgroundRefreshCalls).toBe(2);
-
-      provider.dispose();
-    });
-
-    it('does not refresh on focus gain when not overdue', async () => {
-      const provider = new TestProvider(createMockEmitter());
-      const { state, setFocused } = createMockWindowState(true);
-      provider.setWindowState(state);
-
-      provider.startPeriodicRefresh(60);
-
-      // Focus toggled before timer fires — no overdue
-      setFocused(false);
-      setFocused(true);
-      await vi.advanceTimersByTimeAsync(0);
-      expect(provider.backgroundRefreshCalls).toBe(0);
-
-      provider.dispose();
-    });
-
-    it('allows timer-fired refresh when window is focused', async () => {
+  describe('focus throttling via setWindowState', () => {
+    it('polls at focused interval when focused', async () => {
       const provider = new TestProvider(createMockEmitter());
       const { state } = createMockWindowState(true);
       provider.setWindowState(state);
@@ -490,45 +408,102 @@ describe('BaseProvider', () => {
       await vi.advanceTimersByTimeAsync(60_000);
       expect(provider.backgroundRefreshCalls).toBe(1);
 
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(2);
+
       provider.dispose();
     });
 
-    it('works without window state set (backward compatible)', async () => {
+    it('polls at 2.5x interval when unfocused', async () => {
       const provider = new TestProvider(createMockEmitter());
-      // No setWindowState call — should behave as before
+      const { state } = createMockWindowState(false);
+      provider.setWindowState(state);
+
       provider.startPeriodicRefresh(60);
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(provider.backgroundRefreshCalls).toBe(0);
+
       await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(120_000);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(2);
+
+      provider.dispose();
+    });
+
+    it('refreshes on focus gain if last refresh was longer than focused interval ago', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      const { state, setFocused } = createMockWindowState(false);
+      provider.setWindowState(state);
+
+      provider.startPeriodicRefresh(60);
+      await vi.advanceTimersByTimeAsync(61_000);
+      expect(provider.backgroundRefreshCalls).toBe(0);
+
+      setFocused(true);
+      await vi.advanceTimersByTimeAsync(0);
       expect(provider.backgroundRefreshCalls).toBe(1);
 
       provider.dispose();
     });
 
-    it('does not gate explicit refreshInBackground calls', async () => {
+    it('does not refresh on focus gain if last refresh was recent', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      const { state, setFocused } = createMockWindowState(true);
+      provider.setWindowState(state);
+
+      provider.startPeriodicRefresh(60);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      setFocused(false);
+      await vi.advanceTimersByTimeAsync(30_000);
+      setFocused(true);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      provider.dispose();
+    });
+
+    it('does not throttle explicit refreshInBackground calls', async () => {
       const provider = new TestProvider(createMockEmitter());
       const { state } = createMockWindowState(false);
       provider.setWindowState(state);
 
-      // Direct call should still work even when unfocused
       await provider.refreshInBackground();
       expect(provider.backgroundRefreshCalls).toBe(1);
 
       provider.dispose();
     });
 
-    it('clears overdue flag on stopPeriodicRefresh', async () => {
+    it('works without window state set (backward compatible)', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      provider.startPeriodicRefresh(60);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      provider.dispose();
+    });
+
+    it('stopPeriodicRefresh clears state', async () => {
       const provider = new TestProvider(createMockEmitter());
       const { state, setFocused } = createMockWindowState(false);
       provider.setWindowState(state);
 
       provider.startPeriodicRefresh(60);
-      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(120_000);
       expect(provider.backgroundRefreshCalls).toBe(0);
 
       provider.stopPeriodicRefresh();
-
-      // Focus gain should not trigger refresh since timer was stopped
       setFocused(true);
       await vi.advanceTimersByTimeAsync(0);
+      expect(provider.backgroundRefreshCalls).toBe(0);
+
+      await vi.advanceTimersByTimeAsync(180_000);
       expect(provider.backgroundRefreshCalls).toBe(0);
 
       provider.dispose();
@@ -540,11 +515,8 @@ describe('BaseProvider', () => {
       provider.setWindowState(state);
 
       provider.startPeriodicRefresh(60);
-      await vi.advanceTimersByTimeAsync(60_000);
-
       provider.dispose();
 
-      // Focus gain after dispose should not trigger refresh
       setFocused(true);
       await vi.advanceTimersByTimeAsync(0);
       expect(provider.backgroundRefreshCalls).toBe(0);
@@ -557,36 +529,12 @@ describe('BaseProvider', () => {
 
       provider.setWindowState(first.state);
       provider.setWindowState(second.state);
-
       provider.startPeriodicRefresh(60);
 
-      // Timer fires — second state is focused, so it should refresh
       await vi.advanceTimersByTimeAsync(60_000);
       expect(provider.backgroundRefreshCalls).toBe(1);
 
-      // Old window state fire should not trigger anything
       first.setFocused(true);
-      await vi.advanceTimersByTimeAsync(0);
-      // Still only 1 (no spurious refresh from old subscription)
-      expect(provider.backgroundRefreshCalls).toBe(1);
-
-      provider.dispose();
-    });
-
-    it('triggers an overdue refresh when replacing unfocused state with a focused one', async () => {
-      const provider = new TestProvider(createMockEmitter());
-      const first = createMockWindowState(false);
-      const second = createMockWindowState(true);
-
-      provider.setWindowState(first.state);
-      provider.startPeriodicRefresh(60);
-      await vi.advanceTimersByTimeAsync(60_000);
-      expect(provider.backgroundRefreshCalls).toBe(0);
-
-      provider.setWindowState(second.state);
-      await vi.advanceTimersByTimeAsync(0);
-      expect(provider.backgroundRefreshCalls).toBe(1);
-
       await vi.advanceTimersByTimeAsync(0);
       expect(provider.backgroundRefreshCalls).toBe(1);
 

--- a/packages/shared/src/test/baseProvider.test.ts
+++ b/packages/shared/src/test/baseProvider.test.ts
@@ -572,5 +572,25 @@ describe('BaseProvider', () => {
 
       provider.dispose();
     });
+
+    it('triggers an overdue refresh when replacing unfocused state with a focused one', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      const first = createMockWindowState(false);
+      const second = createMockWindowState(true);
+
+      provider.setWindowState(first.state);
+      provider.startPeriodicRefresh(60);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(0);
+
+      provider.setWindowState(second.state);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      provider.dispose();
+    });
   });
 });

--- a/packages/shared/src/test/baseProvider.test.ts
+++ b/packages/shared/src/test/baseProvider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { BaseProvider, ProviderItem, EventEmitterLike } from '../baseProvider';
+import { BaseProvider, ProviderItem, EventEmitterLike, WindowStateProvider, Disposable } from '../baseProvider';
 
 
 /** Minimal EventEmitter stub for testing. */
@@ -12,6 +12,28 @@ function createMockEmitter(): EventEmitterLike<ProviderItem[]> {
     },
     fire: (data: ProviderItem[]) => { listeners.forEach(l => l(data)); },
     dispose: vi.fn(),
+  };
+}
+
+/** Creates a controllable WindowStateProvider for tests. */
+function createMockWindowState(focused = true): {
+  state: WindowStateProvider;
+  setFocused: (f: boolean) => void;
+} {
+  let isFocused = focused;
+  const listeners: Array<(f: boolean) => void> = [];
+  return {
+    state: {
+      get isFocused() { return isFocused; },
+      onDidChangeFocus: (listener: (f: boolean) => void): Disposable => {
+        listeners.push(listener);
+        return { dispose: () => { const i = listeners.indexOf(listener); if (i >= 0) listeners.splice(i, 1); } };
+      },
+    },
+    setFocused: (f: boolean) => {
+      isFocused = f;
+      listeners.forEach(l => l(f));
+    },
   };
 }
 
@@ -361,6 +383,152 @@ describe('BaseProvider', () => {
       const emitter = createMockEmitter();
       const provider = new TestProvider(emitter);
       expect(provider.onDidDiscoverItems).toBe(emitter.event);
+      provider.dispose();
+    });
+  });
+
+  describe('focus gating via setWindowState', () => {
+    it('skips timer-fired refresh when window is unfocused', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      const { state, setFocused } = createMockWindowState(false);
+      provider.setWindowState(state);
+
+      provider.startPeriodicRefresh(60);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(0);
+
+      // Second tick still skipped
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(0);
+
+      provider.dispose();
+    });
+
+    it('refreshes immediately on focus gain when overdue', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      const { state, setFocused } = createMockWindowState(false);
+      provider.setWindowState(state);
+
+      provider.startPeriodicRefresh(60);
+
+      // Timer fires while unfocused — skipped
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(0);
+
+      // Gaining focus triggers the overdue refresh
+      setFocused(true);
+      // Allow the async refresh to settle
+      await vi.advanceTimersByTimeAsync(0);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      provider.dispose();
+    });
+
+    it('does not refresh on focus gain when not overdue', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      const { state, setFocused } = createMockWindowState(true);
+      provider.setWindowState(state);
+
+      provider.startPeriodicRefresh(60);
+
+      // Focus toggled before timer fires — no overdue
+      setFocused(false);
+      setFocused(true);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(provider.backgroundRefreshCalls).toBe(0);
+
+      provider.dispose();
+    });
+
+    it('allows timer-fired refresh when window is focused', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      const { state } = createMockWindowState(true);
+      provider.setWindowState(state);
+
+      provider.startPeriodicRefresh(60);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      provider.dispose();
+    });
+
+    it('works without window state set (backward compatible)', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      // No setWindowState call — should behave as before
+      provider.startPeriodicRefresh(60);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      provider.dispose();
+    });
+
+    it('does not gate explicit refreshInBackground calls', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      const { state } = createMockWindowState(false);
+      provider.setWindowState(state);
+
+      // Direct call should still work even when unfocused
+      await provider.refreshInBackground();
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      provider.dispose();
+    });
+
+    it('clears overdue flag on stopPeriodicRefresh', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      const { state, setFocused } = createMockWindowState(false);
+      provider.setWindowState(state);
+
+      provider.startPeriodicRefresh(60);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(0);
+
+      provider.stopPeriodicRefresh();
+
+      // Focus gain should not trigger refresh since timer was stopped
+      setFocused(true);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(provider.backgroundRefreshCalls).toBe(0);
+
+      provider.dispose();
+    });
+
+    it('disposes window state subscription on dispose', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      const { state, setFocused } = createMockWindowState(false);
+      provider.setWindowState(state);
+
+      provider.startPeriodicRefresh(60);
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      provider.dispose();
+
+      // Focus gain after dispose should not trigger refresh
+      setFocused(true);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(provider.backgroundRefreshCalls).toBe(0);
+    });
+
+    it('replaces previous window state when called again', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      const first = createMockWindowState(false);
+      const second = createMockWindowState(true);
+
+      provider.setWindowState(first.state);
+      provider.setWindowState(second.state);
+
+      provider.startPeriodicRefresh(60);
+
+      // Timer fires — second state is focused, so it should refresh
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      // Old window state fire should not trigger anything
+      first.setFocused(true);
+      await vi.advanceTimersByTimeAsync(0);
+      // Still only 1 (no spurious refresh from old subscription)
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
       provider.dispose();
     });
   });

--- a/packages/shared/src/test/baseProvider.test.ts
+++ b/packages/shared/src/test/baseProvider.test.ts
@@ -401,7 +401,7 @@ describe('BaseProvider', () => {
   describe('focus gating via setWindowState', () => {
     it('skips timer-fired refresh when window is unfocused', async () => {
       const provider = new TestProvider(createMockEmitter());
-      const { state, setFocused } = createMockWindowState(false);
+      const { state } = createMockWindowState(false);
       provider.setWindowState(state);
 
       provider.startPeriodicRefresh(60);

--- a/packages/shared/src/test/baseProvider.test.ts
+++ b/packages/shared/src/test/baseProvider.test.ts
@@ -160,6 +160,36 @@ describe('BaseProvider', () => {
       provider.dispose();
     });
 
+    it('does not immediately retrigger after an overlong refresh', async () => {
+      const provider = new TestProvider(createMockEmitter());
+
+      let resolveGate!: () => void;
+      provider.refreshGate = {
+        promise: new Promise<void>(r => { resolveGate = r; }),
+        resolve: () => resolveGate(),
+      };
+
+      provider.startPeriodicRefresh(60);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(70_000);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      resolveGate();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      provider.refreshGate = undefined;
+      await vi.advanceTimersByTimeAsync(49_000);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(provider.backgroundRefreshCalls).toBe(2);
+
+      provider.dispose();
+    });
+
     it('stops existing timer when called with invalid interval', async () => {
       const provider = new TestProvider(createMockEmitter());
 

--- a/packages/shared/src/test/baseProvider.test.ts
+++ b/packages/shared/src/test/baseProvider.test.ts
@@ -22,13 +22,14 @@ function createMockWindowState(focused = true): {
 } {
   let isFocused = focused;
   const listeners: Array<(f: boolean) => void> = [];
+  const onDidChangeFocus = vi.fn((listener: (f: boolean) => void): Disposable => {
+    listeners.push(listener);
+    return { dispose: () => { const i = listeners.indexOf(listener); if (i >= 0) listeners.splice(i, 1); } };
+  });
   return {
     state: {
       get isFocused() { return isFocused; },
-      onDidChangeFocus: (listener: (f: boolean) => void): Disposable => {
-        listeners.push(listener);
-        return { dispose: () => { const i = listeners.indexOf(listener); if (i >= 0) listeners.splice(i, 1); } };
-      },
+      onDidChangeFocus,
     },
     setFocused: (f: boolean) => {
       isFocused = f;
@@ -250,6 +251,16 @@ describe('BaseProvider', () => {
       await provider.refreshInBackground();
       expect(provider.backgroundRefreshCalls).toBe(0);
     });
+
+    it('does not subscribe to window state after dispose', () => {
+      const provider = new TestProvider(createMockEmitter());
+      const windowState = createMockWindowState();
+      provider.dispose();
+
+      provider.setWindowState(windowState.state);
+
+      expect(windowState.state.onDidChangeFocus).not.toHaveBeenCalled();
+    });
   });
 
   describe('refreshInBackground concurrency guard', () => {
@@ -420,6 +431,36 @@ describe('BaseProvider', () => {
       // Allow the async refresh to settle
       await vi.advanceTimersByTimeAsync(0);
       expect(provider.backgroundRefreshCalls).toBe(1);
+
+      provider.dispose();
+    });
+
+    it('runs an overdue refresh after an in-flight refresh completes', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      const { state, setFocused } = createMockWindowState(false);
+      provider.setWindowState(state);
+
+      let resolveGate!: () => void;
+      provider.refreshGate = {
+        promise: new Promise<void>(r => { resolveGate = r; }),
+        resolve: () => resolveGate(),
+      };
+
+      provider.startPeriodicRefresh(60);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(0);
+
+      const firstRefresh = provider.refreshInBackground();
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      setFocused(true);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      resolveGate();
+      await firstRefresh;
+      await vi.advanceTimersByTimeAsync(0);
+      expect(provider.backgroundRefreshCalls).toBe(2);
 
       provider.dispose();
     });

--- a/packages/shared/src/test/baseProvider.test.ts
+++ b/packages/shared/src/test/baseProvider.test.ts
@@ -420,16 +420,16 @@ describe('BaseProvider', () => {
       provider.setWindowState(state);
 
       provider.startPeriodicRefresh(60);
-      await vi.advanceTimersByTimeAsync(120_000);
+      await vi.advanceTimersByTimeAsync(149_000);
       expect(provider.backgroundRefreshCalls).toBe(0);
 
-      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(1_000);
       expect(provider.backgroundRefreshCalls).toBe(1);
 
-      await vi.advanceTimersByTimeAsync(120_000);
+      await vi.advanceTimersByTimeAsync(149_000);
       expect(provider.backgroundRefreshCalls).toBe(1);
 
-      await vi.advanceTimersByTimeAsync(60_000);
+      await vi.advanceTimersByTimeAsync(1_000);
       expect(provider.backgroundRefreshCalls).toBe(2);
 
       provider.dispose();


### PR DESCRIPTION
## Summary
- replace hard-skip focus gating in BaseProvider with throttled background polling
- keep focused windows on the configured interval and throttle unfocused windows to 2.5x the interval
- trigger an immediate refresh on focus regain when the focused interval has elapsed since the last successful refresh
- update shared provider tests and the changeset wording to cover the throttling model

## Why
Notifications depend on background polling to detect newly discovered items. Hard-skipping refreshes while the VS Code window was unfocused meant background windows never polled and could miss notification-worthy items entirely.

## What changed
This now follows the same pattern used by Microsoft's vscode-pull-request-github extension:
- focused windows poll at the configured interval
- unfocused windows poll at 2.5x the configured interval
- regaining focus triggers an immediate refresh when the last successful refresh is older than the focused interval
- explicit refreshInBackground() calls remain unthrottled

## Testing
- npm run build
- npm run test

Closes #623
