### PR TITLE
Show Start Git Work guidance for ADO items without repos

### DIFF
--- a/.changeset/show-ado-start-git-work-reason.md
+++ b/.changeset/show-ado-start-git-work-reason.md
@@ -1,0 +1,5 @@
+---
+"devdocket-start-git-work": patch
+---
+
+Show Start Git Work for Azure DevOps work items that lack an associated repo and explain why it is unavailable instead of silently hiding it. Add debug logging when the action is filtered out so provider-data mismatches are easier to diagnose.

--- a/.changeset/show-ado-start-git-work-reason.md
+++ b/.changeset/show-ado-start-git-work-reason.md
@@ -1,5 +1,7 @@
 ---
+"@devdocket/shared": minor
+"devdocket-ado": patch
 "devdocket-start-git-work": patch
 ---
 
-Show Start Git Work for Azure DevOps work items that lack an associated repo and explain why it is unavailable instead of silently hiding it. Add debug logging when the action is filtered out so provider-data mismatches are easier to diagnose.
+Show Start Git Work for Azure DevOps work items that lack an associated repo and explain why it is unavailable instead of silently hiding it. Add a provider capability for surfacing that explanation and debug logging when the action is filtered out so provider-data mismatches are easier to diagnose.

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -308,7 +308,10 @@ export class AdoWorkItemProvider extends BaseProvider {
       const wiType = wi.fields['System.WorkItemType'];
       const state = wi.fields['System.State'];
       const stateBadge: ProviderBadge[] = state ? [{ label: state, variant: 'info', show: 'editor' }] : [];
-      const gitWork = await this.resolveWorkItemGitWork(token, org, projectName, wi, signal);
+      const associatedRepoId = this.extractAssociatedRepoId(wi);
+      const gitWork = associatedRepoId
+        ? await this.resolveWorkItemGitWork(token, org, projectName, wi, associatedRepoId, signal)
+        : undefined;
       items.push({
         externalId: `${org}/${projectName}/${wi.id}`,
         title: `${wiType} ${wi.id}: ${wi.fields['System.Title']}`,
@@ -324,9 +327,11 @@ export class AdoWorkItemProvider extends BaseProvider {
         reason: 'assigned',
         state,
         itemType: 'issue',
-        capabilities: gitWork
-          ? { gitWork }
-          : { startGitWorkUnavailableReason: 'This Azure DevOps work item has no associated git repo, so Start Git Work is unavailable.' },
+        ...(gitWork
+          ? { capabilities: { gitWork } }
+          : !associatedRepoId
+            ? { capabilities: { startGitWorkUnavailableReason: 'This Azure DevOps work item has no associated git repo, so Start Git Work is unavailable.' } }
+            : {}),
         ...(stateBadge.length > 0 ? { badges: stateBadge } : {}),
       });
     }
@@ -340,13 +345,9 @@ export class AdoWorkItemProvider extends BaseProvider {
     org: string,
     project: string,
     workItem: AdoWorkItem,
+    repoId: string,
     signal?: AbortSignal,
   ): Promise<GitWorkInfo | undefined> {
-    const repoId = this.extractAssociatedRepoId(workItem);
-    if (!repoId) {
-      return undefined;
-    }
-
     const repo = await this.fetchGitRepository(token, org, project, repoId, signal);
     if (!repo) {
       return undefined;

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -324,7 +324,9 @@ export class AdoWorkItemProvider extends BaseProvider {
         reason: 'assigned',
         state,
         itemType: 'issue',
-        ...(gitWork ? { capabilities: { gitWork } } : {}),
+        capabilities: gitWork
+          ? { gitWork }
+          : { startGitWorkUnavailableReason: 'This Azure DevOps work item has no associated git repo, so Start Git Work is unavailable.' },
         ...(stateBadge.length > 0 ? { badges: stateBadge } : {}),
       });
     }

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -117,6 +117,7 @@ describe('AdoWorkItemProvider', () => {
       reason: 'assigned',
       state: 'Active',
       itemType: 'issue',
+      capabilities: { startGitWorkUnavailableReason: 'This Azure DevOps work item has no associated git repo, so Start Git Work is unavailable.' },
       badges: [{ label: 'Active', variant: 'info', show: 'editor' }],
     });
     expect(items[1]).toEqual({
@@ -128,6 +129,7 @@ describe('AdoWorkItemProvider', () => {
       reason: 'assigned',
       state: 'Active',
       itemType: 'issue',
+      capabilities: { startGitWorkUnavailableReason: 'This Azure DevOps work item has no associated git repo, so Start Git Work is unavailable.' },
       badges: [{ label: 'Active', variant: 'info', show: 'editor' }],
     });
   });
@@ -158,6 +160,26 @@ describe('AdoWorkItemProvider', () => {
     expect(listener.mock.calls[0][0][0].author).toEqual({
       displayName: 'Jane Doe',
       handle: 'jane@example.com',
+    });
+  });
+
+  it('populates a Start Git Work explanation when a work item has no associated Git repo relation', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => createWiqlResponse([1]) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          value: [createWorkItemDetail(1, 'Fix login bug')],
+        }),
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0][0].capabilities).toEqual({
+      startGitWorkUnavailableReason: 'This Azure DevOps work item has no associated git repo, so Start Git Work is unavailable.',
     });
   });
 

