### PR TITLE
Persist dismissed PR watches across restarts

### DIFF
--- a/.changeset/fix-dismissed-pr-watches.md
+++ b/.changeset/fix-dismissed-pr-watches.md
@@ -1,0 +1,5 @@
+---
+"devdocket": patch
+---
+
+Keep dismissed pull request watches hidden across VS Code restarts so auto-watch does not recreate them after you close and reopen the window.

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -35,6 +35,8 @@ import { performance } from 'perf_hooks';
 export type { DevDocketApi, DevDocketProvider, DevDocketAction, ProviderItem, Disposable, ActivityLogEntry, ActivityType, StateTransitionEvent, DevDocketPRWatcher } from './api/types';
 export { logger } from './services/logger';
 
+let watcherServiceForDeactivation: WatcherService | undefined;
+
 /** Wrap an event callback so unhandled errors (sync or async) are logged instead of crashing. */
 function safeHandler<T extends unknown[]>(label: string, fn: (...args: T) => void | Promise<void>): (...args: T) => void {
   return (...args: T) => {
@@ -475,6 +477,7 @@ function wireEvents(
  */
 export async function activate(context: vscode.ExtensionContext): Promise<DevDocketApi> {
   const activationStart = performance.now();
+  watcherServiceForDeactivation = undefined;
   const log = initializeLogging(context);
   log.info('DevDocket activating...');
 
@@ -644,6 +647,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   registerCommands(context, wg, ar, ss, readStateStore, pr, labelCache, wr, pwr, ws, watchPanelProvider, editorPanelDependencies, incomingPreviewPanelManager, () => mainProvider.toggleSearch());
   logger.info(`Command registration took ${Math.round(performance.now() - commandRegStart)}ms`);
 
+  watcherServiceForDeactivation = ws;
   logger.info(`DevDocket activated in ${Math.round(performance.now() - activationStart)}ms`);
   return api;
 }
@@ -651,9 +655,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
 /**
  * Deactivate the DevDocket extension.
  *
- * All resources are disposed automatically via `context.subscriptions`,
- * so this function is intentionally a no-op.
+ * Flush queued watch persistence before VS Code disposes subscriptions so
+ * dismissals survive window reloads.
  */
-export function deactivate(): void {
-  // All resources are disposed automatically via context.subscriptions.
+export async function deactivate(): Promise<void> {
+  const watcherService = watcherServiceForDeactivation;
+  watcherServiceForDeactivation = undefined;
+  watcherService?.beginShutdown();
+  await watcherService?.flushPersistence();
 }

--- a/packages/core/src/services/watchPersistence.ts
+++ b/packages/core/src/services/watchPersistence.ts
@@ -2,6 +2,12 @@ import * as vscode from 'vscode';
 import { WatchStore } from '../storage/watchStore';
 import type { WatchedPR, WatchedRun } from './watcherService';
 
+function clonePersistedSnapshot(runs: WatchedRun[], prs: WatchedPR[]): { runs: WatchedRun[]; prs: WatchedPR[] } {
+  // Watch persistence is JSON-backed, so cloning through JSON preserves the queued
+  // snapshot without keeping references to later in-memory mutations.
+  return JSON.parse(JSON.stringify({ runs, prs })) as { runs: WatchedRun[]; prs: WatchedPR[] };
+}
+
 type WatcherLogger = {
   info: (msg: string) => void;
   warn: (msg: string) => void;
@@ -15,6 +21,7 @@ export class WatchPersistence {
   private persistedPRWatchKeys: Set<string> | undefined;
   private readonly pendingPRWatchKeys = new Set<string>();
   private persistFailureNotified = false;
+  private pendingSave: Promise<void> = Promise.resolve();
 
   constructor(
     private readonly watchStore: WatchStore,
@@ -55,23 +62,43 @@ export class WatchPersistence {
   }
 
   saveAll(runs: WatchedRun[], prs: WatchedPR[]): void {
-    this.watchStore.saveAll(runs, prs).then(
-      () => {
-        if (this.persistFailureNotified) {
-          this.persistFailureNotified = false;
-          this.logger.info('Watch persistence recovered.');
-        }
-      },
-      err => {
-        this.logger.error(`Failed to persist watches: ${err}`);
-        if (!this.persistFailureNotified) {
-          this.persistFailureNotified = true;
-          void vscode.window.showWarningMessage(
-            'DevDocket could not save watch state. Watches may be lost when the window reloads.',
-          );
-        }
-      },
-    );
+    const snapshot = clonePersistedSnapshot(runs, prs);
+    this.pendingSave = this.pendingSave
+      .catch(() => undefined)
+      .then(() => this.persistSnapshot(snapshot));
+  }
+
+  async flush(): Promise<void> {
+    while (true) {
+      const pendingSave = this.pendingSave;
+      try {
+        await pendingSave;
+      } catch {
+        // saveAll already surfaced the failure; flushing is best-effort.
+      }
+      if (pendingSave === this.pendingSave) {
+        return;
+      }
+    }
+  }
+
+  private async persistSnapshot(snapshot: { runs: WatchedRun[]; prs: WatchedPR[] }): Promise<void> {
+    try {
+      await this.watchStore.saveAll(snapshot.runs, snapshot.prs);
+      if (this.persistFailureNotified) {
+        this.persistFailureNotified = false;
+        this.logger.info('Watch persistence recovered.');
+      }
+    } catch (err) {
+      this.logger.error(`Failed to persist watches: ${err}`);
+      if (!this.persistFailureNotified) {
+        this.persistFailureNotified = true;
+        void vscode.window.showWarningMessage(
+          'DevDocket could not save watch state. Watches may be lost when the window reloads.',
+        );
+      }
+      throw err;
+    }
   }
 
   dispose(): void {

--- a/packages/core/src/services/watchPersistence.ts
+++ b/packages/core/src/services/watchPersistence.ts
@@ -65,7 +65,8 @@ export class WatchPersistence {
     const snapshot = clonePersistedSnapshot(runs, prs);
     this.pendingSave = this.pendingSave
       .catch(() => undefined)
-      .then(() => this.persistSnapshot(snapshot));
+      .then(() => this.persistSnapshot(snapshot))
+      .catch(() => undefined);
   }
 
   async flush(): Promise<void> {

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -507,10 +507,22 @@ export class WatcherService implements vscode.Disposable {
     this.persistence.saveAll(this.getAllWatches(), this.getAllPRWatches());
   }
 
-  dispose(): void {
+  beginShutdown(): void {
+    if (this.disposed) {
+      return;
+    }
     this.disposed = true;
     this.configSubscription?.dispose();
+    this.configSubscription = undefined;
     this.stopPolling();
+  }
+
+  async flushPersistence(): Promise<void> {
+    await this.persistence.flush();
+  }
+
+  dispose(): void {
+    this.beginShutdown();
     for (const subscription of this.poolSubscriptions) {
       subscription.dispose();
     }

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -2,8 +2,13 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import * as vscode from 'vscode';
 import { MockMemento } from 'vscode';
 import { activate, autoWatchAuthoredPRs, deactivate, logger } from '../extension';
+import { JsonFileStore } from '../storage/fileStore';
 import { ReadStateStore } from '../storage/readStateStore';
+import { WatchStore } from '../storage/watchStore';
 import { ProviderRegistry } from '../services/providerRegistry';
+import { PRWatcherRegistry } from '../services/prWatcherRegistry';
+import { WatcherRegistry } from '../services/watcherRegistry';
+import { WatcherService } from '../services/watcherService';
 import { MainViewProvider } from '../views/mainViewProvider';
 import { WatchPanelProvider } from '../views/watchPanelProvider';
 import { WorkItemEditorPanel } from '../views/workItemEditorPanel';
@@ -849,6 +854,67 @@ describe('activate()', () => {
     expect(watcherService.startPRWatch).not.toHaveBeenCalled();
   });
 
+  it('does not re-add dismissed PR watches after a persistence round-trip', async () => {
+    const identifier = {
+      providerId: 'github-prs',
+      prId: '42',
+      displayName: 'PR #42',
+      url: 'https://github.com/owner/repo/pull/42',
+      repo: 'owner/repo',
+    };
+    const watchFile = vscode.Uri.file('C:\\fake\\storage\\watches.json');
+    const loggerStub = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const firstStore = new WatchStore(new JsonFileStore(watchFile, 'watches.json'));
+    const firstRunRegistry = new WatcherRegistry(loggerStub);
+    const firstPRRegistry = new PRWatcherRegistry(loggerStub);
+    const prWatcher = {
+      id: 'github-prs',
+      label: 'GitHub PRs',
+      canWatch: vi.fn((url: string) => url.includes('/pull/42')),
+      parsePRUrl: vi.fn().mockReturnValue(identifier),
+      getPRRunsSnapshot: vi.fn().mockResolvedValue({ prState: 'open', runs: [] }),
+    };
+    firstPRRegistry.register(prWatcher as any);
+    const firstSession = new WatcherService(firstRunRegistry, firstPRRegistry, firstStore, loggerStub);
+
+    await firstSession.startPRWatch(identifier);
+    firstSession.dismissPRWatch(identifier);
+    await firstSession.flushPersistence();
+    firstSession.dispose();
+
+    const secondStore = new WatchStore(new JsonFileStore(watchFile, 'watches.json'));
+    const secondRunRegistry = new WatcherRegistry(loggerStub);
+    const secondPRRegistry = new PRWatcherRegistry(loggerStub);
+    secondPRRegistry.register(prWatcher as any);
+    const secondSession = new WatcherService(secondRunRegistry, secondPRRegistry, secondStore, loggerStub);
+    await secondSession.loadPersistedWatches();
+
+    const providerRegistry = {
+      getProviderItems: vi.fn().mockReturnValue([
+        {
+          externalId: 'owner/repo#42',
+          title: '#42: Authored PR',
+          url: 'https://github.com/owner/repo/pull/42',
+          authored: true,
+        },
+      ]),
+    } as any;
+    const startPRWatchSpy = vi.spyOn(secondSession, 'startPRWatch');
+
+    await autoWatchAuthoredPRs(
+      'github-my-prs',
+      providerRegistry,
+      secondPRRegistry,
+      secondSession,
+      new AbortController().signal,
+    );
+
+    await expect(secondSession.isPRWatched(identifier)).resolves.toBe(true);
+    expect(startPRWatchSpy).not.toHaveBeenCalled();
+    expect(secondSession.getActivePRWatches()).toHaveLength(0);
+    secondSession.dispose();
+  });
+
   it('logs auto-watch failures with URL context and error details', async () => {
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
     const providerRegistry = {
@@ -990,12 +1056,13 @@ describe('activate()', () => {
 });
 
 describe('deactivate()', () => {
-  it('does not throw', () => {
-    expect(() => deactivate()).not.toThrow();
+  it('resolves without throwing', async () => {
+    await expect(deactivate()).resolves.toBeUndefined();
   });
 
-  it('is a synchronous void function', () => {
+  it('returns a promise', async () => {
     const result = deactivate();
-    expect(result).toBeUndefined();
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).resolves.toBeUndefined();
   });
 });

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -357,6 +357,7 @@ describe('WatcherService', () => {
       });
       registry.register(watcher);
       await service.startWatch(createIdentifier());
+      await service.flushPersistence();
       // Reset the saveAll spy to ignore the post-startWatch persist.
       (watchStore.saveAll as ReturnType<typeof vi.fn>).mockClear();
       // Advance timers to start the poll. Don't await — the poll's await
@@ -383,6 +384,29 @@ describe('WatcherService', () => {
       // saveAll is called async — flush
       await vi.advanceTimersByTimeAsync(0);
       expect(watchStore.saveAll).toHaveBeenCalled();
+    });
+
+    it('flushPersistence waits for queued saves', async () => {
+      const watcher = createMockWatcher('test');
+      registry.register(watcher);
+
+      let resolveSave: (() => void) | undefined;
+      (watchStore.saveAll as ReturnType<typeof vi.fn>).mockImplementation(() => new Promise<void>(resolve => {
+        resolveSave = resolve;
+      }));
+
+      await service.startWatch(createIdentifier());
+
+      let flushed = false;
+      const flushPromise = service.flushPersistence().then(() => {
+        flushed = true;
+      });
+      await Promise.resolve();
+
+      expect(flushed).toBe(false);
+      resolveSave?.();
+      await flushPromise;
+      expect(flushed).toBe(true);
     });
 
     it('loads persisted watches on loadPersistedWatches', async () => {


### PR DESCRIPTION
## Summary
- queue watch persistence writes so dismissals are saved in order with immutable snapshots
- flush queued watch persistence during extension shutdown before VS Code disposes services
- add regression coverage for flush behavior and dismissed PR auto-watch round-trips

## Testing
- npm run build
- npm run test

Closes #597
