### PR TITLE
Wait for webview to signal ready before posting initial sidebar data

### DIFF
--- a/.changeset/webview-ready-handshake.md
+++ b/.changeset/webview-ready-handshake.md
@@ -1,0 +1,5 @@
+---
+"devdocket": patch
+---
+
+Wait for the sidebar webview to signal it is ready before posting initial data, with a fallback timeout so first-open content still appears if the ready message never arrives.

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -32,7 +32,7 @@ function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
   };
 }
 
-function createMockWebviewView() {
+function createMockWebviewView(options: { autoReady?: boolean } = {}) {
   let messageHandler: MessageHandler | undefined;
   const webview = {
     html: '',
@@ -43,6 +43,9 @@ function createMockWebviewView() {
     })),
     onDidReceiveMessage: vi.fn((handler: MessageHandler) => {
       messageHandler = handler;
+      if (options.autoReady !== false) {
+        void messageHandler({ type: 'webviewReady' });
+      }
       return { dispose: vi.fn(() => { messageHandler = undefined; }) };
     }),
     postMessage: vi.fn(async () => true),
@@ -52,6 +55,7 @@ function createMockWebviewView() {
     view: { webview, badge: undefined } as any,
     webview,
     simulateMessage: (message: unknown) => messageHandler?.(message) ?? Promise.resolve(),
+    signalReady: () => messageHandler?.({ type: 'webviewReady' }) ?? Promise.resolve(),
     getMessages: () => webview.postMessage.mock.calls.map(([message]) => message),
   };
 }
@@ -877,6 +881,66 @@ describe('MainViewProvider', () => {
     });
   });
 