--- a/packages/ado/src/test/adoWorkItemProvider.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.test.ts
@@ -183,6 +183,39 @@ describe('AdoWorkItemProvider', () => {
     });
   });
 
+  it('does not claim a missing repo when repository metadata lookup fails', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => createWiqlResponse([1]) })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          value: [{
+            ...createWorkItemDetail(1, 'Fix login bug'),
+            relations: [{
+              rel: 'ArtifactLink',
+              url: 'vstfs:///Git/Ref/project-guid%2Frepo-guid%2FGBmain',
+              attributes: { name: 'Branch' },
+            }],
+          }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ value: [{ name: 'Active', category: 'InProgress' }] }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      });
+
+    const listener = vi.fn();
+    provider.onDidDiscoverItems(listener);
+    await provider.refresh();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener.mock.calls[0][0][0]).not.toHaveProperty('capabilities');
+  });
+
   it('populates gitWork when a work item has an associated Git repo relation', async () => {
     mockFetch
       .mockResolvedValueOnce({ ok: true, json: async () => createWiqlResponse([1]) })

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -76,6 +76,11 @@ export interface ProviderItemCapabilities {
    * Returning `undefined` from the thunk means "not currently resolvable".
    */
   gitWork?: GitWorkInfo | (() => Promise<GitWorkInfo | undefined>);
+  /**
+   * Optional user-facing explanation for why Start Git Work cannot run even
+   * though the item should still surface the action in the UI.
+   */
+  startGitWorkUnavailableReason?: string;
 }
 
 export interface ProviderItemAuthor {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -67,6 +67,8 @@ function isValidGitSshCloneUrl(url: string): boolean {
 const GIT_METADATA_TIMEOUT = 30_000;
 /** Timeout for heavy git operations that touch the working tree (worktree add, checkout, fetch). */
 const GIT_CHECKOUT_TIMEOUT = 300_000;
+/** Cap de-duplicated canRun failure logs so long-lived sessions do not retain unbounded history. */
+const MAX_LOGGED_CAN_RUN_FAILURES = 500;
 
 type GetProviderItem = (providerId: string, externalId: string) => ProviderItem | undefined;
 
@@ -120,6 +122,12 @@ export class StartWorkAction implements DevDocketAction {
       const logKey = `${item.id}\0${reason}`;
       if (!this.loggedCanRunFailures.has(logKey)) {
         this.loggedCanRunFailures.add(logKey);
+        if (this.loggedCanRunFailures.size > MAX_LOGGED_CAN_RUN_FAILURES) {
+          const oldestKey = this.loggedCanRunFailures.keys().next().value;
+          if (oldestKey) {
+            this.loggedCanRunFailures.delete(oldestKey);
+          }
+        }
         logger.debug(`Start Git Work unavailable for item ${item.id}: ${reason}`);
       }
     }

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -74,6 +74,11 @@ type ResolvedGitWork = GitWorkInfo & { cloneUrl: string; ref: string };
 
 type WorkMode = 'checkout' | 'worktree';
 
+type CanRunDecision = {
+  canRun: boolean;
+  reason?: string;
+};
+
 type RepoPathPick = vscode.QuickPickItem & (
   | { pickKind: 'repo'; repoPath: string }
   | { pickKind: 'paste' }
@@ -108,17 +113,25 @@ export class StartWorkAction implements DevDocketAction {
   }
 
   canRun(item: Readonly<WorkItem>): boolean {
-    if (item.state !== WorkItemState.InProgress || !item.providerId || !item.externalId) {
-      return false;
+    const decision = this.getCanRunDecision(item);
+    if (!decision.canRun) {
+      logger.debug(`Start Git Work unavailable for item ${item.id}: ${decision.reason ?? 'unknown reason'}`);
     }
-
-    return !!this.getProviderItem(item.providerId, item.externalId)?.capabilities?.gitWork;
+    return decision.canRun;
   }
 
   async run(item: Readonly<WorkItem>): Promise<void> {
+    const providerItem = item.providerId && item.externalId
+      ? this.getProviderItem(item.providerId, item.externalId)
+      : undefined;
     const gitWork = await this.resolveGitWork(item);
     if (!gitWork) {
-      void vscode.window.showErrorMessage('DevDocket: This work item is not supported by Start Git Work.');
+      const unsupportedMessage = this.getUnsupportedMessage(item, providerItem);
+      if (unsupportedMessage) {
+        void vscode.window.showInformationMessage(unsupportedMessage);
+      } else {
+        void vscode.window.showErrorMessage('DevDocket: This work item is not supported by Start Git Work.');
+      }
       return;
     }
 
@@ -137,6 +150,37 @@ export class StartWorkAction implements DevDocketAction {
     } else {
       await this.runIssueFlow(item, gitWork, repoPath);
     }
+  }
+
+  private getCanRunDecision(item: Readonly<WorkItem>): CanRunDecision {
+    if (item.state !== WorkItemState.InProgress) {
+      return { canRun: false, reason: `item state is ${item.state}` };
+    }
+    if (!item.providerId) {
+      return { canRun: false, reason: 'providerId is missing' };
+    }
+    if (!item.externalId) {
+      return { canRun: false, reason: 'externalId is missing' };
+    }
+
+    const providerItem = this.getProviderItem(item.providerId, item.externalId);
+    if (!providerItem) {
+      return { canRun: false, reason: `live provider item ${item.providerId}/${item.externalId} was not found` };
+    }
+    if (providerItem.capabilities?.gitWork) {
+      return { canRun: true };
+    }
+    if (this.getUnsupportedMessage(item, providerItem)) {
+      return { canRun: true };
+    }
+    return { canRun: false, reason: `provider item ${item.providerId}/${item.externalId} has no gitWork capability` };
+  }
+
+  private getUnsupportedMessage(item: Readonly<WorkItem>, providerItem?: ProviderItem): string | undefined {
+    if (item.providerId === 'ado-work-items' && providerItem && !providerItem.capabilities?.gitWork) {
+      return 'DevDocket: This Azure DevOps work item has no associated git repo, so Start Git Work is unavailable.';
+    }
+    return undefined;
   }
 
   private async resolveGitWork(item: Readonly<WorkItem>): Promise<GitWorkInfo | undefined> {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -126,7 +126,7 @@ export class StartWorkAction implements DevDocketAction {
       : undefined;
     const gitWork = await this.resolveGitWork(item);
     if (!gitWork) {
-      const unsupportedMessage = this.getUnsupportedMessage(item, providerItem);
+      const unsupportedMessage = this.getUnsupportedMessage(providerItem);
       if (unsupportedMessage) {
         void vscode.window.showInformationMessage(unsupportedMessage);
       } else {
@@ -170,17 +170,15 @@ export class StartWorkAction implements DevDocketAction {
     if (providerItem.capabilities?.gitWork) {
       return { canRun: true };
     }
-    if (this.getUnsupportedMessage(item, providerItem)) {
+    if (this.getUnsupportedMessage(providerItem)) {
       return { canRun: true };
     }
     return { canRun: false, reason: `provider item ${item.providerId}/${item.externalId} has no gitWork capability` };
   }
 
-  private getUnsupportedMessage(item: Readonly<WorkItem>, providerItem?: ProviderItem): string | undefined {
-    if (item.providerId === 'ado-work-items' && providerItem && !providerItem.capabilities?.gitWork) {
-      return 'DevDocket: This Azure DevOps work item has no associated git repo, so Start Git Work is unavailable.';
-    }
-    return undefined;
+  private getUnsupportedMessage(providerItem?: ProviderItem): string | undefined {
+    const reason = providerItem?.capabilities?.startGitWorkUnavailableReason;
+    return reason ? `DevDocket: ${reason}` : undefined;
   }
 
   private async resolveGitWork(item: Readonly<WorkItem>): Promise<GitWorkInfo | undefined> {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -104,6 +104,7 @@ export class StartWorkAction implements DevDocketAction {
   readonly label = 'Start Git Work';
 
   private readonly globalState: vscode.Memento;
+  private readonly loggedCanRunFailures = new Set<string>();
 
   constructor(
     globalState: vscode.Memento,
@@ -115,7 +116,12 @@ export class StartWorkAction implements DevDocketAction {
   canRun(item: Readonly<WorkItem>): boolean {
     const decision = this.getCanRunDecision(item);
     if (!decision.canRun) {
-      logger.debug(`Start Git Work unavailable for item ${item.id}: ${decision.reason ?? 'unknown reason'}`);
+      const reason = decision.reason ?? 'unknown reason';
+      const logKey = `${item.id}\0${reason}`;
+      if (!this.loggedCanRunFailures.has(logKey)) {
+        this.loggedCanRunFailures.add(logKey);
+        logger.debug(`Start Git Work unavailable for item ${item.id}: ${reason}`);
+      }
     }
     return decision.canRun;
   }

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -64,14 +64,20 @@ function createMockMemento() {
   };
 }
 
-function createAction(items: Record<string, { capabilities?: { gitWork?: GitWork } }> = {}) {
+function createAction(items: Record<string, { capabilities?: { gitWork?: GitWork; startGitWorkUnavailableReason?: string } }> = {}) {
   const memento = createMockMemento();
   const action = new StartWorkAction(memento as any, (providerId, externalId) => items[`${providerId}:${externalId}`] as any);
   return { action, memento };
 }
 
-function discovered(providerId: string, externalId: string, gitWork?: GitWork) {
-  return { [`${providerId}:${externalId}`]: { capabilities: gitWork ? { gitWork } : undefined } };
+function discovered(providerId: string, externalId: string, gitWork?: GitWork, startGitWorkUnavailableReason?: string) {
+  const capabilities = gitWork || startGitWorkUnavailableReason
+    ? {
+      ...(gitWork ? { gitWork } : {}),
+      ...(startGitWorkUnavailableReason ? { startGitWorkUnavailableReason } : {}),
+    }
+    : undefined;
+  return { [`${providerId}:${externalId}`]: { capabilities } };
 }
 
 function mockInputBox(repoPath: string | undefined, baseBranch = 'origin/dev') {
@@ -179,7 +185,12 @@ describe('StartWorkAction', () => {
 
     it('returns true for ADO work items without gitWork so the action can explain why it is unavailable', () => {
       const item = createWorkItem({ providerId: 'ado-work-items', externalId: 'myorg/MyProject/1' });
-      const { action } = createAction(discovered('ado-work-items', 'myorg/MyProject/1'));
+      const { action } = createAction(discovered(
+        'ado-work-items',
+        'myorg/MyProject/1',
+        undefined,
+        'This Azure DevOps work item has no associated git repo, so Start Git Work is unavailable.',
+      ));
 
       expect(action.canRun(item)).toBe(true);
     });
@@ -212,7 +223,12 @@ describe('StartWorkAction', () => {
   describe('run', () => {
     it('explains why Start Git Work is unavailable for ADO work items without an associated repo', async () => {
       const item = createWorkItem({ providerId: 'ado-work-items', externalId: 'myorg/MyProject/1' });
-      const { action } = createAction(discovered('ado-work-items', 'myorg/MyProject/1'));
+      const { action } = createAction(discovered(
+        'ado-work-items',
+        'myorg/MyProject/1',
+        undefined,
+        'This Azure DevOps work item has no associated git repo, so Start Git Work is unavailable.',
+      ));
 
       await action.run(item);
 

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -210,6 +210,15 @@ describe('StartWorkAction', () => {
       expect(mockLogger.debug).toHaveBeenCalledWith('Start Git Work unavailable for item wc-test-1: live provider item provider/item-1 was not found');
     });
 
+    it('logs each false canRun reason only once per item', () => {
+      const item = createWorkItem();
+      const { action } = createAction({});
+
+      expect(action.canRun(item)).toBe(false);
+      expect(action.canRun(item)).toBe(false);
+      expect(mockLogger.debug).toHaveBeenCalledTimes(1);
+    });
+
     it('returns false for non-InProgress items', () => {
       const item = createWorkItem({ state: 'New' });
       const { action } = createAction(discovered('provider', 'item-1', {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { window, workspace } from 'vscode';
 import { StartWorkAction } from '../startWorkAction';
+import { setLogger } from '../logger';
 import * as path from 'path';
 import type { ProviderItemCapabilities } from '@devdocket/shared';
 
@@ -31,6 +32,12 @@ import { execFile } from 'child_process';
 import * as fs from 'fs';
 
 const ORIGIN_REMOTE_V = 'origin\thttps://example.com/acme/repo.git (fetch)\norigin\thttps://example.com/acme/repo.git (push)\n';
+const mockLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
 
 type GitWork = NonNullable<ProviderItemCapabilities['gitWork']>;
 
@@ -140,6 +147,7 @@ function mockNoLocalBranch(remoteOutput = ORIGIN_REMOTE_V) {
 describe('StartWorkAction', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    setLogger(mockLogger);
     (workspace as any).workspaceFolders = [{ uri: { fsPath: '/mock/workspace' } }];
     mockInputBox('/mock/workspace');
     mockQuickPicks();
@@ -160,11 +168,18 @@ describe('StartWorkAction', () => {
       expect(action.canRun(item)).toBe(true);
     });
 
-    it('returns true when a lazy gitWork capability is present', () => {
-      const item = createWorkItem();
-      const { action } = createAction(discovered('provider', 'item-1', async () => ({
+    it('returns true for ADO PRs when a lazy gitWork capability is present', () => {
+      const item = createWorkItem({ providerId: 'ado-pr-reviews', externalId: 'myorg/MyProject/myrepo/101' });
+      const { action } = createAction(discovered('ado-pr-reviews', 'myorg/MyProject/myrepo/101', async () => ({
         kind: 'pr', cloneUrl: 'https://example.com/acme/repo.git', ref: 'feature/topic', repoLabel: 'acme/repo',
       })));
+
+      expect(action.canRun(item)).toBe(true);
+    });
+
+    it('returns true for ADO work items without gitWork so the action can explain why it is unavailable', () => {
+      const item = createWorkItem({ providerId: 'ado-work-items', externalId: 'myorg/MyProject/1' });
+      const { action } = createAction(discovered('ado-work-items', 'myorg/MyProject/1'));
 
       expect(action.canRun(item)).toBe(true);
     });
@@ -181,6 +196,7 @@ describe('StartWorkAction', () => {
       const { action } = createAction({});
 
       expect(action.canRun(item)).toBe(false);
+      expect(mockLogger.debug).toHaveBeenCalledWith('Start Git Work unavailable for item wc-test-1: live provider item provider/item-1 was not found');
     });
 
     it('returns false for non-InProgress items', () => {
@@ -194,6 +210,18 @@ describe('StartWorkAction', () => {
   });
 
   describe('run', () => {
+    it('explains why Start Git Work is unavailable for ADO work items without an associated repo', async () => {
+      const item = createWorkItem({ providerId: 'ado-work-items', externalId: 'myorg/MyProject/1' });
+      const { action } = createAction(discovered('ado-work-items', 'myorg/MyProject/1'));
+
+      await action.run(item);
+
+      expect(window.showInformationMessage).toHaveBeenCalledWith(
+        'DevDocket: This Azure DevOps work item has no associated git repo, so Start Git Work is unavailable.',
+      );
+      expect(execFile).not.toHaveBeenCalled();
+    });
+
     it('creates the provider-suggested branch for an issue', async () => {
       const item = createWorkItem({ providerId: 'fake-vendor', externalId: 'ABC-123' });
       const { action, memento } = createAction(discovered('fake-vendor', 'ABC-123', {


### PR DESCRIPTION
## Summary
- surface Start Git Work for Azure DevOps work items that lack an associated repo so users get an explanation instead of a missing action
- add debug logging for Start Git Work canRun decisions when the action stays hidden
- add provider and action tests covering ADO work items with and without gitWork plus ADO PRs

## Testing
- npm run build
- npm run test

Closes #588
