### PR TITLE
Migrate user-intent stores to file-backed storage for cross-window sync

### DIFF
--- a/.changeset/file-backed-storage.md
+++ b/.changeset/file-backed-storage.md
@@ -1,0 +1,5 @@
+---
+"devdocket": minor
+---
+
+Migrate work items, inbox state, read state, and watches from globalState to file-backed storage so cross-window reloads can read fresh data from disk.

--- a/.github/instructions/storage.instructions.md
+++ b/.github/instructions/storage.instructions.md
@@ -10,7 +10,7 @@ User-intent stores persist to JSON files under `globalStorageUri` via `vscode.wo
 
 `JsonTaskStore`, `InboxStateStore`, and `ReadStateStore` keep in-memory caches plus merge-on-write logic: they re-read the backing file before each persist, merge remote changes with local edits, and then write the merged result back. `WatchStore` is also file-backed and merges against the latest on-disk snapshot while preserving remote-only entries the current window has not loaded.
 
-Because `vscode.workspace.fs.writeFile()` is not atomic, there is no file-locking or write queue. The merge-on-write logic is best-effort conflict reduction; callers should still keep writes scoped to user-intent mutations.
+Because there is no cross-process file-locking or write queue, merge-on-write is still best-effort conflict reduction even though `JsonFileStore` uses a temp-file plus rename pattern for atomic replacement of the final file. Callers should still keep writes scoped to user-intent mutations.
 
 ## One-time Migrations
 

--- a/.github/instructions/storage.instructions.md
+++ b/.github/instructions/storage.instructions.md
@@ -4,17 +4,19 @@ applyTo: "**/storage/**"
 
 # Storage Conventions
 
-## Memento-backed Stores
+## File-backed Stores
 
-All stores persist data via VS Code's `Memento` (`globalState`) API. Each store takes a `Memento` in its constructor and writes via `this.globalState.update(key, data)`.
+User-intent stores persist to JSON files under `globalStorageUri` via `vscode.workspace.fs`, not `globalState`. Each file-backed store receives a `JsonFileStore` (or compatible `FileStore`) and re-reads from disk on load so cross-window invalidation can observe fresh data.
 
-Most stores (e.g., `JsonTaskStore`, `InboxStateStore`, `ReadStateStore`) maintain an in-memory cache populated on first load and expose a private `persist()` method. Simpler stores (e.g., `WatchStore`) read/write directly without a cache. Loading methods vary by store (`loadAll()`, `load()`).
+`JsonTaskStore`, `InboxStateStore`, and `ReadStateStore` keep in-memory caches plus merge-on-write logic: they re-read the backing file before each persist, merge remote changes with local edits, and then write the merged result back. `WatchStore` is also file-backed and merges against the latest on-disk snapshot while preserving remote-only entries the current window has not loaded.
 
-Because `globalState.update()` is atomic from the extension's perspective, there is no write-queue or file-level locking. Stores no longer extend a base class.
+Because `vscode.workspace.fs.writeFile()` is not atomic, there is no file-locking or write queue. The merge-on-write logic is best-effort conflict reduction; callers should still keep writes scoped to user-intent mutations.
 
-## One-time Migration
+## One-time Migrations
 
-`migrateToGlobalState()` in `migration.ts` handles the one-off migration from legacy JSON files (in `globalStorageUri`) to globalState. It is idempotent — guarded by the `devdocket.migrated` flag — and only marks migration complete when every file either migrated successfully or was confirmed absent.
+`migrateToGlobalState()` in `migration.ts` handles the older one-off migration from legacy JSON files (in `globalStorageUri`) to `globalState`. It is idempotent — guarded by the `devdocket.migrated` flag — and only marks migration complete when every file either migrated successfully or was confirmed absent.
+
+`migrateGlobalStateToFiles()` handles the follow-up migration from `globalState` into the new file-backed stores. It is guarded by `devdocket.migrated-to-files`, skips files that already exist so retries do not clobber newer file-backed data, and deliberately leaves the old `globalState` keys in place as rollback fallback.
 
 ### Field Validators
 
@@ -37,14 +39,14 @@ return requiredString(obj, 'id', ctx)
 
 ## Data Stores
 
-Five globalState keys hold persisted data:
+Four user-intent files and one `globalState` cache hold persisted data:
 
-- **`devdocket.workitems`** — Persisted WorkItems with state machine lifecycle (`New` → `InProgress` → `Done` → `Archived`).
-- **`devdocket.inbox-state`** — Thin index mapping `providerId + externalId` → `InboxState` (`unseen` | `accepted` | `dismissed`). Provider item data (title, description, url) is **not persisted** — always read live from the provider.
-- **`devdocket.read-state`** — Set of inbox item IDs the user has viewed.
-- **`devdocket.provider-labels`** — Cached mapping of `providerId` → display label (for example, `"github"` → `"GitHub Issues"`).
-- **`devdocket.watches`** — User-configured watch entries.
+- **`globalStorageUri\workitems.json`** — Persisted WorkItems with state machine lifecycle (`New` → `InProgress` → `Done` → `Archived`).
+- **`globalStorageUri\inbox-state.json`** — Thin index mapping `providerId + externalId` → `InboxState` (`unseen` | `accepted` | `dismissed`). Provider item data (title, description, url) is **not persisted** — always read live from the provider.
+- **`globalStorageUri\read-state.json`** — Set of inbox item IDs the user has viewed.
+- **`globalStorageUri\watches.json`** — User-configured watch entries. The store is file-backed, but live cross-window invalidation is currently only wired for work items, inbox state, and read state; watch changes are picked up on reload.
+- **`globalState['devdocket.provider-labels']`** — Cached mapping of `providerId` → display label (for example, `"github"` → `"GitHub Issues"`). Provider labels are not part of cross-window propagation; startup staleness is acceptable.
 
 ## Provider Items Are References, Not Copies
 
-Items in the Incoming tier and the Sources tab are read live from the provider's in-memory data. The only persisted state is the `inboxState` enum. This keeps data fresh and avoids stale copies. Never cache or persist provider item data beyond the thin `devdocket.inbox-state` globalState entry.
+Items in the Incoming tier and the Sources tab are read live from the provider's in-memory data. The only persisted state is the `inboxState` enum. This keeps data fresh and avoids stale copies. Never cache or persist provider item data beyond the thin `inbox-state.json` file-backed record.

--- a/.github/instructions/storage.instructions.md
+++ b/.github/instructions/storage.instructions.md
@@ -41,10 +41,10 @@ return requiredString(obj, 'id', ctx)
 
 Four user-intent files and one `globalState` cache hold persisted data:
 
-- **`globalStorageUri\workitems.json`** — Persisted WorkItems with state machine lifecycle (`New` → `InProgress` → `Done` → `Archived`).
-- **`globalStorageUri\inbox-state.json`** — Thin index mapping `providerId + externalId` → `InboxState` (`unseen` | `accepted` | `dismissed`). Provider item data (title, description, url) is **not persisted** — always read live from the provider.
-- **`globalStorageUri\read-state.json`** — Set of inbox item IDs the user has viewed.
-- **`globalStorageUri\watches.json`** — User-configured watch entries. The store is file-backed, but live cross-window invalidation is currently only wired for work items, inbox state, and read state; watch changes are picked up on reload.
+- **`globalStorageUri/workitems.json`** — Persisted WorkItems with state machine lifecycle (`New` → `InProgress` → `Done` → `Archived`).
+- **`globalStorageUri/inbox-state.json`** — Thin index mapping `providerId + externalId` → `InboxState` (`unseen` | `accepted` | `dismissed`). Provider item data (title, description, url) is **not persisted** — always read live from the provider.
+- **`globalStorageUri/read-state.json`** — Set of inbox item IDs the user has viewed.
+- **`globalStorageUri/watches.json`** — User-configured watch entries. The store is file-backed, but live cross-window invalidation is currently only wired for work items, inbox state, and read state; watch changes are picked up on reload.
 - **`globalState['devdocket.provider-labels']`** — Cached mapping of `providerId` → display label (for example, `"github"` → `"GitHub Issues"`). Provider labels are not part of cross-window propagation; startup staleness is acceptable.
 
 ## Provider Items Are References, Not Copies

--- a/package-lock.json
+++ b/package-lock.json
@@ -6602,7 +6602,7 @@
     },
     "packages/ado": {
       "name": "devdocket-ado",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*"
@@ -7038,7 +7038,7 @@
     },
     "packages/ai-reviewer": {
       "name": "devdocket-ai-reviewer",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*"
@@ -7474,7 +7474,7 @@
     },
     "packages/core": {
       "name": "devdocket",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*",
@@ -8610,7 +8610,7 @@
     },
     "packages/github": {
       "name": "devdocket-github",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*",
@@ -9047,7 +9047,7 @@
     },
     "packages/shared": {
       "name": "@devdocket/shared",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.3.0",
@@ -9056,7 +9056,7 @@
     },
     "packages/start-git-work": {
       "name": "devdocket-start-git-work",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@devdocket/shared": "*"

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -6,7 +6,8 @@ import { JsonTaskStore } from './storage/jsonTaskStore';
 import { InboxStateStore } from './storage/inboxStateStore';
 import { ReadStateStore } from './storage/readStateStore';
 import { ProviderLabelCache } from './storage/providerLabelCache';
-import { migrateToGlobalState } from './storage/migration';
+import { migrateGlobalStateToFiles, migrateToGlobalState } from './storage/migration';
+import { createJsonFileStore } from './storage/fileStore';
 import { WorkGraph } from './services/workGraph';
 import { ProviderRegistry } from './services/providerRegistry';
 import { checkAutoComplete, showAutoCompleteNotification } from './services/autoComplete';
@@ -53,17 +54,17 @@ function initializeLogging(context: vscode.ExtensionContext): vscode.LogOutputCh
   return log;
 }
 
-async function loadStores(globalState: vscode.Memento): Promise<{ workGraph: WorkGraph; stateStore: InboxStateStore; readStateStore: ReadStateStore; labelCache: ProviderLabelCache }> {
-  const store = new JsonTaskStore(globalState);
+async function loadStores(globalState: vscode.Memento, globalStorageUri: vscode.Uri): Promise<{ workGraph: WorkGraph; stateStore: InboxStateStore; readStateStore: ReadStateStore; labelCache: ProviderLabelCache }> {
+  const store = new JsonTaskStore(createJsonFileStore(globalStorageUri, 'workitems.json', 'workitems.json'));
   const wg = new WorkGraph(store);
   await wg.load();
   logger.debug(`Loaded ${wg.getAll().length} work items`);
 
-  const ss = new InboxStateStore(globalState);
+  const ss = new InboxStateStore(createJsonFileStore(globalStorageUri, 'inbox-state.json', 'inbox-state.json'));
   await ss.load();
   logger.debug('Loaded inbox state');
 
-  const readStateStore = new ReadStateStore(globalState);
+  const readStateStore = new ReadStateStore(createJsonFileStore(globalStorageUri, 'read-state.json', 'read-state.json'));
   await readStateStore.load();
   logger.debug('Loaded read state');
 
@@ -464,7 +465,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const initStart = performance.now();
   const storagePath = context.globalStorageUri.fsPath;
   await migrateToGlobalState(context.globalState, storagePath);
-  const { workGraph: wg, stateStore: ss, readStateStore, labelCache } = await loadStores(context.globalState);
+  await migrateGlobalStateToFiles(context.globalState, context.globalStorageUri);
+  const { workGraph: wg, stateStore: ss, readStateStore, labelCache } = await loadStores(context.globalState, context.globalStorageUri);
   await migrateInboxState(wg, ss);
 
   const pr = new ProviderRegistry(
@@ -479,7 +481,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const adrr = new ActivityDetailRendererRegistry();
   const wr = new WatcherRegistry(logger);
   const pwr = new PRWatcherRegistry(logger);
-  const watchStore = new WatchStore(context.globalState);
+  const watchStore = new WatchStore(createJsonFileStore(context.globalStorageUri, 'watches.json', 'watches.json'));
   const ws = new WatcherService(wr, pwr, watchStore, logger);
   const api = new DevDocketApiImpl(pr, ar, wr, pwr, wg, adrr);
   logger.info(`Store + service init took ${Math.round(performance.now() - initStart)}ms`);
@@ -496,14 +498,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     windowStateEmitter,
   );
 
-  // Cross-window state propagation for work-item and inbox/read-state stores.
+  // Cross-window state propagation for work-item, inbox-state, and read-state stores.
   const stateVersion = new StateVersionService(context.globalStorageUri);
   const bumpStateVersion = () => stateVersion.bump();
   let mainProvider: MainViewProvider | undefined;
   wg.onDidChange(safeHandler('sv:workGraph', (event) => event.source === 'externalReload' ? Promise.resolve() : bumpStateVersion()));
   ss.onDidChange(safeHandler('sv:stateStore', () => bumpStateVersion()));
   readStateStore.onDidChange(safeHandler('sv:readState', () => bumpStateVersion()));
-  labelCache.onDidChange(safeHandler('sv:labelCache', () => bumpStateVersion()));
   stateVersion.onDidExternalStateChange(safeHandler('sv:external', async () => {
     logger.debug('External state change detected — invalidating caches');
     await wg.invalidateAndReload();
@@ -511,8 +512,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
     await ss.load();
     readStateStore.invalidateCache();
     await readStateStore.load();
-    labelCache.invalidateCache();
-    await labelCache.load();
     mainProvider?.scheduleRefresh('discovered');
   }));
 

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -7,7 +7,7 @@ import { InboxStateStore } from './storage/inboxStateStore';
 import { ReadStateStore } from './storage/readStateStore';
 import { ProviderLabelCache } from './storage/providerLabelCache';
 import { migrateGlobalStateToFiles, migrateToGlobalState } from './storage/migration';
-import { createJsonFileStore } from './storage/fileStore';
+import { createJsonFileStore, createMementoStore, type FileStore } from './storage/fileStore';
 import { WorkGraph } from './services/workGraph';
 import { ProviderRegistry } from './services/providerRegistry';
 import { checkAutoComplete, showAutoCompleteNotification } from './services/autoComplete';
@@ -54,17 +54,33 @@ function initializeLogging(context: vscode.ExtensionContext): vscode.LogOutputCh
   return log;
 }
 
-async function loadStores(globalState: vscode.Memento, globalStorageUri: vscode.Uri): Promise<{ workGraph: WorkGraph; stateStore: InboxStateStore; readStateStore: ReadStateStore; labelCache: ProviderLabelCache }> {
-  const store = new JsonTaskStore(createJsonFileStore(globalStorageUri, 'workitems.json', 'workitems.json'));
+function createUserIntentStore<T>(
+  useFileBackedStorage: boolean,
+  globalState: vscode.Memento,
+  globalStorageUri: vscode.Uri,
+  stateKey: string,
+  filename: string,
+): FileStore<T> {
+  return useFileBackedStorage
+    ? createJsonFileStore<T>(globalStorageUri, filename, filename)
+    : createMementoStore<T>(globalState, stateKey);
+}
+
+async function loadStores(
+  globalState: vscode.Memento,
+  globalStorageUri: vscode.Uri,
+  useFileBackedStorage: boolean,
+): Promise<{ workGraph: WorkGraph; stateStore: InboxStateStore; readStateStore: ReadStateStore; labelCache: ProviderLabelCache }> {
+  const store = new JsonTaskStore(createUserIntentStore(useFileBackedStorage, globalState, globalStorageUri, 'devdocket.workitems', 'workitems.json'));
   const wg = new WorkGraph(store);
   await wg.load();
   logger.debug(`Loaded ${wg.getAll().length} work items`);
 
-  const ss = new InboxStateStore(createJsonFileStore(globalStorageUri, 'inbox-state.json', 'inbox-state.json'));
+  const ss = new InboxStateStore(createUserIntentStore(useFileBackedStorage, globalState, globalStorageUri, 'devdocket.inbox-state', 'inbox-state.json'));
   await ss.load();
   logger.debug('Loaded inbox state');
 
-  const readStateStore = new ReadStateStore(createJsonFileStore(globalStorageUri, 'read-state.json', 'read-state.json'));
+  const readStateStore = new ReadStateStore(createUserIntentStore(useFileBackedStorage, globalState, globalStorageUri, 'devdocket.read-state', 'read-state.json'));
   await readStateStore.load();
   logger.debug('Loaded read state');
 
@@ -465,8 +481,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const initStart = performance.now();
   const storagePath = context.globalStorageUri.fsPath;
   await migrateToGlobalState(context.globalState, storagePath);
-  await migrateGlobalStateToFiles(context.globalState, context.globalStorageUri);
-  const { workGraph: wg, stateStore: ss, readStateStore, labelCache } = await loadStores(context.globalState, context.globalStorageUri);
+  const useFileBackedStorage = await migrateGlobalStateToFiles(context.globalState, context.globalStorageUri);
+  const { workGraph: wg, stateStore: ss, readStateStore, labelCache } = await loadStores(context.globalState, context.globalStorageUri, useFileBackedStorage);
   await migrateInboxState(wg, ss);
 
   const pr = new ProviderRegistry(
@@ -481,7 +497,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const adrr = new ActivityDetailRendererRegistry();
   const wr = new WatcherRegistry(logger);
   const pwr = new PRWatcherRegistry(logger);
-  const watchStore = new WatchStore(createJsonFileStore(context.globalStorageUri, 'watches.json', 'watches.json'));
+  const watchStore = new WatchStore(createUserIntentStore(useFileBackedStorage, context.globalState, context.globalStorageUri, 'devdocket.watches', 'watches.json'));
   const ws = new WatcherService(wr, pwr, watchStore, logger);
   const api = new DevDocketApiImpl(pr, ar, wr, pwr, wg, adrr);
   logger.info(`Store + service init took ${Math.round(performance.now() - initStart)}ms`);

--- a/packages/core/src/storage/fileStore.ts
+++ b/packages/core/src/storage/fileStore.ts
@@ -78,10 +78,29 @@ export class JsonFileStore<T> implements FileStore<T> {
   }
 }
 
+export class MementoStore<T> implements FileStore<T> {
+  constructor(
+    private readonly memento: vscode.Memento,
+    private readonly key: string,
+  ) {}
+
+  async read(): Promise<T | undefined> {
+    return this.memento.get<T>(this.key);
+  }
+
+  async write(value: T): Promise<void> {
+    await this.memento.update(this.key, value);
+  }
+}
+
 export function createJsonFileStore<T>(
   globalStorageUri: vscode.Uri,
   filename: string,
   label = filename,
 ): JsonFileStore<T> {
   return new JsonFileStore<T>(vscode.Uri.joinPath(globalStorageUri, filename), label);
+}
+
+export function createMementoStore<T>(memento: vscode.Memento, key: string): MementoStore<T> {
+  return new MementoStore<T>(memento, key);
 }

--- a/packages/core/src/storage/fileStore.ts
+++ b/packages/core/src/storage/fileStore.ts
@@ -1,0 +1,87 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { logger } from '../services/logger';
+
+export interface FileStore<T> {
+  read(): Promise<T | undefined>;
+  write(value: T): Promise<void>;
+}
+
+export function isFileMissingError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+
+  const code = 'code' in err ? (err as { code?: unknown }).code : undefined;
+  return code === 'FileNotFound' || code === 'ENOENT';
+}
+
+function getDirectoryUri(uri: vscode.Uri): vscode.Uri {
+  return uri.scheme === 'file'
+    ? vscode.Uri.file(path.dirname(uri.fsPath))
+    : uri.with({ path: path.posix.dirname(uri.path) });
+}
+
+function getSiblingUri(uri: vscode.Uri, fileName: string): vscode.Uri {
+  return uri.scheme === 'file'
+    ? vscode.Uri.file(path.join(path.dirname(uri.fsPath), fileName))
+    : uri.with({ path: path.posix.join(path.posix.dirname(uri.path), fileName) });
+}
+
+function getBaseName(uri: vscode.Uri): string {
+  return uri.scheme === 'file'
+    ? path.basename(uri.fsPath)
+    : path.posix.basename(uri.path);
+}
+
+export class JsonFileStore<T> implements FileStore<T> {
+  constructor(
+    private readonly uri: vscode.Uri,
+    private readonly label: string,
+  ) {}
+
+  async read(): Promise<T | undefined> {
+    try {
+      const content = await vscode.workspace.fs.readFile(this.uri);
+      return JSON.parse(Buffer.from(content).toString('utf-8')) as T;
+    } catch (err) {
+      if (isFileMissingError(err)) {
+        return undefined;
+      }
+      if (err instanceof SyntaxError) {
+        logger.warn(`Failed to parse ${this.label}`, err);
+      } else {
+        logger.warn(`Failed to read ${this.label}`, err);
+      }
+      return undefined;
+    }
+  }
+
+  async write(value: T): Promise<void> {
+    const tempFileSuffix = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const directoryUri = getDirectoryUri(this.uri);
+    const tempUri = getSiblingUri(this.uri, `${getBaseName(this.uri)}.${tempFileSuffix}.tmp`);
+    const content = Buffer.from(JSON.stringify(value), 'utf-8');
+
+    await vscode.workspace.fs.createDirectory(directoryUri);
+    try {
+      await vscode.workspace.fs.writeFile(tempUri, content);
+      await vscode.workspace.fs.rename(tempUri, this.uri, { overwrite: true });
+    } catch (err) {
+      try {
+        await vscode.workspace.fs.delete(tempUri, { useTrash: false, recursive: false });
+      } catch {
+        // Best-effort cleanup only.
+      }
+      throw err;
+    }
+  }
+}
+
+export function createJsonFileStore<T>(
+  globalStorageUri: vscode.Uri,
+  filename: string,
+  label = filename,
+): JsonFileStore<T> {
+  return new JsonFileStore<T>(vscode.Uri.joinPath(globalStorageUri, filename), label);
+}

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -1,15 +1,13 @@
 import * as vscode from 'vscode';
-import type { Memento } from 'vscode';
 import type { ProviderItem } from '../api/types';
 import { logger } from '../services/logger';
+import type { FileStore } from './fileStore';
 import {
   validateObject,
   requiredString,
   optionalString,
   requiredEnum,
 } from './validation';
-
-const STORAGE_KEY = 'devdocket.inbox-state';
 
 /** Possible states for a provider-discovered item in the inbox workflow. */
 const inboxStates = ['unseen', 'accepted', 'dismissed'] as const;
@@ -47,13 +45,12 @@ function validateInboxStateRecord(value: unknown, index: number): string | undef
 
 /**
  * Persists inbox-state records (`unseen | accepted | dismissed`) for
- * provider-discovered items in VS Code globalState.
+ * provider-discovered items in a JSON file under globalStorageUri.
  *
  * Only the state enum is stored — item data (title, description, url) is
  * always read live from the provider.
  */
 export class InboxStateStore {
-  private readonly globalState: Memento;
   private readonly cache = new Map<string, InboxStateRecord>();
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   readonly onDidChange = this._onDidChange.event;
@@ -63,9 +60,7 @@ export class InboxStateStore {
   /** Keys removed locally since the last load/persist. */
   private removedKeys = new Set<string>();
 
-  constructor(globalState: Memento) {
-    this.globalState = globalState;
-  }
+  constructor(private readonly fileStore: FileStore<unknown[]>) {}
 
   private key(providerId: string, externalId: string): string {
     return `${providerId}::${externalId}`;
@@ -93,14 +88,14 @@ export class InboxStateStore {
   }
 
   /**
-   * Re-reads from globalState, merges remote records with local mutations,
-   * and writes the merged result. Untouched keys adopt the remote view,
-   * locally changed keys win, and locally removed keys stay removed.
+   * Re-reads from disk, merges remote records with local mutations, and writes
+   * the merged result. Untouched keys adopt the remote view, locally changed
+   * keys win, and locally removed keys stay removed.
    */
   private async persist(): Promise<void> {
     const merged = new Map<string, InboxStateRecord>();
 
-    for (const remote of this.parseFromGlobalState()) {
+    for (const remote of await this.parseFromFileStore()) {
       merged.set(this.key(remote.providerId, remote.externalId), remote);
     }
 
@@ -115,7 +110,7 @@ export class InboxStateStore {
       }
     }
 
-    await this.globalState.update(STORAGE_KEY, Array.from(merged.values()));
+    await this.fileStore.write(Array.from(merged.values()));
     this.cache.clear();
     for (const [k, record] of merged) {
       this.cache.set(k, record);
@@ -124,9 +119,9 @@ export class InboxStateStore {
     this.removedKeys.clear();
   }
 
-  /** Parse and validate inbox state records from globalState. */
-  private parseFromGlobalState(): InboxStateRecord[] {
-    const parsed = this.globalState.get<unknown[]>(STORAGE_KEY);
+  /** Parse and validate inbox state records from the backing JSON file. */
+  private async parseFromFileStore(): Promise<InboxStateRecord[]> {
+    const parsed = await this.fileStore.read();
     if (!Array.isArray(parsed)) { return []; }
     const records: InboxStateRecord[] = [];
     for (let i = 0; i < parsed.length; i++) {
@@ -141,7 +136,7 @@ export class InboxStateStore {
   }
 
   /**
-   * Sets the inbox state for a single discovered item and persists to globalState.
+   * Sets the inbox state for a single discovered item and persists to disk.
    *
    * Note: `resurfaceVersion` is only settable via `setStates()`, not here.
    * This method preserves any existing `resurfaceVersion` from the previous record.
@@ -195,7 +190,7 @@ export class InboxStateStore {
   }
 
   /**
-   * Returns all persisted state records, loading from globalState on first call.
+   * Returns all persisted state records, loading from disk on first call.
    */
   async loadAll(): Promise<InboxStateRecord[]> {
     await this.load();
@@ -203,12 +198,12 @@ export class InboxStateStore {
   }
 
   /**
-   * Loads state records from globalState into the cache. No-ops if already loaded.
+   * Loads state records from disk into the cache. No-ops if already loaded.
    */
   async load(): Promise<void> {
     if (this.loaded) { return; }
     this.cache.clear();
-    const records = this.parseFromGlobalState();
+    const records = await this.parseFromFileStore();
     for (const record of records) {
       this.cache.set(this.key(record.providerId, record.externalId), record);
     }
@@ -271,8 +266,8 @@ export class InboxStateStore {
   }
 
   /**
-   * Invalidates the in-memory cache so the next mutation re-reads from
-   * globalState. Used for cross-window change propagation.
+   * Invalidates the in-memory cache so the next mutation re-reads from disk.
+   * Used for cross-window change propagation.
    */
   invalidateCache(): void {
     this.cache.clear();

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -1,7 +1,7 @@
-import type { Memento } from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { ITaskStore } from './taskStore';
 import { logger } from '../services/logger';
+import type { FileStore } from './fileStore';
 import {
   validateObject,
   requiredString,
@@ -11,7 +11,6 @@ import {
   optionalFiniteNumber,
 } from './validation';
 
-const STORAGE_KEY = 'devdocket.workitems';
 const validWorkItemStates = new Set<string>(Object.values(WorkItemState));
 const validItemTypes = new Set(['issue', 'pr']);
 
@@ -63,14 +62,13 @@ function validateWorkItem(value: unknown, index: number): string | undefined {
 }
 
 /**
- * Persists {@link WorkItem} objects in VS Code globalState.
+ * Persists {@link WorkItem} objects in a JSON file under globalStorageUri.
  *
  * An in-memory cache is populated on first load and kept in sync with
- * every mutation. On persist, the store re-reads from globalState and
- * merges to avoid clobbering changes made by other VS Code windows.
+ * every mutation. On persist, the store re-reads from disk and merges to
+ * avoid clobbering changes made by other VS Code windows.
  */
 export class JsonTaskStore implements ITaskStore {
-  private readonly globalState: Memento;
   private cache: Map<string, WorkItem> | null = null;
   /** IDs modified locally since the last successful persist. */
   private dirtyIds = new Set<string>();
@@ -81,15 +79,13 @@ export class JsonTaskStore implements ITaskStore {
   /** Local delete tombstones used to suppress stale reintroductions from other windows. */
   private deletedUpdatedAt = new Map<string, number>();
 
-  constructor(globalState: Memento) {
-    this.globalState = globalState;
-  }
+  constructor(private readonly fileStore: FileStore<unknown[]>) {}
 
   async loadAll(): Promise<WorkItem[]> {
     if (this.cache !== null) {
       return Array.from(this.cache.values());
     }
-    const items = this.parseFromGlobalState();
+    const items = await this.parseFromFileStore();
     this.cache = new Map(items.map(item => [item.id, item]));
     this.syncedUpdatedAt = new Map(items.map(item => [item.id, item.updatedAt]));
     this.dirtyIds.clear();
@@ -105,17 +101,17 @@ export class JsonTaskStore implements ITaskStore {
   }
 
   /**
-   * Re-reads from globalState, adopts untouched remote state, overlays local
-   * mutations, and writes the merged result. Local edits use `updatedAt`
-   * last-writer-wins for shared items, locally removed items stay deleted, and
-   * untouched local items disappear when another window deletes them remotely.
+   * Re-reads from disk, adopts untouched remote state, overlays local mutations,
+   * and writes the merged result. Local edits use `updatedAt` last-writer-wins
+   * for shared items, locally removed items stay deleted, and untouched local
+   * items disappear when another window deletes them remotely.
    */
   private async persist(): Promise<void> {
     if (this.cache === null) {
       await this.loadAll();
     }
     const local = this.getCache();
-    const remoteItems = this.parseFromGlobalState();
+    const remoteItems = await this.parseFromFileStore();
     const remoteById = new Map(remoteItems.map(item => [item.id, item]));
     const merged = new Map<string, WorkItem>();
 
@@ -162,7 +158,7 @@ export class JsonTaskStore implements ITaskStore {
       }
     }
 
-    await this.globalState.update(STORAGE_KEY, Array.from(merged.values()));
+    await this.fileStore.write(Array.from(merged.values()));
     this.cache = merged;
     this.syncedUpdatedAt = new Map(Array.from(merged.values(), item => [item.id, item.updatedAt]));
     for (const [id, deletedAt] of Array.from(this.deletedUpdatedAt.entries())) {
@@ -175,9 +171,9 @@ export class JsonTaskStore implements ITaskStore {
     this.removedIds.clear();
   }
 
-  /** Parse and validate work items from globalState. */
-  private parseFromGlobalState(): WorkItem[] {
-    const parsed = this.globalState.get<unknown[]>(STORAGE_KEY);
+  /** Parse and validate work items from the backing JSON file. */
+  private async parseFromFileStore(): Promise<WorkItem[]> {
+    const parsed = await this.fileStore.read();
     if (!Array.isArray(parsed)) {
       return [];
     }
@@ -225,8 +221,8 @@ export class JsonTaskStore implements ITaskStore {
   }
 
   /**
-   * Invalidates the in-memory cache so the next access re-reads from
-   * globalState. Used for cross-window change propagation.
+   * Invalidates the in-memory cache so the next access re-reads from disk.
+   * Used for cross-window change propagation.
    */
   invalidateCache(): void {
     this.cache = null;

--- a/packages/core/src/storage/migration.ts
+++ b/packages/core/src/storage/migration.ts
@@ -1,9 +1,12 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import * as vscode from 'vscode';
 import type { Memento } from 'vscode';
 import { logger } from '../services/logger';
+import { isFileMissingError, JsonFileStore } from './fileStore';
 
 export const MIGRATED_KEY = 'devdocket.migrated';
+export const FILE_MIGRATED_KEY = 'devdocket.migrated-to-files';
 
 /** Warn when a JSON file exceeds this size (bytes) during migration. */
 const SIZE_WARNING_THRESHOLD = 512 * 1024; // 512 KB
@@ -16,6 +19,13 @@ export const FILE_KEY_MAP: Record<string, string> = {
   'provider-labels.json': 'devdocket.provider-labels',
   'watches.json': 'devdocket.watches',
 };
+
+export const GLOBAL_STATE_FILE_MAP: Array<{ key: string; filename: string }> = [
+  { key: 'devdocket.workitems', filename: 'workitems.json' },
+  { key: 'devdocket.inbox-state', filename: 'inbox-state.json' },
+  { key: 'devdocket.read-state', filename: 'read-state.json' },
+  { key: 'devdocket.watches', filename: 'watches.json' },
+];
 
 function isNodeError(err: unknown): err is NodeJS.ErrnoException {
   return err instanceof Error && 'code' in err;
@@ -70,5 +80,75 @@ export async function migrateToGlobalState(globalState: Memento, storagePath: st
     logger.info('Migration to globalState complete');
   } else {
     logger.warn('Migration incomplete — will retry on next activation');
+  }
+}
+
+/**
+ * One-time migration from globalState to file-backed storage. Idempotent and
+ * rollback-safe: existing files are left untouched so a partial migration can
+ * retry later without clobbering newer file-backed data.
+ */
+export async function migrateGlobalStateToFiles(
+  globalState: Memento,
+  globalStorageUri: vscode.Uri,
+): Promise<void> {
+  if (globalState.get<boolean>(FILE_MIGRATED_KEY)) {
+    return;
+  }
+
+  logger.info('Starting one-time migration from globalState to JSON files...');
+
+  const legacyFilesWereAlreadyMigrated = globalState.get<boolean>(MIGRATED_KEY) === true;
+  let allSucceeded = true;
+
+  try {
+    await vscode.workspace.fs.createDirectory(globalStorageUri);
+  } catch (err) {
+    logger.warn('Failed to create global storage directory for file migration', err);
+    return;
+  }
+
+  for (const { key, filename } of GLOBAL_STATE_FILE_MAP) {
+    const data = globalState.get(key);
+    if (data === undefined) {
+      continue;
+    }
+
+    const fileUri = vscode.Uri.joinPath(globalStorageUri, filename);
+    let fileExists = false;
+    try {
+      await vscode.workspace.fs.readFile(fileUri);
+      fileExists = true;
+    } catch (err) {
+      if (!isFileMissingError(err)) {
+        logger.warn(`Failed to inspect existing file for ${key}`, err);
+        allSucceeded = false;
+        continue;
+      }
+    }
+
+    if (fileExists && !legacyFilesWereAlreadyMigrated) {
+      logger.debug(`Skipping globalState key "${key}" — ${filename} already exists`);
+      continue;
+    }
+
+    if (fileExists) {
+      logger.debug(`Overwriting legacy ${filename} from globalState key "${key}"`);
+    }
+
+    try {
+      await new JsonFileStore(fileUri, filename).write(data);
+      logger.info(`Migrated globalState key "${key}" → ${filename}`);
+    } catch (err) {
+      logger.warn(`Failed to migrate ${key} to ${filename}`, err);
+      allSucceeded = false;
+    }
+  }
+
+  if (allSucceeded) {
+    await globalState.update(FILE_MIGRATED_KEY, true);
+    logger.info('Migration to file-backed storage complete');
+  } else {
+    logger.warn('File-backed migration incomplete — will retry on next activation');
   }
 }

--- a/packages/core/src/storage/migration.ts
+++ b/packages/core/src/storage/migration.ts
@@ -91,9 +91,9 @@ export async function migrateToGlobalState(globalState: Memento, storagePath: st
 export async function migrateGlobalStateToFiles(
   globalState: Memento,
   globalStorageUri: vscode.Uri,
-): Promise<void> {
+): Promise<boolean> {
   if (globalState.get<boolean>(FILE_MIGRATED_KEY)) {
-    return;
+    return true;
   }
 
   logger.info('Starting one-time migration from globalState to JSON files...');
@@ -105,7 +105,7 @@ export async function migrateGlobalStateToFiles(
     await vscode.workspace.fs.createDirectory(globalStorageUri);
   } catch (err) {
     logger.warn('Failed to create global storage directory for file migration', err);
-    return;
+    return false;
   }
 
   for (const { key, filename } of GLOBAL_STATE_FILE_MAP) {
@@ -148,7 +148,9 @@ export async function migrateGlobalStateToFiles(
   if (allSucceeded) {
     await globalState.update(FILE_MIGRATED_KEY, true);
     logger.info('Migration to file-backed storage complete');
-  } else {
-    logger.warn('File-backed migration incomplete — will retry on next activation');
+    return true;
   }
+
+  logger.warn('File-backed migration incomplete — will retry on next activation');
+  return false;
 }

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -1,19 +1,15 @@
 import * as vscode from 'vscode';
-import type { Memento } from 'vscode';
 import type { ProviderItem } from '../api/types';
 import { logger } from '../services/logger';
-
-const STORAGE_KEY = 'devdocket.read-state';
+import type { FileStore } from './fileStore';
 
 /**
  * Persists the set of inbox item IDs that the user has viewed ("read")
  * so read/unread state survives across VS Code restarts.
  *
- * Stored as a string array in VS Code globalState under the key
- * "devdocket.read-state".
+ * Stored as a string array in a JSON file under globalStorageUri.
  */
 export class ReadStateStore {
-  private readonly globalState: Memento;
   private readonly items = new Set<string>();
   private loaded = false;
   private readonly _onDidChange = new vscode.EventEmitter<void>();
@@ -22,20 +18,18 @@ export class ReadStateStore {
   /** Keys removed locally since last load — prevents re-adding from stale remote data. */
   private readonly removedSinceLoad = new Set<string>();
 
-  constructor(globalState: Memento) {
-    this.globalState = globalState;
-  }
+  constructor(private readonly fileStore: FileStore<unknown[]>) {}
 
   has(key: string): boolean {
     return this.items.has(key);
   }
 
   /**
-   * Re-reads from globalState, unions with local set, excludes locally
-   * removed keys, and writes the merged result.
+   * Re-reads from disk, unions with the local set, excludes locally removed
+   * keys, and writes the merged result.
    */
   private async persist(): Promise<void> {
-    const remoteParsed = this.globalState.get<unknown[]>(STORAGE_KEY);
+    const remoteParsed = await this.fileStore.read();
     const merged = new Set(this.items);
     if (Array.isArray(remoteParsed)) {
       for (const item of remoteParsed) {
@@ -44,7 +38,7 @@ export class ReadStateStore {
         }
       }
     }
-    await this.globalState.update(STORAGE_KEY, [...merged]);
+    await this.fileStore.write([...merged]);
     this.items.clear();
     for (const key of merged) {
       this.items.add(key);
@@ -145,7 +139,7 @@ export class ReadStateStore {
 
   async load(): Promise<void> {
     if (this.loaded) { return; }
-    const parsed = this.globalState.get<unknown[]>(STORAGE_KEY);
+    const parsed = await this.fileStore.read();
     this.items.clear();
     if (Array.isArray(parsed)) {
       let invalidCount = 0;
@@ -170,8 +164,8 @@ export class ReadStateStore {
   }
 
   /**
-   * Invalidates the in-memory cache so the next access re-reads from
-   * globalState. Used for cross-window change propagation.
+   * Invalidates the in-memory cache so the next access re-reads from disk.
+   * Used for cross-window change propagation.
    */
   invalidateCache(): void {
     this.items.clear();

--- a/packages/core/src/storage/watchStore.ts
+++ b/packages/core/src/storage/watchStore.ts
@@ -1,9 +1,7 @@
-import type { Memento } from 'vscode';
 import type { PRIdentifier } from '@devdocket/shared';
 import { logger } from '../services/logger';
+import type { FileStore } from './fileStore';
 import type { WatchedRun, WatchedPR } from '../services/watcherService';
-
-const STORAGE_KEY = 'devdocket.watches';
 
 /**
  * Persisted shape: either a legacy plain array of WatchedRun, or the
@@ -14,26 +12,28 @@ interface WatchStoreData {
   prs: WatchedPR[];
 }
 
+function getRunKey(run: WatchedRun): string {
+  return `${run.identifier.providerId}::${run.identifier.repo}::${run.identifier.runId}`;
+}
+
+function getPRKey(pr: WatchedPR): string {
+  return `${pr.identifier.providerId}::${pr.identifier.repo}::${pr.identifier.prId}`;
+}
+
 /**
- * Persists watched pipeline runs and PR watches in VS Code globalState.
+ * Persists watched pipeline runs and PR watches in a JSON file under globalStorageUri.
  *
  * Supports the legacy plain-array format (runs only); legacy data is
  * transparently converted on read.
  */
 export class WatchStore {
-  private readonly globalState: Memento;
+  private lastSeenRunKeys = new Set<string>();
+  private lastSeenPRKeys = new Set<string>();
 
-  constructor(globalState: Memento) {
-    this.globalState = globalState;
-  }
+  constructor(private readonly fileStore: FileStore<unknown>) {}
 
-  /**
-   * Load all persisted data from globalState.
-   * Returns empty arrays if no data exists or data is invalid.
-   * Transparently supports the legacy plain-array format (runs only).
-   */
-  async loadAll(): Promise<WatchStoreData> {
-    const parsed = this.globalState.get<unknown>(STORAGE_KEY);
+  private async readFromFile(): Promise<WatchStoreData> {
+    const parsed = await this.fileStore.read();
     if (parsed === undefined) {
       return { runs: [], prs: [] };
     }
@@ -49,7 +49,7 @@ export class WatchStore {
     }
 
     if (typeof parsed !== 'object' || parsed === null) {
-      logger.warn('Invalid watches data in globalState: expected an object or array');
+      logger.warn('Invalid watches data in file store: expected an object or array');
       return { runs: [], prs: [] };
     }
 
@@ -74,6 +74,18 @@ export class WatchStore {
   }
 
   /**
+   * Load all persisted data from disk.
+   * Returns empty arrays if no data exists or data is invalid.
+   * Transparently supports the legacy plain-array format (runs only).
+   */
+  async loadAll(): Promise<WatchStoreData> {
+    const data = await this.readFromFile();
+    this.lastSeenRunKeys = new Set(data.runs.map(getRunKey));
+    this.lastSeenPRKeys = new Set(data.prs.map(getPRKey));
+    return data;
+  }
+
+  /**
    * Check whether a PR watch exists in persisted state, including dismissed entries.
    */
   async hasPRWatch(identifier: PRIdentifier): Promise<boolean> {
@@ -86,10 +98,39 @@ export class WatchStore {
   }
 
   /**
-   * Save all watches to globalState.
+   * Save all watches to disk while preserving remote-only entries this window
+   * has not previously loaded.
    */
   async saveAll(runs: WatchedRun[], prs: WatchedPR[]): Promise<void> {
-    const data: WatchStoreData = { runs, prs };
-    await this.globalState.update(STORAGE_KEY, data);
+    const remote = await this.readFromFile();
+    const runKeys = new Set(runs.map(getRunKey));
+    const prKeys = new Set(prs.map(getPRKey));
+
+    const mergedRuns = new Map(remote.runs.map(run => [getRunKey(run), run]));
+    for (const key of this.lastSeenRunKeys) {
+      if (!runKeys.has(key)) {
+        mergedRuns.delete(key);
+      }
+    }
+    for (const run of runs) {
+      mergedRuns.set(getRunKey(run), run);
+    }
+
+    const mergedPRs = new Map(remote.prs.map(pr => [getPRKey(pr), pr]));
+    for (const key of this.lastSeenPRKeys) {
+      if (!prKeys.has(key)) {
+        mergedPRs.delete(key);
+      }
+    }
+    for (const pr of prs) {
+      mergedPRs.set(getPRKey(pr), pr);
+    }
+
+    await this.fileStore.write({
+      runs: Array.from(mergedRuns.values()),
+      prs: Array.from(mergedPRs.values()),
+    });
+    this.lastSeenRunKeys = runKeys;
+    this.lastSeenPRKeys = prKeys;
   }
 }

--- a/packages/core/src/test/__mocks__/vscode.ts
+++ b/packages/core/src/test/__mocks__/vscode.ts
@@ -225,6 +225,9 @@ const workspace = {
   fs: {
     readFile: vi.fn().mockRejectedValue(new Error('not found')),
     writeFile: vi.fn().mockResolvedValue(undefined),
+    createDirectory: vi.fn().mockResolvedValue(undefined),
+    rename: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
   },
 };
 

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -7,6 +7,7 @@ import { ProviderRegistry } from '../services/providerRegistry';
 import { MainViewProvider } from '../views/mainViewProvider';
 import { WatchPanelProvider } from '../views/watchPanelProvider';
 import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
+import { useMockFileSystem, type MockFileSystem } from './testFileSystem';
 
 // Stub fs so migration never touches disk
 vi.mock('fs/promises', () => ({
@@ -20,7 +21,7 @@ function createExtensionContext(overrides?: Partial<vscode.ExtensionContext>): v
   const subs: { dispose(): void }[] = [];
   return {
     subscriptions: subs,
-    globalStorageUri: { fsPath: '/fake/storage' } as any,
+    globalStorageUri: vscode.Uri.file('C:\\fake\\storage') as any,
     globalState: new MockMemento(),
     ...overrides,
   } as unknown as vscode.ExtensionContext;
@@ -50,9 +51,11 @@ function getMainProvider(): MainViewProvider {
 
 describe('activate()', () => {
   let context: vscode.ExtensionContext;
+  let fileSystem: MockFileSystem;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    fileSystem = useMockFileSystem();
     context = createExtensionContext();
   });
 
@@ -283,7 +286,7 @@ describe('activate()', () => {
 
       await vi.waitFor(() => {
         expect(pruneSpy).toHaveBeenCalled();
-        expect(globalState.get<string[]>('devdocket.read-state')).toEqual([
+        expect(fileSystem.readJson<string[]>(vscode.Uri.joinPath(context.globalStorageUri, 'read-state.json'))).toEqual([
           'prune-provider::keep',
           'other-provider::stale',
         ]);
@@ -292,7 +295,7 @@ describe('activate()', () => {
       const active = pruneSpy.mock.calls.at(-1)?.[0] as Map<string, unknown[]>;
       expect(active.get('prune-provider')).toEqual([activeItem]);
 
-      const discoveredRecords = globalState.get<Array<{ providerId: string; externalId: string }>>('devdocket.inbox-state') ?? [];
+      const discoveredRecords = fileSystem.readJson<Array<{ providerId: string; externalId: string }>>(vscode.Uri.joinPath(context.globalStorageUri, 'inbox-state.json')) ?? [];
       expect(discoveredRecords.map(record => `${record.providerId}::${record.externalId}`).sort()).toEqual([
         'other-provider::stale',
         'prune-provider::keep',
@@ -328,8 +331,8 @@ describe('activate()', () => {
 
       const active = pruneSpy.mock.calls.at(-1)?.[0] as Map<string, unknown[]>;
       expect(active.get('empty-provider')).toEqual([]);
-      expect(globalState.get<string[]>('devdocket.read-state')).toEqual(['empty-provider::stale']);
-      expect(globalState.get<Array<{ providerId: string; externalId: string }>>('devdocket.inbox-state')).toEqual([
+      expect(fileSystem.readJson<string[]>(vscode.Uri.joinPath(context.globalStorageUri, 'read-state.json'))).toEqual(['empty-provider::stale']);
+      expect(fileSystem.readJson<Array<{ providerId: string; externalId: string }>>(vscode.Uri.joinPath(context.globalStorageUri, 'inbox-state.json'))).toEqual([
         { providerId: 'empty-provider', externalId: 'stale', inboxState: 'accepted' },
       ]);
     } finally {
@@ -411,14 +414,14 @@ describe('activate()', () => {
       } as any);
 
       await vi.waitFor(() => {
-        const records = globalState.get<Array<{ providerId: string; externalId: string }>>('devdocket.inbox-state') ?? [];
+        const records = fileSystem.readJson<Array<{ providerId: string; externalId: string }>>(vscode.Uri.joinPath(context.globalStorageUri, 'inbox-state.json')) ?? [];
         expect(records.some(record => record.providerId === 'truncated-provider' && record.externalId === 'one')).toBe(true);
       });
       await flushMicrotasks();
 
       expect(pruneSpy).not.toHaveBeenCalled();
-      expect(globalState.get<string[]>('devdocket.read-state')).toEqual(['truncated-provider::stale']);
-      const discoveredRecords = globalState.get<Array<{ providerId: string; externalId: string }>>('devdocket.inbox-state') ?? [];
+      expect(fileSystem.readJson<string[]>(vscode.Uri.joinPath(context.globalStorageUri, 'read-state.json'))).toEqual(['truncated-provider::stale']);
+      const discoveredRecords = fileSystem.readJson<Array<{ providerId: string; externalId: string }>>(vscode.Uri.joinPath(context.globalStorageUri, 'inbox-state.json')) ?? [];
       expect(discoveredRecords.some(record => record.providerId === 'truncated-provider' && record.externalId === 'stale')).toBe(true);
     } finally {
       pruneSpy.mockRestore();
@@ -916,7 +919,7 @@ describe('activate()', () => {
     await activate(context);
 
     // The inbox state should contain the accepted state in globalState
-    const discoveredState = globalState.get<unknown[]>('devdocket.inbox-state');
+    const discoveredState = fileSystem.readJson<unknown[]>(vscode.Uri.joinPath(context.globalStorageUri, 'inbox-state.json'));
     expect(discoveredState).toBeDefined();
     const acceptedRecord = (discoveredState as any[]).find(
       (r: any) => r.providerId === 'gh' && r.externalId === 'ext-99' && r.inboxState === 'accepted',

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -918,7 +918,7 @@ describe('activate()', () => {
 
     await activate(context);
 
-    // The inbox state should contain the accepted state in globalState
+    // The inbox state should contain the accepted state in inbox-state.json
     const discoveredState = fileSystem.readJson<unknown[]>(vscode.Uri.joinPath(context.globalStorageUri, 'inbox-state.json'));
     expect(discoveredState).toBeDefined();
     const acceptedRecord = (discoveredState as any[]).find(

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -930,6 +930,35 @@ describe('activate()', () => {
   // ------------------------------------------------------------------
   // 11. Error handling: activate succeeds even with no storage files
   // ------------------------------------------------------------------
+  it('falls back to globalState-backed stores when file migration fails', async () => {
+    const globalState = context.globalState as InstanceType<typeof MockMemento>;
+    const workItems = [
+      {
+        id: 'fallback-1',
+        title: 'Fallback Item',
+        state: 'New',
+        providerId: 'gh',
+        externalId: 'ext-fallback',
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      },
+    ];
+
+    await globalState.update('devdocket.migrated', true);
+    await globalState.update('devdocket.workitems', workItems);
+
+    const writeFile = vscode.workspace.fs.writeFile as ReturnType<typeof vi.fn>;
+    writeFile.mockRejectedValueOnce(new Error('disk full'));
+
+    await activate(context);
+
+    expect(globalState.get('devdocket.migrated-to-files')).toBeUndefined();
+    expect(fileSystem.readJson(vscode.Uri.joinPath(context.globalStorageUri, 'workitems.json'))).toBeUndefined();
+    expect(globalState.get<Array<{ providerId: string; externalId: string; inboxState: string }>>('devdocket.inbox-state')).toEqual([
+      expect.objectContaining({ providerId: 'gh', externalId: 'ext-fallback', inboxState: 'accepted' }),
+    ]);
+  });
+
   it('activates successfully when storage files do not exist (ENOENT)', async () => {
     // Default mock already returns ENOENT — just verify no throw
     const api = await activate(context);

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -635,7 +635,7 @@ describe('InboxStateStore', () => {
       expect(store.getResurfaceVersion('gh', 'pr-1')).toBe('rv-new');
     });
 
-    it('should persist resurfaceVersion to globalState', async () => {
+    it('should persist resurfaceVersion to the backing JSON file', async () => {
       await store.setStates([
         { providerId: 'gh', externalId: 'pr-1', state: 'unseen', resurfaceVersion: 'rv-abc' },
       ]);

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -544,7 +544,7 @@ describe('InboxStateStore', () => {
       expect(store.getVersion('gh', 'pr-1')).toBe('sha-new');
     });
 
-    it('should persist version to globalState', async () => {
+    it('should persist version to the backing JSON file', async () => {
       await store.setState('gh', 'pr-1', 'unseen', 'sha-abc');
 
       const persisted = fileSystem.readJson<unknown[]>(fileUri);

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -189,7 +189,7 @@ describe('InboxStateStore', () => {
       expect(records).toHaveLength(3);
     });
 
-    it('should persist all items to globalState', async () => {
+    it('should persist all items to the backing JSON file', async () => {
       await store.setStates([
         { providerId: 'gh', externalId: 'a', state: 'unseen' },
         { providerId: 'gh', externalId: 'b', state: 'accepted' },

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { MockMemento } from 'vscode';
+import * as vscode from 'vscode';
 import { InboxStateStore } from '../storage/inboxStateStore';
+import { JsonFileStore } from '../storage/fileStore';
+import { useMockFileSystem, type MockFileSystem } from './testFileSystem';
 
 describe('InboxStateStore', () => {
-  let memento: InstanceType<typeof MockMemento>;
+  const fileUri = vscode.Uri.file('C:\\test\\inbox-state.json');
+  let fileSystem: MockFileSystem;
   let store: InboxStateStore;
 
   beforeEach(() => {
-    memento = new MockMemento();
-    store = new InboxStateStore(memento);
+    vi.clearAllMocks();
+    fileSystem = useMockFileSystem();
+    store = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
   });
 
   afterEach(() => {
@@ -26,7 +30,7 @@ describe('InboxStateStore', () => {
   it('should create a record and persist on setState', async () => {
     await store.setState('gh', 'issue-1', 'unseen');
 
-    const persisted = memento.get<unknown[]>('devdocket.inbox-state');
+    const persisted = fileSystem.readJson<unknown[]>(fileUri);
     expect(persisted).toHaveLength(1);
     expect(persisted![0]).toEqual({
       providerId: 'gh',
@@ -92,7 +96,7 @@ describe('InboxStateStore', () => {
     await store.setState('gh', 'issue-1', 'accepted');
     await store.setState('gh', 'issue-2', 'dismissed');
 
-    const store2 = new InboxStateStore(memento);
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
     await store2.load();
 
     expect(store2.getState('gh', 'issue-1')).toBe('accepted');
@@ -104,12 +108,12 @@ describe('InboxStateStore', () => {
 
   describe('schema validation', () => {
     it('should skip records missing providerId', async () => {
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         { externalId: 'issue-1', inboxState: 'unseen' },
         { providerId: 'gh', externalId: 'issue-2', inboxState: 'accepted' },
       ]);
 
-      const store2 = new InboxStateStore(memento);
+      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       const records = await store2.loadAll();
       expect(records).toHaveLength(1);
       expect(records[0].externalId).toBe('issue-2');
@@ -117,12 +121,12 @@ describe('InboxStateStore', () => {
     });
 
     it('should skip records missing externalId', async () => {
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         { providerId: 'gh', inboxState: 'unseen' },
         { providerId: 'gh', externalId: 'issue-2', inboxState: 'accepted' },
       ]);
 
-      const store2 = new InboxStateStore(memento);
+      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       const records = await store2.loadAll();
       expect(records).toHaveLength(1);
       expect(records[0].externalId).toBe('issue-2');
@@ -130,12 +134,12 @@ describe('InboxStateStore', () => {
     });
 
     it('should skip records with invalid inboxState', async () => {
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         { providerId: 'gh', externalId: 'issue-1', inboxState: 'bogus' },
         { providerId: 'gh', externalId: 'issue-2', inboxState: 'accepted' },
       ]);
 
-      const store2 = new InboxStateStore(memento);
+      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       const records = await store2.loadAll();
       expect(records).toHaveLength(1);
       expect(records[0].externalId).toBe('issue-2');
@@ -143,23 +147,23 @@ describe('InboxStateStore', () => {
     });
 
     it('should return empty for non-array data', async () => {
-      await memento.update('devdocket.inbox-state', { not: 'an array' });
+      fileSystem.writeJson(fileUri, { not: 'an array' });
 
-      const store2 = new InboxStateStore(memento);
+      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       const records = await store2.loadAll();
       expect(records).toEqual([]);
       store2.dispose();
     });
 
     it('should skip non-object entries', async () => {
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         'a string',
         42,
         null,
         { providerId: 'gh', externalId: 'issue-1', inboxState: 'accepted' },
       ]);
 
-      const store2 = new InboxStateStore(memento);
+      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       const records = await store2.loadAll();
       expect(records).toHaveLength(1);
       expect(records[0].externalId).toBe('issue-1');
@@ -191,7 +195,7 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'b', state: 'accepted' },
       ]);
 
-      const persisted = memento.get<unknown[]>('devdocket.inbox-state');
+      const persisted = fileSystem.readJson<unknown[]>(fileUri);
       expect(persisted).toHaveLength(2);
     });
 
@@ -284,7 +288,7 @@ describe('InboxStateStore', () => {
     it('invalidateCache forces a re-read on next load', async () => {
       await store.setState('gh', 'issue-1', 'unseen');
 
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         { providerId: 'gh', externalId: 'issue-1', inboxState: 'dismissed' },
       ]);
 
@@ -297,8 +301,8 @@ describe('InboxStateStore', () => {
 
   describe('merge-on-write', () => {
     it('preserves remote additions while persisting local changes', async () => {
-      const windowA = new InboxStateStore(memento);
-      const windowB = new InboxStateStore(memento);
+      const windowA = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const windowB = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       await windowA.load();
 
       await windowB.setState('gh', 'remote', 'accepted');
@@ -317,12 +321,12 @@ describe('InboxStateStore', () => {
     });
 
     it('keeps remote updates for untouched keys', async () => {
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         { providerId: 'gh', externalId: 'shared', inboxState: 'unseen' },
       ]);
 
-      const windowA = new InboxStateStore(memento);
-      const windowB = new InboxStateStore(memento);
+      const windowA = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const windowB = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       await windowA.load();
       await windowB.load();
 
@@ -337,12 +341,12 @@ describe('InboxStateStore', () => {
     });
 
     it('prefers local updates for keys changed in this window', async () => {
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         { providerId: 'gh', externalId: 'shared', inboxState: 'unseen' },
       ]);
 
-      const windowA = new InboxStateStore(memento);
-      const windowB = new InboxStateStore(memento);
+      const windowA = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const windowB = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       await windowA.load();
       await windowB.load();
 
@@ -350,29 +354,34 @@ describe('InboxStateStore', () => {
       await windowA.setState('gh', 'shared', 'accepted');
 
       expect(windowA.getState('gh', 'shared')).toBe('accepted');
-      expect(memento.get<Array<{ inboxState: string }>>('devdocket.inbox-state')?.[0]?.inboxState).toBe('accepted');
+      expect(fileSystem.readJson<Array<{ inboxState: string }>>(fileUri)?.[0]?.inboxState).toBe('accepted');
 
       windowA.dispose();
       windowB.dispose();
     });
 
     it('retains dirty tracking when persist fails', async () => {
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         { providerId: 'gh', externalId: 'shared', inboxState: 'unseen' },
       ]);
 
-      const failingMemento = {
-        get: (key: string) => memento.get(key),
-        update: vi.fn()
-          .mockRejectedValueOnce(new Error('quota exceeded'))
-          .mockImplementation((key: string, value: unknown) => memento.update(key, value)),
+      let failed = false;
+      const failingFileStore = {
+        read: vi.fn(async () => fileSystem.readJson<unknown[]>(fileUri)),
+        write: vi.fn(async (value: unknown[]) => {
+          if (!failed) {
+            failed = true;
+            throw new Error('quota exceeded');
+          }
+          fileSystem.writeJson(fileUri, value);
+        }),
       };
-      const failingStore = new InboxStateStore(failingMemento as any);
+      const failingStore = new InboxStateStore(failingFileStore);
       await failingStore.load();
 
       await expect(failingStore.setState('gh', 'shared', 'accepted')).rejects.toThrow('quota exceeded');
 
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         { providerId: 'gh', externalId: 'shared', inboxState: 'dismissed' },
       ]);
 
@@ -399,11 +408,11 @@ describe('InboxStateStore', () => {
     });
 
     it('setState triggers lazy load if not yet loaded', async () => {
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         { providerId: 'gh', externalId: 'pre-existing', inboxState: 'unseen' },
       ]);
 
-      const freshStore = new InboxStateStore(memento);
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       await freshStore.setState('gh', 'new-item', 'accepted');
 
       expect(freshStore.getState('gh', 'pre-existing')).toBe('unseen');
@@ -412,11 +421,11 @@ describe('InboxStateStore', () => {
     });
 
     it('setStates triggers lazy load if not yet loaded', async () => {
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         { providerId: 'gh', externalId: 'pre-existing', inboxState: 'dismissed' },
       ]);
 
-      const freshStore = new InboxStateStore(memento);
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       await freshStore.setStates([
         { providerId: 'gh', externalId: 'new-item', state: 'unseen' },
       ]);
@@ -491,7 +500,7 @@ describe('InboxStateStore', () => {
       expect(store.getState('gh', 'item-1199')).toBe('unseen');
 
       // Verify persistence by reloading from a fresh instance
-      const store2 = new InboxStateStore(memento);
+      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       await store2.load();
       const reloaded = await store2.loadAll();
       expect(reloaded).toHaveLength(1200);
@@ -538,16 +547,16 @@ describe('InboxStateStore', () => {
     it('should persist version to globalState', async () => {
       await store.setState('gh', 'pr-1', 'unseen', 'sha-abc');
 
-      const persisted = memento.get<unknown[]>('devdocket.inbox-state');
+      const persisted = fileSystem.readJson<unknown[]>(fileUri);
       expect((persisted![0] as any).version).toBe('sha-abc');
     });
 
     it('should load version from globalState', async () => {
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         { providerId: 'gh', externalId: 'pr-1', inboxState: 'accepted', version: 'sha-disk' },
       ]);
 
-      const freshStore = new InboxStateStore(memento);
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       await freshStore.load();
       expect(freshStore.getVersion('gh', 'pr-1')).toBe('sha-disk');
       freshStore.dispose();
@@ -570,12 +579,12 @@ describe('InboxStateStore', () => {
     });
 
     it('should skip records with non-string version during load', async () => {
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         { providerId: 'gh', externalId: 'pr-1', inboxState: 'accepted', version: 42 },
         { providerId: 'gh', externalId: 'pr-2', inboxState: 'accepted', version: 'valid' },
       ]);
 
-      const freshStore = new InboxStateStore(memento);
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       const records = await freshStore.loadAll();
       expect(records).toHaveLength(1);
       expect(records[0].externalId).toBe('pr-2');
@@ -631,28 +640,28 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'pr-1', state: 'unseen', resurfaceVersion: 'rv-abc' },
       ]);
 
-      const persisted = memento.get<unknown[]>('devdocket.inbox-state');
+      const persisted = fileSystem.readJson<unknown[]>(fileUri);
       expect((persisted![0] as any).resurfaceVersion).toBe('rv-abc');
     });
 
     it('should load resurfaceVersion from globalState', async () => {
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         { providerId: 'gh', externalId: 'pr-1', inboxState: 'accepted', resurfaceVersion: 'rv-disk' },
       ]);
 
-      const freshStore = new InboxStateStore(memento);
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       await freshStore.load();
       expect(freshStore.getResurfaceVersion('gh', 'pr-1')).toBe('rv-disk');
       freshStore.dispose();
     });
 
     it('should skip records with non-string resurfaceVersion during load', async () => {
-      await memento.update('devdocket.inbox-state', [
+      fileSystem.writeJson(fileUri, [
         { providerId: 'gh', externalId: 'pr-1', inboxState: 'accepted', resurfaceVersion: 99 },
         { providerId: 'gh', externalId: 'pr-2', inboxState: 'accepted', resurfaceVersion: 'valid' },
       ]);
 
-      const freshStore = new InboxStateStore(memento);
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       const records = await freshStore.loadAll();
       expect(records).toHaveLength(1);
       expect(records[0].externalId).toBe('pr-2');

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -551,7 +551,7 @@ describe('InboxStateStore', () => {
       expect((persisted![0] as any).version).toBe('sha-abc');
     });
 
-    it('should load version from globalState', async () => {
+    it('should load version from the backing JSON file', async () => {
       fileSystem.writeJson(fileUri, [
         { providerId: 'gh', externalId: 'pr-1', inboxState: 'accepted', version: 'sha-disk' },
       ]);

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -644,7 +644,7 @@ describe('InboxStateStore', () => {
       expect((persisted![0] as any).resurfaceVersion).toBe('rv-abc');
     });
 
-    it('should load resurfaceVersion from globalState', async () => {
+    it('should load resurfaceVersion from the backing JSON file', async () => {
       fileSystem.writeJson(fileUri, [
         { providerId: 'gh', externalId: 'pr-1', inboxState: 'accepted', resurfaceVersion: 'rv-disk' },
       ]);

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -205,7 +205,7 @@ describe('JsonTaskStore', () => {
       expect(items[0].id).toBe('valid');
     });
 
-    it('returns empty when globalState contains a non-array', async () => {
+    it('returns empty when the backing JSON file contains a non-array', async () => {
       fileSystem.writeJson(fileUri, { not: 'an array' });
 
       const store2 = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -118,7 +118,7 @@ describe('JsonTaskStore', () => {
       expect(items.find(i => i.id === 'new-item')!.title).toBe('Brand New');
     });
 
-    it('persists all items to globalState', async () => {
+    it('persists all items to the backing JSON file', async () => {
       await store.saveAll([
         makeItem({ id: 'x', title: 'X' }),
         makeItem({ id: 'y', title: 'Y' }),

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -141,7 +141,7 @@ describe('JsonTaskStore', () => {
     });
   });
 
-  it('persists data to globalState', async () => {
+  it('persists data to the backing JSON file', async () => {
     await store.save(makeItem());
     const persisted = fileSystem.readJson<WorkItem[]>(fileUri);
     expect(persisted).toHaveLength(1);

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -291,7 +291,7 @@ describe('JsonTaskStore', () => {
       // Window A creates item1
       await store.save(makeItem({ id: 'item1', title: 'Window A item', updatedAt: 1000 }));
 
-      // Simulate another window adding item2 directly to globalState
+      // Simulate another window adding item2 directly to the shared JSON file
       const current = fileSystem.readJson<WorkItem[]>(fileUri) ?? [];
       fileSystem.writeJson(fileUri, [
         ...current,

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -1,15 +1,19 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { MockMemento } from 'vscode';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { JsonTaskStore } from '../storage/jsonTaskStore';
+import { JsonFileStore } from '../storage/fileStore';
 import { WorkItem, WorkItemState } from '../models/workItem';
+import { useMockFileSystem, type MockFileSystem } from './testFileSystem';
 
 describe('JsonTaskStore', () => {
-  let memento: InstanceType<typeof MockMemento>;
+  const fileUri = vscode.Uri.file('C:\\test\\workitems.json');
+  let fileSystem: MockFileSystem;
   let store: JsonTaskStore;
 
   beforeEach(() => {
-    memento = new MockMemento();
-    store = new JsonTaskStore(memento);
+    vi.clearAllMocks();
+    fileSystem = useMockFileSystem();
+    store = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
   });
 
   function makeItem(overrides: Partial<WorkItem> = {}): WorkItem {
@@ -120,7 +124,7 @@ describe('JsonTaskStore', () => {
         makeItem({ id: 'y', title: 'Y' }),
       ]);
 
-      const persisted = memento.get<WorkItem[]>('devdocket.workitems');
+      const persisted = fileSystem.readJson<WorkItem[]>(fileUri);
       expect(persisted).toHaveLength(2);
       expect(persisted!.map((i: WorkItem) => i.id).sort()).toEqual(['x', 'y']);
     });
@@ -139,90 +143,90 @@ describe('JsonTaskStore', () => {
 
   it('persists data to globalState', async () => {
     await store.save(makeItem());
-    const persisted = memento.get<WorkItem[]>('devdocket.workitems');
+    const persisted = fileSystem.readJson<WorkItem[]>(fileUri);
     expect(persisted).toHaveLength(1);
     expect(persisted![0].id).toBe('test-1');
   });
 
-  it('loads from a fresh store instance sharing same Memento', async () => {
+  it('loads from a fresh store instance sharing the same file', async () => {
     await store.save(makeItem({ id: 'a' }));
     await store.save(makeItem({ id: 'b' }));
 
-    const store2 = new JsonTaskStore(memento);
+    const store2 = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
     const items = await store2.loadAll();
     expect(items).toHaveLength(2);
   });
 
   describe('schema validation', () => {
     it('skips items missing an id', async () => {
-      await memento.update('devdocket.workitems', [
+      fileSystem.writeJson(fileUri, [
         { title: 'No ID', state: 'New', createdAt: 1000, updatedAt: 1000 },
         makeItem({ id: 'valid' }),
       ]);
 
-      const store2 = new JsonTaskStore(memento);
+      const store2 = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
       const items = await store2.loadAll();
       expect(items).toHaveLength(1);
       expect(items[0].id).toBe('valid');
     });
 
     it('skips items missing a title', async () => {
-      await memento.update('devdocket.workitems', [
+      fileSystem.writeJson(fileUri, [
         { id: 'no-title', state: 'New', createdAt: 1000, updatedAt: 1000 },
         makeItem({ id: 'valid' }),
       ]);
 
-      const store2 = new JsonTaskStore(memento);
+      const store2 = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
       const items = await store2.loadAll();
       expect(items).toHaveLength(1);
       expect(items[0].id).toBe('valid');
     });
 
     it('skips items with an invalid state', async () => {
-      await memento.update('devdocket.workitems', [
+      fileSystem.writeJson(fileUri, [
         { id: 'bad-state', title: 'Bad', state: 'InvalidState', createdAt: 1000, updatedAt: 1000 },
         makeItem({ id: 'valid' }),
       ]);
 
-      const store2 = new JsonTaskStore(memento);
+      const store2 = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
       const items = await store2.loadAll();
       expect(items).toHaveLength(1);
       expect(items[0].id).toBe('valid');
     });
 
     it('skips non-object entries', async () => {
-      await memento.update('devdocket.workitems', [
+      fileSystem.writeJson(fileUri, [
         'a string', 42, null, makeItem({ id: 'valid' }),
       ]);
 
-      const store2 = new JsonTaskStore(memento);
+      const store2 = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
       const items = await store2.loadAll();
       expect(items).toHaveLength(1);
       expect(items[0].id).toBe('valid');
     });
 
     it('returns empty when globalState contains a non-array', async () => {
-      await memento.update('devdocket.workitems', { not: 'an array' });
+      fileSystem.writeJson(fileUri, { not: 'an array' });
 
-      const store2 = new JsonTaskStore(memento);
+      const store2 = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
       const items = await store2.loadAll();
       expect(items).toEqual([]);
     });
 
     it('skips items missing createdAt', async () => {
-      await memento.update('devdocket.workitems', [
+      fileSystem.writeJson(fileUri, [
         { id: 'no-created', title: 'Missing ts', state: 'New', updatedAt: 1000 },
         makeItem({ id: 'valid' }),
       ]);
 
-      const store2 = new JsonTaskStore(memento);
+      const store2 = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
       const items = await store2.loadAll();
       expect(items).toHaveLength(1);
       expect(items[0].id).toBe('valid');
     });
 
     it('skips items with invalid optional fields', async () => {
-      await memento.update('devdocket.workitems', [
+      fileSystem.writeJson(fileUri, [
         { ...makeItem({ id: 'bad-url' }), url: 123 },
         { ...makeItem({ id: 'bad-provider' }), providerId: 42 },
         { ...makeItem({ id: 'bad-external' }), externalId: true },
@@ -231,26 +235,26 @@ describe('JsonTaskStore', () => {
         makeItem({ id: 'valid' }),
       ]);
 
-      const store2 = new JsonTaskStore(memento);
+      const store2 = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
       const items = await store2.loadAll();
       expect(items).toHaveLength(1);
       expect(items[0].id).toBe('valid');
     });
 
     it('skips items with non-array activityLog', async () => {
-      await memento.update('devdocket.workitems', [
+      fileSystem.writeJson(fileUri, [
         { ...makeItem({ id: 'bad-log' }), activityLog: 'not an array' },
         makeItem({ id: 'valid' }),
       ]);
 
-      const store2 = new JsonTaskStore(memento);
+      const store2 = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
       const items = await store2.loadAll();
       expect(items).toHaveLength(1);
       expect(items[0].id).toBe('valid');
     });
 
     it('skips items with malformed activityLog entries', async () => {
-      await memento.update('devdocket.workitems', [
+      fileSystem.writeJson(fileUri, [
         { ...makeItem({ id: 'bad-entry' }), activityLog: [{ timestamp: 'not-a-number', type: 'created' }] },
         { ...makeItem({ id: 'missing-type' }), activityLog: [{ timestamp: 1000 }] },
         { ...makeItem({ id: 'null-entry' }), activityLog: [null] },
@@ -258,14 +262,14 @@ describe('JsonTaskStore', () => {
         { ...makeItem({ id: 'good' }), activityLog: [{ timestamp: 1000, type: 'created' }] },
       ]);
 
-      const store2 = new JsonTaskStore(memento);
+      const store2 = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
       const items = await store2.loadAll();
       expect(items).toHaveLength(1);
       expect(items[0].id).toBe('good');
     });
 
     it('accepts items with valid activityLog', async () => {
-      await memento.update('devdocket.workitems', [
+      fileSystem.writeJson(fileUri, [
         {
           ...makeItem({ id: 'with-log' }),
           activityLog: [
@@ -275,7 +279,7 @@ describe('JsonTaskStore', () => {
         },
       ]);
 
-      const store2 = new JsonTaskStore(memento);
+      const store2 = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
       const items = await store2.loadAll();
       expect(items).toHaveLength(1);
       expect(items[0].activityLog).toHaveLength(2);
@@ -288,8 +292,8 @@ describe('JsonTaskStore', () => {
       await store.save(makeItem({ id: 'item1', title: 'Window A item', updatedAt: 1000 }));
 
       // Simulate another window adding item2 directly to globalState
-      const current = memento.get<WorkItem[]>('devdocket.workitems') ?? [];
-      await memento.update('devdocket.workitems', [
+      const current = fileSystem.readJson<WorkItem[]>(fileUri) ?? [];
+      fileSystem.writeJson(fileUri, [
         ...current,
         makeItem({ id: 'item2', title: 'Window B item', updatedAt: 2000 }),
       ]);
@@ -297,7 +301,7 @@ describe('JsonTaskStore', () => {
       // Window A saves item3 — should preserve item2 from remote
       await store.save(makeItem({ id: 'item3', title: 'Another A item', updatedAt: 3000 }));
 
-      const persisted = memento.get<WorkItem[]>('devdocket.workitems')!;
+      const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       expect(persisted).toHaveLength(3);
       expect(persisted.map(i => i.id).sort()).toEqual(['item1', 'item2', 'item3']);
     });
@@ -306,14 +310,14 @@ describe('JsonTaskStore', () => {
       await store.save(makeItem({ id: 'shared', title: 'Original', updatedAt: 1000 }));
 
       // Another window writes an older version
-      await memento.update('devdocket.workitems', [
+      fileSystem.writeJson(fileUri, [
         makeItem({ id: 'shared', title: 'Remote older', updatedAt: 500 }),
       ]);
 
       // Window A updates the item
       await store.save(makeItem({ id: 'shared', title: 'Local newer', updatedAt: 2000 }));
 
-      const persisted = memento.get<WorkItem[]>('devdocket.workitems')!;
+      const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       expect(persisted).toHaveLength(1);
       expect(persisted[0].title).toBe('Local newer');
     });
@@ -322,14 +326,14 @@ describe('JsonTaskStore', () => {
       await store.save(makeItem({ id: 'shared', title: 'Original', updatedAt: 1000 }));
 
       // Another window writes a newer version
-      await memento.update('devdocket.workitems', [
+      fileSystem.writeJson(fileUri, [
         makeItem({ id: 'shared', title: 'Remote newer', updatedAt: 5000 }),
       ]);
 
       // Window A saves an unrelated item — merge should pick up remote's newer version
       await store.save(makeItem({ id: 'other', title: 'Other', updatedAt: 3000 }));
 
-      const persisted = memento.get<WorkItem[]>('devdocket.workitems')!;
+      const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       const shared = persisted.find(i => i.id === 'shared');
       expect(shared?.title).toBe('Remote newer');
     });
@@ -339,14 +343,14 @@ describe('JsonTaskStore', () => {
       await store.delete('to-delete');
 
       // Remote still has the item (from before the delete)
-      await memento.update('devdocket.workitems', [
+      fileSystem.writeJson(fileUri, [
         makeItem({ id: 'to-delete', title: 'Still here', updatedAt: 1000 }),
       ]);
 
       // Window A saves something else — should not restore deleted item
       await store.save(makeItem({ id: 'new', title: 'New', updatedAt: 2000 }));
 
-      const persisted = memento.get<WorkItem[]>('devdocket.workitems')!;
+      const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       expect(persisted).toHaveLength(1);
       expect(persisted[0].id).toBe('new');
     });
@@ -357,14 +361,14 @@ describe('JsonTaskStore', () => {
 
       await store.save(makeItem({ id: 'shared', title: 'Original', updatedAt: 1000 }));
 
-      const windowB = new JsonTaskStore(memento);
+      const windowB = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
       await windowB.loadAll();
       await windowB.save(makeItem({ id: 'shared', title: 'Remote update', updatedAt: 2000 }));
 
       await store.delete('shared');
       await store.save(makeItem({ id: 'other', title: 'Other', updatedAt: 3000 }));
 
-      const persisted = memento.get<WorkItem[]>('devdocket.workitems')!;
+      const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       expect(persisted.map(item => item.id).sort()).toEqual(['other']);
 
       vi.useRealTimers();
@@ -374,12 +378,12 @@ describe('JsonTaskStore', () => {
       await store.save(makeItem({ id: 'shared', title: 'Shared', updatedAt: 1000 }));
 
       // Another window deletes the item entirely.
-      await memento.update('devdocket.workitems', []);
+      fileSystem.writeJson(fileUri, []);
 
       // This window only changes an unrelated item, so the deleted item should stay deleted.
       await store.save(makeItem({ id: 'other', title: 'Other', updatedAt: 2000 }));
 
-      const persisted = memento.get<WorkItem[]>('devdocket.workitems')!;
+      const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       expect(persisted).toHaveLength(1);
       expect(persisted[0].id).toBe('other');
     });
@@ -391,13 +395,13 @@ describe('JsonTaskStore', () => {
       await store.save(makeItem({ id: 'shared', title: 'Original', updatedAt: 1000 }));
       await store.delete('shared');
 
-      await memento.update('devdocket.workitems', [
+      fileSystem.writeJson(fileUri, [
         makeItem({ id: 'shared', title: 'Remote newer', updatedAt: Date.now() + 1 }),
       ]);
 
       await store.save(makeItem({ id: 'other', title: 'Other', updatedAt: Date.now() + 2 }));
 
-      const persisted = memento.get<WorkItem[]>('devdocket.workitems')!;
+      const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       expect(persisted.map(item => item.id).sort()).toEqual(['other', 'shared']);
       expect(persisted.find(item => item.id === 'shared')?.title).toBe('Remote newer');
 
@@ -408,7 +412,7 @@ describe('JsonTaskStore', () => {
       await store.save(makeItem({ id: 'a', title: 'Original' }));
 
       // Another window modifies the data
-      await memento.update('devdocket.workitems', [
+      fileSystem.writeJson(fileUri, [
         makeItem({ id: 'a', title: 'Modified by other window' }),
       ]);
 

--- a/packages/core/src/test/migrateGlobalStateToFiles.test.ts
+++ b/packages/core/src/test/migrateGlobalStateToFiles.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import * as vscode from 'vscode';
+import { MockMemento } from 'vscode';
+import { migrateGlobalStateToFiles, FILE_MIGRATED_KEY } from '../storage/migration';
+import { useMockFileSystem, type MockFileSystem } from './testFileSystem';
+
+vi.mock('../services/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('migrateGlobalStateToFiles', () => {
+  const globalStorageUri = vscode.Uri.file('C:\\test\\global-storage');
+  let memento: InstanceType<typeof MockMemento>;
+  let fileSystem: MockFileSystem;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    memento = new MockMemento();
+    fileSystem = useMockFileSystem();
+  });
+
+  it('migrates user-intent globalState keys into files and sets the migrated flag', async () => {
+    await memento.update('devdocket.workitems', [{ id: 'w1' }]);
+    await memento.update('devdocket.inbox-state', [{ providerId: 'gh', externalId: '1', inboxState: 'accepted' }]);
+    await memento.update('devdocket.read-state', ['gh::1']);
+    await memento.update('devdocket.watches', { runs: [], prs: [] });
+    await memento.update('devdocket.provider-labels', { gh: 'GitHub' });
+
+    await migrateGlobalStateToFiles(memento, globalStorageUri);
+
+    expect(fileSystem.readJson(vscode.Uri.joinPath(globalStorageUri, 'workitems.json'))).toEqual([{ id: 'w1' }]);
+    expect(fileSystem.readJson(vscode.Uri.joinPath(globalStorageUri, 'inbox-state.json'))).toEqual([{ providerId: 'gh', externalId: '1', inboxState: 'accepted' }]);
+    expect(fileSystem.readJson(vscode.Uri.joinPath(globalStorageUri, 'read-state.json'))).toEqual(['gh::1']);
+    expect(fileSystem.readJson(vscode.Uri.joinPath(globalStorageUri, 'watches.json'))).toEqual({ runs: [], prs: [] });
+    expect(fileSystem.readJson(vscode.Uri.joinPath(globalStorageUri, 'provider-labels.json'))).toBeUndefined();
+    expect(memento.get(FILE_MIGRATED_KEY)).toBe(true);
+  });
+
+  it('is idempotent when the migrated flag is already set', async () => {
+    await memento.update(FILE_MIGRATED_KEY, true);
+    await migrateGlobalStateToFiles(memento, globalStorageUri);
+    expect(vscode.workspace.fs.writeFile).not.toHaveBeenCalled();
+  });
+
+  it('does not overwrite an existing file when no legacy file migration ran', async () => {
+    await memento.update('devdocket.workitems', [{ id: 'stale-global-state' }]);
+    fileSystem.writeJson(vscode.Uri.joinPath(globalStorageUri, 'workitems.json'), [{ id: 'fresh-file-data' }]);
+
+    await migrateGlobalStateToFiles(memento, globalStorageUri);
+
+    expect(fileSystem.readJson(vscode.Uri.joinPath(globalStorageUri, 'workitems.json'))).toEqual([{ id: 'fresh-file-data' }]);
+    expect(memento.get(FILE_MIGRATED_KEY)).toBe(true);
+  });
+
+  it('overwrites stale legacy files when the old file-to-globalState migration already ran', async () => {
+    await memento.update('devdocket.migrated', true);
+    await memento.update('devdocket.workitems', [{ id: 'fresh-global-state' }]);
+    fileSystem.writeJson(vscode.Uri.joinPath(globalStorageUri, 'workitems.json'), [{ id: 'stale-legacy-file' }]);
+
+    await migrateGlobalStateToFiles(memento, globalStorageUri);
+
+    expect(fileSystem.readJson(vscode.Uri.joinPath(globalStorageUri, 'workitems.json'))).toEqual([{ id: 'fresh-global-state' }]);
+    expect(memento.get(FILE_MIGRATED_KEY)).toBe(true);
+  });
+
+  it('does not set the migrated flag when a file write fails', async () => {
+    await memento.update('devdocket.workitems', [{ id: 'w1' }]);
+    (vscode.workspace.fs.writeFile as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('disk full'));
+
+    await migrateGlobalStateToFiles(memento, globalStorageUri);
+
+    expect(memento.get(FILE_MIGRATED_KEY)).toBeUndefined();
+  });
+});

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -1,15 +1,19 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { MockMemento } from 'vscode';
+import * as vscode from 'vscode';
 import type { ProviderItem } from '../api/types';
 import { ReadStateStore } from '../storage/readStateStore';
+import { JsonFileStore } from '../storage/fileStore';
+import { useMockFileSystem, type MockFileSystem } from './testFileSystem';
 
 describe('ReadStateStore', () => {
-  let memento: InstanceType<typeof MockMemento>;
+  const fileUri = vscode.Uri.file('C:\\test\\read-state.json');
+  let fileSystem: MockFileSystem;
   let store: ReadStateStore;
 
   beforeEach(() => {
-    memento = new MockMemento();
-    store = new ReadStateStore(memento);
+    vi.clearAllMocks();
+    fileSystem = useMockFileSystem();
+    store = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
   });
 
   afterEach(() => {
@@ -25,7 +29,7 @@ describe('ReadStateStore', () => {
     await store.load();
     expect(await store.add('gh::issue-1')).toBe(true);
 
-    const persisted = memento.get<string[]>('devdocket.read-state');
+    const persisted = fileSystem.readJson<string[]>(fileUri);
     expect(persisted).toEqual(['gh::issue-1']);
   });
 
@@ -53,7 +57,7 @@ describe('ReadStateStore', () => {
     expect(store.has('gh::2')).toBe(true);
     expect(store.has('gh::3')).toBe(false);
 
-    const persisted = memento.get<string[]>('devdocket.read-state');
+    const persisted = fileSystem.readJson<string[]>(fileUri);
     expect(persisted).toEqual(['gh::2']);
   });
 
@@ -78,7 +82,7 @@ describe('ReadStateStore', () => {
     await store.add('gh::1');
     await store.add('jira::2');
 
-    const store2 = new ReadStateStore(memento);
+    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
     await store2.load();
     expect(store2.has('gh::1')).toBe(true);
     expect(store2.has('jira::2')).toBe(true);
@@ -86,9 +90,9 @@ describe('ReadStateStore', () => {
   });
 
   it('should skip non-string elements in the array', async () => {
-    await memento.update('devdocket.read-state', ['valid::1', 42, null, true, 'valid::2', { obj: true }]);
+    fileSystem.writeJson(fileUri, ['valid::1', 42, null, true, 'valid::2', { obj: true }]);
 
-    const store2 = new ReadStateStore(memento);
+    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
     await store2.load();
     const keys = [...store2.keys()].sort();
     expect(keys).toEqual(['valid::1', 'valid::2']);
@@ -104,9 +108,9 @@ describe('ReadStateStore', () => {
   });
 
   it('should auto-load when deleteMany() is called before load()', async () => {
-    await memento.update('devdocket.read-state', ['gh::existing', 'gh::remove']);
+    fileSystem.writeJson(fileUri, ['gh::existing', 'gh::remove']);
 
-    const freshStore = new ReadStateStore(memento);
+    const freshStore = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
     await freshStore.deleteMany(['gh::remove']);
 
     expect(freshStore.has('gh::existing')).toBe(true);
@@ -114,9 +118,9 @@ describe('ReadStateStore', () => {
   });
 
   it('should auto-load when add() is called before load()', async () => {
-    await memento.update('devdocket.read-state', ['gh::existing']);
+    fileSystem.writeJson(fileUri, ['gh::existing']);
 
-    const freshStore = new ReadStateStore(memento);
+    const freshStore = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
     await freshStore.add('gh::new');
 
     expect(freshStore.has('gh::existing')).toBe(true);
@@ -143,24 +147,24 @@ describe('ReadStateStore', () => {
 
   describe('merge-on-write', () => {
     it('preserves remote additions while persisting local changes', async () => {
-      const windowA = new ReadStateStore(memento);
-      const windowB = new ReadStateStore(memento);
+      const windowA = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      const windowB = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
       await windowA.load();
 
       await windowB.add('gh::remote');
       await windowA.add('gh::local');
 
-      expect(memento.get<string[]>('devdocket.read-state')?.sort()).toEqual(['gh::local', 'gh::remote']);
+      expect(fileSystem.readJson<string[]>(fileUri)?.sort()).toEqual(['gh::local', 'gh::remote']);
 
       windowA.dispose();
       windowB.dispose();
     });
 
     it('keeps locally removed keys deleted while preserving remote additions', async () => {
-      await memento.update('devdocket.read-state', ['gh::keep', 'gh::remove']);
+      fileSystem.writeJson(fileUri, ['gh::keep', 'gh::remove']);
 
-      const windowA = new ReadStateStore(memento);
-      const windowB = new ReadStateStore(memento);
+      const windowA = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      const windowB = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
       await windowA.load();
       await windowB.load();
 
@@ -168,27 +172,27 @@ describe('ReadStateStore', () => {
       await windowA.deleteMany(['gh::remove']);
 
       expect([...windowA.keys()].sort()).toEqual(['gh::keep', 'gh::remote']);
-      expect(memento.get<string[]>('devdocket.read-state')?.sort()).toEqual(['gh::keep', 'gh::remote']);
+      expect(fileSystem.readJson<string[]>(fileUri)?.sort()).toEqual(['gh::keep', 'gh::remote']);
 
       windowA.dispose();
       windowB.dispose();
     });
 
     it('allows remote re-additions after a successful persist', async () => {
-      await memento.update('devdocket.read-state', ['gh::shared']);
+      fileSystem.writeJson(fileUri, ['gh::shared']);
 
-      const windowA = new ReadStateStore(memento);
+      const windowA = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
       await windowA.load();
 
       await windowA.deleteMany(['gh::shared']);
 
-      const windowB = new ReadStateStore(memento);
+      const windowB = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
       await windowB.load();
       await windowB.add('gh::shared');
 
       await windowA.add('gh::local');
 
-      expect(memento.get<string[]>('devdocket.read-state')?.sort()).toEqual(['gh::local', 'gh::shared']);
+      expect(fileSystem.readJson<string[]>(fileUri)?.sort()).toEqual(['gh::local', 'gh::shared']);
 
       windowA.dispose();
       windowB.dispose();
@@ -197,7 +201,7 @@ describe('ReadStateStore', () => {
     it('invalidateCache forces a re-read on next load', async () => {
       await store.add('gh::issue-1');
 
-      await memento.update('devdocket.read-state', ['gh::issue-2']);
+      fileSystem.writeJson(fileUri, ['gh::issue-2']);
 
       store.invalidateCache();
       await store.load();
@@ -287,9 +291,9 @@ describe('ReadStateStore', () => {
     });
 
     it('lazy-loads on first call', async () => {
-      await memento.update('devdocket.read-state', ['gh::keep', 'gh::stale']);
+      fileSystem.writeJson(fileUri, ['gh::keep', 'gh::stale']);
 
-      const freshStore = new ReadStateStore(memento);
+      const freshStore = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
       const activeItems = new Map<string, ProviderItem[]>([
         ['gh', [{ externalId: 'keep', title: 'Keep' }]],
       ]);
@@ -299,14 +303,14 @@ describe('ReadStateStore', () => {
       expect(pruned).toBe(1);
       expect(freshStore.has('gh::keep')).toBe(true);
       expect(freshStore.has('gh::stale')).toBe(false);
-      expect(memento.get<string[]>('devdocket.read-state')).toEqual(['gh::keep']);
+      expect(fileSystem.readJson<string[]>(fileUri)).toEqual(['gh::keep']);
       freshStore.dispose();
     });
 
     it('ignores legacy stored keys without the provider delimiter', async () => {
-      await memento.update('devdocket.read-state', ['legacy-key', 'gh::stale']);
+      fileSystem.writeJson(fileUri, ['legacy-key', 'gh::stale']);
 
-      const freshStore = new ReadStateStore(memento);
+      const freshStore = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
       const activeItems = new Map<string, ProviderItem[]>([
         ['gh', [{ externalId: 'keep', title: 'Keep' }]],
       ]);
@@ -315,7 +319,7 @@ describe('ReadStateStore', () => {
 
       expect(pruned).toBe(1);
       expect([...freshStore.keys()]).toEqual(['legacy-key']);
-      expect(memento.get<string[]>('devdocket.read-state')).toEqual(['legacy-key']);
+      expect(fileSystem.readJson<string[]>(fileUri)).toEqual(['legacy-key']);
       freshStore.dispose();
     });
 

--- a/packages/core/src/test/testFileSystem.ts
+++ b/packages/core/src/test/testFileSystem.ts
@@ -1,0 +1,66 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { vi } from 'vitest';
+
+function createMissingFileError(filePath: string): Error & { code: string } {
+  return Object.assign(new Error(`ENOENT: no such file or directory, open '${filePath}'`), { code: 'ENOENT' });
+}
+
+export interface MockFileSystem {
+  clear(): void;
+  readJson<T>(uri: vscode.Uri): T | undefined;
+  writeJson(uri: vscode.Uri, value: unknown): void;
+  writeRaw(uri: vscode.Uri, value: string): void;
+}
+
+export function useMockFileSystem(): MockFileSystem {
+  const files = new Map<string, Uint8Array>();
+
+  const normalize = (uri: vscode.Uri): string => path.normalize(uri.fsPath ?? uri.path ?? uri.toString());
+
+  (vscode.workspace.fs.readFile as ReturnType<typeof vi.fn>).mockImplementation(async (uri: vscode.Uri) => {
+    const key = normalize(uri);
+    const content = files.get(key);
+    if (!content) {
+      throw createMissingFileError(key);
+    }
+    return content;
+  });
+
+  (vscode.workspace.fs.writeFile as ReturnType<typeof vi.fn>).mockImplementation(async (uri: vscode.Uri, content: Uint8Array) => {
+    files.set(normalize(uri), Uint8Array.from(content));
+  });
+
+  (vscode.workspace.fs.createDirectory as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  (vscode.workspace.fs.rename as ReturnType<typeof vi.fn>).mockImplementation(async (oldUri: vscode.Uri, newUri: vscode.Uri) => {
+    const oldKey = normalize(oldUri);
+    const content = files.get(oldKey);
+    if (!content) {
+      throw createMissingFileError(oldKey);
+    }
+    files.set(normalize(newUri), content);
+    files.delete(oldKey);
+  });
+  (vscode.workspace.fs.delete as ReturnType<typeof vi.fn>).mockImplementation(async (uri: vscode.Uri) => {
+    files.delete(normalize(uri));
+  });
+
+  return {
+    clear(): void {
+      files.clear();
+    },
+    readJson<T>(uri: vscode.Uri): T | undefined {
+      const content = files.get(normalize(uri));
+      if (!content) {
+        return undefined;
+      }
+      return JSON.parse(Buffer.from(content).toString('utf-8')) as T;
+    },
+    writeJson(uri: vscode.Uri, value: unknown): void {
+      files.set(normalize(uri), Buffer.from(JSON.stringify(value), 'utf-8'));
+    },
+    writeRaw(uri: vscode.Uri, value: string): void {
+      files.set(normalize(uri), Buffer.from(value, 'utf-8'));
+    },
+  };
+}

--- a/packages/core/src/test/watchStore.test.ts
+++ b/packages/core/src/test/watchStore.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MockMemento } from 'vscode';
+import * as vscode from 'vscode';
 import { WatchStore } from '../storage/watchStore';
+import { JsonFileStore } from '../storage/fileStore';
+import { useMockFileSystem, type MockFileSystem } from './testFileSystem';
 import type { WatchedRun, WatchedPR } from '../services/watcherService';
 
 vi.mock('../services/logger', () => ({
@@ -43,12 +45,14 @@ function createTestPRWatch(overrides?: Partial<WatchedPR>): WatchedPR {
 }
 
 describe('WatchStore', () => {
-  let memento: InstanceType<typeof MockMemento>;
+  const fileUri = vscode.Uri.file('C:\\test\\watches.json');
+  let fileSystem: MockFileSystem;
   let store: WatchStore;
 
   beforeEach(() => {
-    memento = new MockMemento();
-    store = new WatchStore(memento);
+    vi.clearAllMocks();
+    fileSystem = useMockFileSystem();
+    store = new WatchStore(new JsonFileStore(fileUri, 'watches.json'));
   });
 
   describe('loadAll', () => {
@@ -60,7 +64,7 @@ describe('WatchStore', () => {
     it('loads valid watches from new envelope format', async () => {
       const watch = createTestWatch();
       const prWatch = createTestPRWatch();
-      await memento.update('devdocket.watches', { runs: [watch], prs: [prWatch] });
+      fileSystem.writeJson(fileUri, { runs: [watch], prs: [prWatch] });
 
       const result = await store.loadAll();
       expect(result.runs).toHaveLength(1);
@@ -71,7 +75,7 @@ describe('WatchStore', () => {
 
     it('migrates legacy plain array format', async () => {
       const watch = createTestWatch();
-      await memento.update('devdocket.watches', [watch]);
+      fileSystem.writeJson(fileUri, [watch]);
 
       const result = await store.loadAll();
       expect(result.runs).toHaveLength(1);
@@ -80,7 +84,7 @@ describe('WatchStore', () => {
     });
 
     it('returns empty arrays for non-object/non-array data', async () => {
-      await memento.update('devdocket.watches', 'just a string');
+      fileSystem.writeJson(fileUri, 'just a string');
 
       const result = await store.loadAll();
       expect(result).toEqual({ runs: [], prs: [] });
@@ -89,7 +93,7 @@ describe('WatchStore', () => {
     it('filters out entries missing required fields', async () => {
       const valid = createTestWatch();
       const invalid = { foo: 'bar' };
-      await memento.update('devdocket.watches', { runs: [valid, invalid], prs: [] });
+      fileSystem.writeJson(fileUri, { runs: [valid, invalid], prs: [] });
 
       const result = await store.loadAll();
       expect(result.runs).toHaveLength(1);
@@ -99,13 +103,13 @@ describe('WatchStore', () => {
   describe('hasPRWatch', () => {
     it('returns true for persisted dismissed PR watches', async () => {
       const prWatch = createTestPRWatch({ dismissed: true });
-      await memento.update('devdocket.watches', { runs: [], prs: [prWatch] });
+      fileSystem.writeJson(fileUri, { runs: [], prs: [prWatch] });
 
       await expect(store.hasPRWatch(prWatch.identifier)).resolves.toBe(true);
     });
 
     it('returns false when the PR watch is not persisted', async () => {
-      await memento.update('devdocket.watches', { runs: [], prs: [] });
+      fileSystem.writeJson(fileUri, { runs: [], prs: [] });
 
       await expect(store.hasPRWatch(createTestPRWatch().identifier)).resolves.toBe(false);
     });
@@ -117,7 +121,7 @@ describe('WatchStore', () => {
       const prWatch = createTestPRWatch();
       await store.saveAll([watch], [prWatch]);
 
-      const persisted = memento.get<{ runs: WatchedRun[]; prs: WatchedPR[] }>('devdocket.watches');
+      const persisted = fileSystem.readJson<{ runs: WatchedRun[]; prs: WatchedPR[] }>(fileUri);
       expect(persisted!.runs).toHaveLength(1);
       expect(persisted!.runs[0].identifier.runId).toBe('123');
       expect(persisted!.prs).toHaveLength(1);

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { MockMemento } from 'vscode';
+import * as vscode from 'vscode';
 import { WorkGraph } from '../services/workGraph';
 import { WorkItemState } from '../models/workItem';
 import { JsonTaskStore } from '../storage/jsonTaskStore';
+import { JsonFileStore } from '../storage/fileStore';
 import { ITaskStore } from '../storage/taskStore';
+import { useMockFileSystem } from './testFileSystem';
 
 function createMockStore(): ITaskStore {
   const items: Map<string, any> = new Map();
@@ -106,8 +108,9 @@ describe('WorkGraph', () => {
   });
 
   it('serializes concurrent mutations so state and field updates both survive', async () => {
-    const memento = new MockMemento();
-    const realStore = new JsonTaskStore(memento);
+    useMockFileSystem();
+    const fileUri = vscode.Uri.file('C:\\test\\workgraph-items.json');
+    const realStore = new JsonTaskStore(new JsonFileStore(fileUri, 'workgraph-items.json'));
     const realGraph = new WorkGraph(realStore);
     await realGraph.load();
     const item = await realGraph.createItem({ title: 'A' });
@@ -122,7 +125,7 @@ describe('WorkGraph', () => {
     expect(updated?.title).toBe('B');
     expect(updated?.activityLog?.map(entry => entry.type)).toEqual(['created', 'state-changed', 'updated']);
 
-    const freshGraph = new WorkGraph(new JsonTaskStore(memento));
+    const freshGraph = new WorkGraph(new JsonTaskStore(new JsonFileStore(fileUri, 'workgraph-items.json')));
     await freshGraph.load();
     const persisted = freshGraph.getItem(item.id);
     expect(persisted?.state).toBe(WorkItemState.InProgress);


### PR DESCRIPTION
## Summary
- move work items, inbox state, read state, and watches from `globalState` to file-backed JSON storage in `globalStorageUri`
- add a safe `FileStore` abstraction with temp-file + rename writes, plus migration from `globalState` to files
- keep `provider-labels` in `globalState` and remove it from cross-window propagation wiring
- update storage docs and tests for file-backed storage, including cross-window store scenarios and migration coverage

## Problem
PR #628 added a `StateVersionService` signal for cross-window updates, but the underlying stores still re-read via `globalState.get()`, which returns per-process cached data. That meant another VS Code window could receive the signal and still load stale state.

## Fix
This change makes user-intent stores re-read fresh JSON files from `globalStorageUri` instead of `globalState`, so cache invalidation plus reload now observes current on-disk state. It also adds a one-time migration from `globalState` to files and preserves the old `globalState` keys as rollback fallback.

## Migration safety
- runs after the existing legacy file-to-`globalState` migration
- guarded by `devdocket.migrated-to-files`
- overwrites stale legacy files when the older migration already ran
- otherwise skips existing files so retries do not clobber newer file-backed data
- leaves the old `globalState` keys in place for rollback fallback

## Testing
- `npm run build`
- `npm run test`
- added store tests that exercise shared file-backed storage and cache invalidation/reload behavior
- added migration tests for happy path, idempotency, stale legacy file overwrite, and write-failure retry behavior

Closes #642