+  it('does not post refresh messages until the webview signals ready', async () => {
+    vi.useFakeTimers();
+    const provider = createProvider(
+      createMockWorkGraph([makeWorkItem({ id: 'queue-1', title: 'Queue 1', sortOrder: 0 })]),
+      createProviderRegistry({ github: [{ externalId: 'incoming-1', title: 'Incoming item', state: 'open' }] }),
+      createStateStore(),
+    );
+    const mockView = createMockWebviewView({ autoReady: false });
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    provider.scheduleRefresh('state');
+
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(mockView.webview.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('flushes buffered refresh reasons after the webview signals ready', async () => {
+    vi.useFakeTimers();
+    const provider = createProvider(
+      createMockWorkGraph([makeWorkItem({ id: 'queue-1', title: 'Queue 1', sortOrder: 0 })]),
+      createProviderRegistry({ github: [{ externalId: 'incoming-1', title: 'Incoming item', state: 'open' }] }),
+      createStateStore(),
+    );
+    const mockView = createMockWebviewView({ autoReady: false });
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    provider.scheduleRefresh('state');
+    await vi.advanceTimersByTimeAsync(50);
+    expect(mockView.webview.postMessage).not.toHaveBeenCalled();
+
+    await mockView.signalReady();
+    await vi.advanceTimersByTimeAsync(50);
+
+    expect(findPostedMessage(mockView, 'updateItems')).toBeDefined();
+    expect(findPostedMessage(mockView, 'updateSources')).toBeDefined();
+  });
+
+  it('falls back to posting buffered refresh messages after the ready timeout elapses', async () => {
+    vi.useFakeTimers();
+    const provider = createProvider(
+      createMockWorkGraph([makeWorkItem({ id: 'queue-1', title: 'Queue 1', sortOrder: 0 })]),
+      createProviderRegistry({ github: [{ externalId: 'incoming-1', title: 'Incoming item', state: 'open' }] }),
+      createStateStore(),
+    );
+    const mockView = createMockWebviewView({ autoReady: false });
+
+    provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    provider.scheduleRefresh('state');
+    await vi.advanceTimersByTimeAsync(50);
+    expect(mockView.webview.postMessage).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(2999);
+    expect(mockView.webview.postMessage).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(51);
+    expect(findPostedMessage(mockView, 'updateItems')).toBeDefined();
+    expect(findPostedMessage(mockView, 'updateSources')).toBeDefined();
+  });
+
   it('skips sources updates for read-state-only refreshes', async () => {
     vi.useFakeTimers();
     const provider = createProvider(
@@ -911,6 +975,7 @@ describe('MainViewProvider', () => {
     const mockView = createMockWebviewView();
 
     provider.resolveWebviewView(mockView.view, {} as any, {} as any);
+    mockView.webview.postMessage.mockClear();
     provider.scheduleRefresh('workGraph');
     provider.scheduleRefresh('state');
 

--- a/packages/core/src/views/mainTypes.ts
+++ b/packages/core/src/views/mainTypes.ts
@@ -13,6 +13,7 @@ export type ExtensionMessage =
   | { type: 'updateTitle'; title: string };
 
 export type WebviewMessage =
+  | { type: 'webviewReady' }
   | { type: 'openItem'; itemId: string; providerId?: string; externalId?: string }
   | { type: 'openSourceItem'; providerId: string; externalId: string }
   | { type: 'showProviderHealth'; providerId: string }

--- a/packages/core/src/views/mainViewProvider.ts
+++ b/packages/core/src/views/mainViewProvider.ts
@@ -40,10 +40,13 @@ export type RefreshReason =
 export class MainViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewId = 'devdocket.main';
   private static readonly REFRESH_DEBOUNCE_MS = 50;
+  private static readonly WEBVIEW_READY_TIMEOUT_MS = 3000;
 
   private view?: vscode.WebviewView;
   private refreshTimer?: ReturnType<typeof setTimeout>;
+  private webviewReadyTimer?: ReturnType<typeof setTimeout>;
   private pendingRefreshReasons = new Set<RefreshReason>();
+  private webviewReady = false;
   private disposed = false;
 
   constructor(
@@ -66,6 +69,10 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
       clearTimeout(this.refreshTimer);
       this.refreshTimer = undefined;
     }
+    if (this.webviewReadyTimer) {
+      clearTimeout(this.webviewReadyTimer);
+      this.webviewReadyTimer = undefined;
+    }
     this.pendingRefreshReasons.clear();
   }
 
@@ -75,6 +82,7 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     _token: vscode.CancellationToken,
   ): void {
     this.view = webviewView;
+    this.webviewReady = false;
 
     webviewView.webview.options = {
       enableScripts: true,
@@ -85,6 +93,17 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
     webviewView.webview.onDidReceiveMessage((message: WebviewMessage) => {
       void this.handleMessage(message);
     });
+
+    if (this.webviewReadyTimer) {
+      clearTimeout(this.webviewReadyTimer);
+    }
+    this.webviewReadyTimer = setTimeout(() => {
+      if (!this.webviewReady && this.view === webviewView && !this.disposed) {
+        this.webviewReady = true;
+        this.scheduleRefresh('discovered');
+      }
+      this.webviewReadyTimer = undefined;
+    }, MainViewProvider.WEBVIEW_READY_TIMEOUT_MS);
 
     this.scheduleRefresh('discovered');
   }
@@ -115,6 +134,14 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
 
   private refresh(reasons: ReadonlySet<RefreshReason>): void {
     if (!this.view) {
+      return;
+    }
+    if (!this.webviewReady) {
+      // The ready/fallback paths call scheduleRefresh('discovered') to re-arm
+      // the debounce timer and flush these buffered reasons once delivery is safe.
+      for (const reason of reasons) {
+        this.pendingRefreshReasons.add(reason);
+      }
       return;
     }
 
@@ -456,6 +483,14 @@ export class MainViewProvider implements vscode.WebviewViewProvider {
 
   private async handleMessage(message: WebviewMessage): Promise<void> {
     switch (message.type) {
+      case 'webviewReady':
+        this.webviewReady = true;
+        if (this.webviewReadyTimer) {
+          clearTimeout(this.webviewReadyTimer);
+          this.webviewReadyTimer = undefined;
+        }
+        this.scheduleRefresh('discovered');
+        break;
       case 'openItem': {
         const workItem = this.workGraph.getItem(message.itemId);
         if (workItem) {

--- a/packages/core/src/webview/sidebar/App.tsx
+++ b/packages/core/src/webview/sidebar/App.tsx
@@ -140,6 +140,9 @@ export function App() {
 
     window.addEventListener('message', handler);
 
+    // Signal that the webview is ready to receive extension messages.
+    postMessage({ type: 'webviewReady' });
+
     // Required: VS Code's keybinding service does NOT see keystrokes that
     // happen inside a sidebar webview view's iframe (registerWebviewViewProvider).
     // The package.json `devdocket.toggleSearch` keybinding only fires when focus


### PR DESCRIPTION
## Summary
- wait for the sidebar webview to signal `webviewReady` before posting the initial sidebar payload
- buffer refresh reasons until the webview is ready, with a 3-second fallback timeout so the sidebar does not stay empty forever
- add tests covering the pre-ready hold, ready flush, and timeout fallback paths

## Testing
- npm run build
- npm run test

Closes #641

Refs microsoft/vscode#91891.
