### PR TITLE
Add merge-on-write and cross-window state propagation

### DIFF
--- a/.changeset/write-safety-cross-window.md
+++ b/.changeset/write-safety-cross-window.md
@@ -1,0 +1,5 @@
+---
+"devdocket": minor
+---
+
+Add merge-on-write to all globalState-backed stores and cross-window change propagation via a version file, preventing silent data loss when multiple VS Code windows write concurrently.

--- a/.changeset/write-safety-cross-window.md
+++ b/.changeset/write-safety-cross-window.md
@@ -2,4 +2,4 @@
 "devdocket": minor
 ---
 
-Add merge-on-write to all globalState-backed stores and cross-window change propagation via a version file, preventing silent data loss when multiple VS Code windows write concurrently.
+Add merge-on-write to work items, inbox state, read state, and provider labels plus cross-window change propagation via a version file, preventing silent data loss when multiple VS Code windows write concurrently.

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -16,6 +16,7 @@ import { WatcherRegistry } from './services/watcherRegistry';
 import { PRWatcherRegistry } from './services/prWatcherRegistry';
 import { WatcherService } from './services/watcherService';
 import { WatchStore } from './storage/watchStore';
+import { StateVersionService } from './services/stateVersionService';
 import { WatchesStatusBar } from './views/watchesStatusBar';
 import { ProviderHealthStatusBar } from './views/providerHealthStatusBar';
 import { WatchPanelProvider } from './views/watchPanelProvider';
@@ -483,6 +484,22 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const api = new DevDocketApiImpl(pr, ar, wr, pwr, wg, adrr);
   logger.info(`Store + service init took ${Math.round(performance.now() - initStart)}ms`);
 
+  // Cross-window state propagation: bump version on mutations, invalidate on external changes
+  const stateVersion = new StateVersionService(context.globalStorageUri);
+  wg.onDidChange(safeHandler('sv:workGraph', () => stateVersion.bump()));
+  ss.onDidChange(safeHandler('sv:stateStore', () => stateVersion.bump()));
+  readStateStore.onDidChange(safeHandler('sv:readState', () => stateVersion.bump()));
+  ws.onDidChangeWatchedRuns(safeHandler('sv:watchedRuns', () => stateVersion.bump()));
+  ws.onDidChangePRWatches(safeHandler('sv:watchedPRs', () => stateVersion.bump()));
+  stateVersion.onDidExternalStateChange(safeHandler('sv:external', async () => {
+    logger.debug('External state change detected — invalidating caches');
+    wg.invalidateAndReload();
+    ss.invalidateCache();
+    await ss.load();
+    readStateStore.invalidateCache();
+    await readStateStore.load();
+  }));
+
   const watchPanelProvider = new WatchPanelProvider(context.extensionUri, ws, wg, pr);
 
   const eventWiringStart = performance.now();
@@ -588,6 +605,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     { dispose: () => pr.dispose() },
     { dispose: () => ar.dispose() },
     { dispose: () => adrr.dispose() },
+    { dispose: () => stateVersion.dispose() },
   );
 
   const commandRegStart = performance.now();

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -484,20 +484,25 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const api = new DevDocketApiImpl(pr, ar, wr, pwr, wg, adrr);
   logger.info(`Store + service init took ${Math.round(performance.now() - initStart)}ms`);
 
-  // Cross-window state propagation: bump version on mutations, invalidate on external changes
+  // Cross-window state propagation for work-item and inbox/read-state stores.
   const stateVersion = new StateVersionService(context.globalStorageUri);
-  wg.onDidChange(safeHandler('sv:workGraph', () => stateVersion.bump()));
-  ss.onDidChange(safeHandler('sv:stateStore', () => stateVersion.bump()));
-  readStateStore.onDidChange(safeHandler('sv:readState', () => stateVersion.bump()));
-  ws.onDidChangeWatchedRuns(safeHandler('sv:watchedRuns', () => stateVersion.bump()));
-  ws.onDidChangePRWatches(safeHandler('sv:watchedPRs', () => stateVersion.bump()));
+  let suppressStateVersionBump = false;
+  const bumpStateVersion = () => suppressStateVersionBump ? Promise.resolve() : stateVersion.bump();
+  wg.onDidChange(safeHandler('sv:workGraph', () => bumpStateVersion()));
+  ss.onDidChange(safeHandler('sv:stateStore', () => bumpStateVersion()));
+  readStateStore.onDidChange(safeHandler('sv:readState', () => bumpStateVersion()));
   stateVersion.onDidExternalStateChange(safeHandler('sv:external', async () => {
     logger.debug('External state change detected — invalidating caches');
-    wg.invalidateAndReload();
-    ss.invalidateCache();
-    await ss.load();
-    readStateStore.invalidateCache();
-    await readStateStore.load();
+    suppressStateVersionBump = true;
+    try {
+      await wg.invalidateAndReload();
+      ss.invalidateCache();
+      await ss.load();
+      readStateStore.invalidateCache();
+      await readStateStore.load();
+    } finally {
+      suppressStateVersionBump = false;
+    }
   }));
 
   const watchPanelProvider = new WatchPanelProvider(context.extensionUri, ws, wg, pr);

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -487,9 +487,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   // Cross-window state propagation for work-item and inbox/read-state stores.
   const stateVersion = new StateVersionService(context.globalStorageUri);
   const bumpStateVersion = () => stateVersion.bump();
+  let mainProvider: MainViewProvider | undefined;
   wg.onDidChange(safeHandler('sv:workGraph', (event) => event.source === 'externalReload' ? Promise.resolve() : bumpStateVersion()));
   ss.onDidChange(safeHandler('sv:stateStore', () => bumpStateVersion()));
   readStateStore.onDidChange(safeHandler('sv:readState', () => bumpStateVersion()));
+  labelCache.onDidChange(safeHandler('sv:labelCache', () => bumpStateVersion()));
   stateVersion.onDidExternalStateChange(safeHandler('sv:external', async () => {
     logger.debug('External state change detected — invalidating caches');
     await wg.invalidateAndReload();
@@ -497,6 +499,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     await ss.load();
     readStateStore.invalidateCache();
     await readStateStore.load();
+    labelCache.invalidateCache();
+    await labelCache.load();
+    mainProvider?.scheduleRefresh('discovered');
   }));
 
   const watchPanelProvider = new WatchPanelProvider(context.extensionUri, ws, wg, pr);
@@ -510,7 +515,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
 
   const providerHealthStatusBar = new ProviderHealthStatusBar(pr);
 
-  const mainProvider = new MainViewProvider(
+  mainProvider = new MainViewProvider(
     context.extensionUri,
     wg,
     pr,
@@ -598,6 +603,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     { dispose: () => wg.dispose() },
     { dispose: () => ss.dispose() },
     { dispose: () => readStateStore.dispose() },
+    { dispose: () => labelCache.dispose() },
     { dispose: () => ws.dispose() },
     { dispose: () => wr.dispose() },
     { dispose: () => pwr.dispose() },

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -486,23 +486,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
 
   // Cross-window state propagation for work-item and inbox/read-state stores.
   const stateVersion = new StateVersionService(context.globalStorageUri);
-  let suppressStateVersionBump = false;
-  const bumpStateVersion = () => suppressStateVersionBump ? Promise.resolve() : stateVersion.bump();
-  wg.onDidChange(safeHandler('sv:workGraph', () => bumpStateVersion()));
+  const bumpStateVersion = () => stateVersion.bump();
+  wg.onDidChange(safeHandler('sv:workGraph', (event) => event.source === 'externalReload' ? Promise.resolve() : bumpStateVersion()));
   ss.onDidChange(safeHandler('sv:stateStore', () => bumpStateVersion()));
   readStateStore.onDidChange(safeHandler('sv:readState', () => bumpStateVersion()));
   stateVersion.onDidExternalStateChange(safeHandler('sv:external', async () => {
     logger.debug('External state change detected — invalidating caches');
-    suppressStateVersionBump = true;
-    try {
-      await wg.invalidateAndReload();
-      ss.invalidateCache();
-      await ss.load();
-      readStateStore.invalidateCache();
-      await readStateStore.load();
-    } finally {
-      suppressStateVersionBump = false;
-    }
+    await wg.invalidateAndReload();
+    ss.invalidateCache();
+    await ss.load();
+    readStateStore.invalidateCache();
+    await readStateStore.load();
   }));
 
   const watchPanelProvider = new WatchPanelProvider(context.extensionUri, ws, wg, pr);

--- a/packages/core/src/services/stateVersionService.ts
+++ b/packages/core/src/services/stateVersionService.ts
@@ -1,0 +1,100 @@
+import * as vscode from 'vscode';
+import { logger } from './logger';
+
+/**
+ * Cross-window change propagation via a version file in globalStorageUri.
+ *
+ * On every user-intent state mutation (work items, inbox state, watches, etc.),
+ * the caller bumps the version. Other VS Code windows detect the file change
+ * via a FileSystemWatcher and fire `onDidExternalStateChange` so consumers can
+ * invalidate their caches and re-render.
+ *
+ * Each instance is identified by a unique ID so it can ignore its own writes.
+ */
+export class StateVersionService {
+  private readonly _onDidExternalStateChange = new vscode.EventEmitter<void>();
+  /** Fires when another window has mutated persisted state. */
+  readonly onDidExternalStateChange = this._onDidExternalStateChange.event;
+
+  private readonly versionFileUri: vscode.Uri;
+  private readonly instanceId: string;
+  private watcher: vscode.FileSystemWatcher | undefined;
+  private debounceTimer: ReturnType<typeof setTimeout> | undefined;
+  private disposed = false;
+  private static readonly DEBOUNCE_MS = 100;
+
+  constructor(globalStorageUri: vscode.Uri) {
+    this.versionFileUri = vscode.Uri.joinPath(globalStorageUri, 'state-version.json');
+    this.instanceId = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    this.startWatching(globalStorageUri);
+  }
+
+  private startWatching(globalStorageUri: vscode.Uri): void {
+    try {
+      // Watch the parent directory for changes to the version file
+      const pattern = new vscode.RelativePattern(globalStorageUri, 'state-version.json');
+      this.watcher = vscode.workspace.createFileSystemWatcher(pattern);
+      this.watcher.onDidChange(() => this.onFileChanged());
+      this.watcher.onDidCreate(() => this.onFileChanged());
+    } catch (err) {
+      logger.warn('StateVersionService: failed to create file watcher, cross-window propagation disabled', err);
+    }
+  }
+
+  private onFileChanged(): void {
+    if (this.disposed) { return; }
+
+    // Debounce rapid changes
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = undefined;
+      void this.checkVersion();
+    }, StateVersionService.DEBOUNCE_MS);
+  }
+
+  private async checkVersion(): Promise<void> {
+    if (this.disposed) { return; }
+    try {
+      const content = await vscode.workspace.fs.readFile(this.versionFileUri);
+      const data = JSON.parse(Buffer.from(content).toString('utf-8'));
+      if (data.instanceId !== this.instanceId) {
+        this._onDidExternalStateChange.fire();
+      }
+    } catch {
+      // File doesn't exist or is invalid — ignore
+    }
+  }
+
+  /**
+   * Bumps the version file to signal other windows that state has changed.
+   * Call this after any user-intent state mutation.
+   */
+  async bump(): Promise<void> {
+    if (this.disposed) { return; }
+    try {
+      const data = JSON.stringify({
+        instanceId: this.instanceId,
+        version: Date.now(),
+      });
+      await vscode.workspace.fs.writeFile(
+        this.versionFileUri,
+        Buffer.from(data, 'utf-8'),
+      );
+    } catch (err) {
+      // Non-critical — worst case is a missed cross-window update
+      logger.debug('StateVersionService: failed to bump version file', err);
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) { return; }
+    this.disposed = true;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+    }
+    this.watcher?.dispose();
+    this._onDidExternalStateChange.dispose();
+  }
+}

