### PR TITLE
Sanitize AI reviewer GitHub worktree directories

### DIFF
--- a/.changeset/sanitize-github-worktree-path.md
+++ b/.changeset/sanitize-github-worktree-path.md
@@ -1,0 +1,5 @@
+---
+"devdocket-ai-reviewer": patch
+---
+
+Sanitize GitHub worktree repo directories the same way they are cleaned up so AI Reviewer worktrees stay consistent for repository names with unsafe path characters.

--- a/packages/ai-reviewer/src/repoManager.ts
+++ b/packages/ai-reviewer/src/repoManager.ts
@@ -42,6 +42,7 @@ function resetGitVersionCheck(): void {
 /** @internal Test-only hooks for repoManager.ts. */
 export const __testing = {
   resetGitVersionCheck,
+  repoDirFor,
 };
 
 export interface WorktreeInfo {
@@ -84,6 +85,18 @@ async function gitAdoAuth(args: string[], cwd: string, token: string, timeout = 
 
 function sanitizePathSegment(segment: string): string {
   return segment.replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'repo';
+}
+
+type RepoDirInput =
+  | { provider: 'github'; org: string; repo: string }
+  | { provider: 'ado'; org: string; project: string; repo: string };
+
+function repoDirFor(input: RepoDirInput): string {
+  if (input.provider === 'github') {
+    return `${sanitizePathSegment(input.org)}-${sanitizePathSegment(input.repo)}`;
+  }
+
+  return sanitizePathSegment(`ado-${input.org}-${input.project}-${input.repo}`);
 }
 
 function sanitizeUrlForLog(url: string): string {
@@ -210,7 +223,7 @@ export class RepoManager {
     const key = this.githubKey(org, repo, prNumber);
     this.log.info(`Parsed GitHub PR: org=${org}, repo=${repo}, prNumber=${prNumber}`);
 
-    const repoDir = `${org}-${repo}`;
+    const repoDir = repoDirFor({ provider: 'github', org, repo });
     const repoBase = path.join(this.storageUri.fsPath, 'repos', repoDir);
     const clonePath = path.join(repoBase, 'clone');
     const worktreePath = path.join(repoBase, 'worktrees', `pr-${prNumber}`);
@@ -352,7 +365,7 @@ export class RepoManager {
     const key = this.adoKey(org, project, repo, prNumber);
     this.log.info(`Parsed ADO PR: org=${org}, project=${project}, repo=${repo}, prNumber=${prNumber}`);
 
-    const repoDir = sanitizePathSegment(`ado-${org}-${project}-${repo}`);
+    const repoDir = repoDirFor({ provider: 'ado', org, project, repo });
     const repoBase = path.join(this.storageUri.fsPath, 'repos', repoDir);
     const clonePath = path.join(repoBase, 'clone');
     const worktreePath = path.join(repoBase, 'worktrees', `pr-${prNumber}`);
@@ -511,9 +524,10 @@ export class RepoManager {
     }
 
     if (repoBases.size === 0) {
-      repoBases.add(path.join(this.storageUri.fsPath, 'repos', sanitizePathSegment(`${org}-${repo}`)));
-      if (org.includes('/')) {
-        repoBases.add(path.join(this.storageUri.fsPath, 'repos', sanitizePathSegment(`ado-${org}-${repo}`)));
+      repoBases.add(path.join(this.storageUri.fsPath, 'repos', repoDirFor({ provider: 'github', org, repo })));
+      const [adoOrg, project, ...rest] = org.split('/');
+      if (adoOrg && project && rest.length === 0) {
+        repoBases.add(path.join(this.storageUri.fsPath, 'repos', repoDirFor({ provider: 'ado', org: adoOrg, project, repo })));
       }
     }
 

--- a/packages/ai-reviewer/src/test/repoManager.test.ts
+++ b/packages/ai-reviewer/src/test/repoManager.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { authentication, workspace, mockLogOutputChannel } from 'vscode';
 import { RepoManager, parsePrUrl, __testing } from '../repoManager';
 import { GitExecError } from '../tools/gitUtils';
-const { resetGitVersionCheck } = __testing;
+const { resetGitVersionCheck, repoDirFor } = __testing;
 
 // Mock child_process
 vi.mock('child_process', () => ({
@@ -28,6 +28,16 @@ function setProcessPlatform(platform: NodeJS.Platform): void {
 
 function createRepoManager(): RepoManager {
   return new RepoManager({ fsPath: '/mock/storage' } as never, mockLogOutputChannel as never);
+}
+
+function repoManagerInternals(manager: RepoManager): {
+  ensureGitHubWorktree: (prUrl: string, org: string, repo: string, prNumber: string) => Promise<{ clonePath: string }>;
+  ensureAdoWorktree: (prUrl: string, org: string, project: string, repo: string, prNumber: string) => Promise<{ clonePath: string }>;
+} {
+  return manager as unknown as {
+    ensureGitHubWorktree: (prUrl: string, org: string, repo: string, prNumber: string) => Promise<{ clonePath: string }>;
+    ensureAdoWorktree: (prUrl: string, org: string, project: string, repo: string, prNumber: string) => Promise<{ clonePath: string }>;
+  };
 }
 
 function getCloneArgs(): string[] {
@@ -158,6 +168,18 @@ describe('parsePrUrl', () => {
   });
 });
 
+describe('repoDirFor', () => {
+  it('sanitizes GitHub org and repo segments independently', () => {
+    expect(repoDirFor({ provider: 'github', org: 'octo corp', repo: 'repo:name' })).toBe('octo-corp-repo-name');
+  });
+
+  it('preserves the existing ADO repo directory format', () => {
+    expect(repoDirFor({ provider: 'ado', org: 'org name', project: 'project name', repo: 'repo@name' })).toBe(
+      'ado-org-name-project-name-repo-name',
+    );
+  });
+});
+
 describe('RepoManager', () => {
   let manager: RepoManager;
 
@@ -212,6 +234,44 @@ describe('RepoManager', () => {
       await expect(manager.ensureWorktree('https://example.com/not-pr?token=secret#frag')).rejects.toThrow(
         'Invalid PR URL: https://example.com/not-pr',
       );
+    });
+
+    it('uses the same sanitized GitHub repo directory for creation and cleanup', async () => {
+      const internals = repoManagerInternals(manager);
+      const info = await internals.ensureGitHubWorktree(
+        'https://github.com/octo%20corp/repo%3Aname/pull/42',
+        'octo corp',
+        'repo:name',
+        '42',
+      );
+      vi.mocked(workspace.fs.delete).mockClear();
+
+      await manager.removeRepo('octo corp', 'repo:name');
+
+      const expectedRepoBase = `/mock/storage/repos/${repoDirFor({ provider: 'github', org: 'octo corp', repo: 'repo:name' })}`;
+      expect(normalizePath(info.clonePath)).toBe(`${expectedRepoBase}/clone`);
+      const deletedPaths = vi.mocked(workspace.fs.delete).mock.calls.map(call => normalizePath((call[0] as { fsPath: string }).fsPath));
+      expect(deletedPaths).toContain(expectedRepoBase);
+    });
+
+    it('keeps the ADO repo directory naming in sync between creation and cleanup', async () => {
+      mockAdoPrDetails();
+      const internals = repoManagerInternals(manager);
+      const info = await internals.ensureAdoWorktree(
+        'https://dev.azure.com/org%20name/project%20name/_git/repo%40name/pullrequest/42',
+        'org name',
+        'project name',
+        'repo@name',
+        '42',
+      );
+      vi.mocked(workspace.fs.delete).mockClear();
+
+      await manager.removeRepo('org name/project name', 'repo@name');
+
+      const expectedRepoBase = `/mock/storage/repos/${repoDirFor({ provider: 'ado', org: 'org name', project: 'project name', repo: 'repo@name' })}`;
+      expect(normalizePath(info.clonePath)).toBe(`${expectedRepoBase}/clone`);
+      const deletedPaths = vi.mocked(workspace.fs.delete).mock.calls.map(call => normalizePath((call[0] as { fsPath: string }).fsPath));
+      expect(deletedPaths).toContain(expectedRepoBase);
     });
 
     it('redacts query strings and fragments from parse-failing URLs', async () => {


### PR DESCRIPTION
## Summary
- route GitHub and ADO repo directory naming through a shared `repoDirFor` helper in AI Reviewer
- sanitize GitHub org/repo path segments so worktree creation matches cleanup behavior
- add repo manager tests covering GitHub sanitization, unchanged ADO naming, and creation/cleanup parity
- add a patch changeset for `devdocket-ai-reviewer`

## Testing
- npm run build
- npm run test

## Notes
- No case normalization was added; this change keeps existing casing behavior and only eliminates sanitization mismatches.

Closes #580
