### PR TITLE
Activate provider extensions when DevDocket sidebar opens

### DIFF
--- a/.changeset/provider-activation-on-sidebar-open.md
+++ b/.changeset/provider-activation-on-sidebar-open.md
@@ -1,0 +1,8 @@
+---
+"devdocket-github": patch
+"devdocket-ado": patch
+"devdocket-start-git-work": patch
+"devdocket-ai-reviewer": patch
+---
+
+Activate provider and action extensions when the DevDocket sidebar opens, not only at VS Code startup. This ensures extensions installed mid-session (e.g., via Settings Sync) activate the first time the user opens the DevDocket sidebar instead of requiring a VS Code restart.

--- a/packages/ado/package.json
+++ b/packages/ado/package.json
@@ -41,7 +41,8 @@
     "devdocket.devdocket"
   ],
   "activationEvents": [
-    "onStartupFinished"
+    "onStartupFinished",
+    "onView:devdocket.main"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/packages/ai-reviewer/package.json
+++ b/packages/ai-reviewer/package.json
@@ -43,7 +43,8 @@
     "devdocket.devdocket"
   ],
   "activationEvents": [
-    "onStartupFinished"
+    "onStartupFinished",
+    "onView:devdocket.main"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -41,7 +41,8 @@
     "devdocket.devdocket"
   ],
   "activationEvents": [
-    "onStartupFinished"
+    "onStartupFinished",
+    "onView:devdocket.main"
   ],
   "main": "./dist/extension.js",
   "contributes": {

--- a/packages/start-git-work/package.json
+++ b/packages/start-git-work/package.json
@@ -39,7 +39,8 @@
     "devdocket.devdocket"
   ],
   "activationEvents": [
-    "onStartupFinished"
+    "onStartupFinished",
+    "onView:devdocket.main"
   ],
   "main": "./dist/extension.js",
   "contributes": {


### PR DESCRIPTION
## Summary
- fix satellite extensions that were installed mid-session but never activated until VS Code restarted
- add DevDocket sidebar activation so GitHub, ADO, Start Git Work, and AI Reviewer activate when the sidebar opens
- keep startup activation in place by retaining the existing startup event

## Testing
- npm run build
- npm run test

Closes #630
