### PR TITLE
Cancel abandoned auth retries before prompting users

### DIFF
--- a/.changeset/fix-auth-session-cancellation.md
+++ b/.changeset/fix-auth-session-cancellation.md
@@ -1,0 +1,9 @@
+---
+"@devdocket/shared": minor
+"devdocket": patch
+"devdocket-github": patch
+"devdocket-ado": patch
+"devdocket-ai-reviewer": patch
+---
+
+Prevent background and cancelled auth flows from reusing orphaned VS Code authentication sessions, and only prompt interactively after a silent session check for user-initiated refreshes and PR actions.

--- a/packages/ado/src/adoAuth.ts
+++ b/packages/ado/src/adoAuth.ts
@@ -33,21 +33,16 @@ export async function retryAdoWithAuth(
   signal?: AbortSignal,
   options: Omit<AdoAuthOptions, 'signal'> = {},
 ): Promise<Response | undefined> {
-  try {
-    const session = await getAdoSession({ ...options, signal });
-    if (session) {
-      const requestSignal = signal ? combineSignals(signal, 30_000) : AbortSignal.timeout(30_000);
-      return await fetch(apiUrl, {
-        headers: { 'Accept': 'application/json', 'User-Agent': 'DevDocket-VSCode', 'Authorization': `Bearer ${session.accessToken}` },
-        signal: requestSignal,
-      });
-    }
-  } catch (error) {
-    if (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
-      throw error;
-    }
+  const session = await getAdoSession({ ...options, signal });
+  if (!session) {
+    return undefined;
   }
-  return undefined;
+
+  const requestSignal = signal ? combineSignals(signal, 30_000) : AbortSignal.timeout(30_000);
+  return await fetch(apiUrl, {
+    headers: { 'Accept': 'application/json', 'User-Agent': 'DevDocket-VSCode', 'Authorization': `Bearer ${session.accessToken}` },
+    signal: requestSignal,
+  });
 }
 
 /** Throw a descriptive error for a non-ok ADO API response. */

--- a/packages/ado/src/adoAuth.ts
+++ b/packages/ado/src/adoAuth.ts
@@ -43,7 +43,7 @@ export async function retryAdoWithAuth(
       });
     }
   } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
+    if (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
       throw error;
     }
   }

--- a/packages/ado/src/adoAuth.ts
+++ b/packages/ado/src/adoAuth.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { combineSignals, createAbortError } from '@devdocket/shared';
+import { combineSignals, getSessionWithAuthFallback } from '@devdocket/shared';
 
 export const ADO_AUTH_SCOPE = '499b84ac-1321-427f-aa17-267ca6975798/.default';
 
@@ -18,52 +18,13 @@ export async function getAdoHeaders(): Promise<Record<string, string>> {
   return headers;
 }
 
-function raceWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
-  if (!signal) {
-    return promise;
-  }
-  if (signal.aborted) {
-    return Promise.reject(createAbortError());
-  }
-
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(createAbortError());
-    signal.addEventListener('abort', onAbort, { once: true });
-    promise.then(
-      value => {
-        signal.removeEventListener('abort', onAbort);
-        resolve(value);
-      },
-      error => {
-        signal.removeEventListener('abort', onAbort);
-        reject(error);
-      },
-    );
-  });
-}
-
 export async function getAdoSession(options: AdoAuthOptions = {}): Promise<vscode.AuthenticationSession | undefined> {
-  const { interactive = false, signal } = options;
-  if (signal?.aborted) {
-    throw createAbortError();
-  }
-
-  const session = await raceWithAbort(
-    vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], { silent: true }),
-    signal,
-  );
-  if (session || !interactive) {
-    return session;
-  }
-
-  if (signal?.aborted) {
-    throw createAbortError();
-  }
-
-  return raceWithAbort(
-    vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], { createIfNone: true }),
-    signal,
-  );
+  return getSessionWithAuthFallback({
+    interactive: options.interactive,
+    signal: options.signal,
+    getSilent: () => vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], { silent: true }),
+    getInteractive: () => vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], { createIfNone: true }),
+  });
 }
 
 /** Retry a request with ADO auth, prompting only for interactive callers. */
@@ -72,7 +33,7 @@ export async function retryAdoWithAuth(
   signal?: AbortSignal,
   options: Omit<AdoAuthOptions, 'signal'> = {},
 ): Promise<Response | undefined> {
-  const authSignal = signal ? combineSignals(signal, 30_000) : undefined;
+  const authSignal = signal ? combineSignals(signal, 30_000) : AbortSignal.timeout(30_000);
   try {
     const session = await getAdoSession({ ...options, signal: authSignal });
     if (session) {

--- a/packages/ado/src/adoAuth.ts
+++ b/packages/ado/src/adoAuth.ts
@@ -33,13 +33,13 @@ export async function retryAdoWithAuth(
   signal?: AbortSignal,
   options: Omit<AdoAuthOptions, 'signal'> = {},
 ): Promise<Response | undefined> {
-  const authSignal = signal ? combineSignals(signal, 30_000) : AbortSignal.timeout(30_000);
   try {
-    const session = await getAdoSession({ ...options, signal: authSignal });
+    const session = await getAdoSession({ ...options, signal });
     if (session) {
+      const requestSignal = signal ? combineSignals(signal, 30_000) : AbortSignal.timeout(30_000);
       return await fetch(apiUrl, {
         headers: { 'Accept': 'application/json', 'User-Agent': 'DevDocket-VSCode', 'Authorization': `Bearer ${session.accessToken}` },
-        signal: authSignal,
+        signal: requestSignal,
       });
     }
   } catch (error) {

--- a/packages/ado/src/adoAuth.ts
+++ b/packages/ado/src/adoAuth.ts
@@ -1,6 +1,12 @@
 import * as vscode from 'vscode';
+import { combineSignals, createAbortError } from '@devdocket/shared';
 
 export const ADO_AUTH_SCOPE = '499b84ac-1321-427f-aa17-267ca6975798/.default';
+
+export interface AdoAuthOptions {
+  interactive?: boolean;
+  signal?: AbortSignal;
+}
 
 /** Get ADO API headers, attaching auth if a silent session is available. */
 export async function getAdoHeaders(): Promise<Record<string, string>> {
@@ -12,17 +18,74 @@ export async function getAdoHeaders(): Promise<Record<string, string>> {
   return headers;
 }
 
-/** Retry a request with interactive ADO auth (prompts user to sign in). */
-export async function retryAdoWithAuth(apiUrl: string, signal?: AbortSignal): Promise<Response | undefined> {
+function raceWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  if (signal.aborted) {
+    return Promise.reject(createAbortError());
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(createAbortError());
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      value => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      error => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function getAdoSession(options: AdoAuthOptions = {}): Promise<vscode.AuthenticationSession | undefined> {
+  const { interactive = false, signal } = options;
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+
+  const session = await raceWithAbort(
+    vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], { silent: true }),
+    signal,
+  );
+  if (session || !interactive) {
+    return session;
+  }
+
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+
+  return raceWithAbort(
+    vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], { createIfNone: true }),
+    signal,
+  );
+}
+
+/** Retry a request with ADO auth, prompting only for interactive callers. */
+export async function retryAdoWithAuth(
+  apiUrl: string,
+  signal?: AbortSignal,
+  options: Omit<AdoAuthOptions, 'signal'> = {},
+): Promise<Response | undefined> {
+  const authSignal = signal ? combineSignals(signal, 30_000) : undefined;
   try {
-    const session = await vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], { createIfNone: true });
+    const session = await getAdoSession({ ...options, signal: authSignal });
     if (session) {
       return await fetch(apiUrl, {
         headers: { 'Accept': 'application/json', 'User-Agent': 'DevDocket-VSCode', 'Authorization': `Bearer ${session.accessToken}` },
-        signal,
+        signal: authSignal,
       });
     }
-  } catch { /* user declined */ }
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw error;
+    }
+  }
   return undefined;
 }
 

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -1,8 +1,8 @@
 import * as vscode from 'vscode';
-import { BaseProvider, ProviderItem, type GitWorkInfo, type ProviderBadge, isValidUrlSegment, combineSignals, safeDecodeComponent, type ResolvedItem } from '@devdocket/shared';
+import { BaseProvider, ProviderItem, type GitWorkInfo, type ProviderBadge, type ProviderRefreshOptions, isValidUrlSegment, combineSignals, safeDecodeComponent, type ResolvedItem } from '@devdocket/shared';
 import { logger } from './logger';
 import { OrgConfig, resolveProjectList } from './configParser';