--- a/packages/core/src/services/stateVersionService.ts
+++ b/packages/core/src/services/stateVersionService.ts
@@ -4,7 +4,7 @@ import { logger } from './logger';
 /**
  * Cross-window change propagation via a version file in globalStorageUri.
  *
- * On every user-intent state mutation (work items, inbox state, watches, etc.),
+ * On every user-intent mutation of the work-item and inbox/read-state stores,
  * the caller bumps the version. Other VS Code windows detect the file change
  * via a FileSystemWatcher and fire `onDidExternalStateChange` so consumers can
  * invalidate their caches and re-render.

--- a/packages/core/src/services/stateVersionService.ts
+++ b/packages/core/src/services/stateVersionService.ts
@@ -23,6 +23,7 @@ export class StateVersionService {
   private disposed = false;
   private lastExternalVersionKey: string | undefined;
   private lastBumpedVersion = 0;
+  private bumpTail: Promise<void> = Promise.resolve();
   private static readonly DEBOUNCE_MS = 100;
 
   constructor(globalStorageUri: vscode.Uri) {
@@ -82,22 +83,26 @@ export class StateVersionService {
    * Call this after any user-intent state mutation.
    */
   async bump(): Promise<void> {
-    if (this.disposed) { return; }
-    try {
+    const next = this.bumpTail.catch(() => undefined).then(async () => {
+      if (this.disposed) { return; }
       const version = Math.max(Date.now(), this.lastBumpedVersion + 1);
-      const data = JSON.stringify({
-        instanceId: this.instanceId,
-        version,
-      });
-      await vscode.workspace.fs.writeFile(
-        this.versionFileUri,
-        Buffer.from(data, 'utf-8'),
-      );
       this.lastBumpedVersion = version;
-    } catch (err) {
-      // Non-critical — worst case is a missed cross-window update
-      logger.debug('StateVersionService: failed to bump version file', err);
-    }
+      try {
+        const data = JSON.stringify({
+          instanceId: this.instanceId,
+          version,
+        });
+        await vscode.workspace.fs.writeFile(
+          this.versionFileUri,
+          Buffer.from(data, 'utf-8'),
+        );
+      } catch (err) {
+        // Non-critical — worst case is a missed cross-window update
+        logger.debug('StateVersionService: failed to bump version file', err);
+      }
+    });
+    this.bumpTail = next;
+    await next;
   }
 
   dispose(): void {

--- a/packages/core/src/services/stateVersionService.ts
+++ b/packages/core/src/services/stateVersionService.ts
@@ -21,6 +21,7 @@ export class StateVersionService {
   private watcher: vscode.FileSystemWatcher | undefined;
   private debounceTimer: ReturnType<typeof setTimeout> | undefined;
   private disposed = false;
+  private lastExternalVersionKey: string | undefined;
   private static readonly DEBOUNCE_MS = 100;
 
   constructor(globalStorageUri: vscode.Uri) {
@@ -59,9 +60,17 @@ export class StateVersionService {
     try {
       const content = await vscode.workspace.fs.readFile(this.versionFileUri);
       const data = JSON.parse(Buffer.from(content).toString('utf-8'));
-      if (data.instanceId !== this.instanceId) {
-        this._onDidExternalStateChange.fire();
+      if (data.instanceId === this.instanceId) {
+        return;
       }
+
+      const versionKey = `${String(data.instanceId)}::${String(data.version)}`;
+      if (this.lastExternalVersionKey === versionKey) {
+        return;
+      }
+
+      this.lastExternalVersionKey = versionKey;
+      this._onDidExternalStateChange.fire();
     } catch {
       // File doesn't exist or is invalid — ignore
     }

--- a/packages/core/src/services/stateVersionService.ts
+++ b/packages/core/src/services/stateVersionService.ts
@@ -22,6 +22,7 @@ export class StateVersionService {
   private debounceTimer: ReturnType<typeof setTimeout> | undefined;
   private disposed = false;
   private lastExternalVersionKey: string | undefined;
+  private lastBumpedVersion = 0;
   private static readonly DEBOUNCE_MS = 100;
 
   constructor(globalStorageUri: vscode.Uri) {
@@ -83,14 +84,16 @@ export class StateVersionService {
   async bump(): Promise<void> {
     if (this.disposed) { return; }
     try {
+      const version = Math.max(Date.now(), this.lastBumpedVersion + 1);
       const data = JSON.stringify({
         instanceId: this.instanceId,
-        version: Date.now(),
+        version,
       });
       await vscode.workspace.fs.writeFile(
         this.versionFileUri,
         Buffer.from(data, 'utf-8'),
       );
+      this.lastBumpedVersion = version;
     } catch (err) {
       // Non-critical — worst case is a missed cross-window update
       logger.debug('StateVersionService: failed to bump version file', err);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -664,13 +664,15 @@ export class WorkGraph {
    * new data, this window invalidates its stale cache and re-reads.
    */
   async invalidateAndReload(): Promise<void> {
-    this.store.invalidateCache?.();
-    try {
-      await this.load();
-      this.emitDidChange('externalReload');
-    } catch (err) {
-      logger.error('WorkGraph: failed to reload after cache invalidation', err);
-    }
+    return this.withLock(async () => {
+      this.store.invalidateCache?.();
+      try {
+        await this.load();
+        this.emitDidChange('externalReload');
+      } catch (err) {
+        logger.error('WorkGraph: failed to reload after cache invalidation', err);
+      }
+    });
   }
 }
 

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -16,6 +16,11 @@ export const VALID_TRANSITIONS: ReadonlyMap<WorkItemState, ReadonlySet<WorkItemS
   [WorkItemState.Archived, new Set([WorkItemState.New])],
 ]);
 
+type WorkGraphChangeSource = 'local' | 'externalReload';
+interface WorkGraphChangeEvent {
+  source: WorkGraphChangeSource;
+}
+
 /**
  * In-memory graph of {@link WorkItem}s backed by a persistent {@link ITaskStore}.
  * Provides CRUD operations, state transitions, and ordering.
@@ -29,7 +34,7 @@ export class WorkGraph {
   /** Lazily-built index of items grouped by state; nulled on any mutation to {@link items}. */
   private stateCache: Map<WorkItemState, WorkItem[]> | null = null;
   private currentMutation: Promise<void> = Promise.resolve();
-  private readonly _onDidChange = new vscode.EventEmitter<void>();
+  private readonly _onDidChange = new vscode.EventEmitter<WorkGraphChangeEvent>();
   private readonly _onDidTransitionState = new vscode.EventEmitter<{ itemId: string; item: WorkItem; oldState: string; newState: string }>();
   /**
    * Fires when this graph changes through public mutation operations exposed by {@link WorkGraph},
@@ -42,6 +47,10 @@ export class WorkGraph {
   readonly onDidTransitionState = this._onDidTransitionState.event;
 
   constructor(private readonly store: ITaskStore) {}
+
+  private emitDidChange(source: WorkGraphChangeSource = 'local'): void {
+    this._onDidChange.fire({ source });
+  }
 
   private async withLock<T>(work: () => Promise<T>): Promise<T> {
     const prev = this.currentMutation;
@@ -227,7 +236,7 @@ export class WorkGraph {
       }
     }
     this.invalidateStateCache();
-    this._onDidChange.fire();
+    this.emitDidChange();
     logger.info(`Created work item: ${item.id}`);
     return item;
   }
@@ -272,7 +281,7 @@ export class WorkGraph {
     await this.store.save(updated);
     this.items.set(id, updated);
     this.invalidateStateCache();
-    this._onDidChange.fire();
+    this.emitDidChange();
     logger.info(`Updated work item: ${id}`);
   }
 
@@ -319,7 +328,7 @@ export class WorkGraph {
     await this.store.save(updated);
     this.items.set(id, updated);
     this.invalidateStateCache();
-    this._onDidChange.fire();
+    this.emitDidChange();
     this._onDidTransitionState.fire({ itemId: id, item: updated, oldState: item.state, newState });
     logger.info(`Transitioned work item ${id} to ${newState}`);
   }
@@ -360,13 +369,13 @@ export class WorkGraph {
 
     const index = siblings.findIndex((s) => s.id === id);
     if (index === -1) {
-      if (didMutate) { this._onDidChange.fire(); }
+      if (didMutate) { this.emitDidChange(); }
       return;
     }
 
     const swapIndex = direction === 'up' ? index - 1 : index + 1;
     if (swapIndex < 0 || swapIndex >= siblings.length) {
-      if (didMutate) { this._onDidChange.fire(); }
+      if (didMutate) { this.emitDidChange(); }
       return;
     }
 
@@ -380,7 +389,7 @@ export class WorkGraph {
     this.items.set(updatedItem.id, updatedItem);
     this.items.set(updatedSwap.id, updatedSwap);
     this.invalidateStateCache();
-    this._onDidChange.fire();
+    this.emitDidChange();
   }
 
   /** Move a work item to the first position among siblings in the same state. */
@@ -417,7 +426,7 @@ export class WorkGraph {
         this.items.set(updated.id, updated);
       }
       this.invalidateStateCache();
-      this._onDidChange.fire();
+      this.emitDidChange();
     }
   }
 
@@ -466,7 +475,7 @@ export class WorkGraph {
         this.items.set(updated.id, updated);
       }
       this.invalidateStateCache();
-      this._onDidChange.fire();
+      this.emitDidChange();
     }
   }
 
@@ -505,7 +514,7 @@ export class WorkGraph {
         this.items.set(updated.id, updated);
       }
       this.invalidateStateCache();
-      this._onDidChange.fire();
+      this.emitDidChange();
     }
   }
 
@@ -545,7 +554,7 @@ export class WorkGraph {
       }
     } finally {
       if (deleted > 0) {
-        this._onDidChange.fire();
+        this.emitDidChange();
       }
     }
 
@@ -598,7 +607,7 @@ export class WorkGraph {
     this.items.delete(id);
     this.invalidateStateCache();
     if (!options?.silent) {
-      this._onDidChange.fire();
+      this.emitDidChange();
     }
     logger.info(`Deleted work item: ${id}`);
   }
@@ -633,7 +642,7 @@ export class WorkGraph {
     await this.store.save(updated);
     this.items.set(id, updated);
     this.invalidateStateCache();
-    this._onDidChange.fire();
+    this.emitDidChange();
   }
 
   /** Append an entry to the log, trimming the oldest entries if the cap is exceeded. */
@@ -658,7 +667,7 @@ export class WorkGraph {
     this.store.invalidateCache?.();
     try {
       await this.load();
-      this._onDidChange.fire();
+      this.emitDidChange('externalReload');
     } catch (err) {
       logger.error('WorkGraph: failed to reload after cache invalidation', err);
     }

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -654,13 +654,14 @@ export class WorkGraph {
    * Used for cross-window change propagation — when another window writes
    * new data, this window invalidates its stale cache and re-reads.
    */
-  invalidateAndReload(): void {
+  async invalidateAndReload(): Promise<void> {
     this.store.invalidateCache?.();
-    void this.load().then(() => {
+    try {
+      await this.load();
       this._onDidChange.fire();
-    }).catch(err => {
+    } catch (err) {
       logger.error('WorkGraph: failed to reload after cache invalidation', err);
-    });
+    }
   }
 }
 

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -648,6 +648,22 @@ export class WorkGraph {
     this._onDidChange.dispose();
     this._onDidTransitionState.dispose();
   }
+
+  /**
+   * Invalidates the store's cache and reloads all items from globalState.
+   * Used for cross-window change propagation — when another window writes
+   * new data, this window invalidates its stale cache and re-reads.
+   */
+  invalidateAndReload(): void {
+    if ('invalidateCache' in this.store && typeof (this.store as any).invalidateCache === 'function') {
+      (this.store as any).invalidateCache();
+    }
+    void this.load().then(() => {
+      this._onDidChange.fire();
+    }).catch(err => {
+      logger.error('WorkGraph: failed to reload after cache invalidation', err);
+    });
+  }
 }
 
 function generateId(): string {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -655,9 +655,7 @@ export class WorkGraph {
    * new data, this window invalidates its stale cache and re-reads.
    */
   invalidateAndReload(): void {
-    if ('invalidateCache' in this.store && typeof (this.store as any).invalidateCache === 'function') {
-      (this.store as any).invalidateCache();
-    }
+    this.store.invalidateCache?.();
     void this.load().then(() => {
       this._onDidChange.fire();
     }).catch(err => {

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -115,13 +115,13 @@ export class InboxStateStore {
       }
     }
 
+    await this.globalState.update(STORAGE_KEY, Array.from(merged.values()));
     this.cache.clear();
     for (const [k, record] of merged) {
       this.cache.set(k, record);
     }
     this.dirtyKeys.clear();
     this.removedKeys.clear();
-    await this.globalState.update(STORAGE_KEY, Array.from(merged.values()));
   }
 
   /** Parse and validate inbox state records from globalState. */

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -58,6 +58,8 @@ export class InboxStateStore {
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   readonly onDidChange = this._onDidChange.event;
   private loaded = false;
+  /** Keys known at load time — used to distinguish "pruned locally" from "added remotely". */
+  private loadedKeys = new Set<string>();
 
   constructor(globalState: Memento) {
     this.globalState = globalState;
@@ -88,8 +90,47 @@ export class InboxStateStore {
     return this.cache.get(this.key(providerId, externalId))?.resurfaceVersion;
   }
 
+  /**
+   * Re-reads from globalState, merges remote records with the local cache,
+   * and writes the merged result. Local changes take precedence for the same key.
+   * Remote additions (keys not known at load time) are preserved.
+   */
   private async persist(): Promise<void> {
-    await this.globalState.update(STORAGE_KEY, Array.from(this.cache.values()));
+    const remoteRecords = this.parseFromGlobalState();
+    const merged = new Map(this.cache);
+
+    for (const remote of remoteRecords) {
+      const k = this.key(remote.providerId, remote.externalId);
+      if (!merged.has(k) && !this.loadedKeys.has(k)) {
+        // Remote has a record we never saw — added by another window
+        merged.set(k, remote);
+      }
+      // else: local cache has it (local wins) or we pruned it (stay pruned)
+    }
+
+    // Update cache and tracking
+    this.cache.clear();
+    for (const [k, record] of merged) {
+      this.cache.set(k, record);
+    }
+    this.loadedKeys = new Set(merged.keys());
+    await this.globalState.update(STORAGE_KEY, Array.from(merged.values()));
+  }
+
+  /** Parse and validate inbox state records from globalState. */
+  private parseFromGlobalState(): InboxStateRecord[] {
+    const parsed = this.globalState.get<unknown[]>(STORAGE_KEY);
+    if (!Array.isArray(parsed)) { return []; }
+    const records: InboxStateRecord[] = [];
+    for (let i = 0; i < parsed.length; i++) {
+      const error = validateInboxStateRecord(parsed[i], i);
+      if (error) {
+        logger.warn(`Skipping invalid inbox state record: ${error}`);
+        continue;
+      }
+      records.push(parsed[i] as InboxStateRecord);
+    }
+    return records;
   }
 
   /**
@@ -155,18 +196,13 @@ export class InboxStateStore {
    */
   async load(): Promise<void> {
     if (this.loaded) { return; }
-    const parsed = this.globalState.get<unknown[]>(STORAGE_KEY);
     this.cache.clear();
-    if (Array.isArray(parsed)) {
-      for (let i = 0; i < parsed.length; i++) {
-        const error = validateInboxStateRecord(parsed[i], i);
-        if (error) {
-          logger.warn(`Skipping invalid inbox state record: ${error}`);
-          continue;
-        }
-        const record = parsed[i] as InboxStateRecord;
-        this.cache.set(this.key(record.providerId, record.externalId), record);
-      }
+    const records = this.parseFromGlobalState();
+    for (const record of records) {
+      this.cache.set(this.key(record.providerId, record.externalId), record);
+    }
+    this.loadedKeys = new Set(this.cache.keys());
+    if (records.length > 0) {
       logger.debug(`Loaded inbox state: ${this.cache.size} entries`);
     }
     this.loaded = true;
@@ -218,5 +254,15 @@ export class InboxStateStore {
   /** Disposes the change event emitter. */
   dispose(): void {
     this._onDidChange.dispose();
+  }
+
+  /**
+   * Invalidates the in-memory cache so the next mutation re-reads from
+   * globalState. Used for cross-window change propagation.
+   */
+  invalidateCache(): void {
+    this.cache.clear();
+    this.loadedKeys.clear();
+    this.loaded = false;
   }
 }

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -58,8 +58,10 @@ export class InboxStateStore {
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   readonly onDidChange = this._onDidChange.event;
   private loaded = false;
-  /** Keys known at load time — used to distinguish "pruned locally" from "added remotely". */
-  private loadedKeys = new Set<string>();
+  /** Keys modified locally since the last load/persist. */
+  private dirtyKeys = new Set<string>();
+  /** Keys removed locally since the last load/persist. */
+  private removedKeys = new Set<string>();
 
   constructor(globalState: Memento) {
     this.globalState = globalState;
@@ -91,29 +93,34 @@ export class InboxStateStore {
   }
 
   /**
-   * Re-reads from globalState, merges remote records with the local cache,
-   * and writes the merged result. Local changes take precedence for the same key.
-   * Remote additions (keys not known at load time) are preserved.
+   * Re-reads from globalState, merges remote records with local mutations,
+   * and writes the merged result. Untouched keys adopt the remote view,
+   * locally changed keys win, and locally removed keys stay removed.
    */
   private async persist(): Promise<void> {
-    const remoteRecords = this.parseFromGlobalState();
-    const merged = new Map(this.cache);
+    const merged = new Map<string, InboxStateRecord>();
 
-    for (const remote of remoteRecords) {
-      const k = this.key(remote.providerId, remote.externalId);
-      if (!merged.has(k) && !this.loadedKeys.has(k)) {
-        // Remote has a record we never saw — added by another window
-        merged.set(k, remote);
-      }
-      // else: local cache has it (local wins) or we pruned it (stay pruned)
+    for (const remote of this.parseFromGlobalState()) {
+      merged.set(this.key(remote.providerId, remote.externalId), remote);
     }
 
-    // Update cache and tracking
+    for (const k of this.removedKeys) {
+      merged.delete(k);
+    }
+
+    for (const k of this.dirtyKeys) {
+      const local = this.cache.get(k);
+      if (local) {
+        merged.set(k, local);
+      }
+    }
+
     this.cache.clear();
     for (const [k, record] of merged) {
       this.cache.set(k, record);
     }
-    this.loadedKeys = new Set(merged.keys());
+    this.dirtyKeys.clear();
+    this.removedKeys.clear();
     await this.globalState.update(STORAGE_KEY, Array.from(merged.values()));
   }
 
@@ -153,6 +160,8 @@ export class InboxStateStore {
       newRecord.resurfaceVersion = previousValue.resurfaceVersion;
     }
     this.cache.set(k, newRecord);
+    this.dirtyKeys.add(k);
+    this.removedKeys.delete(k);
     await this.persist();
     this._onDidChange.fire();
   }
@@ -178,6 +187,8 @@ export class InboxStateStore {
         newRecord.resurfaceVersion = previousRecord.resurfaceVersion;
       }
       this.cache.set(k, newRecord);
+      this.dirtyKeys.add(k);
+      this.removedKeys.delete(k);
     }
     await this.persist();
     this._onDidChange.fire();
@@ -201,7 +212,8 @@ export class InboxStateStore {
     for (const record of records) {
       this.cache.set(this.key(record.providerId, record.externalId), record);
     }
-    this.loadedKeys = new Set(this.cache.keys());
+    this.dirtyKeys.clear();
+    this.removedKeys.clear();
     if (records.length > 0) {
       logger.debug(`Loaded inbox state: ${this.cache.size} entries`);
     }
@@ -244,6 +256,8 @@ export class InboxStateStore {
 
     for (const k of staleKeys) {
       this.cache.delete(k);
+      this.removedKeys.add(k);
+      this.dirtyKeys.delete(k);
     }
 
     await this.persist();
@@ -262,7 +276,8 @@ export class InboxStateStore {
    */
   invalidateCache(): void {
     this.cache.clear();
-    this.loadedKeys.clear();
+    this.dirtyKeys.clear();
+    this.removedKeys.clear();
     this.loaded = false;
   }
 }

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -103,6 +103,9 @@ export class JsonTaskStore implements ITaskStore {
    * Items deleted locally (in loadedIds but not in cache) stay deleted.
    */
   private async persist(): Promise<void> {
+    if (this.cache === null) {
+      await this.loadAll();
+    }
     const local = this.getCache();
     const remoteItems = this.parseFromGlobalState();
     const merged = new Map(local);

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -211,9 +211,8 @@ export class JsonTaskStore implements ITaskStore {
 
   async delete(id: string): Promise<void> {
     if (this.cache === null) { await this.loadAll(); }
-    const existing = this.getCache().get(id);
-    if (existing) {
-      this.deletedUpdatedAt.set(id, existing.updatedAt);
+    if (this.getCache().has(id)) {
+      this.deletedUpdatedAt.set(id, Date.now());
     }
     this.getCache().delete(id);
     this.removedIds.add(id);

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -72,8 +72,14 @@ function validateWorkItem(value: unknown, index: number): string | undefined {
 export class JsonTaskStore implements ITaskStore {
   private readonly globalState: Memento;
   private cache: Map<string, WorkItem> | null = null;
-  /** IDs known at load time — used to distinguish "deleted locally" from "added remotely". */
-  private loadedIds = new Set<string>();
+  /** IDs modified locally since the last successful persist. */
+  private dirtyIds = new Set<string>();
+  /** IDs deleted locally since the last successful persist. */
+  private removedIds = new Set<string>();
+  /** Last persisted or loaded updatedAt value for each known item. */
+  private syncedUpdatedAt = new Map<string, number>();
+  /** Local delete tombstones used to suppress stale reintroductions from other windows. */
+  private deletedUpdatedAt = new Map<string, number>();
 
   constructor(globalState: Memento) {
     this.globalState = globalState;
@@ -85,7 +91,9 @@ export class JsonTaskStore implements ITaskStore {
     }
     const items = this.parseFromGlobalState();
     this.cache = new Map(items.map(item => [item.id, item]));
-    this.loadedIds = new Set(this.cache.keys());
+    this.syncedUpdatedAt = new Map(items.map(item => [item.id, item.updatedAt]));
+    this.dirtyIds.clear();
+    this.removedIds.clear();
     return items;
   }
 
@@ -97,10 +105,10 @@ export class JsonTaskStore implements ITaskStore {
   }
 
   /**
-   * Re-reads from globalState, merges remote items with the local cache,
-   * and writes the merged result. Items modified locally (by `updatedAt`)
-   * take precedence. Items added remotely (not in loadedIds) are preserved.
-   * Items deleted locally (in loadedIds but not in cache) stay deleted.
+   * Re-reads from globalState, adopts untouched remote state, overlays local
+   * mutations, and writes the merged result. Local edits use `updatedAt`
+   * last-writer-wins for shared items, locally removed items stay deleted, and
+   * untouched local items disappear when another window deletes them remotely.
    */
   private async persist(): Promise<void> {
     if (this.cache === null) {
@@ -108,29 +116,59 @@ export class JsonTaskStore implements ITaskStore {
     }
     const local = this.getCache();
     const remoteItems = this.parseFromGlobalState();
-    const merged = new Map(local);
+    const remoteById = new Map(remoteItems.map(item => [item.id, item]));
+    const merged = new Map<string, WorkItem>();
 
     for (const remote of remoteItems) {
-      if (merged.has(remote.id)) {
-        // Both windows have this item — keep the one with the later updatedAt
-        const localItem = merged.get(remote.id)!;
-        if (remote.updatedAt > localItem.updatedAt) {
-          merged.set(remote.id, remote);
-        }
-      } else if (!this.loadedIds.has(remote.id)) {
-        // Remote has an item we never saw — added by another window
-        merged.set(remote.id, remote);
+      const deletedAt = this.deletedUpdatedAt.get(remote.id);
+      if (deletedAt !== undefined && remote.updatedAt <= deletedAt) {
+        continue;
       }
-      // else: item was in loadedIds but deleted from local cache — locally deleted
+      merged.set(remote.id, remote);
     }
 
-    this.cache = merged;
-    // Track newly discovered remote IDs so future persists can distinguish
-    // "deleted locally" from "never seen"
-    for (const id of merged.keys()) {
-      this.loadedIds.add(id);
+    for (const [id, localItem] of local) {
+      if (this.dirtyIds.has(id) || this.removedIds.has(id)) {
+        continue;
+      }
+
+      const remoteItem = remoteById.get(id);
+      if (remoteItem) {
+        continue;
+      }
+
+      const syncedUpdatedAt = this.syncedUpdatedAt.get(id);
+      if (syncedUpdatedAt !== undefined && localItem.updatedAt !== syncedUpdatedAt) {
+        merged.set(id, localItem);
+      }
     }
+
+    for (const id of this.removedIds) {
+      merged.delete(id);
+    }
+
+    for (const id of this.dirtyIds) {
+      const localItem = local.get(id);
+      if (!localItem) {
+        continue;
+      }
+      const remoteItem = merged.get(id);
+      if (!remoteItem || localItem.updatedAt >= remoteItem.updatedAt) {
+        merged.set(id, localItem);
+      }
+    }
+
     await this.globalState.update(STORAGE_KEY, Array.from(merged.values()));
+    this.cache = merged;
+    this.syncedUpdatedAt = new Map(Array.from(merged.values(), item => [item.id, item.updatedAt]));
+    for (const [id, deletedAt] of Array.from(this.deletedUpdatedAt.entries())) {
+      const mergedItem = merged.get(id);
+      if (mergedItem && mergedItem.updatedAt > deletedAt) {
+        this.deletedUpdatedAt.delete(id);
+      }
+    }
+    this.dirtyIds.clear();
+    this.removedIds.clear();
   }
 
   /** Parse and validate work items from globalState. */
@@ -154,6 +192,9 @@ export class JsonTaskStore implements ITaskStore {
   async save(item: WorkItem): Promise<void> {
     if (this.cache === null) { await this.loadAll(); }
     this.getCache().set(item.id, item);
+    this.dirtyIds.add(item.id);
+    this.removedIds.delete(item.id);
+    this.deletedUpdatedAt.delete(item.id);
     await this.persist();
   }
 
@@ -161,13 +202,22 @@ export class JsonTaskStore implements ITaskStore {
     if (this.cache === null) { await this.loadAll(); }
     for (const item of items) {
       this.getCache().set(item.id, item);
+      this.dirtyIds.add(item.id);
+      this.removedIds.delete(item.id);
+      this.deletedUpdatedAt.delete(item.id);
     }
     await this.persist();
   }
 
   async delete(id: string): Promise<void> {
     if (this.cache === null) { await this.loadAll(); }
+    const existing = this.getCache().get(id);
+    if (existing) {
+      this.deletedUpdatedAt.set(id, existing.updatedAt);
+    }
     this.getCache().delete(id);
+    this.removedIds.add(id);
+    this.dirtyIds.delete(id);
     await this.persist();
   }
 
@@ -177,6 +227,9 @@ export class JsonTaskStore implements ITaskStore {
    */
   invalidateCache(): void {
     this.cache = null;
-    this.loadedIds.clear();
+    this.syncedUpdatedAt.clear();
+    this.deletedUpdatedAt.clear();
+    this.dirtyIds.clear();
+    this.removedIds.clear();
   }
 }

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -144,7 +144,11 @@ export class JsonTaskStore implements ITaskStore {
     }
 
     for (const id of this.removedIds) {
-      merged.delete(id);
+      const remoteItem = merged.get(id);
+      const deletedAt = this.deletedUpdatedAt.get(id);
+      if (remoteItem && deletedAt !== undefined && remoteItem.updatedAt <= deletedAt) {
+        merged.delete(id);
+      }
     }
 
     for (const id of this.dirtyIds) {

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -66,11 +66,14 @@ function validateWorkItem(value: unknown, index: number): string | undefined {
  * Persists {@link WorkItem} objects in VS Code globalState.
  *
  * An in-memory cache is populated on first load and kept in sync with
- * every mutation.
+ * every mutation. On persist, the store re-reads from globalState and
+ * merges to avoid clobbering changes made by other VS Code windows.
  */
 export class JsonTaskStore implements ITaskStore {
   private readonly globalState: Memento;
   private cache: Map<string, WorkItem> | null = null;
+  /** IDs known at load time — used to distinguish "deleted locally" from "added remotely". */
+  private loadedIds = new Set<string>();
 
   constructor(globalState: Memento) {
     this.globalState = globalState;
@@ -80,9 +83,57 @@ export class JsonTaskStore implements ITaskStore {
     if (this.cache !== null) {
       return Array.from(this.cache.values());
     }
+    const items = this.parseFromGlobalState();
+    this.cache = new Map(items.map(item => [item.id, item]));
+    this.loadedIds = new Set(this.cache.keys());
+    return items;
+  }
+
+  private getCache(): Map<string, WorkItem> {
+    if (this.cache === null) {
+      throw new Error('Cache not initialized — call loadAll() first');
+    }
+    return this.cache;
+  }
+
+  /**
+   * Re-reads from globalState, merges remote items with the local cache,
+   * and writes the merged result. Items modified locally (by `updatedAt`)
+   * take precedence. Items added remotely (not in loadedIds) are preserved.
+   * Items deleted locally (in loadedIds but not in cache) stay deleted.
+   */
+  private async persist(): Promise<void> {
+    const local = this.getCache();
+    const remoteItems = this.parseFromGlobalState();
+    const merged = new Map(local);
+
+    for (const remote of remoteItems) {
+      if (merged.has(remote.id)) {
+        // Both windows have this item — keep the one with the later updatedAt
+        const localItem = merged.get(remote.id)!;
+        if (remote.updatedAt > localItem.updatedAt) {
+          merged.set(remote.id, remote);
+        }
+      } else if (!this.loadedIds.has(remote.id)) {
+        // Remote has an item we never saw — added by another window
+        merged.set(remote.id, remote);
+      }
+      // else: item was in loadedIds but deleted from local cache — locally deleted
+    }
+
+    this.cache = merged;
+    // Track newly discovered remote IDs so future persists can distinguish
+    // "deleted locally" from "never seen"
+    for (const id of merged.keys()) {
+      this.loadedIds.add(id);
+    }
+    await this.globalState.update(STORAGE_KEY, Array.from(merged.values()));
+  }
+
+  /** Parse and validate work items from globalState. */
+  private parseFromGlobalState(): WorkItem[] {
     const parsed = this.globalState.get<unknown[]>(STORAGE_KEY);
     if (!Array.isArray(parsed)) {
-      this.cache = new Map();
       return [];
     }
     const items: WorkItem[] = [];
@@ -94,19 +145,7 @@ export class JsonTaskStore implements ITaskStore {
         items.push(parsed[i] as WorkItem);
       }
     }
-    this.cache = new Map(items.map(item => [item.id, item]));
     return items;
-  }
-
-  private getCache(): Map<string, WorkItem> {
-    if (this.cache === null) {
-      throw new Error('Cache not initialized — call loadAll() first');
-    }
-    return this.cache;
-  }
-
-  private async persist(): Promise<void> {
-    await this.globalState.update(STORAGE_KEY, Array.from(this.getCache().values()));
   }
 
   async save(item: WorkItem): Promise<void> {
@@ -127,5 +166,14 @@ export class JsonTaskStore implements ITaskStore {
     if (this.cache === null) { await this.loadAll(); }
     this.getCache().delete(id);
     await this.persist();
+  }
+
+  /**
+   * Invalidates the in-memory cache so the next access re-reads from
+   * globalState. Used for cross-window change propagation.
+   */
+  invalidateCache(): void {
+    this.cache = null;
+    this.loadedIds.clear();
   }
 }

--- a/packages/core/src/storage/providerLabelCache.ts
+++ b/packages/core/src/storage/providerLabelCache.ts
@@ -37,7 +37,16 @@ export class ProviderLabelCache {
   async set(providerId: string, label: string): Promise<void> {
     if (this.labels.get(providerId) === label) { return; }
     this.labels.set(providerId, label);
+    // Re-read from globalState and merge (remote additions preserved, local wins on conflict)
+    const remote = this.globalState.get<Record<string, unknown>>(STORAGE_KEY);
     const obj = Object.create(null) as Record<string, string>;
+    if (remote && typeof remote === 'object' && !Array.isArray(remote)) {
+      for (const [key, value] of Object.entries(remote)) {
+        if (typeof value === 'string') {
+          obj[key] = value;
+        }
+      }
+    }
     for (const [key, value] of this.labels) {
       obj[key] = value;
     }

--- a/packages/core/src/storage/providerLabelCache.ts
+++ b/packages/core/src/storage/providerLabelCache.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import type { Memento } from 'vscode';
 
 const STORAGE_KEY = 'devdocket.provider-labels';
@@ -7,9 +8,11 @@ const STORAGE_KEY = 'devdocket.provider-labels';
  * can show human-friendly group names immediately on startup, before
  * provider extensions have registered.
  */
-export class ProviderLabelCache {
+export class ProviderLabelCache implements vscode.Disposable {
   private readonly globalState: Memento;
   private labels = new Map<string, string>();
+  private readonly _onDidChange = new vscode.EventEmitter<void>();
+  readonly onDidChange = this._onDidChange.event;
 
   constructor(globalState: Memento) {
     this.globalState = globalState;
@@ -51,5 +54,14 @@ export class ProviderLabelCache {
       obj[key] = value;
     }
     await this.globalState.update(STORAGE_KEY, obj);
+    this._onDidChange.fire();
+  }
+
+  invalidateCache(): void {
+    this.labels.clear();
+  }
+
+  dispose(): void {
+    this._onDidChange.dispose();
   }
 }

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -44,12 +44,12 @@ export class ReadStateStore {
         }
       }
     }
-    // Update local state to match merged
+    await this.globalState.update(STORAGE_KEY, [...merged]);
     this.items.clear();
     for (const key of merged) {
       this.items.add(key);
     }
-    await this.globalState.update(STORAGE_KEY, [...merged]);
+    this.removedSinceLoad.clear();
   }
 
   /** Returns true only when the key is newly added. Persists automatically. */
@@ -161,6 +161,7 @@ export class ReadStateStore {
       }
       logger.debug(`Loaded read state: ${this.items.size} entries`);
     }
+    this.removedSinceLoad.clear();
     this.loaded = true;
   }
 

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -19,6 +19,8 @@ export class ReadStateStore {
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   /** Fires whenever the set of read keys changes (add, addMany, deleteMany, prune). */
   readonly onDidChange = this._onDidChange.event;
+  /** Keys removed locally since last load — prevents re-adding from stale remote data. */
+  private readonly removedSinceLoad = new Set<string>();
 
   constructor(globalState: Memento) {
     this.globalState = globalState;
@@ -28,8 +30,26 @@ export class ReadStateStore {
     return this.items.has(key);
   }
 
+  /**
+   * Re-reads from globalState, unions with local set, excludes locally
+   * removed keys, and writes the merged result.
+   */
   private async persist(): Promise<void> {
-    await this.globalState.update(STORAGE_KEY, [...this.items]);
+    const remoteParsed = this.globalState.get<unknown[]>(STORAGE_KEY);
+    const merged = new Set(this.items);
+    if (Array.isArray(remoteParsed)) {
+      for (const item of remoteParsed) {
+        if (typeof item === 'string' && !this.removedSinceLoad.has(item)) {
+          merged.add(item);
+        }
+      }
+    }
+    // Update local state to match merged
+    this.items.clear();
+    for (const key of merged) {
+      this.items.add(key);
+    }
+    await this.globalState.update(STORAGE_KEY, [...merged]);
   }
 
   /** Returns true only when the key is newly added. Persists automatically. */
@@ -68,7 +88,10 @@ export class ReadStateStore {
     if (!this.loaded) { await this.load(); }
     let changed = false;
     for (const key of keys) {
-      if (this.items.delete(key)) { changed = true; }
+      if (this.items.delete(key)) {
+        changed = true;
+        this.removedSinceLoad.add(key);
+      }
     }
     if (changed) {
       await this.persist();
@@ -112,6 +135,7 @@ export class ReadStateStore {
 
     for (const key of staleKeys) {
       this.items.delete(key);
+      this.removedSinceLoad.add(key);
     }
 
     await this.persist();
@@ -142,5 +166,15 @@ export class ReadStateStore {
 
   dispose(): void {
     this._onDidChange.dispose();
+  }
+
+  /**
+   * Invalidates the in-memory cache so the next access re-reads from
+   * globalState. Used for cross-window change propagation.
+   */
+  invalidateCache(): void {
+    this.items.clear();
+    this.removedSinceLoad.clear();
+    this.loaded = false;
   }
 }

--- a/packages/core/src/storage/taskStore.ts
+++ b/packages/core/src/storage/taskStore.ts
@@ -5,4 +5,5 @@ export interface ITaskStore {
   save(item: WorkItem): Promise<void>;
   saveAll(items: WorkItem[]): Promise<void>;
   delete(id: string): Promise<void>;
+  invalidateCache?(): void;
 }

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -214,6 +214,16 @@ const workspace = {
   }),
   onDidChangeConfiguration: vi.fn((listener: Function) => _onDidChangeConfigurationEmitter.event(listener)),
   _onDidChangeConfigurationEmitter,
+  createFileSystemWatcher: vi.fn(() => ({
+    onDidChange: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidCreate: vi.fn(() => ({ dispose: vi.fn() })),
+    onDidDelete: vi.fn(() => ({ dispose: vi.fn() })),
+    dispose: vi.fn(),
+  })),
+  fs: {
+    readFile: vi.fn().mockRejectedValue(new Error('not found')),
+    writeFile: vi.fn().mockResolvedValue(undefined),
+  },
 };
 
 class MockThemeColor {
@@ -246,6 +256,10 @@ const authentication = {
   getSession: vi.fn().mockResolvedValue(undefined),
 };
 
+class MockRelativePattern {
+  constructor(public base: any, public pattern: string) {}
+}
+
 export {
   MockEventEmitter as EventEmitter,
   MockThemeIcon as ThemeIcon,
@@ -257,6 +271,7 @@ export {
   MockCancellationTokenSource as CancellationTokenSource,
   MockDisposable as Disposable,
   MockStatusBarItem as StatusBarItem,
+  MockRelativePattern as RelativePattern,
   MockMemento,
   MockMemento as Memento,
   TreeItemCollapsibleState,

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -355,6 +355,37 @@ describe('InboxStateStore', () => {
       windowA.dispose();
       windowB.dispose();
     });
+
+    it('retains dirty tracking when persist fails', async () => {
+      await memento.update('devdocket.inbox-state', [
+        { providerId: 'gh', externalId: 'shared', inboxState: 'unseen' },
+      ]);
+
+      const failingMemento = {
+        get: (key: string) => memento.get(key),
+        update: vi.fn()
+          .mockRejectedValueOnce(new Error('quota exceeded'))
+          .mockImplementation((key: string, value: unknown) => memento.update(key, value)),
+      };
+      const failingStore = new InboxStateStore(failingMemento as any);
+      await failingStore.load();
+
+      await expect(failingStore.setState('gh', 'shared', 'accepted')).rejects.toThrow('quota exceeded');
+
+      await memento.update('devdocket.inbox-state', [
+        { providerId: 'gh', externalId: 'shared', inboxState: 'dismissed' },
+      ]);
+
+      await failingStore.setState('gh', 'other', 'unseen');
+
+      const records = await failingStore.loadAll();
+      expect(records.map(record => `${record.externalId}:${record.inboxState}`).sort()).toEqual([
+        'other:unseen',
+        'shared:accepted',
+      ]);
+
+      failingStore.dispose();
+    });
   });
 
   // ── Edge cases ────────────────────────────────────────────────────

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -280,6 +280,81 @@ describe('InboxStateStore', () => {
       expect(store.getState('gh', 'issue-1')).toBe('accepted');
       expect(store.getState('gh', 'issue-2')).toBe('dismissed');
     });
+
+    it('invalidateCache forces a re-read on next load', async () => {
+      await store.setState('gh', 'issue-1', 'unseen');
+
+      await memento.update('devdocket.inbox-state', [
+        { providerId: 'gh', externalId: 'issue-1', inboxState: 'dismissed' },
+      ]);
+
+      store.invalidateCache();
+      await store.load();
+
+      expect(store.getState('gh', 'issue-1')).toBe('dismissed');
+    });
+  });
+
+  describe('merge-on-write', () => {
+    it('preserves remote additions while persisting local changes', async () => {
+      const windowA = new InboxStateStore(memento);
+      const windowB = new InboxStateStore(memento);
+      await windowA.load();
+
+      await windowB.setState('gh', 'remote', 'accepted');
+      await windowA.setState('gh', 'local', 'unseen');
+
+      const records = (await windowA.loadAll())
+        .map(record => `${record.providerId}::${record.externalId}:${record.inboxState}`)
+        .sort();
+      expect(records).toEqual([
+        'gh::local:unseen',
+        'gh::remote:accepted',
+      ]);
+
+      windowA.dispose();
+      windowB.dispose();
+    });
+
+    it('keeps remote updates for untouched keys', async () => {
+      await memento.update('devdocket.inbox-state', [
+        { providerId: 'gh', externalId: 'shared', inboxState: 'unseen' },
+      ]);
+
+      const windowA = new InboxStateStore(memento);
+      const windowB = new InboxStateStore(memento);
+      await windowA.load();
+      await windowB.load();
+
+      await windowB.setState('gh', 'shared', 'dismissed');
+      await windowA.setState('gh', 'local', 'accepted');
+
+      expect(windowA.getState('gh', 'shared')).toBe('dismissed');
+      expect(windowA.getState('gh', 'local')).toBe('accepted');
+
+      windowA.dispose();
+      windowB.dispose();
+    });
+
+    it('prefers local updates for keys changed in this window', async () => {
+      await memento.update('devdocket.inbox-state', [
+        { providerId: 'gh', externalId: 'shared', inboxState: 'unseen' },
+      ]);
+
+      const windowA = new InboxStateStore(memento);
+      const windowB = new InboxStateStore(memento);
+      await windowA.load();
+      await windowB.load();
+
+      await windowB.setState('gh', 'shared', 'dismissed');
+      await windowA.setState('gh', 'shared', 'accepted');
+
+      expect(windowA.getState('gh', 'shared')).toBe('accepted');
+      expect(memento.get<Array<{ inboxState: string }>>('devdocket.inbox-state')?.[0]?.inboxState).toBe('accepted');
+
+      windowA.dispose();
+      windowB.dispose();
+    });
   });
 
   // ── Edge cases ────────────────────────────────────────────────────

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -351,6 +351,20 @@ describe('JsonTaskStore', () => {
       expect(persisted[0].id).toBe('new');
     });
 
+    it('honors remote deletions for untouched items', async () => {
+      await store.save(makeItem({ id: 'shared', title: 'Shared', updatedAt: 1000 }));
+
+      // Another window deletes the item entirely.
+      await memento.update('devdocket.workitems', []);
+
+      // This window only changes an unrelated item, so the deleted item should stay deleted.
+      await store.save(makeItem({ id: 'other', title: 'Other', updatedAt: 2000 }));
+
+      const persisted = memento.get<WorkItem[]>('devdocket.workitems')!;
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0].id).toBe('other');
+    });
+
     it('invalidateCache forces re-read on next access', async () => {
       await store.save(makeItem({ id: 'a', title: 'Original' }));
 

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -384,6 +384,26 @@ describe('JsonTaskStore', () => {
       expect(persisted[0].id).toBe('other');
     });
 
+    it('keeps newer remote updates that arrive after a local delete', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-21T02:00:00Z'));
+
+      await store.save(makeItem({ id: 'shared', title: 'Original', updatedAt: 1000 }));
+      await store.delete('shared');
+
+      await memento.update('devdocket.workitems', [
+        makeItem({ id: 'shared', title: 'Remote newer', updatedAt: Date.now() + 1 }),
+      ]);
+
+      await store.save(makeItem({ id: 'other', title: 'Other', updatedAt: Date.now() + 2 }));
+
+      const persisted = memento.get<WorkItem[]>('devdocket.workitems')!;
+      expect(persisted.map(item => item.id).sort()).toEqual(['other', 'shared']);
+      expect(persisted.find(item => item.id === 'shared')?.title).toBe('Remote newer');
+
+      vi.useRealTimers();
+    });
+
     it('invalidateCache forces re-read on next access', async () => {
       await store.save(makeItem({ id: 'a', title: 'Original' }));
 

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -351,6 +351,25 @@ describe('JsonTaskStore', () => {
       expect(persisted[0].id).toBe('new');
     });
 
+    it('uses delete time when suppressing stale remote reintroductions', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-21T02:00:00Z'));
+
+      await store.save(makeItem({ id: 'shared', title: 'Original', updatedAt: 1000 }));
+
+      const windowB = new JsonTaskStore(memento);
+      await windowB.loadAll();
+      await windowB.save(makeItem({ id: 'shared', title: 'Remote update', updatedAt: 2000 }));
+
+      await store.delete('shared');
+      await store.save(makeItem({ id: 'other', title: 'Other', updatedAt: 3000 }));
+
+      const persisted = memento.get<WorkItem[]>('devdocket.workitems')!;
+      expect(persisted.map(item => item.id).sort()).toEqual(['other']);
+
+      vi.useRealTimers();
+    });
+
     it('honors remote deletions for untouched items', async () => {
       await store.save(makeItem({ id: 'shared', title: 'Shared', updatedAt: 1000 }));
 

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -281,4 +281,88 @@ describe('JsonTaskStore', () => {
       expect(items[0].activityLog).toHaveLength(2);
     });
   });
+
+  describe('merge-on-write (multi-window safety)', () => {
+    it('preserves items added by another window during persist', async () => {
+      // Window A creates item1
+      await store.save(makeItem({ id: 'item1', title: 'Window A item', updatedAt: 1000 }));
+
+      // Simulate another window adding item2 directly to globalState
+      const current = memento.get<WorkItem[]>('devdocket.workitems') ?? [];
+      await memento.update('devdocket.workitems', [
+        ...current,
+        makeItem({ id: 'item2', title: 'Window B item', updatedAt: 2000 }),
+      ]);
+
+      // Window A saves item3 — should preserve item2 from remote
+      await store.save(makeItem({ id: 'item3', title: 'Another A item', updatedAt: 3000 }));
+
+      const persisted = memento.get<WorkItem[]>('devdocket.workitems')!;
+      expect(persisted).toHaveLength(3);
+      expect(persisted.map(i => i.id).sort()).toEqual(['item1', 'item2', 'item3']);
+    });
+
+    it('keeps locally modified item when it has later updatedAt', async () => {
+      await store.save(makeItem({ id: 'shared', title: 'Original', updatedAt: 1000 }));
+
+      // Another window writes an older version
+      await memento.update('devdocket.workitems', [
+        makeItem({ id: 'shared', title: 'Remote older', updatedAt: 500 }),
+      ]);
+
+      // Window A updates the item
+      await store.save(makeItem({ id: 'shared', title: 'Local newer', updatedAt: 2000 }));
+
+      const persisted = memento.get<WorkItem[]>('devdocket.workitems')!;
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0].title).toBe('Local newer');
+    });
+
+    it('takes remote item when it has later updatedAt', async () => {
+      await store.save(makeItem({ id: 'shared', title: 'Original', updatedAt: 1000 }));
+
+      // Another window writes a newer version
+      await memento.update('devdocket.workitems', [
+        makeItem({ id: 'shared', title: 'Remote newer', updatedAt: 5000 }),
+      ]);
+
+      // Window A saves an unrelated item — merge should pick up remote's newer version
+      await store.save(makeItem({ id: 'other', title: 'Other', updatedAt: 3000 }));
+
+      const persisted = memento.get<WorkItem[]>('devdocket.workitems')!;
+      const shared = persisted.find(i => i.id === 'shared');
+      expect(shared?.title).toBe('Remote newer');
+    });
+
+    it('does not restore locally deleted items from remote', async () => {
+      await store.save(makeItem({ id: 'to-delete', title: 'Delete me', updatedAt: 1000 }));
+      await store.delete('to-delete');
+
+      // Remote still has the item (from before the delete)
+      await memento.update('devdocket.workitems', [
+        makeItem({ id: 'to-delete', title: 'Still here', updatedAt: 1000 }),
+      ]);
+
+      // Window A saves something else — should not restore deleted item
+      await store.save(makeItem({ id: 'new', title: 'New', updatedAt: 2000 }));
+
+      const persisted = memento.get<WorkItem[]>('devdocket.workitems')!;
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0].id).toBe('new');
+    });
+
+    it('invalidateCache forces re-read on next access', async () => {
+      await store.save(makeItem({ id: 'a', title: 'Original' }));
+
+      // Another window modifies the data
+      await memento.update('devdocket.workitems', [
+        makeItem({ id: 'a', title: 'Modified by other window' }),
+      ]);
+
+      store.invalidateCache();
+      const items = await store.loadAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].title).toBe('Modified by other window');
+    });
+  });
 });

--- a/packages/core/src/test/providerLabelCache.test.ts
+++ b/packages/core/src/test/providerLabelCache.test.ts
@@ -75,4 +75,25 @@ describe('ProviderLabelCache', () => {
     expect(cache2.get('jira')).toBe('Jira Board');
     expect(cache2.get('ado')).toBe('Azure DevOps');
   });
+
+  it('fires onDidChange after a successful set', async () => {
+    const cache = new ProviderLabelCache(memento);
+    const listener = vi.fn();
+    cache.onDidChange(listener);
+
+    await cache.set('github', 'GitHub Issues');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidateCache clears the in-memory labels until reload', async () => {
+    const cache = new ProviderLabelCache(memento);
+    await cache.set('github', 'GitHub Issues');
+
+    cache.invalidateCache();
+    expect(cache.get('github')).toBeUndefined();
+
+    await cache.load();
+    expect(cache.get('github')).toBe('GitHub Issues');
+  });
 });

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -141,6 +141,51 @@ describe('ReadStateStore', () => {
     expect(result).toEqual([]);
   });
 
+  describe('merge-on-write', () => {
+    it('preserves remote additions while persisting local changes', async () => {
+      const windowA = new ReadStateStore(memento);
+      const windowB = new ReadStateStore(memento);
+      await windowA.load();
+
+      await windowB.add('gh::remote');
+      await windowA.add('gh::local');
+
+      expect(memento.get<string[]>('devdocket.read-state')?.sort()).toEqual(['gh::local', 'gh::remote']);
+
+      windowA.dispose();
+      windowB.dispose();
+    });
+
+    it('keeps locally removed keys deleted while preserving remote additions', async () => {
+      await memento.update('devdocket.read-state', ['gh::keep', 'gh::remove']);
+
+      const windowA = new ReadStateStore(memento);
+      const windowB = new ReadStateStore(memento);
+      await windowA.load();
+      await windowB.load();
+
+      await windowB.add('gh::remote');
+      await windowA.deleteMany(['gh::remove']);
+
+      expect([...windowA.keys()].sort()).toEqual(['gh::keep', 'gh::remote']);
+      expect(memento.get<string[]>('devdocket.read-state')?.sort()).toEqual(['gh::keep', 'gh::remote']);
+
+      windowA.dispose();
+      windowB.dispose();
+    });
+
+    it('invalidateCache forces a re-read on next load', async () => {
+      await store.add('gh::issue-1');
+
+      await memento.update('devdocket.read-state', ['gh::issue-2']);
+
+      store.invalidateCache();
+      await store.load();
+
+      expect([...store.keys()]).toEqual(['gh::issue-2']);
+    });
+  });
+
   describe('prune', () => {
     it('removes only stale keys belonging to providers that returned items', async () => {
       await store.addMany(['gh::keep', 'gh::stale', 'jira::stale']);

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -174,6 +174,26 @@ describe('ReadStateStore', () => {
       windowB.dispose();
     });
 
+    it('allows remote re-additions after a successful persist', async () => {
+      await memento.update('devdocket.read-state', ['gh::shared']);
+
+      const windowA = new ReadStateStore(memento);
+      await windowA.load();
+
+      await windowA.deleteMany(['gh::shared']);
+
+      const windowB = new ReadStateStore(memento);
+      await windowB.load();
+      await windowB.add('gh::shared');
+
+      await windowA.add('gh::local');
+
+      expect(memento.get<string[]>('devdocket.read-state')?.sort()).toEqual(['gh::local', 'gh::shared']);
+
+      windowA.dispose();
+      windowB.dispose();
+    });
+
     it('invalidateCache forces a re-read on next load', async () => {
       await store.add('gh::issue-1');
 

--- a/packages/core/src/test/stateVersionService.test.ts
+++ b/packages/core/src/test/stateVersionService.test.ts
@@ -119,6 +119,19 @@ describe('StateVersionService', () => {
     service.dispose();
   });
 
+  it('serializes concurrent bumps so each write gets a unique version', async () => {
+    vi.setSystemTime(new Date('2026-05-21T02:00:00Z'));
+    const service = new StateVersionService(vscode.Uri.file('C:\\state'));
+
+    await Promise.all([service.bump(), service.bump(), service.bump()]);
+
+    const versions = (vscode.workspace.fs.writeFile as any).mock.calls.slice(0, 3)
+      .map(([, content]: [unknown, Uint8Array]) => JSON.parse(Buffer.from(content).toString('utf-8')).version);
+    expect(new Set(versions).size).toBe(3);
+
+    service.dispose();
+  });
+
   it('stops reacting after dispose', async () => {
     const service = new StateVersionService(vscode.Uri.file('C:\\state'));
     const listener = vi.fn();

--- a/packages/core/src/test/stateVersionService.test.ts
+++ b/packages/core/src/test/stateVersionService.test.ts
@@ -105,6 +105,20 @@ describe('StateVersionService', () => {
     service.dispose();
   });
 
+  it('writes a unique version for consecutive same-millisecond bumps', async () => {
+    vi.setSystemTime(new Date('2026-05-21T02:00:00Z'));
+    const service = new StateVersionService(vscode.Uri.file('C:\\state'));
+
+    await service.bump();
+    await service.bump();
+
+    const firstPayload = JSON.parse(Buffer.from((vscode.workspace.fs.writeFile as any).mock.calls[0][1]).toString('utf-8'));
+    const secondPayload = JSON.parse(Buffer.from((vscode.workspace.fs.writeFile as any).mock.calls[1][1]).toString('utf-8'));
+    expect(secondPayload.version).toBeGreaterThan(firstPayload.version);
+
+    service.dispose();
+  });
+
   it('stops reacting after dispose', async () => {
     const service = new StateVersionService(vscode.Uri.file('C:\\state'));
     const listener = vi.fn();

--- a/packages/core/src/test/stateVersionService.test.ts
+++ b/packages/core/src/test/stateVersionService.test.ts
@@ -87,6 +87,24 @@ describe('StateVersionService', () => {
     service.dispose();
   });
 
+  it('does not fire repeatedly for the same external version', async () => {
+    const service = new StateVersionService(vscode.Uri.file('C:\\state'));
+    const listener = vi.fn();
+    service.onDidExternalStateChange(listener);
+    (vscode.workspace.fs.readFile as any).mockResolvedValue(
+      Buffer.from(JSON.stringify({ instanceId: 'other-window', version: 123 }), 'utf-8'),
+    );
+
+    onDidChange?.();
+    await vi.advanceTimersByTimeAsync(100);
+    onDidChange?.();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    service.dispose();
+  });
+
   it('stops reacting after dispose', async () => {
     const service = new StateVersionService(vscode.Uri.file('C:\\state'));
     const listener = vi.fn();

--- a/packages/core/src/test/stateVersionService.test.ts
+++ b/packages/core/src/test/stateVersionService.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { StateVersionService } from '../services/stateVersionService';
+
+describe('StateVersionService', () => {
+  let onDidChange: (() => void) | undefined;
+  let onDidCreate: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    onDidChange = undefined;
+    onDidCreate = undefined;
+
+    (vscode.workspace.createFileSystemWatcher as any).mockImplementation(() => ({
+      onDidChange: (listener: () => void) => {
+        onDidChange = listener;
+        return { dispose: vi.fn() };
+      },
+      onDidCreate: (listener: () => void) => {
+        onDidCreate = listener;
+        return { dispose: vi.fn() };
+      },
+      onDidDelete: vi.fn(() => ({ dispose: vi.fn() })),
+      dispose: vi.fn(),
+    }));
+    (vscode.workspace.fs.readFile as any).mockRejectedValue(new Error('not found'));
+    (vscode.workspace.fs.writeFile as any).mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('writes a version file when bumped', async () => {
+    const service = new StateVersionService(vscode.Uri.file('C:\\state'));
+
+    await service.bump();
+
+    expect(vscode.workspace.createFileSystemWatcher).toHaveBeenCalledWith(
+      expect.objectContaining({ pattern: 'state-version.json' }),
+    );
+    expect(vscode.workspace.fs.writeFile).toHaveBeenCalledTimes(1);
+
+    const [uri, content] = (vscode.workspace.fs.writeFile as any).mock.calls[0];
+    expect(uri.fsPath).toBe('C:\\state\\state-version.json');
+
+    const payload = JSON.parse(Buffer.from(content).toString('utf-8'));
+    expect(payload.instanceId).toEqual(expect.any(String));
+    expect(payload.version).toEqual(expect.any(Number));
+
+    service.dispose();
+  });
+
+  it('ignores its own version writes', async () => {
+    const service = new StateVersionService(vscode.Uri.file('C:\\state'));
+    const listener = vi.fn();
+    service.onDidExternalStateChange(listener);
+
+    await service.bump();
+    const [, content] = (vscode.workspace.fs.writeFile as any).mock.calls[0];
+    (vscode.workspace.fs.readFile as any).mockResolvedValue(content);
+
+    onDidChange?.();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(listener).not.toHaveBeenCalled();
+
+    service.dispose();
+  });
+
+  it('fires once for debounced external changes', async () => {
+    const service = new StateVersionService(vscode.Uri.file('C:\\state'));
+    const listener = vi.fn();
+    service.onDidExternalStateChange(listener);
+    (vscode.workspace.fs.readFile as any).mockResolvedValue(
+      Buffer.from(JSON.stringify({ instanceId: 'other-window', version: 123 }), 'utf-8'),
+    );
+
+    onDidChange?.();
+    onDidCreate?.();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(vscode.workspace.fs.readFile).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    service.dispose();
+  });
+
+  it('stops reacting after dispose', async () => {
+    const service = new StateVersionService(vscode.Uri.file('C:\\state'));
+    const listener = vi.fn();
+    service.onDidExternalStateChange(listener);
+    (vscode.workspace.fs.readFile as any).mockResolvedValue(
+      Buffer.from(JSON.stringify({ instanceId: 'other-window', version: 123 }), 'utf-8'),
+    );
+
+    service.dispose();
+    onDidChange?.();
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(vscode.workspace.fs.readFile).not.toHaveBeenCalled();
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -161,6 +161,15 @@ describe('WorkGraph', () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
+  it('tags invalidateAndReload change events as external reloads', async () => {
+    const listener = vi.fn();
+    graph.onDidChange(listener);
+
+    await graph.invalidateAndReload();
+
+    expect(listener).toHaveBeenCalledWith({ source: 'externalReload' });
+  });
+
   it('sets notes on create', async () => {
     const item = await graph.createItem({
       title: 'Detailed',


### PR DESCRIPTION
## Summary
- add merge-on-write safeguards for work items, inbox state, read state, and provider labels so concurrent VS Code windows preserve remote additions and avoid clobbering newer local changes
- add cross-window change propagation with a version file and file watcher so other windows invalidate stale caches and reload state after external writes
- add focused coverage for merge-on-write behavior, cache invalidation, and version-file signaling

Closes #625

## Key design decisions
- Merge-on-write is a best-effort safety net around `globalState.update(...)`, not a distributed lock. Each store re-reads persisted state before writing and applies store-specific merge rules.
- Cross-window notifications use a small version file in `globalStorageUri` because VS Code globalState has no native cross-window change event.
- Store merge semantics remain domain-specific:
  - work items use `updatedAt` last-writer-wins for shared records
  - inbox state tracks dirty and removed keys so untouched remote updates survive while local edits still win
  - read state unions remote additions while honoring local removals
  - provider labels use local-wins overlay semantics on conflict
- External reloads suppress self-bumps so propagation does not loop when a window reloads after another window writes.

## Validation
- npm run build
- npm run test