-import { getAdoHeaders, retryAdoWithAuth, throwAdoApiError, ADO_AUTH_SCOPE } from './adoAuth';
+import { ADO_AUTH_SCOPE, getAdoHeaders, getAdoSession, retryAdoWithAuth, throwAdoApiError } from './adoAuth';
 
 // Azure DevOps WIQL query response
 interface WiqlResponse {
@@ -80,7 +80,7 @@ export class AdoWorkItemProvider extends BaseProvider {
    * Performs a user-triggered refresh of assigned ADO work items.
    * Prompts for authentication if no session exists.
    */
-  async refresh(token?: vscode.CancellationToken): Promise<void> {
+  async refresh(token?: vscode.CancellationToken, options?: ProviderRefreshOptions): Promise<void> {
     if (this._isRefreshing) {
       return;
     }
@@ -88,15 +88,25 @@ export class AdoWorkItemProvider extends BaseProvider {
     this._isRefreshing = true;
     const abortController = new AbortController();
     const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
+    const interactive = options?.interactive ?? true;
     try {
       logger.info('Fetching assigned ADO work items...');
       if (token?.isCancellationRequested) {
         return;
       }
 
-      const session = await vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], {
-        createIfNone: true,
-      }).catch(() => null);
+      let session: vscode.AuthenticationSession | undefined;
+      try {
+        session = await getAdoSession({
+          interactive,
+          signal: abortController.signal,
+        });
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          throw err;
+        }
+        session = undefined;
+      }
 
       if (token?.isCancellationRequested) {
         return;
@@ -106,7 +116,7 @@ export class AdoWorkItemProvider extends BaseProvider {
         return;
       }
 
-      await this.fetchAndPublishWorkItems(session.accessToken, true, abortController.signal);
+      await this.fetchAndPublishWorkItems(session.accessToken, interactive, abortController.signal);
       this.markRefreshSuccess();
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError') {
@@ -706,7 +716,7 @@ export class AdoWorkItemProvider extends BaseProvider {
     let response = await fetch(apiUrl, { headers, signal });
 
     if (response.status === 404 && !wasAuthenticated && !signal?.aborted) {
-      const retryResponse = await retryAdoWithAuth(apiUrl, signal);
+      const retryResponse = await retryAdoWithAuth(apiUrl, signal, { interactive: true });
       if (retryResponse) { response = retryResponse; }
     }
 

--- a/packages/ado/src/baseAdoPrProvider.ts
+++ b/packages/ado/src/baseAdoPrProvider.ts
@@ -3,6 +3,7 @@ import {
   BaseProvider,
   ProviderItem,
   type ProviderBadge,
+  type ProviderRefreshOptions,
   isValidUrlSegment,
   combineSignals,
   createAbortError,
@@ -13,7 +14,7 @@ import {
 } from '@devdocket/shared';
 import { logger } from './logger';
 import { OrgConfig, resolveProjectList } from './configParser';
-import { getAdoHeaders, retryAdoWithAuth, throwAdoApiError, ADO_AUTH_SCOPE } from './adoAuth';
+import { ADO_AUTH_SCOPE, getAdoHeaders, getAdoSession, retryAdoWithAuth, throwAdoApiError } from './adoAuth';
 
 export interface AdoPullRequest {
   pullRequestId: number;
@@ -75,7 +76,7 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
     super(new vscode.EventEmitter<ProviderItem[]>());
   }
 
-  async refresh(token?: vscode.CancellationToken): Promise<void> {
+  async refresh(token?: vscode.CancellationToken, options?: ProviderRefreshOptions): Promise<void> {
     if (this._isRefreshing) {
       return;
     }
@@ -83,15 +84,25 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
     this._isRefreshing = true;
     const abortController = new AbortController();
     const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
+    const interactive = options?.interactive ?? true;
     try {
       logger.info(`Fetching ADO ${this.logLabel}...`);
       if (token?.isCancellationRequested) {
         return;
       }
 
-      const session = await vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], {
-        createIfNone: true,
-      }).catch(() => null);
+      let session: vscode.AuthenticationSession | undefined;
+      try {
+        session = await getAdoSession({
+          interactive,
+          signal: abortController.signal,
+        });
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          throw err;
+        }
+        session = undefined;
+      }
 
       if (token?.isCancellationRequested) {
         return;
@@ -101,7 +112,7 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
         return;
       }
 
-      await this.fetchAndPublishPrs(session.accessToken, true, session.account.id, abortController.signal);
+      await this.fetchAndPublishPrs(session.accessToken, interactive, session.account.id, abortController.signal);
       this.markRefreshSuccess();
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError' && abortController.signal.aborted && token?.isCancellationRequested) {
@@ -357,7 +368,7 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
     let response = await fetch(apiUrl, { headers, signal });
 
     if (response.status === 404 && !wasAuthenticated && !signal?.aborted) {
-      const retryResponse = await retryAdoWithAuth(apiUrl, signal);
+      const retryResponse = await retryAdoWithAuth(apiUrl, signal, { interactive: true });
       if (retryResponse) {
         response = retryResponse;
       }
@@ -426,7 +437,7 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
         signal: combineSignals(undefined, 30_000),
       });
       if (response.status === 401 || response.status === 403 || (response.status === 404 && !wasAuthenticated)) {
-        const retryResponse = await retryAdoWithAuth(detailUrl);
+        const retryResponse = await retryAdoWithAuth(detailUrl, undefined, { interactive: true });
         if (retryResponse) { response = retryResponse; }
       }
       if (!response.ok) {

--- a/packages/ado/src/test/adoAuth.test.ts
+++ b/packages/ado/src/test/adoAuth.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { authentication } from 'vscode';
+import { retryAdoWithAuth } from '../adoAuth';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('retryAdoWithAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws abort without requesting a session when already cancelled', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(retryAdoWithAuth('https://dev.azure.com/org/_apis/test', controller.signal, { interactive: true }))
+      .rejects.toMatchObject({ name: 'AbortError' });
+    expect(authentication.getSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects when cancellation fires while waiting for getSession', async () => {
+    const controller = new AbortController();
+    const pending = deferred<any>();
+    vi.mocked(authentication.getSession).mockReturnValueOnce(pending.promise);
+
+    const promise = retryAdoWithAuth('https://dev.azure.com/org/_apis/test', controller.signal, { interactive: true });
+    controller.abort();
+    pending.resolve(undefined);
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('checks for a silent session before skipping background retries', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValueOnce(undefined as never);
+
+    await expect(retryAdoWithAuth('https://dev.azure.com/org/_apis/test', undefined, { interactive: false }))
+      .resolves.toBeUndefined();
+    expect(authentication.getSession).toHaveBeenCalledTimes(1);
+    expect(authentication.getSession).toHaveBeenCalledWith(
+      'microsoft',
+      ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+      { silent: true },
+    );
+  });
+
+  it('falls back to createIfNone only for interactive callers', async () => {
+    vi.mocked(authentication.getSession)
+      .mockResolvedValueOnce(undefined as never)
+      .mockResolvedValueOnce({ accessToken: 'interactive-token' } as never);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await retryAdoWithAuth('https://dev.azure.com/org/_apis/test', undefined, { interactive: true });
+
+    expect(authentication.getSession).toHaveBeenNthCalledWith(
+      1,
+      'microsoft',
+      ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+      { silent: true },
+    );
+    expect(authentication.getSession).toHaveBeenNthCalledWith(
+      2,
+      'microsoft',
+      ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+      { createIfNone: true },
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/ado/src/test/adoAuth.test.ts
+++ b/packages/ado/src/test/adoAuth.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { authentication } from 'vscode';
 import { retryAdoWithAuth } from '../adoAuth';
 
@@ -15,6 +15,10 @@ function deferred<T>() {
 describe('retryAdoWithAuth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('throws abort without requesting a session when already cancelled', async () => {

--- a/packages/ado/src/test/adoPrReviewProvider.extended.test.ts
+++ b/packages/ado/src/test/adoPrReviewProvider.extended.test.ts
@@ -440,7 +440,7 @@ describe('AdoPrReviewProvider — extended', () => {
       );
     });
 
-    it('uses createIfNone: true for user-triggered refresh', async () => {
+    it('checks for a cached session before prompting on user-triggered refresh', async () => {
       mockFetch
         .mockResolvedValueOnce(mockConnectionData())
         .mockResolvedValueOnce({
@@ -453,7 +453,7 @@ describe('AdoPrReviewProvider — extended', () => {
       expect(authentication.getSession).toHaveBeenCalledWith(
         'microsoft',
         ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
-        { createIfNone: true },
+        { silent: true },
       );
     });
   });

--- a/packages/ado/src/test/adoWorkItemProvider.extended.test.ts
+++ b/packages/ado/src/test/adoWorkItemProvider.extended.test.ts
@@ -852,7 +852,7 @@ describe('AdoWorkItemProvider — extended', () => {
       );
     });
 
-    it('uses createIfNone: true for user-triggered refresh', async () => {
+    it('checks for a cached session before prompting on user-triggered refresh', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => createWiqlResponse([]),
@@ -863,7 +863,7 @@ describe('AdoWorkItemProvider — extended', () => {
       expect(authentication.getSession).toHaveBeenCalledWith(
         'microsoft',
         ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
-        { createIfNone: true },
+        { silent: true },
       );
     });
   });

--- a/packages/ai-reviewer/src/adoPrClient.ts
+++ b/packages/ai-reviewer/src/adoPrClient.ts
@@ -51,6 +51,13 @@ interface AdoCommitDiffResponse {
 type FetchLike = typeof fetch;
 type SessionProvider = (options?: AuthRequestOptions) => Promise<vscode.AuthenticationSession | undefined>;
 
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) {
+    return;
+  }
+  throw signal.reason instanceof Error ? signal.reason : createAbortError();
+}
+
 export class AdoPrClient {
   constructor(
     private readonly fetchImpl: FetchLike = fetch,
@@ -58,6 +65,7 @@ export class AdoPrClient {
   ) {}
 
   async fetchPullRequestDetails(parts: AdoPrUrlParts, options: AuthRequestOptions = {}): Promise<AdoPullRequestDetails | undefined> {
+    throwIfAborted(options.signal);
     const session = await raceWithAbort(this.getSessionImpl(options), options.signal);
     if (!session) return undefined;
 
@@ -80,6 +88,7 @@ export class AdoPrClient {
   }
 
   async fetchDiffResult(parts: AdoPrUrlParts, options: AuthRequestOptions = {}): Promise<AdoDiffResult | undefined> {
+    throwIfAborted(options.signal);
     const session = await raceWithAbort(this.getSessionImpl(options), options.signal);
     if (!session) return undefined;
 
@@ -132,6 +141,7 @@ export class AdoPrClient {
     comment: AdoThreadCommentInput,
     options: AuthRequestOptions = { interactive: true },
   ): Promise<void> {
+    throwIfAborted(options.signal);
     const session = await raceWithAbort(this.getSessionImpl(options), options.signal);
     if (!session) {
       throw new Error('Azure DevOps authentication is required to post review comments');

--- a/packages/ai-reviewer/src/adoPrClient.ts
+++ b/packages/ai-reviewer/src/adoPrClient.ts
@@ -80,9 +80,6 @@ export class AdoPrClient {
   }
 
   async fetchDiffResult(parts: AdoPrUrlParts, options: AuthRequestOptions = {}): Promise<AdoDiffResult | undefined> {
-    if (options.signal?.aborted) {
-      throw createAbortError();
-    }
     const session = await raceWithAbort(this.getSessionImpl(options), options.signal);
     if (!session) return undefined;
 

--- a/packages/ai-reviewer/src/adoPrClient.ts
+++ b/packages/ai-reviewer/src/adoPrClient.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { combineSignals, createAbortError } from '@devdocket/shared';
+import { combineSignals, createAbortError, raceWithAbort } from '@devdocket/shared';
 import type { AdoPrUrlParts } from './prUrl';
 import { ADO_AUTH_SCOPE, getAdoSession, type AuthRequestOptions } from './auth';
 
@@ -50,30 +50,6 @@ interface AdoCommitDiffResponse {
 
 type FetchLike = typeof fetch;
 type SessionProvider = (options?: AuthRequestOptions) => Promise<vscode.AuthenticationSession | undefined>;
-
-function raceWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
-  if (!signal) {
-    return promise;
-  }
-  if (signal.aborted) {
-    return Promise.reject(createAbortError());
-  }
-
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(createAbortError());
-    signal.addEventListener('abort', onAbort, { once: true });
-    promise.then(
-      value => {
-        signal.removeEventListener('abort', onAbort);
-        resolve(value);
-      },
-      error => {
-        signal.removeEventListener('abort', onAbort);
-        reject(error);
-      },
-    );
-  });
-}
 
 export class AdoPrClient {
   constructor(

--- a/packages/ai-reviewer/src/adoPrClient.ts
+++ b/packages/ai-reviewer/src/adoPrClient.ts
@@ -58,9 +58,6 @@ export class AdoPrClient {
   ) {}
 
   async fetchPullRequestDetails(parts: AdoPrUrlParts, options: AuthRequestOptions = {}): Promise<AdoPullRequestDetails | undefined> {
-    if (options.signal?.aborted) {
-      throw createAbortError();
-    }
     const session = await raceWithAbort(this.getSessionImpl(options), options.signal);
     if (!session) return undefined;
 

--- a/packages/ai-reviewer/src/adoPrClient.ts
+++ b/packages/ai-reviewer/src/adoPrClient.ts
@@ -1,8 +1,9 @@
 import * as vscode from 'vscode';
+import { combineSignals, createAbortError } from '@devdocket/shared';
 import type { AdoPrUrlParts } from './prUrl';
+import { ADO_AUTH_SCOPE, getAdoSession, type AuthRequestOptions } from './auth';
 
-// Azure DevOps' first-party Microsoft Entra resource ID, matching packages/ado auth.
-export const ADO_AUTH_SCOPE = '499b84ac-1321-427f-aa17-267ca6975798/.default';
+export { ADO_AUTH_SCOPE };
 export const ADO_SYNTHETIC_DIFF_NOTICE = 'Azure DevOps returned change metadata; when a local worktree is available DevDocket replaces this with a full git diff.';
 const ADO_API_VERSION = '7.1';
 const ADO_THREADS_API_VERSION = '7.1-preview.1';
@@ -48,25 +49,49 @@ interface AdoCommitDiffResponse {
 }
 
 type FetchLike = typeof fetch;
-type SessionProvider = (createIfNone: boolean) => Promise<vscode.AuthenticationSession | undefined>;
+type SessionProvider = (options?: AuthRequestOptions) => Promise<vscode.AuthenticationSession | undefined>;
+
+function raceWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  if (signal.aborted) {
+    return Promise.reject(createAbortError());
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(createAbortError());
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      value => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      error => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+  });
+}
 
 export class AdoPrClient {
   constructor(
     private readonly fetchImpl: FetchLike = fetch,
-    private readonly getSessionImpl: SessionProvider = async createIfNone => vscode.authentication.getSession(
-      'microsoft',
-      [ADO_AUTH_SCOPE],
-      { createIfNone },
-    ),
+    private readonly getSessionImpl: SessionProvider = options => getAdoSession(options),
   ) {}
 
-  async fetchPullRequestDetails(parts: AdoPrUrlParts): Promise<AdoPullRequestDetails | undefined> {
-    const session = await this.getSessionImpl(true);
+  async fetchPullRequestDetails(parts: AdoPrUrlParts, options: AuthRequestOptions = {}): Promise<AdoPullRequestDetails | undefined> {
+    if (options.signal?.aborted) {
+      throw createAbortError();
+    }
+    const session = await raceWithAbort(this.getSessionImpl(options), options.signal);
     if (!session) return undefined;
 
+    const signal = options.signal ? combineSignals(options.signal, 30_000) : AbortSignal.timeout(30_000);
     const response = await this.fetchImpl(this.prApiUrl(parts), {
       headers: this.jsonHeaders(session.accessToken),
-      signal: AbortSignal.timeout(30_000),
+      signal,
     });
 
     if (!response.ok) {
@@ -76,18 +101,22 @@ export class AdoPrClient {
     return response.json() as Promise<AdoPullRequestDetails>;
   }
 
-  async fetchDiff(parts: AdoPrUrlParts): Promise<string | undefined> {
-    const result = await this.fetchDiffResult(parts);
+  async fetchDiff(parts: AdoPrUrlParts, options: AuthRequestOptions = {}): Promise<string | undefined> {
+    const result = await this.fetchDiffResult(parts, options);
     return result?.diff;
   }
 
-  async fetchDiffResult(parts: AdoPrUrlParts): Promise<AdoDiffResult | undefined> {
-    const session = await this.getSessionImpl(true);
+  async fetchDiffResult(parts: AdoPrUrlParts, options: AuthRequestOptions = {}): Promise<AdoDiffResult | undefined> {
+    if (options.signal?.aborted) {
+      throw createAbortError();
+    }
+    const session = await raceWithAbort(this.getSessionImpl(options), options.signal);
     if (!session) return undefined;
 
+    const signal = options.signal ? combineSignals(options.signal, 30_000) : AbortSignal.timeout(30_000);
     const detailsResponse = await this.fetchImpl(this.prApiUrl(parts), {
       headers: this.jsonHeaders(session.accessToken),
-      signal: AbortSignal.timeout(30_000),
+      signal,
     });
 
     if (!detailsResponse.ok) {
@@ -103,7 +132,7 @@ export class AdoPrClient {
 
     const diffResponse = await this.fetchImpl(this.diffApiUrl(parts, baseVersion, targetVersion), {
       headers: this.jsonHeaders(session.accessToken),
-      signal: AbortSignal.timeout(30_000),
+      signal,
     });
 
     if (!diffResponse.ok) {
@@ -127,8 +156,11 @@ export class AdoPrClient {
     return { diff: renderAdoDiffSummary(parts, details, parsed, synthetic), synthetic };
   }
 
-  async postThread(parts: AdoPrUrlParts, comment: AdoThreadCommentInput): Promise<void> {
-    const session = await this.getSessionImpl(true);
+  async postThread(parts: AdoPrUrlParts, comment: AdoThreadCommentInput, options: AuthRequestOptions = {}): Promise<void> {
+    if (options.signal?.aborted) {
+      throw createAbortError();
+    }
+    const session = await raceWithAbort(this.getSessionImpl(options), options.signal);
     if (!session) {
       throw new Error('Azure DevOps authentication is required to post review comments');
     }
@@ -158,6 +190,7 @@ export class AdoPrClient {
       };
     }
 
+    const signal = options.signal ? combineSignals(options.signal, 30_000) : AbortSignal.timeout(30_000);
     const response = await this.fetchImpl(this.threadsApiUrl(parts), {
       method: 'POST',
       headers: {
@@ -165,7 +198,7 @@ export class AdoPrClient {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(30_000),
+      signal,
     });
 
     if (!response.ok) {

--- a/packages/ai-reviewer/src/adoPrClient.ts
+++ b/packages/ai-reviewer/src/adoPrClient.ts
@@ -89,10 +89,10 @@ export class AdoPrClient {
     const session = await raceWithAbort(this.getSessionImpl(options), options.signal);
     if (!session) return undefined;
 
-    const signal = options.signal ? combineSignals(options.signal, 30_000) : AbortSignal.timeout(30_000);
+    const detailsSignal = options.signal ? combineSignals(options.signal, 30_000) : AbortSignal.timeout(30_000);
     const detailsResponse = await this.fetchImpl(this.prApiUrl(parts), {
       headers: this.jsonHeaders(session.accessToken),
-      signal,
+      signal: detailsSignal,
     });
 
     if (!detailsResponse.ok) {
@@ -106,9 +106,10 @@ export class AdoPrClient {
       throw new Error('Azure DevOps PR metadata did not include source and target versions');
     }
 
+    const diffSignal = options.signal ? combineSignals(options.signal, 30_000) : AbortSignal.timeout(30_000);
     const diffResponse = await this.fetchImpl(this.diffApiUrl(parts, baseVersion, targetVersion), {
       headers: this.jsonHeaders(session.accessToken),
-      signal,
+      signal: diffSignal,
     });
 
     if (!diffResponse.ok) {

--- a/packages/ai-reviewer/src/adoPrClient.ts
+++ b/packages/ai-reviewer/src/adoPrClient.ts
@@ -132,9 +132,6 @@ export class AdoPrClient {
     comment: AdoThreadCommentInput,
     options: AuthRequestOptions = { interactive: true },
   ): Promise<void> {
-    if (options.signal?.aborted) {
-      throw createAbortError();
-    }
     const session = await raceWithAbort(this.getSessionImpl(options), options.signal);
     if (!session) {
       throw new Error('Azure DevOps authentication is required to post review comments');

--- a/packages/ai-reviewer/src/adoPrClient.ts
+++ b/packages/ai-reviewer/src/adoPrClient.ts
@@ -133,7 +133,11 @@ export class AdoPrClient {
     return { diff: renderAdoDiffSummary(parts, details, parsed, synthetic), synthetic };
   }
 
-  async postThread(parts: AdoPrUrlParts, comment: AdoThreadCommentInput, options: AuthRequestOptions = {}): Promise<void> {
+  async postThread(
+    parts: AdoPrUrlParts,
+    comment: AdoThreadCommentInput,
+    options: AuthRequestOptions = { interactive: true },
+  ): Promise<void> {
     if (options.signal?.aborted) {
       throw createAbortError();
     }

--- a/packages/ai-reviewer/src/aiReviewAction.ts
+++ b/packages/ai-reviewer/src/aiReviewAction.ts
@@ -72,7 +72,7 @@ export class AiReviewAction extends BasePrAction {
         }
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') {
-          throw err;
+          return;
         }
         console.error(`${this.progressTitle}: failed to fetch diff:`, err);
         vscode.window.showWarningMessage(`${this.progressTitle}: Failed to fetch PR diff`);

--- a/packages/ai-reviewer/src/aiReviewAction.ts
+++ b/packages/ai-reviewer/src/aiReviewAction.ts
@@ -54,16 +54,25 @@ export class AiReviewAction extends BasePrAction {
     let diff: string | undefined;
     if (adoParts) {
       try {
-        const adoDiff = await new AdoPrClient().fetchDiffResult(adoParts);
-        diff = adoDiff?.diff;
-        adoDiffWasSynthetic = adoDiff?.synthetic ?? false;
+        const abortController = new AbortController();
+        const cancelListener = token.onCancellationRequested?.(() => abortController.abort());
+        try {
+          const adoDiff = await new AdoPrClient().fetchDiffResult(adoParts, {
+            interactive: true,
+            signal: abortController.signal,
+          });
+          diff = adoDiff?.diff;
+          adoDiffWasSynthetic = adoDiff?.synthetic ?? false;
+        } finally {
+          cancelListener?.dispose();
+        }
       } catch (err) {
         console.error(`${this.progressTitle}: failed to fetch diff:`, err);
         vscode.window.showWarningMessage(`${this.progressTitle}: Failed to fetch PR diff`);
         return;
       }
     } else {
-      diff = await this.fetchDiff(item.url!);
+      diff = await this.fetchDiff(item.url!, token);
     }
     if (diff === undefined) {
       if (adoParts) {
@@ -86,7 +95,7 @@ export class AiReviewAction extends BasePrAction {
     progress.report({ message: 'Preparing repository...' });
     let worktreeInfo: WorktreeInfo | undefined;
     try {
-      worktreeInfo = await this.repoManager.ensureWorktree(item.url!);
+      worktreeInfo = await this.repoManager.ensureWorktree(item.url!, token);
       this.log.info('Worktree ready for code review');
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/packages/ai-reviewer/src/aiReviewAction.ts
+++ b/packages/ai-reviewer/src/aiReviewAction.ts
@@ -67,6 +67,9 @@ export class AiReviewAction extends BasePrAction {
           cancelListener?.dispose();
         }
       } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          throw err;
+        }
         console.error(`${this.progressTitle}: failed to fetch diff:`, err);
         vscode.window.showWarningMessage(`${this.progressTitle}: Failed to fetch PR diff`);
         return;

--- a/packages/ai-reviewer/src/aiReviewAction.ts
+++ b/packages/ai-reviewer/src/aiReviewAction.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { createAbortError } from '@devdocket/shared';
 import { BasePrAction, sanitizePrUrl } from './basePrAction';
 import { DEFAULT_REVIEW_PROMPT } from './defaultPrompt';
 import { fenceDiff } from './diffFence';
@@ -54,6 +55,9 @@ export class AiReviewAction extends BasePrAction {
     let diff: string | undefined;
     if (adoParts) {
       try {
+        if (token.isCancellationRequested) {
+          throw createAbortError();
+        }
         const abortController = new AbortController();
         const cancelListener = token.onCancellationRequested?.(() => abortController.abort());
         try {

--- a/packages/ai-reviewer/src/aiWalkthroughAction.ts
+++ b/packages/ai-reviewer/src/aiWalkthroughAction.ts
@@ -27,7 +27,7 @@ export class AiWalkthroughAction extends BasePrAction {
     this.log.info('Preparing worktree for walkthrough');
 
     try {
-      await this.repoManager.ensureWorktree(item.url!);
+      await this.repoManager.ensureWorktree(item.url!, token);
       this.log.info('Worktree ready');
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/packages/ai-reviewer/src/auth.ts
+++ b/packages/ai-reviewer/src/auth.ts
@@ -1,0 +1,81 @@
+import * as vscode from 'vscode';
+import { createAbortError } from '@devdocket/shared';
+
+export const ADO_AUTH_SCOPE = '499b84ac-1321-427f-aa17-267ca6975798/.default';
+
+export interface AuthRequestOptions {
+  interactive?: boolean;
+  signal?: AbortSignal;
+}
+
+function raceWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  if (signal.aborted) {
+    return Promise.reject(createAbortError());
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(createAbortError());
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      value => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      error => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function getGitHubSession(options: AuthRequestOptions = {}): Promise<vscode.AuthenticationSession | undefined> {
+  const { interactive = false, signal } = options;
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+
+  const session = await raceWithAbort(
+    vscode.authentication.getSession('github', ['repo'], { silent: true }),
+    signal,
+  );
+  if (session || !interactive) {
+    return session;
+  }
+
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+
+  return raceWithAbort(
+    vscode.authentication.getSession('github', ['repo'], { createIfNone: true }),
+    signal,
+  );
+}
+
+export async function getAdoSession(options: AuthRequestOptions = {}): Promise<vscode.AuthenticationSession | undefined> {
+  const { interactive = false, signal } = options;
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+
+  const session = await raceWithAbort(
+    vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], { silent: true }),
+    signal,
+  );
+  if (session || !interactive) {
+    return session;
+  }
+
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+
+  return raceWithAbort(
+    vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], { createIfNone: true }),
+    signal,
+  );
+}

--- a/packages/ai-reviewer/src/auth.ts
+++ b/packages/ai-reviewer/src/auth.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
-import { createAbortError } from '@devdocket/shared';
+import { getSessionWithAuthFallback } from '@devdocket/shared';
 
+// Must match ADO_AUTH_SCOPE in packages/ado/src/adoAuth.ts.
+// Cannot import directly due to package-boundary constraints.
 export const ADO_AUTH_SCOPE = '499b84ac-1321-427f-aa17-267ca6975798/.default';
 
 export interface AuthRequestOptions {
@@ -8,74 +10,20 @@ export interface AuthRequestOptions {
   signal?: AbortSignal;
 }
 
-function raceWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
-  if (!signal) {
-    return promise;
-  }
-  if (signal.aborted) {
-    return Promise.reject(createAbortError());
-  }
-
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(createAbortError());
-    signal.addEventListener('abort', onAbort, { once: true });
-    promise.then(
-      value => {
-        signal.removeEventListener('abort', onAbort);
-        resolve(value);
-      },
-      error => {
-        signal.removeEventListener('abort', onAbort);
-        reject(error);
-      },
-    );
+export async function getGitHubSession(options: AuthRequestOptions = {}): Promise<vscode.AuthenticationSession | undefined> {
+  return getSessionWithAuthFallback({
+    interactive: options.interactive,
+    signal: options.signal,
+    getSilent: () => vscode.authentication.getSession('github', ['repo'], { silent: true }),
+    getInteractive: () => vscode.authentication.getSession('github', ['repo'], { createIfNone: true }),
   });
 }
 
-export async function getGitHubSession(options: AuthRequestOptions = {}): Promise<vscode.AuthenticationSession | undefined> {
-  const { interactive = false, signal } = options;
-  if (signal?.aborted) {
-    throw createAbortError();
-  }
-
-  const session = await raceWithAbort(
-    vscode.authentication.getSession('github', ['repo'], { silent: true }),
-    signal,
-  );
-  if (session || !interactive) {
-    return session;
-  }
-
-  if (signal?.aborted) {
-    throw createAbortError();
-  }
-
-  return raceWithAbort(
-    vscode.authentication.getSession('github', ['repo'], { createIfNone: true }),
-    signal,
-  );
-}
-
 export async function getAdoSession(options: AuthRequestOptions = {}): Promise<vscode.AuthenticationSession | undefined> {
-  const { interactive = false, signal } = options;
-  if (signal?.aborted) {
-    throw createAbortError();
-  }
-
-  const session = await raceWithAbort(
-    vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], { silent: true }),
-    signal,
-  );
-  if (session || !interactive) {
-    return session;
-  }
-
-  if (signal?.aborted) {
-    throw createAbortError();
-  }
-
-  return raceWithAbort(
-    vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], { createIfNone: true }),
-    signal,
-  );
+  return getSessionWithAuthFallback({
+    interactive: options.interactive,
+    signal: options.signal,
+    getSilent: () => vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], { silent: true }),
+    getInteractive: () => vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], { createIfNone: true }),
+  });
 }

--- a/packages/ai-reviewer/src/basePrAction.ts
+++ b/packages/ai-reviewer/src/basePrAction.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { createAbortError } from '@devdocket/shared';
+import { combineSignals, createAbortError } from '@devdocket/shared';
 import type { WorkItem, DevDocketAction } from './types';
 import { parseAdoPrUrl, parsePullRequestUrl, parsePrUrl } from './prUrl';
 import { AdoPrClient } from './adoPrClient';
@@ -95,6 +95,9 @@ export abstract class BasePrAction implements DevDocketAction {
 
       return undefined;
     } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        throw err;
+      }
       console.error(`${this.progressTitle}: failed to fetch diff:`, err);
       vscode.window.showWarningMessage(`${this.progressTitle}: Failed to fetch PR diff`);
       return undefined;
@@ -125,7 +128,7 @@ export abstract class BasePrAction implements DevDocketAction {
             Accept: 'application/vnd.github.diff',
             'X-GitHub-Api-Version': '2022-11-28',
           },
-          signal: abortController.signal,
+          signal: combineSignals(abortController.signal, 30_000),
         },
       );
 

--- a/packages/ai-reviewer/src/basePrAction.ts
+++ b/packages/ai-reviewer/src/basePrAction.ts
@@ -112,6 +112,9 @@ export abstract class BasePrAction implements DevDocketAction {
     const abortController = new AbortController();
     const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
     try {
+      if (token?.isCancellationRequested) {
+        throw createAbortError();
+      }
       const session = await getGitHubSession({ interactive: true, signal: abortController.signal });
       if (!session) {
         vscode.window.showWarningMessage(

--- a/packages/ai-reviewer/src/basePrAction.ts
+++ b/packages/ai-reviewer/src/basePrAction.ts
@@ -60,16 +60,23 @@ export abstract class BasePrAction implements DevDocketAction {
 
     if (!await confirmAiUsage(this.confirmationMessage)) return;
 
-    await vscode.window.withProgress(
-      {
-        location: vscode.ProgressLocation.Notification,
-        title: this.progressTitle,
-        cancellable: true,
-      },
-      async (progress, token) => {
-        await this.doWork(item, progress, token);
-      },
-    );
+    try {
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: this.progressTitle,
+          cancellable: true,
+        },
+        async (progress, token) => {
+          await this.doWork(item, progress, token);
+        },
+      );
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        return;
+      }
+      throw err;
+    }
   }
 
   async fetchDiff(url: string, token?: vscode.CancellationToken): Promise<string | undefined> {

--- a/packages/ai-reviewer/src/basePrAction.ts
+++ b/packages/ai-reviewer/src/basePrAction.ts
@@ -1,7 +1,9 @@
 import * as vscode from 'vscode';
+import { createAbortError } from '@devdocket/shared';
 import type { WorkItem, DevDocketAction } from './types';
 import { parseAdoPrUrl, parsePullRequestUrl, parsePrUrl } from './prUrl';
 import { AdoPrClient } from './adoPrClient';
+import { getGitHubSession } from './auth';
 import { confirmAiUsage } from './confirmAiUsage';
 import { fenceDiff } from './diffFence';
 import { sanitizePrUrl } from './promptSanitization';
@@ -70,16 +72,25 @@ export abstract class BasePrAction implements DevDocketAction {
     );
   }
 
-  async fetchDiff(url: string): Promise<string | undefined> {
+  async fetchDiff(url: string, token?: vscode.CancellationToken): Promise<string | undefined> {
     try {
       const github = this.parseGitHubPrUrl(url);
       if (github) {
-        return await this.fetchGitHubDiff(github.repo, github.prNumber);
+        return await this.fetchGitHubDiff(github.repo, github.prNumber, token);
       }
 
       const ado = parseAdoPrUrl(url);
       if (ado) {
-        return await new AdoPrClient().fetchDiff(ado);
+        const abortController = new AbortController();
+        const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
+        try {
+          if (token?.isCancellationRequested) {
+            throw createAbortError();
+          }
+          return await new AdoPrClient().fetchDiff(ado, { interactive: true, signal: abortController.signal });
+        } finally {
+          cancelListener?.dispose();
+        }
       }
 
       return undefined;
@@ -90,34 +101,42 @@ export abstract class BasePrAction implements DevDocketAction {
     }
   }
 
-  private async fetchGitHubDiff(repo: string, prNumber: string): Promise<string | undefined> {
-    const session = await vscode.authentication.getSession('github', ['repo'], {
-      createIfNone: true,
-    });
-    if (!session) {
-      vscode.window.showWarningMessage(
-        `${this.progressTitle}: GitHub authentication is required to fetch the PR diff.`,
-      );
-      return undefined;
-    }
+  private async fetchGitHubDiff(
+    repo: string,
+    prNumber: string,
+    token?: vscode.CancellationToken,
+  ): Promise<string | undefined> {
+    const abortController = new AbortController();
+    const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
+    try {
+      const session = await getGitHubSession({ interactive: true, signal: abortController.signal });
+      if (!session) {
+        vscode.window.showWarningMessage(
+          `${this.progressTitle}: GitHub authentication is required to fetch the PR diff.`,
+        );
+        return undefined;
+      }
 
-    const response = await fetch(
-      `https://api.github.com/repos/${repo}/pulls/${prNumber}`,
-      {
-        headers: {
-          Authorization: `Bearer ${session.accessToken}`,
-          Accept: 'application/vnd.github.diff',
-          'X-GitHub-Api-Version': '2022-11-28',
+      const response = await fetch(
+        `https://api.github.com/repos/${repo}/pulls/${prNumber}`,
+        {
+          headers: {
+            Authorization: `Bearer ${session.accessToken}`,
+            Accept: 'application/vnd.github.diff',
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+          signal: abortController.signal,
         },
-        signal: AbortSignal.timeout(30_000),
-      },
-    );
+      );
 
-    if (!response.ok) {
-      vscode.window.showWarningMessage(`${this.progressTitle}: GitHub API returned ${response.status}`);
-      return undefined;
+      if (!response.ok) {
+        vscode.window.showWarningMessage(`${this.progressTitle}: GitHub API returned ${response.status}`);
+        return undefined;
+      }
+      return response.text();
+    } finally {
+      cancelListener?.dispose();
     }
-    return response.text();
   }
 
   /** Load the prompt, using a custom file if configured, otherwise the built-in default. */

--- a/packages/ai-reviewer/src/repoManager.ts
+++ b/packages/ai-reviewer/src/repoManager.ts
@@ -226,132 +226,135 @@ export class RepoManager {
 
     const abortController = new AbortController();
     const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
-    this.log.info('Requesting GitHub auth session');
-    if (token?.isCancellationRequested) {
-      throw createAbortError();
-    }
-    const session = await getGitHubSession({ interactive: true, signal: abortController.signal });
-    if (!session) {
-      this.log.error('GitHub authentication not available');
-      throw new Error('GitHub authentication required');
-    }
-    this.log.debug(`GitHub auth obtained — account: ${session.account?.label ?? 'unknown'}`);
+    try {
+      this.log.info('Requesting GitHub auth session');
+      if (token?.isCancellationRequested) {
+        throw createAbortError();
+      }
+      const session = await getGitHubSession({ interactive: true, signal: abortController.signal });
+      if (!session) {
+        this.log.error('GitHub authentication not available');
+        throw new Error('GitHub authentication required');
+      }
+      this.log.debug(`GitHub auth obtained — account: ${session.account?.label ?? 'unknown'}`);
 
-    const cloneUrl = `https://github.com/${org}/${repo}.git`;
-    const cloneExists = await this.ensureValidGitDirectory(clonePath, 'repository');
-    this.log.debug(`Clone directory exists and is valid: ${cloneExists}`);
-    if (!cloneExists) {
-      this.log.info('Cloning repository');
-      this.log.debug(`Clone destination: ${clonePath}`);
-      const cloneParent = path.dirname(clonePath);
+      const cloneUrl = `https://github.com/${org}/${repo}.git`;
+      const cloneExists = await this.ensureValidGitDirectory(clonePath, 'repository');
+      this.log.debug(`Clone directory exists and is valid: ${cloneExists}`);
+      if (!cloneExists) {
+        this.log.info('Cloning repository');
+        this.log.debug(`Clone destination: ${clonePath}`);
+        const cloneParent = path.dirname(clonePath);
+        await withPathContext(
+          'Failed to create repository directory',
+          'directory',
+          cloneParent,
+          vscode.workspace.fs.createDirectory(vscode.Uri.file(cloneParent)),
+        );
+        await withPathContext(
+          'Failed to clone repository',
+          'repo',
+          clonePath,
+          gitAuth(
+            cloneArgs(['clone', '--no-checkout', cloneUrl, clonePath]),
+            cloneParent,
+            session.accessToken,
+            300_000,
+          ),
+        );
+        this.log.info('Clone complete');
+      }
+      await configureLongPaths(clonePath);
+
+      this.log.info('Fetching PR metadata from GitHub API');
+      const prMeta = await this.fetchPrMetadata(org, repo, prNumber, session.accessToken);
+      const baseRef = prMeta.baseRef;
+      const headRef = `pr-${prNumber}`;
+      const diffHeadRef = 'HEAD';
+
+      if (!isValidRef(baseRef)) {
+        const safeBaseRef = JSON.stringify(baseRef);
+        this.log.error(`Invalid base ref from GitHub API: ${safeBaseRef}`);
+        throw new Error(`Invalid base ref from GitHub API: ${safeBaseRef}`);
+      }
+      this.log.info(`PR metadata — baseRef: ${baseRef}, headSha: ${prMeta.headSha}, local headRef: ${headRef}`);
+
+      const worktreeExists = await this.ensureValidGitDirectory(worktreePath, 'worktree', clonePath);
+      this.log.debug(`Worktree directory exists and is valid: ${worktreeExists}`);
+      if (worktreeExists) {
+        this.log.info('Updating existing worktree — fetching PR head');
+        await withPathContext(
+          'Failed to fetch PR head',
+          'worktree',
+          worktreePath,
+          gitAuth(['fetch', 'origin', `pull/${prNumber}/head`], worktreePath, session.accessToken, 300_000),
+        );
+        await withPathContext(
+          'Failed to reset worktree',
+          'worktree',
+          worktreePath,
+          gitExec(['reset', '--hard', 'FETCH_HEAD'], worktreePath),
+        );
+        this.log.info('Worktree updated');
+      } else {
+        this.log.info('Creating new worktree — fetching PR head');
+        await withPathContext(
+          'Failed to fetch PR head',
+          'repo',
+          clonePath,
+          gitAuth(['fetch', 'origin', `pull/${prNumber}/head:${headRef}`], clonePath, session.accessToken, 300_000),
+        );
+        this.log.info('PR head fetched');
+      }
+
+      this.log.info(`Fetching base branch: ${baseRef}`);
       await withPathContext(
-        'Failed to create repository directory',
-        'directory',
-        cloneParent,
-        vscode.workspace.fs.createDirectory(vscode.Uri.file(cloneParent)),
-      );
-      await withPathContext(
-        'Failed to clone repository',
+        'Failed to fetch base branch',
         'repo',
         clonePath,
         gitAuth(
-          cloneArgs(['clone', '--no-checkout', cloneUrl, clonePath]),
-          cloneParent,
+          ['fetch', 'origin', `refs/heads/${baseRef}:refs/remotes/origin/${baseRef}`],
+          clonePath,
           session.accessToken,
           300_000,
         ),
       );
-      this.log.info('Clone complete');
-    }
-    await configureLongPaths(clonePath);
+      this.log.info('Base branch fetched');
 
-    this.log.info('Fetching PR metadata from GitHub API');
-    const prMeta = await this.fetchPrMetadata(org, repo, prNumber, session.accessToken);
-    const baseRef = prMeta.baseRef;
-    const headRef = `pr-${prNumber}`;
-    const diffHeadRef = 'HEAD';
-
-    if (!isValidRef(baseRef)) {
-      const safeBaseRef = JSON.stringify(baseRef);
-      this.log.error(`Invalid base ref from GitHub API: ${safeBaseRef}`);
-      throw new Error(`Invalid base ref from GitHub API: ${safeBaseRef}`);
-    }
-    this.log.info(`PR metadata — baseRef: ${baseRef}, headSha: ${prMeta.headSha}, local headRef: ${headRef}`);
-
-    const worktreeExists = await this.ensureValidGitDirectory(worktreePath, 'worktree', clonePath);
-    this.log.debug(`Worktree directory exists and is valid: ${worktreeExists}`);
-    if (worktreeExists) {
-      this.log.info('Updating existing worktree — fetching PR head');
-      await withPathContext(
-        'Failed to fetch PR head',
-        'worktree',
-        worktreePath,
-        gitAuth(['fetch', 'origin', `pull/${prNumber}/head`], worktreePath, session.accessToken, 300_000),
-      );
-      await withPathContext(
-        'Failed to reset worktree',
-        'worktree',
-        worktreePath,
-        gitExec(['reset', '--hard', 'FETCH_HEAD'], worktreePath),
-      );
-      this.log.info('Worktree updated');
-    } else {
-      this.log.info('Creating new worktree — fetching PR head');
-      await withPathContext(
-        'Failed to fetch PR head',
-        'repo',
-        clonePath,
-        gitAuth(['fetch', 'origin', `pull/${prNumber}/head:${headRef}`], clonePath, session.accessToken, 300_000),
-      );
-      this.log.info('PR head fetched');
-    }
-
-    this.log.info(`Fetching base branch: ${baseRef}`);
-    await withPathContext(
-      'Failed to fetch base branch',
-      'repo',
-      clonePath,
-      gitAuth(
-        ['fetch', 'origin', `refs/heads/${baseRef}:refs/remotes/origin/${baseRef}`],
-        clonePath,
-        session.accessToken,
-        300_000,
-      ),
-    );
-    this.log.info('Base branch fetched');
-
-    if (!worktreeExists) {
-      if (cloneExists) {
-        await this.pruneWorktreeMetadata(clonePath);
+      if (!worktreeExists) {
+        if (cloneExists) {
+          await this.pruneWorktreeMetadata(clonePath);
+        }
+        this.log.info('Creating worktree');
+        this.log.debug(`Worktree destination: ${worktreePath}, ref: ${headRef}`);
+        await withPathContext(
+          'Failed to create worktree',
+          'worktree',
+          worktreePath,
+          gitExec(['worktree', 'add', worktreePath, headRef], clonePath),
+        );
+        this.log.info('Worktree created');
       }
-      this.log.info('Creating worktree');
-      this.log.debug(`Worktree destination: ${worktreePath}, ref: ${headRef}`);
-      await withPathContext(
-        'Failed to create worktree',
-        'worktree',
+
+      const info: WorktreeInfo = {
         worktreePath,
-        gitExec(['worktree', 'add', worktreePath, headRef], clonePath),
-      );
-      this.log.info('Worktree created');
+        clonePath,
+        org,
+        repo,
+        prNumber,
+        headRef: diffHeadRef,
+        baseRef: `origin/${baseRef}`,
+        prUrl,
+        provider: 'github',
+      };
+
+      this.worktrees.set(key, info);
+      validWorktreePaths.add(path.resolve(worktreePath));
+      this.log.debug(`ensureWorktree complete — worktree ready at ${worktreePath}`);
+      return info;
+    } finally {
+      cancelListener?.dispose();
     }
-
-    const info: WorktreeInfo = {
-      worktreePath,
-      clonePath,
-      org,
-      repo,
-      prNumber,
-      headRef: diffHeadRef,
-      baseRef: `origin/${baseRef}`,
-      prUrl,
-      provider: 'github',
-    };
-
-    this.worktrees.set(key, info);
-    validWorktreePaths.add(path.resolve(worktreePath));
-    this.log.debug(`ensureWorktree complete — worktree ready at ${worktreePath}`);
-    cancelListener?.dispose();
-    return info;
   }
 
   private async ensureAdoWorktree(
@@ -373,115 +376,118 @@ export class RepoManager {
 
     const abortController = new AbortController();
     const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
-    if (token?.isCancellationRequested) {
-      throw createAbortError();
-    }
+    try {
+      if (token?.isCancellationRequested) {
+        throw createAbortError();
+      }
 
-    const session = await getAdoSession({ interactive: true, signal: abortController.signal });
-    if (!session) {
-      this.log.error('Microsoft authentication not available');
-      throw new Error('Azure DevOps authentication required');
-    }
+      const session = await getAdoSession({ interactive: true, signal: abortController.signal });
+      if (!session) {
+        this.log.error('Microsoft authentication not available');
+        throw new Error('Azure DevOps authentication required');
+      }
 
-    const details = await new AdoPrClient(fetch, async () => session).fetchPullRequestDetails(
-      { org, project, repo, prId: prNumber },
-      { interactive: true, signal: abortController.signal },
-    );
-    if (!details) {
-      throw new Error('Azure DevOps authentication required');
-    }
-
-    const sourceRef = details.sourceRefName;
-    const targetRef = details.targetRefName;
-    if (!sourceRef || !targetRef || !isValidRef(sourceRef) || !isValidRef(targetRef)) {
-      throw new Error('Azure DevOps PR metadata contained missing or invalid source or target refs');
-    }
-
-    const cloneUrl = `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(project)}/_git/${encodeURIComponent(repo)}`;
-    if (!isValidCloneUrl(cloneUrl)) {
-      throw new Error('Azure DevOps repository clone URL is invalid');
-    }
-
-    const cloneExists = await this.ensureValidGitDirectory(clonePath, 'repository');
-    if (!cloneExists) {
-      this.log.info('Cloning Azure Repos repository');
-      const cloneParent = path.dirname(clonePath);
-      await withPathContext(
-        'Failed to create repository directory',
-        'directory',
-        cloneParent,
-        vscode.workspace.fs.createDirectory(vscode.Uri.file(cloneParent)),
+      const details = await new AdoPrClient(fetch, async () => session).fetchPullRequestDetails(
+        { org, project, repo, prId: prNumber },
+        { interactive: true, signal: abortController.signal },
       );
+      if (!details) {
+        throw new Error('Azure DevOps authentication required');
+      }
+
+      const sourceRef = details.sourceRefName;
+      const targetRef = details.targetRefName;
+      if (!sourceRef || !targetRef || !isValidRef(sourceRef) || !isValidRef(targetRef)) {
+        throw new Error('Azure DevOps PR metadata contained missing or invalid source or target refs');
+      }
+
+      const cloneUrl = `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(project)}/_git/${encodeURIComponent(repo)}`;
+      if (!isValidCloneUrl(cloneUrl)) {
+        throw new Error('Azure DevOps repository clone URL is invalid');
+      }
+
+      const cloneExists = await this.ensureValidGitDirectory(clonePath, 'repository');
+      if (!cloneExists) {
+        this.log.info('Cloning Azure Repos repository');
+        const cloneParent = path.dirname(clonePath);
+        await withPathContext(
+          'Failed to create repository directory',
+          'directory',
+          cloneParent,
+          vscode.workspace.fs.createDirectory(vscode.Uri.file(cloneParent)),
+        );
+        await withPathContext(
+          'Failed to clone Azure Repos repository',
+          'repo',
+          clonePath,
+          gitAdoAuth(
+            cloneArgs(['clone', '--no-checkout', cloneUrl, clonePath]),
+            cloneParent,
+            session.accessToken,
+            300_000,
+          ),
+        );
+        this.log.info('ADO clone complete');
+      }
+      await configureLongPaths(clonePath);
+
+      const headRef = `refs/devdocket/ado/pr-${prNumber}-head`;
+      const baseRef = `refs/devdocket/ado/pr-${prNumber}-base`;
+      // Force-update DevDocket-owned refs so force-pushed PR branches are reflected accurately.
       await withPathContext(
-        'Failed to clone Azure Repos repository',
+        'Failed to fetch ADO source ref',
         'repo',
         clonePath,
-        gitAdoAuth(
-          cloneArgs(['clone', '--no-checkout', cloneUrl, clonePath]),
-          cloneParent,
-          session.accessToken,
-          300_000,
-        ),
+        gitAdoAuth(['fetch', 'origin', `+${sourceRef}:${headRef}`], clonePath, session.accessToken, 300_000),
       );
-      this.log.info('ADO clone complete');
-    }
-    await configureLongPaths(clonePath);
-
-    const headRef = `refs/devdocket/ado/pr-${prNumber}-head`;
-    const baseRef = `refs/devdocket/ado/pr-${prNumber}-base`;
-    // Force-update DevDocket-owned refs so force-pushed PR branches are reflected accurately.
-    await withPathContext(
-      'Failed to fetch ADO source ref',
-      'repo',
-      clonePath,
-      gitAdoAuth(['fetch', 'origin', `+${sourceRef}:${headRef}`], clonePath, session.accessToken, 300_000),
-    );
-    await withPathContext(
-      'Failed to fetch ADO target ref',
-      'repo',
-      clonePath,
-      gitAdoAuth(['fetch', 'origin', `+${targetRef}:${baseRef}`], clonePath, session.accessToken, 300_000),
-    );
-
-    const worktreeExists = await this.ensureValidGitDirectory(worktreePath, 'worktree', clonePath);
-    if (worktreeExists) {
-      this.log.info('Updating existing ADO worktree');
       await withPathContext(
-        'Failed to reset ADO worktree',
-        'worktree',
-        worktreePath,
-        gitExec(['reset', '--hard', headRef], worktreePath),
+        'Failed to fetch ADO target ref',
+        'repo',
+        clonePath,
+        gitAdoAuth(['fetch', 'origin', `+${targetRef}:${baseRef}`], clonePath, session.accessToken, 300_000),
       );
-    } else {
-      if (cloneExists) {
-        await this.pruneWorktreeMetadata(clonePath);
+
+      const worktreeExists = await this.ensureValidGitDirectory(worktreePath, 'worktree', clonePath);
+      if (worktreeExists) {
+        this.log.info('Updating existing ADO worktree');
+        await withPathContext(
+          'Failed to reset ADO worktree',
+          'worktree',
+          worktreePath,
+          gitExec(['reset', '--hard', headRef], worktreePath),
+        );
+      } else {
+        if (cloneExists) {
+          await this.pruneWorktreeMetadata(clonePath);
+        }
+        this.log.info('Creating ADO worktree');
+        await withPathContext(
+          'Failed to create ADO worktree',
+          'worktree',
+          worktreePath,
+          gitExec(['worktree', 'add', '--detach', worktreePath, headRef], clonePath),
+        );
       }
-      this.log.info('Creating ADO worktree');
-      await withPathContext(
-        'Failed to create ADO worktree',
-        'worktree',
+
+      const info: WorktreeInfo = {
         worktreePath,
-        gitExec(['worktree', 'add', '--detach', worktreePath, headRef], clonePath),
-      );
+        clonePath,
+        org: `${org}/${project}`,
+        repo,
+        prNumber,
+        headRef,
+        baseRef,
+        prUrl,
+        provider: 'ado',
+      };
+
+      this.worktrees.set(key, info);
+      validWorktreePaths.add(path.resolve(worktreePath));
+      this.log.debug(`ensureAdoWorktree complete — worktree ready at ${worktreePath}`);
+      return info;
+    } finally {
+      cancelListener?.dispose();
     }
-
-    const info: WorktreeInfo = {
-      worktreePath,
-      clonePath,
-      org: `${org}/${project}`,
-      repo,
-      prNumber,
-      headRef,
-      baseRef,
-      prUrl,
-      provider: 'ado',
-    };
-
-    this.worktrees.set(key, info);
-    validWorktreePaths.add(path.resolve(worktreePath));
-    this.log.debug(`ensureAdoWorktree complete — worktree ready at ${worktreePath}`);
-    cancelListener?.dispose();
-    return info;
   }
 
   /** Check if worktree already exists and return info, or undefined. */

--- a/packages/ai-reviewer/src/repoManager.ts
+++ b/packages/ai-reviewer/src/repoManager.ts
@@ -381,15 +381,14 @@ export class RepoManager {
     const abortController = new AbortController();
     const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
     try {
-      if (token?.isCancellationRequested) {
-        throw createAbortError();
-      }
+      this.throwIfCancelled(token, abortController.signal);
 
       const session = await getAdoSession({ interactive: true, signal: abortController.signal });
       if (!session) {
         this.log.error('Microsoft authentication not available');
         throw new Error('Azure DevOps authentication required');
       }
+      this.throwIfCancelled(token, abortController.signal);
 
       const details = await new AdoPrClient(fetch, async () => session).fetchPullRequestDetails(
         { org, project, repo, prId: prNumber },
@@ -398,6 +397,7 @@ export class RepoManager {
       if (!details) {
         throw new Error('Azure DevOps authentication required');
       }
+      this.throwIfCancelled(token, abortController.signal);
 
       const sourceRef = details.sourceRefName;
       const targetRef = details.targetRefName;
@@ -433,8 +433,10 @@ export class RepoManager {
         );
         this.log.info('ADO clone complete');
       }
+      this.throwIfCancelled(token, abortController.signal);
       await configureLongPaths(clonePath);
 
+      this.throwIfCancelled(token, abortController.signal);
       const headRef = `refs/devdocket/ado/pr-${prNumber}-head`;
       const baseRef = `refs/devdocket/ado/pr-${prNumber}-base`;
       // Force-update DevDocket-owned refs so force-pushed PR branches are reflected accurately.
@@ -451,6 +453,7 @@ export class RepoManager {
         gitAdoAuth(['fetch', 'origin', `+${targetRef}:${baseRef}`], clonePath, session.accessToken, 300_000),
       );
 
+      this.throwIfCancelled(token, abortController.signal);
       const worktreeExists = await this.ensureValidGitDirectory(worktreePath, 'worktree', clonePath);
       if (worktreeExists) {
         this.log.info('Updating existing ADO worktree');

--- a/packages/ai-reviewer/src/repoManager.ts
+++ b/packages/ai-reviewer/src/repoManager.ts
@@ -1,8 +1,10 @@
 import * as vscode from 'vscode';
+import { createAbortError } from '@devdocket/shared';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import { parseAdoPrUrl, parsePrUrl } from './prUrl';
-import { ADO_AUTH_SCOPE, AdoPrClient } from './adoPrClient';
+import { AdoPrClient } from './adoPrClient';
+import { getAdoSession, getGitHubSession } from './auth';
 import { GitExecError, gitExec } from './tools/gitUtils';
 import { validWorktreePaths } from './tools/worktreeRegistry';
 import { isValidRef } from './tools/refValidation';
@@ -189,24 +191,30 @@ export class RepoManager {
   ) {}
 
   /** Clone repo if needed, create worktree if needed, fetch + checkout PR branch. */
-  async ensureWorktree(prUrl: string): Promise<WorktreeInfo> {
+  async ensureWorktree(prUrl: string, token?: vscode.CancellationToken): Promise<WorktreeInfo> {
     const logPrUrl = sanitizeUrlForLog(prUrl);
     this.log.debug(`ensureWorktree called — prUrl: ${logPrUrl}`);
     const github = parsePrUrl(prUrl);
     if (github) {
-      return this.ensureGitHubWorktree(prUrl, github.org, github.repo, github.prNumber);
+      return this.ensureGitHubWorktree(prUrl, github.org, github.repo, github.prNumber, token);
     }
 
     const ado = parseAdoPrUrl(prUrl);
     if (ado) {
-      return this.ensureAdoWorktree(prUrl, ado.org, ado.project, ado.repo, ado.prId);
+      return this.ensureAdoWorktree(prUrl, ado.org, ado.project, ado.repo, ado.prId, token);
     }
 
     this.log.error(`Invalid PR URL: ${logPrUrl}`);
     throw new Error(`Invalid PR URL: ${logPrUrl}`);
   }
 
-  private async ensureGitHubWorktree(prUrl: string, org: string, repo: string, prNumber: string): Promise<WorktreeInfo> {
+  private async ensureGitHubWorktree(
+    prUrl: string,
+    org: string,
+    repo: string,
+    prNumber: string,
+    token?: vscode.CancellationToken,
+  ): Promise<WorktreeInfo> {
     const key = this.githubKey(org, repo, prNumber);
     this.log.info(`Parsed GitHub PR: org=${org}, repo=${repo}, prNumber=${prNumber}`);
 
@@ -216,10 +224,13 @@ export class RepoManager {
     const worktreePath = path.join(repoBase, 'worktrees', `pr-${prNumber}`);
     this.log.debug(`Paths — clonePath: ${clonePath}, worktreePath: ${worktreePath}`);
 
+    const abortController = new AbortController();
+    const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
     this.log.info('Requesting GitHub auth session');
-    const session = await vscode.authentication.getSession('github', ['repo'], {
-      createIfNone: true,
-    });
+    if (token?.isCancellationRequested) {
+      throw createAbortError();
+    }
+    const session = await getGitHubSession({ interactive: true, signal: abortController.signal });
     if (!session) {
       this.log.error('GitHub authentication not available');
       throw new Error('GitHub authentication required');
@@ -339,6 +350,7 @@ export class RepoManager {
     this.worktrees.set(key, info);
     validWorktreePaths.add(path.resolve(worktreePath));
     this.log.debug(`ensureWorktree complete — worktree ready at ${worktreePath}`);
+    cancelListener?.dispose();
     return info;
   }
 
@@ -348,6 +360,7 @@ export class RepoManager {
     project: string,
     repo: string,
     prNumber: string,
+    token?: vscode.CancellationToken,
   ): Promise<WorktreeInfo> {
     const key = this.adoKey(org, project, repo, prNumber);
     this.log.info(`Parsed ADO PR: org=${org}, project=${project}, repo=${repo}, prNumber=${prNumber}`);
@@ -358,15 +371,22 @@ export class RepoManager {
     const worktreePath = path.join(repoBase, 'worktrees', `pr-${prNumber}`);
     this.log.debug(`ADO paths — clonePath: ${clonePath}, worktreePath: ${worktreePath}`);
 
-    const session = await vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], {
-      createIfNone: true,
-    });
+    const abortController = new AbortController();
+    const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
+    if (token?.isCancellationRequested) {
+      throw createAbortError();
+    }
+
+    const session = await getAdoSession({ interactive: true, signal: abortController.signal });
     if (!session) {
       this.log.error('Microsoft authentication not available');
       throw new Error('Azure DevOps authentication required');
     }
 
-    const details = await new AdoPrClient(fetch, async () => session).fetchPullRequestDetails({ org, project, repo, prId: prNumber });
+    const details = await new AdoPrClient(fetch, async () => session).fetchPullRequestDetails(
+      { org, project, repo, prId: prNumber },
+      { interactive: true, signal: abortController.signal },
+    );
     if (!details) {
       throw new Error('Azure DevOps authentication required');
     }
@@ -460,6 +480,7 @@ export class RepoManager {
     this.worktrees.set(key, info);
     validWorktreePaths.add(path.resolve(worktreePath));
     this.log.debug(`ensureAdoWorktree complete — worktree ready at ${worktreePath}`);
+    cancelListener?.dispose();
     return info;
   }
 

--- a/packages/ai-reviewer/src/repoManager.ts
+++ b/packages/ai-reviewer/src/repoManager.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { createAbortError } from '@devdocket/shared';
+import { combineSignals, createAbortError } from '@devdocket/shared';
 import * as path from 'path';
 import * as fs from 'fs/promises';
 import { parseAdoPrUrl, parsePrUrl } from './prUrl';
@@ -228,15 +228,14 @@ export class RepoManager {
     const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
     try {
       this.log.info('Requesting GitHub auth session');
-      if (token?.isCancellationRequested) {
-        throw createAbortError();
-      }
+      this.throwIfCancelled(token, abortController.signal);
       const session = await getGitHubSession({ interactive: true, signal: abortController.signal });
       if (!session) {
         this.log.error('GitHub authentication not available');
         throw new Error('GitHub authentication required');
       }
       this.log.debug(`GitHub auth obtained — account: ${session.account?.label ?? 'unknown'}`);
+      this.throwIfCancelled(token, abortController.signal);
 
       const cloneUrl = `https://github.com/${org}/${repo}.git`;
       const cloneExists = await this.ensureValidGitDirectory(clonePath, 'repository');
@@ -264,10 +263,12 @@ export class RepoManager {
         );
         this.log.info('Clone complete');
       }
+      this.throwIfCancelled(token, abortController.signal);
       await configureLongPaths(clonePath);
 
+      this.throwIfCancelled(token, abortController.signal);
       this.log.info('Fetching PR metadata from GitHub API');
-      const prMeta = await this.fetchPrMetadata(org, repo, prNumber, session.accessToken);
+      const prMeta = await this.fetchPrMetadata(org, repo, prNumber, session.accessToken, abortController.signal);
       const baseRef = prMeta.baseRef;
       const headRef = `pr-${prNumber}`;
       const diffHeadRef = 'HEAD';
@@ -278,6 +279,7 @@ export class RepoManager {
         throw new Error(`Invalid base ref from GitHub API: ${safeBaseRef}`);
       }
       this.log.info(`PR metadata — baseRef: ${baseRef}, headSha: ${prMeta.headSha}, local headRef: ${headRef}`);
+      this.throwIfCancelled(token, abortController.signal);
 
       const worktreeExists = await this.ensureValidGitDirectory(worktreePath, 'worktree', clonePath);
       this.log.debug(`Worktree directory exists and is valid: ${worktreeExists}`);
@@ -307,6 +309,7 @@ export class RepoManager {
         this.log.info('PR head fetched');
       }
 
+      this.throwIfCancelled(token, abortController.signal);
       this.log.info(`Fetching base branch: ${baseRef}`);
       await withPathContext(
         'Failed to fetch base branch',
@@ -320,6 +323,7 @@ export class RepoManager {
         ),
       );
       this.log.info('Base branch fetched');
+      this.throwIfCancelled(token, abortController.signal);
 
       if (!worktreeExists) {
         if (cloneExists) {
@@ -571,6 +575,12 @@ export class RepoManager {
     return undefined;
   }
 
+  private throwIfCancelled(token?: vscode.CancellationToken, signal?: AbortSignal): void {
+    if (token?.isCancellationRequested || signal?.aborted) {
+      throw createAbortError();
+    }
+  }
+
   private githubKey(org: string, repo: string, prNumber: string): string {
     return `github:${org}/${repo}#${prNumber}`;
   }
@@ -628,6 +638,7 @@ export class RepoManager {
     repo: string,
     prNumber: string,
     token: string,
+    signal?: AbortSignal,
   ): Promise<{ baseRef: string; headSha: string }> {
     const response = await fetch(
       `https://api.github.com/repos/${org}/${repo}/pulls/${prNumber}`,
@@ -637,7 +648,7 @@ export class RepoManager {
           Accept: 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28',
         },
-        signal: AbortSignal.timeout(30_000),
+        signal: combineSignals(signal, 30_000),
       },
     );
 

--- a/packages/ai-reviewer/src/test/adoPrClient.test.ts
+++ b/packages/ai-reviewer/src/test/adoPrClient.test.ts
@@ -277,6 +277,16 @@ describe('AdoPrClient', () => {
     expect(body.threadContext).toBeUndefined();
   });
 
+  it('defaults postThread to interactive auth', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(response({ id: 123 }));
+    const getSession = vi.fn().mockResolvedValue({ accessToken: 'ado-token' });
+    const client = new AdoPrClient(fetchMock as never, getSession as never);
+
+    await client.postThread(parts, { content: 'Overall review summary.' });
+
+    expect(getSession).toHaveBeenCalledWith({ interactive: true });
+  });
+
   it('normalizes ADO file paths', () => {
     expect(normalizeAdoFilePath('src\\app.ts')).toBe('/src/app.ts');
     expect(normalizeAdoFilePath('/src/app.ts')).toBe('/src/app.ts');

--- a/packages/ai-reviewer/src/test/adoPrClient.test.ts
+++ b/packages/ai-reviewer/src/test/adoPrClient.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { authentication } from 'vscode';
 import { AdoPrClient, normalizeAdoFilePath } from '../adoPrClient';
 
 const parts = {
@@ -12,6 +13,16 @@ function session() {
   return Promise.resolve({ accessToken: 'ado-token' } as never);
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function response(body: unknown, ok = true, status = 200) {
   return {
     ok,
@@ -22,6 +33,64 @@ function response(body: unknown, ok = true, status = 200) {
 }
 
 describe('AdoPrClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws abort without requesting a session when already cancelled', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const getSession = vi.fn();
+    const client = new AdoPrClient(vi.fn() as never, getSession as never);
+
+    await expect(client.fetchDiffResult(parts, { interactive: true, signal: controller.signal }))
+      .rejects.toMatchObject({ name: 'AbortError' });
+    expect(getSession).not.toHaveBeenCalled();
+  });
+
+  it('checks for a silent session before prompting interactively', async () => {
+    vi.mocked(authentication.getSession)
+      .mockResolvedValueOnce(undefined as never)
+      .mockResolvedValueOnce({ accessToken: 'ado-token' } as never);
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response({
+        sourceRefName: 'refs/heads/feature',
+        targetRefName: 'refs/heads/main',
+        lastMergeSourceCommit: { commitId: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' },
+        lastMergeTargetCommit: { commitId: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' },
+      }))
+      .mockResolvedValueOnce(response({ changes: [] }));
+    const client = new AdoPrClient(fetchMock as never);
+
+    await client.fetchDiffResult(parts, { interactive: true });
+
+    expect(authentication.getSession).toHaveBeenNthCalledWith(
+      1,
+      'microsoft',
+      ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+      { silent: true },
+    );
+    expect(authentication.getSession).toHaveBeenNthCalledWith(
+      2,
+      'microsoft',
+      ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
+      { createIfNone: true },
+    );
+  });
+
+  it('rejects when cancellation fires while waiting for auth', async () => {
+    const controller = new AbortController();
+    const pending = deferred<any>();
+    const getSession = vi.fn().mockReturnValueOnce(pending.promise);
+    const client = new AdoPrClient(vi.fn() as never, getSession as never);
+
+    const promise = client.fetchDiffResult(parts, { interactive: true, signal: controller.signal });
+    controller.abort();
+    pending.resolve(undefined);
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
   it('fetches PR metadata and commit diff from Azure DevOps', async () => {
     const fetchMock = vi.fn()
       .mockResolvedValueOnce(response({

--- a/packages/ai-reviewer/src/test/aiReviewAction.test.ts
+++ b/packages/ai-reviewer/src/test/aiReviewAction.test.ts
@@ -180,7 +180,7 @@ describe('AiReviewAction', () => {
       await action.run(item);
 
       // Verify worktree was prepared
-      expect(mockRepoManager.ensureWorktree).toHaveBeenCalledWith('https://github.com/owner/repo/pull/42');
+      expect(mockRepoManager.ensureWorktree).toHaveBeenCalledWith('https://github.com/owner/repo/pull/42', expect.anything());
 
       // Verify fetch was called with the GitHub API
       expect(mockFetch).toHaveBeenCalledWith(
@@ -367,7 +367,7 @@ describe('AiReviewAction', () => {
       expect(authentication.getSession).toHaveBeenCalledWith(
         'microsoft',
         ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
-        { createIfNone: true },
+        { silent: true },
       );
       expect(String(mockFetch.mock.calls[1][0])).toContain('/diffs/commits?');
     });
@@ -738,7 +738,7 @@ describe('AiReviewAction', () => {
       await action.run(item);
 
       // ensureWorktree reuses existing clone/worktree
-      expect(mockRepoManager.ensureWorktree).toHaveBeenCalledWith('https://github.com/owner/repo/pull/42');
+      expect(mockRepoManager.ensureWorktree).toHaveBeenCalledWith('https://github.com/owner/repo/pull/42', expect.anything());
     });
 
     it('does not call ensureWorktree for non-PR URLs', async () => {

--- a/packages/ai-reviewer/src/test/aiWalkthroughAction.test.ts
+++ b/packages/ai-reviewer/src/test/aiWalkthroughAction.test.ts
@@ -66,7 +66,7 @@ describe('AiWalkthroughAction', () => {
       const item = createWorkItem();
       await action.run(item);
 
-      expect(mockRepoManager.ensureWorktree).toHaveBeenCalledWith('https://github.com/owner/repo/pull/42');
+      expect(mockRepoManager.ensureWorktree).toHaveBeenCalledWith('https://github.com/owner/repo/pull/42', expect.anything());
       expect(commands.executeCommand).toHaveBeenCalledWith('workbench.action.chat.newChat');
     });
 
@@ -85,7 +85,7 @@ describe('AiWalkthroughAction', () => {
       const item = createWorkItem();
       await action.run(item);
 
-      expect(mockRepoManager.ensureWorktree).toHaveBeenCalledWith('https://github.com/owner/repo/pull/42');
+      expect(mockRepoManager.ensureWorktree).toHaveBeenCalledWith('https://github.com/owner/repo/pull/42', expect.anything());
     });
 
     it('opens chat with correct query after preparing worktree', async () => {

--- a/packages/ai-reviewer/src/test/repoManager.test.ts
+++ b/packages/ai-reviewer/src/test/repoManager.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as vscode from 'vscode';
 import { authentication, workspace, mockLogOutputChannel } from 'vscode';
 import { RepoManager, parsePrUrl, __testing } from '../repoManager';
 import { GitExecError } from '../tools/gitUtils';
@@ -124,6 +125,26 @@ async function rejectedMessage(promise: Promise<unknown>): Promise<string> {
   throw new Error('Expected promise to reject');
 }
 
+function createCancellationToken() {
+  let cancelled = false;
+  let listener: (() => void) | undefined;
+  return {
+    token: {
+      get isCancellationRequested() {
+        return cancelled;
+      },
+      onCancellationRequested: vi.fn((cb: () => void) => {
+        listener = cb;
+        return { dispose: vi.fn() };
+      }),
+    } as unknown as vscode.CancellationToken,
+    cancel() {
+      cancelled = true;
+      listener?.();
+    },
+  };
+}
+
 describe('parsePrUrl', () => {
   it('parses a valid GitHub PR URL', () => {
     const result = parsePrUrl('https://github.com/owner/repo/pull/42');
@@ -206,6 +227,41 @@ describe('RepoManager', () => {
   describe('ensureWorktree', () => {
     it('throws for invalid PR URLs', async () => {
       await expect(manager.ensureWorktree('not-a-url')).rejects.toThrow('Invalid PR URL');
+    });
+
+    it('throws abort before requesting auth when already cancelled', async () => {
+      const cancellation = createCancellationToken();
+      cancellation.cancel();
+
+      await expect(manager.ensureWorktree('https://github.com/owner/repo/pull/42', cancellation.token))
+        .rejects.toMatchObject({ name: 'AbortError' });
+      expect(authentication.getSession).not.toHaveBeenCalled();
+    });
+
+    it('checks for a silent GitHub session before prompting during worktree setup', async () => {
+      vi.mocked(authentication.getSession)
+        .mockResolvedValueOnce(undefined as never)
+        .mockResolvedValueOnce({ accessToken: 'mock-token' } as never);
+
+      await manager.ensureWorktree('https://github.com/owner/repo/pull/42');
+
+      expect(authentication.getSession).toHaveBeenNthCalledWith(1, 'github', ['repo'], { silent: true });
+      expect(authentication.getSession).toHaveBeenNthCalledWith(2, 'github', ['repo'], { createIfNone: true });
+    });
+
+    it('rejects when cancellation fires while waiting for GitHub auth', async () => {
+      const cancellation = createCancellationToken();
+      let resolveSession!: (value: unknown) => void;
+      const pendingSession = new Promise<unknown>(resolve => {
+        resolveSession = resolve;
+      });
+      vi.mocked(authentication.getSession).mockReturnValueOnce(pendingSession as never);
+
+      const promise = manager.ensureWorktree('https://github.com/owner/repo/pull/42', cancellation.token);
+      cancellation.cancel();
+      resolveSession(undefined);
+
+      await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
     });
 
     it('does not include query strings or fragments in invalid URL errors', async () => {
@@ -805,7 +861,7 @@ describe('RepoManager', () => {
       expect(authentication.getSession).toHaveBeenCalledWith(
         'microsoft',
         ['499b84ac-1321-427f-aa17-267ca6975798/.default'],
-        { createIfNone: true },
+        { silent: true },
       );
       expect(info.provider).toBe('ado');
       expect(info.prUrl).toBe(url);

--- a/packages/ai-reviewer/src/test/walkthroughParticipant.test.ts
+++ b/packages/ai-reviewer/src/test/walkthroughParticipant.test.ts
@@ -91,6 +91,7 @@ describe('WalkthroughParticipant', () => {
 
       expect(mockRepoManager.ensureWorktree).toHaveBeenCalledWith(
         'https://github.com/owner/repo/pull/42',
+        expect.anything(),
       );
     });
 
@@ -107,6 +108,7 @@ describe('WalkthroughParticipant', () => {
 
       expect(mockRepoManager.ensureWorktree).toHaveBeenCalledWith(
         'https://dev.azure.com/org/project/_git/repo/pullrequest/42',
+        expect.anything(),
       );
     });
 
@@ -208,6 +210,7 @@ describe('WalkthroughParticipant', () => {
 
       expect(mockRepoManager.ensureWorktree).toHaveBeenCalledWith(
         'https://github.com/owner/repo/pull/42',
+        expect.anything(),
       );
     });
 

--- a/packages/ai-reviewer/src/walkthroughParticipant.ts
+++ b/packages/ai-reviewer/src/walkthroughParticipant.ts
@@ -90,7 +90,7 @@ export class WalkthroughParticipant {
       this.log.info('No cached worktree info — preparing worktree');
       response.progress('Cloning repository and preparing worktree…');
       try {
-        info = await this.repoManager.ensureWorktree(prUrl);
+        info = await this.repoManager.ensureWorktree(prUrl, token);
         this.log.debug(`Worktree ready at ${info.worktreePath}`);
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -2,4 +2,4 @@
 // existing intra-core imports (e.g. `from '../api/types'`).
 export type { Disposable, Event, ProviderItem, ProviderItemAuthor, ProviderItemCapabilities, GitWorkInfo, ProviderBadge, RelatedItemRef, ResolvedItem, DevDocketRunWatcher, DevDocketPRWatcher } from '@devdocket/shared';
 export type { ActivityLogEntry, ActivityType } from '@devdocket/shared';
-export type { StateTransitionEvent, DevDocketProvider, DevDocketAction, DevDocketApi, ActivityDetailRender, ActivityDetailRenderer } from '@devdocket/shared';
+export type { StateTransitionEvent, ProviderRefreshOptions, DevDocketProvider, DevDocketAction, DevDocketApi, ActivityDetailRender, ActivityDetailRenderer } from '@devdocket/shared';

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -205,7 +205,7 @@ export class ProviderRegistry {
     this._loadingProviders.add(provider.id);
     this._onDidRegisterProvider.fire();
     this._onDidChangeProviderItems.fire();
-    this.refreshWithTimeout(provider)
+    this.refreshWithTimeout(provider, undefined, false)
       .finally(() => {
         this._loadingProviders.delete(provider.id);
         if (!this._disposed) {
@@ -358,7 +358,7 @@ export class ProviderRegistry {
         outcome = 'cancelled';
       } else {
         logger.debug(`Provider ${provider.id} refreshing...`);
-        outcome = await this.refreshWithTimeout(provider, token);
+        outcome = await this.refreshWithTimeout(provider, token, true);
       }
 
       completedProviderIds.add(provider.id);
@@ -392,10 +392,14 @@ export class ProviderRegistry {
       return 'cancelled';
     }
     logger.debug(`Provider ${provider.id} refreshing...`);
-    return this.refreshWithTimeout(provider, token);
+    return this.refreshWithTimeout(provider, token, true);
   }
 
-  private refreshWithTimeout(provider: DevDocketProvider, parentToken?: vscode.CancellationToken): Promise<ProviderRefreshOutcome> {
+  private refreshWithTimeout(
+    provider: DevDocketProvider,
+    parentToken?: vscode.CancellationToken,
+    interactive = false,
+  ): Promise<ProviderRefreshOutcome> {
     this.cancelPendingRefresh(provider.id);
     const cts = new vscode.CancellationTokenSource();
     let timedOut = false;
@@ -416,7 +420,7 @@ export class ProviderRegistry {
 
     let providerRefreshPromise: Promise<void>;
     try {
-      providerRefreshPromise = Promise.resolve(provider.refresh(cts.token));
+      providerRefreshPromise = Promise.resolve(provider.refresh(cts.token, { interactive }));
     } catch (err) {
       providerRefreshPromise = Promise.reject(err);
     }

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -121,6 +121,13 @@ describe('ProviderRegistry', () => {
     expect(provider.refresh).toHaveBeenCalledTimes(1);
   });
 
+  it('treats registration refreshes as non-interactive', () => {
+    const provider = createMockProvider('registration-auth');
+    registry.register(provider);
+
+    expect(provider.refresh).toHaveBeenCalledWith(expect.anything(), { interactive: false });
+  });
+
   it('applies window state to already registered providers that support it', () => {
     const provider = {
       ...createMockProvider('window-aware'),
@@ -274,6 +281,16 @@ describe('ProviderRegistry', () => {
     expect(p2.refresh).toHaveBeenCalledTimes(1);
   });
 
+  it('treats refreshAll as interactive', async () => {
+    const provider = createMockProvider('refresh-all-auth');
+    registry.register(provider);
+    vi.mocked(provider.refresh).mockClear();
+
+    await registry.refreshAll();
+
+    expect(provider.refresh).toHaveBeenCalledWith(expect.anything(), { interactive: true });
+  });
+
   it('handles refresh errors gracefully in refreshAll', async () => {
     const p1 = createMockProvider('p1');
     vi.mocked(p1.refresh).mockRejectedValueOnce(new Error('network error'));
@@ -382,6 +399,16 @@ describe('ProviderRegistry', () => {
 
   it('returns cancelled when refreshing an unregistered provider by id', async () => {
     await expect(registry.refreshProvider('missing')).resolves.toBe('cancelled');
+  });
+
+  it('treats single-provider refreshes as interactive', async () => {
+    const provider = createMockProvider('single-refresh-auth');
+    registry.register(provider);
+    vi.mocked(provider.refresh).mockClear();
+
+    await registry.refreshProvider('single-refresh-auth');
+
+    expect(provider.refresh).toHaveBeenCalledWith(expect.anything(), { interactive: true });
   });
 
   it('cleans up all subscriptions on dispose', () => {
@@ -983,6 +1010,7 @@ describe('ProviderRegistry', () => {
 
       expect(provider.refresh).toHaveBeenCalledWith(
         expect.objectContaining({ isCancellationRequested: false }),
+        { interactive: false },
       );
     });
 

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -64,7 +64,11 @@ export abstract class BaseGitHubProvider extends BaseProvider {
 
       if (!session || token?.isCancellationRequested) {
         if (!session) {
-          logger.info('User cancelled GitHub authentication');
+          if (interactive) {
+            logger.info('User cancelled GitHub authentication');
+          } else {
+            logger.debug('No cached GitHub session available for non-interactive refresh');
+          }
         }
         return;
       }

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
-import { BaseProvider, ProviderItem, createAbortError, runWorkerPool, type RelatedItemRef } from '@devdocket/shared';
+import { BaseProvider, ProviderItem, createAbortError, runWorkerPool, type ProviderRefreshOptions, type RelatedItemRef } from '@devdocket/shared';
 import { fetchPrCrossReferencesBatch } from './githubGraphql';
+import { getGitHubSession } from './githubApiHelpers';
 import { logger } from './logger';
 import { matchesRepoPatterns, parseRepoPatterns, type RepoPattern } from './repoPattern';
 
@@ -31,7 +32,7 @@ export abstract class BaseGitHubProvider extends BaseProvider {
     return ['repo'];
   }
 
-  async refresh(token?: vscode.CancellationToken): Promise<void> {
+  async refresh(token?: vscode.CancellationToken, options?: ProviderRefreshOptions): Promise<void> {
     if (this._isRefreshing) {
       return;
     }
@@ -39,6 +40,7 @@ export abstract class BaseGitHubProvider extends BaseProvider {
     this._isRefreshing = true;
     const abortController = new AbortController();
     const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
+    const interactive = options?.interactive ?? true;
     try {
       if (token?.isCancellationRequested) {
         return;
@@ -46,10 +48,14 @@ export abstract class BaseGitHubProvider extends BaseProvider {
 
       let session: vscode.AuthenticationSession | undefined;
       try {
-        session = await vscode.authentication.getSession('github', this.getAuthenticationScopes(), {
-          createIfNone: true,
+        session = await getGitHubSession(this.getAuthenticationScopes(), {
+          interactive,
+          signal: abortController.signal,
         });
       } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          throw err;
+        }
         const message = err instanceof Error ? err.message : String(err);
         logger.error('GitHub authentication failed', err);
         this.showGitHubAuthenticationWarning(`DevDocket GitHub: Authentication failed — ${message}`);
@@ -63,7 +69,7 @@ export abstract class BaseGitHubProvider extends BaseProvider {
         return;
       }
 
-      await this.fetchAndPublish(session.accessToken, true, abortController.signal);
+      await this.fetchAndPublish(session.accessToken, interactive, abortController.signal);
       this.markRefreshSuccess();
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError' && abortController.signal.aborted && token?.isCancellationRequested) {

--- a/packages/github/src/gitWorkCapabilities.ts
+++ b/packages/github/src/gitWorkCapabilities.ts
@@ -57,7 +57,7 @@ export function createGitHubPrGitWork(repoName: string, number: number, prApiUrl
     });
 
     if ((response.status === 401 || response.status === 403 || (response.status === 404 && !wasAuthenticated))) {
-      const retryResponse = await retryWithAuth(url);
+      const retryResponse = await retryWithAuth(url, undefined, { interactive: true });
       if (retryResponse) { response = retryResponse; }
     }
 

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { isValidGitHubRepo, combineSignals, createAbortError, runWorkerPoolSettled, type ProviderBadge } from '@devdocket/shared';
+import { isValidGitHubRepo, combineSignals, createAbortError, getSessionWithAuthFallback, runWorkerPoolSettled, type ProviderBadge } from '@devdocket/shared';
 import { logger } from './logger';
 
 export interface GitHubAuthOptions {
@@ -155,55 +155,16 @@ export async function getHeaders(): Promise<Record<string, string>> {
   return headers;
 }
 
-function raceWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
-  if (!signal) {
-    return promise;
-  }
-  if (signal.aborted) {
-    return Promise.reject(createAbortError());
-  }
-
-  return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(createAbortError());
-    signal.addEventListener('abort', onAbort, { once: true });
-    promise.then(
-      value => {
-        signal.removeEventListener('abort', onAbort);
-        resolve(value);
-      },
-      error => {
-        signal.removeEventListener('abort', onAbort);
-        reject(error);
-      },
-    );
-  });
-}
-
 export async function getGitHubSession(
   scopes: readonly string[],
   options: GitHubAuthOptions = {},
 ): Promise<vscode.AuthenticationSession | undefined> {
-  const { interactive = false, signal } = options;
-  if (signal?.aborted) {
-    throw createAbortError();
-  }
-
-  const session = await raceWithAbort(
-    vscode.authentication.getSession('github', [...scopes], { silent: true }),
-    signal,
-  );
-  if (session || !interactive) {
-    return session;
-  }
-
-  if (signal?.aborted) {
-    throw createAbortError();
-  }
-
-  return raceWithAbort(
-    vscode.authentication.getSession('github', [...scopes], { createIfNone: true }),
-    signal,
-  );
+  return getSessionWithAuthFallback({
+    interactive: options.interactive,
+    signal: options.signal,
+    getSilent: () => vscode.authentication.getSession('github', [...scopes], { silent: true }),
+    getInteractive: () => vscode.authentication.getSession('github', [...scopes], { createIfNone: true }),
+  });
 }
 
 /** Retry a request with GitHub auth, prompting only for interactive callers. */
@@ -212,7 +173,7 @@ export async function retryWithAuth(
   signal?: AbortSignal,
   options: Omit<GitHubAuthOptions, 'signal'> = {},
 ): Promise<Response | undefined> {
-  const authSignal = signal ? combineSignals(signal, 30_000) : undefined;
+  const authSignal = signal ? combineSignals(signal, 30_000) : AbortSignal.timeout(30_000);
   try {
     const session = await getGitHubSession(['repo'], { ...options, signal: authSignal });
     if (session) {

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -173,27 +173,21 @@ export async function retryWithAuth(
   signal?: AbortSignal,
   options: Omit<GitHubAuthOptions, 'signal'> = {},
 ): Promise<Response | undefined> {
-  try {
-    const session = await getGitHubSession(['repo'], { ...options, signal });
-    if (session) {
-      const requestSignal = signal ? combineSignals(signal, 30_000) : AbortSignal.timeout(30_000);
-      return await fetch(apiUrl, {
-        headers: {
-          'Accept': 'application/vnd.github+json',
-          'User-Agent': 'DevDocket-VSCode',
-          'X-GitHub-Api-Version': '2022-11-28',
-          'Authorization': `Bearer ${session.accessToken}`,
-        },
-        signal: requestSignal,
-      });
-    }
-  } catch (error) {
-    if (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
-      throw error;
-    }
-    logger.debug('User declined GitHub authentication prompt');
+  const session = await getGitHubSession(['repo'], { ...options, signal });
+  if (!session) {
+    return undefined;
   }
-  return undefined;
+
+  const requestSignal = signal ? combineSignals(signal, 30_000) : AbortSignal.timeout(30_000);
+  return await fetch(apiUrl, {
+    headers: {
+      'Accept': 'application/vnd.github+json',
+      'User-Agent': 'DevDocket-VSCode',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'Authorization': `Bearer ${session.accessToken}`,
+    },
+    signal: requestSignal,
+  });
 }
 
 /**

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -173,10 +173,10 @@ export async function retryWithAuth(
   signal?: AbortSignal,
   options: Omit<GitHubAuthOptions, 'signal'> = {},
 ): Promise<Response | undefined> {
-  const authSignal = signal ? combineSignals(signal, 30_000) : AbortSignal.timeout(30_000);
   try {
-    const session = await getGitHubSession(['repo'], { ...options, signal: authSignal });
+    const session = await getGitHubSession(['repo'], { ...options, signal });
     if (session) {
+      const requestSignal = signal ? combineSignals(signal, 30_000) : AbortSignal.timeout(30_000);
       return await fetch(apiUrl, {
         headers: {
           'Accept': 'application/vnd.github+json',
@@ -184,7 +184,7 @@ export async function retryWithAuth(
           'X-GitHub-Api-Version': '2022-11-28',
           'Authorization': `Bearer ${session.accessToken}`,
         },
-        signal: authSignal,
+        signal: requestSignal,
       });
     }
   } catch (error) {

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -188,7 +188,7 @@ export async function retryWithAuth(
       });
     }
   } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
+    if (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
       throw error;
     }
     logger.debug('User declined GitHub authentication prompt');

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -2,6 +2,11 @@ import * as vscode from 'vscode';
 import { isValidGitHubRepo, combineSignals, createAbortError, runWorkerPoolSettled, type ProviderBadge } from '@devdocket/shared';
 import { logger } from './logger';
 
+export interface GitHubAuthOptions {
+  interactive?: boolean;
+  signal?: AbortSignal;
+}
+
 export interface GitHubIssue {
   number: number;
   title: string;
@@ -150,10 +155,66 @@ export async function getHeaders(): Promise<Record<string, string>> {
   return headers;
 }
 
-/** Retry a request with interactive auth (prompts user to sign in). */
-export async function retryWithAuth(apiUrl: string, signal?: AbortSignal): Promise<Response | undefined> {
+function raceWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  if (signal.aborted) {
+    return Promise.reject(createAbortError());
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(createAbortError());
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      value => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      error => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function getGitHubSession(
+  scopes: readonly string[],
+  options: GitHubAuthOptions = {},
+): Promise<vscode.AuthenticationSession | undefined> {
+  const { interactive = false, signal } = options;
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+
+  const session = await raceWithAbort(
+    vscode.authentication.getSession('github', [...scopes], { silent: true }),
+    signal,
+  );
+  if (session || !interactive) {
+    return session;
+  }
+
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+
+  return raceWithAbort(
+    vscode.authentication.getSession('github', [...scopes], { createIfNone: true }),
+    signal,
+  );
+}
+
+/** Retry a request with GitHub auth, prompting only for interactive callers. */
+export async function retryWithAuth(
+  apiUrl: string,
+  signal?: AbortSignal,
+  options: Omit<GitHubAuthOptions, 'signal'> = {},
+): Promise<Response | undefined> {
+  const authSignal = signal ? combineSignals(signal, 30_000) : undefined;
   try {
-    const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: true });
+    const session = await getGitHubSession(['repo'], { ...options, signal: authSignal });
     if (session) {
       return await fetch(apiUrl, {
         headers: {
@@ -162,10 +223,13 @@ export async function retryWithAuth(apiUrl: string, signal?: AbortSignal): Promi
           'X-GitHub-Api-Version': '2022-11-28',
           'Authorization': `Bearer ${session.accessToken}`,
         },
-        signal,
+        signal: authSignal,
       });
     }
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw error;
+    }
     logger.debug('User declined GitHub authentication prompt');
   }
   return undefined;

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -189,7 +189,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
 
     if (!response.ok && !wasAuthenticated && !signal?.aborted &&
         (response.status === 404 || looksLikeRateLimited403(response))) {
-      const retryResponse = await retryWithAuth(apiUrl, signal);
+      const retryResponse = await retryWithAuth(apiUrl, signal, { interactive: true });
       if (retryResponse) { response = retryResponse; }
     }
 

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -141,7 +141,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
 
     if (!response.ok && !wasAuthenticated && !signal?.aborted &&
         (response.status === 404 || looksLikeRateLimited403(response))) {
-      const retryResponse = await retryWithAuth(apiUrl, signal);
+      const retryResponse = await retryWithAuth(apiUrl, signal, { interactive: true });
       if (retryResponse) { response = retryResponse; }
     }
 

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -89,7 +89,7 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
 
     if (!response.ok && !wasAuthenticated && !signal?.aborted &&
         (response.status === 404 || looksLikeRateLimited403(response))) {
-      const retryResponse = await retryWithAuth(apiUrl, signal);
+      const retryResponse = await retryWithAuth(apiUrl, signal, { interactive: true });
       if (retryResponse) { response = retryResponse; }
     }
 

--- a/packages/github/src/test/githubApiHelpers.test.ts
+++ b/packages/github/src/test/githubApiHelpers.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { filterMergedGitHubPrs, isMergedGitHubPr, throwApiError, looksLikeRateLimited403, type GitHubIssue } from '../githubApiHelpers';
+import { authentication } from 'vscode';
+import { filterMergedGitHubPrs, isMergedGitHubPr, throwApiError, looksLikeRateLimited403, retryWithAuth, type GitHubIssue } from '../githubApiHelpers';
 import { setLogger } from '../logger';
 import { makeErrorResponse } from './responseMocks';
 
@@ -74,6 +75,16 @@ describe('isMergedGitHubPr', () => {
   });
 });
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('filterMergedGitHubPrs', () => {
   it('fetches PR details for closed PR search results before filtering merged PRs', async () => {
     const openPr = createPr(1, 'open');
@@ -99,6 +110,56 @@ describe('filterMergedGitHubPrs', () => {
       'https://api.github.com/repos/owner/repo/pulls/2',
       'https://api.github.com/repos/owner/repo/pulls/3',
     ]);
+  });
+});
+
+describe('retryWithAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('throws abort without requesting a session when already cancelled', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(retryWithAuth('https://api.github.com/test', controller.signal, { interactive: true }))
+      .rejects.toMatchObject({ name: 'AbortError' });
+    expect(authentication.getSession).not.toHaveBeenCalled();
+  });
+
+  it('rejects when cancellation fires while waiting for getSession', async () => {
+    const controller = new AbortController();
+    const pending = deferred<any>();
+    vi.mocked(authentication.getSession).mockReturnValueOnce(pending.promise);
+
+    const promise = retryWithAuth('https://api.github.com/test', controller.signal, { interactive: true });
+    controller.abort();
+    pending.resolve(undefined);
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('checks for a silent session before skipping background retries', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValueOnce(undefined as never);
+
+    await expect(retryWithAuth('https://api.github.com/test', undefined, { interactive: false }))
+      .resolves.toBeUndefined();
+    expect(authentication.getSession).toHaveBeenCalledTimes(1);
+    expect(authentication.getSession).toHaveBeenCalledWith('github', ['repo'], { silent: true });
+  });
+
+  it('falls back to createIfNone only for interactive callers', async () => {
+    vi.mocked(authentication.getSession)
+      .mockResolvedValueOnce(undefined as never)
+      .mockResolvedValueOnce({ accessToken: 'interactive-token' } as never);
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await retryWithAuth('https://api.github.com/test', undefined, { interactive: true });
+
+    expect(authentication.getSession).toHaveBeenNthCalledWith(1, 'github', ['repo'], { silent: true });
+    expect(authentication.getSession).toHaveBeenNthCalledWith(2, 'github', ['repo'], { createIfNone: true });
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -116,7 +116,7 @@ describe('GitHubMentionsProvider', () => {
 
     await provider.refresh();
 
-    expect(authentication.getSession).toHaveBeenCalledWith('github', ['repo', 'read:org'], { createIfNone: true });
+    expect(authentication.getSession).toHaveBeenCalledWith('github', ['repo', 'read:org'], { silent: true });
   });
 
   it('discovers mentioned issues and PRs', async () => {

--- a/packages/shared/src/apiTypes.ts
+++ b/packages/shared/src/apiTypes.ts
@@ -53,6 +53,17 @@ export interface StateTransitionEvent {
 }
 
 /**
+ * Options that describe how a provider refresh was initiated.
+ */
+export interface ProviderRefreshOptions {
+  /**
+   * Whether the refresh was explicitly initiated by the user and may prompt
+   * for authentication when a cached session is unavailable.
+   */
+  readonly interactive?: boolean;
+}
+
+/**
  * A provider that discovers work items from an external source.
  *
  * Providers are registered via {@link DevDocketApi.registerProvider} and emit
@@ -89,7 +100,7 @@ export interface DevDocketProvider {
    * VS Code extensions typically pass a `vscode.CancellationToken` which
    * structurally satisfies {@link CancellationTokenLike}.
    */
-  refresh(token?: CancellationTokenLike): Promise<void>;
+  refresh(token?: CancellationTokenLike, options?: ProviderRefreshOptions): Promise<void>;
   /**
    * Attempt to resolve a URL into an item this provider can manage.
    *

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -1,3 +1,6 @@
+import type { ProviderRefreshOptions } from './apiTypes';
+import type { CancellationTokenLike } from './runWatcher';
+
 // Minimal re-declarations to avoid depending on the vscode module
 
 /** A handle that releases a resource when disposed. */
@@ -382,7 +385,7 @@ export abstract class BaseProvider {
   /** Override to provide the background refresh implementation. */
   protected abstract doBackgroundRefresh(): Promise<void>;
 
-  abstract refresh(token?: unknown, options?: unknown): Promise<void>;
+  abstract refresh(token?: CancellationTokenLike, options?: ProviderRefreshOptions): Promise<void>;
 
   dispose(): void {
     if (this._disposed) {

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -382,7 +382,7 @@ export abstract class BaseProvider {
   /** Override to provide the background refresh implementation. */
   protected abstract doBackgroundRefresh(): Promise<void>;
 
-  abstract refresh(token?: unknown): Promise<void>;
+  abstract refresh(token?: unknown, options?: unknown): Promise<void>;
 
   dispose(): void {
     if (this._disposed) {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,7 +10,7 @@ export { isValidUrlSegment, isValidGitHubRepo, isValidRepoSlug, sanitizeUrlSegme
 export { validateRefreshInterval } from './refreshInterval';
 export type { DevDocketRunWatcher, RunIdentifier, RunStatus, JobStatus, RunState, RunConclusion, CancellationTokenLike } from './runWatcher';
 export type { DevDocketPRWatcher, PRIdentifier, PRState, PRRunsSnapshot } from './prWatcher';
-export { combineSignals, createAbortError } from './signalUtils';
+export { combineSignals, createAbortError, raceWithAbort, getSessionWithAuthFallback } from './signalUtils';
 export { runWorkerPool, runWorkerPoolSettled } from './concurrency';
 export { WorkItemState } from './workItem';
 export type { WorkItem, WorkItemInput, ActivityLogEntry, ActivityType } from './workItem';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,4 +14,4 @@ export { combineSignals, createAbortError } from './signalUtils';
 export { runWorkerPool, runWorkerPoolSettled } from './concurrency';
 export { WorkItemState } from './workItem';
 export type { WorkItem, WorkItemInput, ActivityLogEntry, ActivityType } from './workItem';
-export type { DevDocketProvider, DevDocketAction, DevDocketApi, StateTransitionEvent, ActivityDetailRender, ActivityDetailRenderer } from './apiTypes';
+export type { DevDocketProvider, DevDocketAction, DevDocketApi, StateTransitionEvent, ProviderRefreshOptions, ActivityDetailRender, ActivityDetailRenderer } from './apiTypes';

--- a/packages/shared/src/signalUtils.ts
+++ b/packages/shared/src/signalUtils.ts
@@ -11,16 +11,20 @@ export function createAbortError(): Error {
   return error;
 }
 
+function getAbortReason(signal: AbortSignal): Error {
+  return signal.reason instanceof Error ? signal.reason : createAbortError();
+}
+
 export function raceWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
   if (!signal) {
     return promise;
   }
   if (signal.aborted) {
-    return Promise.reject(createAbortError());
+    return Promise.reject(getAbortReason(signal));
   }
 
   return new Promise<T>((resolve, reject) => {
-    const onAbort = () => reject(createAbortError());
+    const onAbort = () => reject(getAbortReason(signal));
     signal.addEventListener('abort', onAbort, { once: true });
     promise.then(
       value => {
@@ -43,7 +47,7 @@ export async function getSessionWithAuthFallback<T>(options: {
 }): Promise<T | undefined> {
   const { interactive = false, signal, getSilent, getInteractive } = options;
   if (signal?.aborted) {
-    throw createAbortError();
+    throw getAbortReason(signal);
   }
 
   const session = await raceWithAbort(getSilent(), signal);
@@ -52,7 +56,7 @@ export async function getSessionWithAuthFallback<T>(options: {
   }
 
   if (signal?.aborted) {
-    throw createAbortError();
+    throw getAbortReason(signal);
   }
 
   return raceWithAbort(getInteractive(), signal);

--- a/packages/shared/src/signalUtils.ts
+++ b/packages/shared/src/signalUtils.ts
@@ -11,6 +11,53 @@ export function createAbortError(): Error {
   return error;
 }
 
+export function raceWithAbort<T>(promise: Promise<T>, signal?: AbortSignal): Promise<T> {
+  if (!signal) {
+    return promise;
+  }
+  if (signal.aborted) {
+    return Promise.reject(createAbortError());
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(createAbortError());
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(
+      value => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      error => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+  });
+}
+
+export async function getSessionWithAuthFallback<T>(options: {
+  interactive?: boolean;
+  signal?: AbortSignal;
+  getSilent: () => Promise<T | undefined>;
+  getInteractive: () => Promise<T | undefined>;
+}): Promise<T | undefined> {
+  const { interactive = false, signal, getSilent, getInteractive } = options;
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+
+  const session = await raceWithAbort(getSilent(), signal);
+  if (session || !interactive) {
+    return session;
+  }
+
+  if (signal?.aborted) {
+    throw createAbortError();
+  }
+
+  return raceWithAbort(getInteractive(), signal);
+}
+
 /**
  * Combines a cancellation signal with a per-request timeout into a single AbortSignal.
  * Node 18 compatible — does not use AbortSignal.any() (requires Node 20.3+).

--- a/packages/shared/src/test/signalUtils.test.ts
+++ b/packages/shared/src/test/signalUtils.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { combineSignals } from '../signalUtils';
+import { combineSignals, getSessionWithAuthFallback, raceWithAbort } from '../signalUtils';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 describe('combineSignals', () => {
   afterEach(() => {
@@ -94,5 +104,78 @@ describe('combineSignals', () => {
     const combined = combineSignals(cancelController.signal, 60_000);
     expect(combined.aborted).toBe(true);
     expect((combined.reason as Error).message).toBe('race condition');
+  });
+});
+
+describe('raceWithAbort', () => {
+  it('rejects with the signal reason when already aborted', async () => {
+    const controller = new AbortController();
+    const timeoutError = new DOMException('The operation timed out.', 'TimeoutError');
+    controller.abort(timeoutError);
+
+    await expect(raceWithAbort(Promise.resolve('ok'), controller.signal)).rejects.toBe(timeoutError);
+  });
+
+  it('rejects with the signal reason when aborted during the race', async () => {
+    const controller = new AbortController();
+    const pending = deferred<string>();
+    const timeoutError = new DOMException('The operation timed out.', 'TimeoutError');
+
+    const promise = raceWithAbort(pending.promise, controller.signal);
+    controller.abort(timeoutError);
+    pending.resolve('ok');
+
+    await expect(promise).rejects.toBe(timeoutError);
+  });
+});
+
+describe('getSessionWithAuthFallback', () => {
+  it('throws the signal reason when already aborted', async () => {
+    const controller = new AbortController();
+    const timeoutError = new DOMException('The operation timed out.', 'TimeoutError');
+    controller.abort(timeoutError);
+
+    await expect(getSessionWithAuthFallback({
+      interactive: true,
+      signal: controller.signal,
+      getSilent: async () => undefined,
+      getInteractive: async () => 'session',
+    })).rejects.toBe(timeoutError);
+  });
+
+  it('throws the signal reason when aborted synchronously inside getSilent', async () => {
+    const controller = new AbortController();
+    const timeoutError = new DOMException('The operation timed out.', 'TimeoutError');
+
+    await expect(getSessionWithAuthFallback({
+      interactive: true,
+      signal: controller.signal,
+      getSilent: async () => {
+        controller.abort(timeoutError);
+        return undefined;
+      },
+      getInteractive: async () => 'session',
+    })).rejects.toBe(timeoutError);
+  });
+
+  it('throws the signal reason when abort races the post-silent guard', async () => {
+    const controller = new AbortController();
+    const timeoutError = new DOMException('The operation timed out.', 'TimeoutError');
+    const silent = deferred<undefined>();
+
+    const result = getSessionWithAuthFallback({
+      interactive: true,
+      signal: controller.signal,
+      getSilent: () => silent.promise,
+      getInteractive: async () => 'session',
+    });
+
+    await Promise.resolve();
+    silent.resolve(undefined);
+    await Promise.resolve();
+    await Promise.resolve();
+    controller.abort(timeoutError);
+
+    await expect(result).rejects.toBe(timeoutError);
   });
 });


### PR DESCRIPTION
## Summary
- make provider refreshes pass an explicit interactive flag so registration/background refreshes stay silent while user-triggered refreshes can prompt
- race GitHub and Azure DevOps session acquisition against cancellation and enforce silent-first auth before any interactive fallback
- propagate cancellation-aware auth/session handling through AI review, walkthrough, and repo worktree flows, and add regression tests plus changesets

## Testing
- npm run build
- npm run test

Closes #579
