### PR TITLE
Fix Start Git Work for Azure DevOps pull requests

### DIFF
--- a/.changeset/ado-pr-start-git-work-fix.md
+++ b/.changeset/ado-pr-start-git-work-fix.md
@@ -1,0 +1,8 @@
+---
+"@devdocket/shared": minor
+"devdocket": patch
+"devdocket-ado": patch
+"devdocket-start-git-work": patch
+---
+
+Fix Azure DevOps pull requests imported by URL so Start Git Work can use provider-supplied git metadata across reloads, and accept valid Azure DevOps HTTPS clone URLs during PR checkout.

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { BaseProvider, ProviderItem, type GitWorkInfo, type ProviderBadge, type ProviderRefreshOptions, isValidUrlSegment, combineSignals, safeDecodeComponent, type ResolvedItem } from '@devdocket/shared';
+import { BaseProvider, ProviderItem, type GitWorkInfo, type ProviderBadge, type ProviderRefreshOptions, type ResolveUrlOptions, isValidUrlSegment, combineSignals, safeDecodeComponent, type ResolvedItem } from '@devdocket/shared';
 import { logger } from './logger';
 import { OrgConfig, resolveProjectList } from './configParser';
 import { ADO_AUTH_SCOPE, getAdoHeaders, getAdoSession, retryAdoWithAuth, throwAdoApiError } from './adoAuth';
@@ -701,7 +701,7 @@ export class AdoWorkItemProvider extends BaseProvider {
 
   private static readonly ADO_WORKITEM_PATTERN = /^https?:\/\/dev\.azure\.com\/([^/]+)\/([^/]+)\/_workitems\/edit\/(\d+)\b/i;
 
-  async resolveUrl(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined> {
+  async resolveUrl(url: string, signal?: AbortSignal, options?: ResolveUrlOptions): Promise<ResolvedItem | undefined> {
     const match = url.trim().match(AdoWorkItemProvider.ADO_WORKITEM_PATTERN);
     if (!match) { return undefined; }
     const [, rawOrg, rawProject, idStr] = match;
@@ -716,7 +716,7 @@ export class AdoWorkItemProvider extends BaseProvider {
     let response = await fetch(apiUrl, { headers, signal });
 
     if (response.status === 404 && !wasAuthenticated && !signal?.aborted) {
-      const retryResponse = await retryAdoWithAuth(apiUrl, signal, { interactive: true });
+      const retryResponse = await retryAdoWithAuth(apiUrl, signal, { interactive: options?.interactive ?? true });
       if (retryResponse) { response = retryResponse; }
     }
 

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -715,8 +715,8 @@ export class AdoWorkItemProvider extends BaseProvider {
 
     let response = await fetch(apiUrl, { headers, signal });
 
-    if (response.status === 404 && !wasAuthenticated && !signal?.aborted) {
-      const retryResponse = await retryAdoWithAuth(apiUrl, signal, { interactive: options?.interactive ?? true });
+    if (response.status === 404 && !wasAuthenticated && !signal?.aborted && options?.interactive !== false) {
+      const retryResponse = await retryAdoWithAuth(apiUrl, signal, { interactive: true });
       if (retryResponse) { response = retryResponse; }
     }
 

--- a/packages/ado/src/baseAdoPrProvider.ts
+++ b/packages/ado/src/baseAdoPrProvider.ts
@@ -367,10 +367,15 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
       throwAdoApiError(response, `ADO PR ${org}/${project}/${repo}#${id}`);
     }
 
-    const data = await response.json() as {
+    const data = await response.json() as AdoPullRequest & {
       title: string;
       description: string | null;
-      repository: { name: string; project: { name: string } };
+      repository: {
+        name: string;
+        project: { name: string };
+        webUrl?: string;
+        remoteUrl?: string;
+      };
     };
     const projectName = data.repository.project.name;
     const repoName = data.repository.name;
@@ -382,6 +387,18 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
       externalId: `${org}/${projectName}/${repoName}/${id}`,
       group: `${projectName}/${repoName}`,
       providerId: this.id,
+      itemType: 'pr',
+      capabilities: {
+        gitWork: this.createPrGitWork({
+          ...data,
+          pullRequestId: id,
+          repository: {
+            ...data.repository,
+            name: repoName,
+            project: { name: projectName },
+          },
+        }, org),
+      },
     };
   }
 

--- a/packages/ado/src/baseAdoPrProvider.ts
+++ b/packages/ado/src/baseAdoPrProvider.ts
@@ -4,6 +4,7 @@ import {
   ProviderItem,
   type ProviderBadge,
   type ProviderRefreshOptions,
+  type ResolveUrlOptions,
   isValidUrlSegment,
   combineSignals,
   createAbortError,
@@ -350,7 +351,7 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
     return parsed.filter(item => closedSet.has(item.id)).map(item => item.id);
   }
 
-  async resolveUrl(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined> {
+  async resolveUrl(url: string, signal?: AbortSignal, options?: ResolveUrlOptions): Promise<ResolvedItem | undefined> {
     const match = url.trim().match(BaseAdoPrProvider.ADO_PR_PATTERN);
     if (!match) {
       return undefined;

--- a/packages/ado/src/baseAdoPrProvider.ts
+++ b/packages/ado/src/baseAdoPrProvider.ts
@@ -368,7 +368,7 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
 
     let response = await fetch(apiUrl, { headers, signal });
 
-    if (response.status === 404 && !wasAuthenticated && !signal?.aborted) {
+    if (response.status === 404 && !wasAuthenticated && !signal?.aborted && options?.interactive !== false) {
       const retryResponse = await retryAdoWithAuth(apiUrl, signal, { interactive: true });
       if (retryResponse) {
         response = retryResponse;

--- a/packages/ado/src/test/resolveUrl.test.ts
+++ b/packages/ado/src/test/resolveUrl.test.ts
@@ -57,6 +57,8 @@ describe('AdoPrReviewProvider.resolveUrl', () => {
       externalId: 'myorg/MyProject/myrepo/42',
       group: 'MyProject/myrepo',
       providerId: 'ado-pr-reviews',
+      itemType: 'pr',
+      capabilities: { gitWork: expect.any(Function) },
     });
   });
 

--- a/packages/ado/src/test/resolveUrl.test.ts
+++ b/packages/ado/src/test/resolveUrl.test.ts
@@ -215,6 +215,21 @@ describe('AdoPrReviewProvider.resolveUrl', () => {
       }),
     );
   });
+
+  it('skips interactive auth retry when resolveUrl is non-interactive', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    });
+
+    await expect(
+      provider.resolveUrl('https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/42', undefined, { interactive: false }),
+    ).rejects.toThrow('not found');
+
+    expect(vi.mocked(authentication.getSession)).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('AdoWorkItemProvider.resolveUrl', () => {
@@ -551,5 +566,20 @@ describe('AdoWorkItemProvider.resolveUrl', () => {
         }),
       }),
     );
+  });
+
+  it('skips interactive auth retry for work-item resolveUrl when non-interactive', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    });
+
+    await expect(
+      provider.resolveUrl('https://dev.azure.com/myorg/MyProject/_workitems/edit/99', undefined, { interactive: false }),
+    ).rejects.toThrow('not found');
+
+    expect(vi.mocked(authentication.getSession)).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/api/types.ts
+++ b/packages/core/src/api/types.ts
@@ -2,4 +2,4 @@
 // existing intra-core imports (e.g. `from '../api/types'`).
 export type { Disposable, Event, ProviderItem, ProviderItemAuthor, ProviderItemCapabilities, GitWorkInfo, ProviderBadge, RelatedItemRef, ResolvedItem, DevDocketRunWatcher, DevDocketPRWatcher } from '@devdocket/shared';
 export type { ActivityLogEntry, ActivityType } from '@devdocket/shared';
-export type { StateTransitionEvent, ProviderRefreshOptions, DevDocketProvider, DevDocketAction, DevDocketApi, ActivityDetailRender, ActivityDetailRenderer } from '@devdocket/shared';
+export type { StateTransitionEvent, ProviderRefreshOptions, ResolveUrlOptions, DevDocketProvider, DevDocketAction, DevDocketApi, ActivityDetailRender, ActivityDetailRenderer } from '@devdocket/shared';

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -389,6 +389,8 @@ async function handleCreateItemFromUrl(
     { providerId: details.providerId, externalId: details.externalId, url: details.url, ...(group ? { group } : {}) },
   );
 
+  providerRegistry.registerSyntheticResolvedItem(details.providerId, details);
+
   const providerLabel = createdItem.providerId ? labelCache.get(createdItem.providerId) : undefined;
   WorkItemEditorPanel.open(context, workGraph, providerRegistry, createdItem, editorPanelDependencies, providerLabel);
   void vscode.window.showInformationMessage(`DevDocket: Created "${details.title}"`);

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -353,7 +353,7 @@ async function handleCreateItemFromUrl(
       (_progress, token) => {
         const controller = new AbortController();
         token.onCancellationRequested(() => controller.abort());
-        return providerRegistry.resolveUrl(url.trim(), controller.signal);
+        return providerRegistry.resolveUrl(url.trim(), controller.signal, { interactive: true });
       },
     );
   } catch (error) {

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -495,6 +495,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
       const item = wg.findItemByProvenance(providerId, externalId);
       if (item) { await wg.addActivity(item.id, type, detail); }
     },
+    () => wg.getAll(),
   );
   const ar = new ActionRegistry();
   const adrr = new ActivityDetailRendererRegistry();

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -366,7 +366,7 @@ export class ProviderRegistry {
       }
 
       try {
-        const resolved = await provider.resolveUrl(importedItem.url, undefined, { interactive: false });
+        const resolved = await provider.resolveUrl(importedItem.url, AbortSignal.timeout(30_000), { interactive: false });
         if (!resolved || resolved.externalId !== importedItem.externalId) {
           continue;
         }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -385,9 +385,10 @@ export class ProviderRegistry {
       return liveItems;
     }
 
+    const liveExternalIds = new Set(liveItems.map(item => item.externalId));
     const merged = [...liveItems];
     for (const [externalId, item] of syntheticItems) {
-      if (!liveItems.some(liveItem => liveItem.externalId === externalId)) {
+      if (!liveExternalIds.has(externalId)) {
         merged.push(item);
       }
     }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -44,6 +44,31 @@ function isWindowStateAwareProvider(provider: DevDocketProvider): provider is De
   return typeof (provider as Partial<WindowStateAwareProvider>).setWindowState === 'function';
 }
 
+function toSyntheticProviderItem(details: ResolvedItem): ProviderItem | undefined {
+  if (!details.itemType && !details.capabilities && !details.author && details.authored === undefined) {
+    return undefined;
+  }
+
+  return {
+    externalId: details.externalId,
+    title: details.title,
+    description: details.notes || undefined,
+    url: details.url,
+    group: details.group,
+    ...(details.author ? { author: details.author } : {}),
+    ...(details.authored !== undefined ? { authored: details.authored } : {}),
+    ...(details.badges ? { badges: details.badges } : {}),
+    ...(details.canonicalId ? { canonicalId: details.canonicalId } : {}),
+    ...(details.capabilities ? { capabilities: details.capabilities } : {}),
+    ...(details.itemType ? { itemType: details.itemType } : {}),
+    ...(details.reason ? { reason: details.reason } : {}),
+    ...(details.relatedItems ? { relatedItems: details.relatedItems } : {}),
+    ...(details.resurfaceVersion ? { resurfaceVersion: details.resurfaceVersion } : {}),
+    ...(details.state ? { state: details.state } : {}),
+    ...(details.version ? { version: details.version } : {}),
+  };
+}
+
 /**
  * Central registry for {@link DevDocketProvider} instances.
  *
@@ -61,6 +86,7 @@ export class ProviderRegistry {
   private readonly providers = new Map<string, DevDocketProvider>();
   private readonly subscriptions = new Map<string, { dispose(): void }>();
   private readonly providerItems = new Map<string, ProviderItem[]>();
+  private readonly syntheticProviderItems = new Map<string, Map<string, ProviderItem>>();
   private readonly _onDidChangeProviderItems = new vscode.EventEmitter<void>();
   /** Fired whenever any provider's provider items change. */
   readonly onDidChangeProviderItems = this._onDidChangeProviderItems.event;
@@ -118,6 +144,7 @@ export class ProviderRegistry {
     private readonly getWorkItemState?: (providerId: string, externalId: string) => WorkItemState | undefined,
     // Kept for constructor compatibility; suppressed version bumps no longer log activity.
     _addActivity?: (providerId: string, externalId: string, type: ActivityType, detail?: string) => Promise<void>,
+    private readonly getImportedWorkItems?: () => Array<{ providerId?: string; externalId?: string; url?: string }>,
   ) {}
 
   /**
@@ -172,6 +199,9 @@ export class ProviderRegistry {
     if (!this.providerItems.has(provider.id)) {
       this.providerItems.set(provider.id, []);
     }
+    if (!this.syntheticProviderItems.has(provider.id)) {
+      this.syntheticProviderItems.set(provider.id, new Map());
+    }
     logger.info(`Registered provider: ${provider.id} (${provider.label})`);
 
     const sub = provider.onDidDiscoverItems((items) => {
@@ -210,6 +240,7 @@ export class ProviderRegistry {
         this._loadingProviders.delete(provider.id);
         if (!this._disposed) {
           this._onDidChangeProviderItems.fire();
+          void this.rehydrateSyntheticProviderItems(provider);
         }
       });
 
@@ -219,6 +250,7 @@ export class ProviderRegistry {
       this.subscriptions.get(provider.id)?.dispose();
       this.subscriptions.delete(provider.id);
       this.providerItems.delete(provider.id);
+      this.syntheticProviderItems.delete(provider.id);
       this.previousDiscoveredIds.delete(provider.id);
       this.lastRefreshTruncated.delete(provider.id);
       this.healthStatus.delete(provider.id);
@@ -275,13 +307,79 @@ export class ProviderRegistry {
   }
 
   /**
+   * Cache a provider item synthesized from URL resolution so actions can use its
+   * capabilities before the provider rediscovers it naturally.
+   */
+  registerSyntheticProviderItem(providerId: string, item: ProviderItem): void {
+    if (!this.providers.has(providerId)) {
+      return;
+    }
+
+    let syntheticItems = this.syntheticProviderItems.get(providerId);
+    if (!syntheticItems) {
+      syntheticItems = new Map<string, ProviderItem>();
+      this.syntheticProviderItems.set(providerId, syntheticItems);
+    }
+
+    syntheticItems.set(item.externalId, { ...item });
+    this._onDidChangeProviderItems.fire();
+  }
+
+  registerSyntheticResolvedItem(providerId: string, details: ResolvedItem): void {
+    const item = toSyntheticProviderItem(details);
+    if (!item) {
+      return;
+    }
+
+    this.registerSyntheticProviderItem(providerId, item);
+  }
+
+  private async rehydrateSyntheticProviderItems(provider: DevDocketProvider): Promise<void> {
+    if (typeof provider.resolveUrl !== 'function' || !this.getImportedWorkItems) {
+      return;
+    }
+
+    for (const importedItem of this.getImportedWorkItems()) {
+      if (importedItem.providerId !== provider.id || !importedItem.externalId || !importedItem.url) {
+        continue;
+      }
+      if (this.findProviderItem(provider.id, importedItem.externalId)) {
+        continue;
+      }
+
+      try {
+        const resolved = await provider.resolveUrl(importedItem.url);
+        if (!resolved || resolved.externalId !== importedItem.externalId) {
+          continue;
+        }
+
+        this.registerSyntheticResolvedItem(provider.id, resolved);
+      } catch (error) {
+        logger.debug(`Failed to rehydrate URL-imported item ${provider.id}:${importedItem.externalId}`, error);
+      }
+    }
+  }
+
+  /**
    * Get the provider items for a specific provider.
    *
    * @param providerId - The provider identifier.
    * @returns The array of provider items, or an empty array if the provider has none.
    */
   getProviderItems(providerId: string): ProviderItem[] {
-    return this.providerItems.get(providerId) ?? [];
+    const liveItems = this.providerItems.get(providerId) ?? [];
+    const syntheticItems = this.syntheticProviderItems.get(providerId);
+    if (!syntheticItems || syntheticItems.size === 0) {
+      return liveItems;
+    }
+
+    const merged = [...liveItems];
+    for (const [externalId, item] of syntheticItems) {
+      if (!liveItems.some(liveItem => liveItem.externalId === externalId)) {
+        merged.push(item);
+      }
+    }
+    return merged;
   }
 
   /**
@@ -290,7 +388,7 @@ export class ProviderRegistry {
    * @returns A map keyed by provider ID, with each value being the provider's provider items.
    */
   getAllProviderItems(): Map<string, ProviderItem[]> {
-    return this.providerItems;
+    return new Map(Array.from(this.providers.keys(), providerId => [providerId, this.getProviderItems(providerId)]));
   }
 
   /**

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -360,7 +360,7 @@ export class ProviderRegistry {
       }
 
       try {
-        const resolved = await provider.resolveUrl(importedItem.url);
+        const resolved = await provider.resolveUrl(importedItem.url, undefined, { interactive: false });
         if (!resolved || resolved.externalId !== importedItem.externalId) {
           continue;
         }
@@ -433,11 +433,11 @@ export class ProviderRegistry {
    * Ask each registered provider to resolve a URL.
    * Returns the first successful result, or `undefined` if no provider recognizes the URL.
    */
-  async resolveUrl(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined> {
+  async resolveUrl(url: string, signal?: AbortSignal, options?: ResolveUrlOptions): Promise<ResolvedItem | undefined> {
     for (const provider of this.providers.values()) {
       if (typeof provider.resolveUrl !== 'function') { continue; }
       try {
-        const result = await provider.resolveUrl(url, signal);
+        const result = await provider.resolveUrl(url, signal, options);
         if (result) { return { ...result, providerId: provider.id }; }
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') { throw error; }

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -352,7 +352,13 @@ export class ProviderRegistry {
     }
 
     for (const importedItem of this.getImportedWorkItems()) {
+      if (this._disposed || !this.providers.has(provider.id)) {
+        return;
+      }
       if (importedItem.providerId !== provider.id || !importedItem.externalId || !importedItem.url) {
+        continue;
+      }
+      if (this.getWorkItemState && !isActiveWorkItemState(this.getWorkItemState(provider.id, importedItem.externalId))) {
         continue;
       }
       if (this.findProviderItem(provider.id, importedItem.externalId)) {

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { DevDocketProvider, ProviderItem, type ResolvedItem } from '../api/types';
+import { DevDocketProvider, ProviderItem, type ResolveUrlOptions, type ResolvedItem } from '../api/types';
 import type { WindowStateProvider } from '@devdocket/shared';
 import { InboxStateStore, InboxState } from '../storage/inboxStateStore';
 import { ProviderLabelCache } from '../storage/providerLabelCache';
@@ -45,7 +45,19 @@ function isWindowStateAwareProvider(provider: DevDocketProvider): provider is De
 }
 
 function toSyntheticProviderItem(details: ResolvedItem): ProviderItem | undefined {
-  if (!details.itemType && !details.capabilities && !details.author && details.authored === undefined) {
+  if (
+    !details.itemType
+    && !details.capabilities
+    && !details.author
+    && details.authored === undefined
+    && !details.badges
+    && !details.canonicalId
+    && !details.reason
+    && !details.relatedItems
+    && !details.resurfaceVersion
+    && !details.state
+    && !details.version
+  ) {
     return undefined;
   }
 

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -96,7 +96,7 @@ function createMockStateStore(): { [K in keyof UsedStateStoreMethods]: Mock } {
   };
 }
 
-type UsedProviderRegistryMethods = Pick<ProviderRegistry, 'refreshAll' | 'resolveUrl' | 'getAllProviderItems' | 'getProviderItems' | 'getProviderLabel' | 'getProviders'>;
+type UsedProviderRegistryMethods = Pick<ProviderRegistry, 'refreshAll' | 'resolveUrl' | 'getAllProviderItems' | 'getProviderItems' | 'getProviderLabel' | 'getProviders' | 'registerSyntheticResolvedItem'>;
 
 function createMockProviderRegistry(): { [K in keyof UsedProviderRegistryMethods]: Mock } {
   return {
@@ -109,6 +109,7 @@ function createMockProviderRegistry(): { [K in keyof UsedProviderRegistryMethods
       { id: 'github', label: 'GitHub' },
       { id: 'ado', label: 'Azure DevOps' },
     ]),
+    registerSyntheticResolvedItem: vi.fn(),
   };
 }
 
@@ -370,6 +371,15 @@ describe('registerCommands', () => {
       externalId: 'owner/repo#42',
       group: 'owner/repo',
       providerId: 'github-pr-reviews',
+      itemType: 'pr',
+      capabilities: {
+        gitWork: vi.fn(async () => ({
+          kind: 'pr',
+          cloneUrl: 'https://github.com/owner/repo.git',
+          ref: 'feature/topic',
+          repoLabel: 'owner/repo',
+        })),
+      },
     };
 
     beforeEach(() => {
@@ -383,6 +393,14 @@ describe('registerCommands', () => {
       await invoke('devdocket.createItemFromUrl');
 
       expect(workGraph.createItem).toHaveBeenCalled();
+      expect(providerRegistry.registerSyntheticResolvedItem).toHaveBeenCalledWith(
+        'github-pr-reviews',
+        expect.objectContaining({
+          externalId: 'owner/repo#42',
+          itemType: 'pr',
+          capabilities: expect.objectContaining({ gitWork: expect.any(Function) }),
+        }),
+      );
       expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
         expect.stringContaining('Created'),
       );

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -393,6 +393,11 @@ describe('registerCommands', () => {
       await invoke('devdocket.createItemFromUrl');
 
       expect(workGraph.createItem).toHaveBeenCalled();
+      expect(providerRegistry.resolveUrl).toHaveBeenCalledWith(
+        'https://github.com/owner/repo/pull/42',
+        expect.any(AbortSignal),
+        { interactive: true },
+      );
       expect(providerRegistry.registerSyntheticResolvedItem).toHaveBeenCalledWith(
         'github-pr-reviews',
         expect.objectContaining({

--- a/packages/core/src/test/devDocketApi.test.ts
+++ b/packages/core/src/test/devDocketApi.test.ts
@@ -146,6 +146,27 @@ describe('DevDocketApiImpl', () => {
       expect(api.getProviderItem('test-provider', 'missing')).toBeUndefined();
       expect(api.getProviderItem('missing-provider', 'item-1')).toBeUndefined();
     });
+
+    it('returns synthetic provider items registered from URL resolution', () => {
+      const emitter = new vscode.EventEmitter<ProviderItem[]>();
+      const provider: DevDocketProvider = {
+        id: 'test-provider',
+        label: 'Test Provider',
+        onDidDiscoverItems: emitter.event,
+        refresh: vi.fn().mockResolvedValue(undefined),
+      };
+
+      api.registerProvider(provider);
+      providerRegistry.registerSyntheticProviderItem('test-provider', {
+        externalId: 'item-2',
+        title: 'Imported Item',
+        itemType: 'pr',
+      });
+
+      expect(api.getProviderItem('test-provider', 'item-2')).toEqual(
+        expect.objectContaining({ externalId: 'item-2', itemType: 'pr' }),
+      );
+    });
   });
 
   describe('registerAction', () => {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -181,7 +181,7 @@ describe('ProviderRegistry', () => {
     const reg = new ProviderRegistry(
       stateStore,
       undefined,
-      undefined,
+      () => WorkItemState.InProgress,
       undefined,
       () => [{
         providerId: 'ado-pr-reviews',
@@ -195,6 +195,43 @@ describe('ProviderRegistry', () => {
       expect.objectContaining({ externalId: 'myorg/MyProject/myrepo/42', itemType: 'pr' }),
     ));
     expect(provider.resolveUrl).toHaveBeenCalledWith('https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/42', undefined, { interactive: false });
+  });
+
+  it('rehydrates only active imported work items', async () => {
+    const provider = {
+      ...createMockProvider('ado-pr-reviews'),
+      resolveUrl: vi.fn(async () => ({
+        title: '#42: Imported PR',
+        notes: 'Imported notes',
+        url: 'https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/42',
+        externalId: 'myorg/MyProject/myrepo/42',
+        providerId: 'ado-pr-reviews',
+        itemType: 'pr' as const,
+        capabilities: { gitWork: { kind: 'pr' as const, cloneUrl: 'https://myorg@dev.azure.com/myorg/MyProject/_git/myrepo', ref: 'users/me/fix' } },
+      })),
+    };
+    const reg = new ProviderRegistry(
+      stateStore,
+      undefined,
+      (_providerId, externalId) => externalId === 'myorg/MyProject/myrepo/42' ? WorkItemState.Archived : WorkItemState.InProgress,
+      undefined,
+      () => [
+        {
+          providerId: 'ado-pr-reviews',
+          externalId: 'myorg/MyProject/myrepo/42',
+          url: 'https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/42',
+        },
+        {
+          providerId: 'ado-pr-reviews',
+          externalId: 'myorg/MyProject/myrepo/43',
+          url: 'https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/43',
+        },
+      ],
+    );
+
+    reg.register(provider);
+    await vi.waitFor(() => expect(provider.resolveUrl).toHaveBeenCalledTimes(1));
+    expect(provider.resolveUrl).toHaveBeenCalledWith('https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/43', undefined, { interactive: false });
   });
 
   it('throws on duplicate provider id', () => {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -106,6 +106,77 @@ describe('ProviderRegistry', () => {
     expect(typeof disposable.dispose).toBe('function');
   });
 
+  it('exposes synthetic provider items registered from URL resolution', async () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+    await vi.waitFor(() => expect(registry.loading).toBe(false));
+
+    registry.registerSyntheticProviderItem('gh', {
+      externalId: 'owner/repo#42',
+      title: '#42: Imported PR',
+      itemType: 'pr',
+      capabilities: { gitWork: { kind: 'pr', cloneUrl: 'https://github.com/owner/repo.git', ref: 'feature/topic' } },
+    });
+
+    expect(registry.getProviderItems('gh')).toEqual([
+      expect.objectContaining({ externalId: 'owner/repo#42', itemType: 'pr' }),
+    ]);
+    expect(registry.findProviderItem('gh', 'owner/repo#42')).toEqual(
+      expect.objectContaining({ externalId: 'owner/repo#42' }),
+    );
+  });
+
+  it('prefers live provider items over synthetic URL-imported items with the same external id', async () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+    await vi.waitFor(() => expect(registry.loading).toBe(false));
+
+    registry.registerSyntheticProviderItem('gh', {
+      externalId: 'owner/repo#42',
+      title: '#42: Imported PR',
+      itemType: 'pr',
+      capabilities: { gitWork: { kind: 'pr', cloneUrl: 'https://github.com/owner/repo.git', ref: 'feature/topic' } },
+    });
+    provider.fireItems([{ externalId: 'owner/repo#42', title: '#42: Live PR' }]);
+
+    await vi.waitFor(() => expect(registry.findProviderItem('gh', 'owner/repo#42')?.title).toBe('#42: Live PR'));
+    expect(registry.getProviderItems('gh')).toEqual([
+      expect.objectContaining({ externalId: 'owner/repo#42', title: '#42: Live PR' }),
+    ]);
+  });
+
+  it('rehydrates synthetic URL-imported items for registered providers on startup', async () => {
+    const provider = {
+      ...createMockProvider('ado-pr-reviews'),
+      resolveUrl: vi.fn(async () => ({
+        title: '#42: Imported PR',
+        notes: 'Imported notes',
+        url: 'https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/42',
+        externalId: 'myorg/MyProject/myrepo/42',
+        providerId: 'ado-pr-reviews',
+        itemType: 'pr' as const,
+        capabilities: { gitWork: { kind: 'pr' as const, cloneUrl: 'https://myorg@dev.azure.com/myorg/MyProject/_git/myrepo', ref: 'users/me/fix' } },
+      })),
+    };
+    const reg = new ProviderRegistry(
+      stateStore,
+      undefined,
+      undefined,
+      undefined,
+      () => [{
+        providerId: 'ado-pr-reviews',
+        externalId: 'myorg/MyProject/myrepo/42',
+        url: 'https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/42',
+      }],
+    );
+
+    reg.register(provider);
+    await vi.waitFor(() => expect(reg.findProviderItem('ado-pr-reviews', 'myorg/MyProject/myrepo/42')).toEqual(
+      expect.objectContaining({ externalId: 'myorg/MyProject/myrepo/42', itemType: 'pr' }),
+    ));
+    expect(provider.resolveUrl).toHaveBeenCalledWith('https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/42');
+  });
+
   it('throws on duplicate provider id', () => {
     const provider1 = createMockProvider('dup');
     const provider2 = createMockProvider('dup');

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -126,6 +126,26 @@ describe('ProviderRegistry', () => {
     );
   });
 
+  it('keeps synthetic items when only metadata fields like state or reason are present', async () => {
+    const provider = createMockProvider('gh');
+    registry.register(provider);
+    await vi.waitFor(() => expect(registry.loading).toBe(false));
+
+    registry.registerSyntheticResolvedItem('gh', {
+      title: '#42: Imported PR',
+      notes: '',
+      url: 'https://example.com/42',
+      externalId: 'owner/repo#42',
+      providerId: 'gh',
+      reason: 'review_requested',
+      state: 'open',
+    });
+
+    expect(registry.findProviderItem('gh', 'owner/repo#42')).toEqual(
+      expect.objectContaining({ externalId: 'owner/repo#42', reason: 'review_requested', state: 'open' }),
+    );
+  });
+
   it('prefers live provider items over synthetic URL-imported items with the same external id', async () => {
     const provider = createMockProvider('gh');
     registry.register(provider);

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -194,7 +194,11 @@ describe('ProviderRegistry', () => {
     await vi.waitFor(() => expect(reg.findProviderItem('ado-pr-reviews', 'myorg/MyProject/myrepo/42')).toEqual(
       expect.objectContaining({ externalId: 'myorg/MyProject/myrepo/42', itemType: 'pr' }),
     ));
-    expect(provider.resolveUrl).toHaveBeenCalledWith('https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/42', undefined, { interactive: false });
+    expect(provider.resolveUrl).toHaveBeenCalledWith(
+      'https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/42',
+      expect.any(AbortSignal),
+      { interactive: false },
+    );
   });
 
   it('rehydrates only active imported work items', async () => {
@@ -231,7 +235,11 @@ describe('ProviderRegistry', () => {
 
     reg.register(provider);
     await vi.waitFor(() => expect(provider.resolveUrl).toHaveBeenCalledTimes(1));
-    expect(provider.resolveUrl).toHaveBeenCalledWith('https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/43', undefined, { interactive: false });
+    expect(provider.resolveUrl).toHaveBeenCalledWith(
+      'https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/43',
+      expect.any(AbortSignal),
+      { interactive: false },
+    );
   });
 
   it('throws on duplicate provider id', () => {

--- a/packages/core/src/test/providerRegistry.test.ts
+++ b/packages/core/src/test/providerRegistry.test.ts
@@ -194,7 +194,7 @@ describe('ProviderRegistry', () => {
     await vi.waitFor(() => expect(reg.findProviderItem('ado-pr-reviews', 'myorg/MyProject/myrepo/42')).toEqual(
       expect.objectContaining({ externalId: 'myorg/MyProject/myrepo/42', itemType: 'pr' }),
     ));
-    expect(provider.resolveUrl).toHaveBeenCalledWith('https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/42');
+    expect(provider.resolveUrl).toHaveBeenCalledWith('https://dev.azure.com/myorg/MyProject/_git/myrepo/pullrequest/42', undefined, { interactive: false });
   });
 
   it('throws on duplicate provider id', () => {
@@ -2232,7 +2232,17 @@ describe('ProviderRegistry', () => {
 
       const signal = AbortSignal.abort();
       await registry.resolveUrl('https://u', signal);
-      expect((p1 as any).resolveUrl).toHaveBeenCalledWith('https://u', signal);
+      expect((p1 as any).resolveUrl).toHaveBeenCalledWith('https://u', signal, undefined);
+    });
+
+    it('passes resolveUrl options to the provider', async () => {
+      const p1 = createMockProvider('opts');
+      (p1 as any).resolveUrl = vi.fn(async () => undefined);
+      registry.register(p1);
+      await nextTick();
+
+      await registry.resolveUrl('https://u', undefined, { interactive: false });
+      expect((p1 as any).resolveUrl).toHaveBeenCalledWith('https://u', undefined, { interactive: false });
     });
   });
 });

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import { Lexer, type Token, type Tokens } from 'marked';
-import { ProviderItem, combineSignals, runWorkerPoolSettled, safeDecodeComponent, type RelatedItemRef, type ResolvedItem } from '@devdocket/shared';
+import { ProviderItem, combineSignals, runWorkerPoolSettled, safeDecodeComponent, type RelatedItemRef, type ResolveUrlOptions, type ResolvedItem } from '@devdocket/shared';
 import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
@@ -167,7 +167,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
   private static readonly GITHUB_ISSUE_PATTERN = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)\b/i;
   private static readonly GITHUB_PR_PATTERN = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)\b/i;
 
-  async resolveUrl(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined> {
+  async resolveUrl(url: string, signal?: AbortSignal, options?: ResolveUrlOptions): Promise<ResolvedItem | undefined> {
     const trimmed = url.trim();
     const issueMatch = trimmed.match(GitHubMentionsProvider.GITHUB_ISSUE_PATTERN);
     const prMatch = trimmed.match(GitHubMentionsProvider.GITHUB_PR_PATTERN);
@@ -189,7 +189,7 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
 
     if (!response.ok && !wasAuthenticated && !signal?.aborted &&
         (response.status === 404 || looksLikeRateLimited403(response))) {
-      const retryResponse = await retryWithAuth(apiUrl, signal, { interactive: true });
+      const retryResponse = await retryWithAuth(apiUrl, signal, { interactive: options?.interactive ?? true });
       if (retryResponse) { response = retryResponse; }
     }
 

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { ProviderItem, combineSignals, createAbortError, runWorkerPool, safeDecodeComponent, type RelatedItemRef, type ResolvedItem } from '@devdocket/shared';
+import { ProviderItem, combineSignals, createAbortError, runWorkerPool, safeDecodeComponent, type RelatedItemRef, type ResolveUrlOptions, type ResolvedItem } from '@devdocket/shared';
 import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
@@ -125,7 +125,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
 
   private static readonly GITHUB_PR_PATTERN = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)\b/i;
 
-  async resolveUrl(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined> {
+  async resolveUrl(url: string, signal?: AbortSignal, options?: ResolveUrlOptions): Promise<ResolvedItem | undefined> {
     const match = url.trim().match(GitHubPrReviewProvider.GITHUB_PR_PATTERN);
     if (!match) { return undefined; }
     const [, rawOwner, rawRepo, numStr] = match;
@@ -141,7 +141,7 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
 
     if (!response.ok && !wasAuthenticated && !signal?.aborted &&
         (response.status === 404 || looksLikeRateLimited403(response))) {
-      const retryResponse = await retryWithAuth(apiUrl, signal, { interactive: true });
+      const retryResponse = await retryWithAuth(apiUrl, signal, { interactive: options?.interactive ?? true });
       if (retryResponse) { response = retryResponse; }
     }
 

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -1,4 +1,4 @@
-import { ProviderItem, combineSignals, createAbortError, safeDecodeComponent, type ResolvedItem } from '@devdocket/shared';
+import { ProviderItem, combineSignals, createAbortError, safeDecodeComponent, type ResolveUrlOptions, type ResolvedItem } from '@devdocket/shared';
 import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
@@ -73,7 +73,7 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
 
   private static readonly GITHUB_ISSUE_PATTERN = /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/issues\/(\d+)\b/i;
 
-  async resolveUrl(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined> {
+  async resolveUrl(url: string, signal?: AbortSignal, options?: ResolveUrlOptions): Promise<ResolvedItem | undefined> {
     const match = url.trim().match(GitHubIssueProvider.GITHUB_ISSUE_PATTERN);
     if (!match) { return undefined; }
     const [, rawOwner, rawRepo, numStr] = match;
@@ -89,7 +89,7 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
 
     if (!response.ok && !wasAuthenticated && !signal?.aborted &&
         (response.status === 404 || looksLikeRateLimited403(response))) {
-      const retryResponse = await retryWithAuth(apiUrl, signal, { interactive: true });
+      const retryResponse = await retryWithAuth(apiUrl, signal, { interactive: options?.interactive ?? true });
       if (retryResponse) { response = retryResponse; }
     }
 

--- a/packages/shared/src/apiTypes.ts
+++ b/packages/shared/src/apiTypes.ts
@@ -64,6 +64,17 @@ export interface ProviderRefreshOptions {
 }
 
 /**
+ * Options that describe how URL resolution was initiated.
+ */
+export interface ResolveUrlOptions {
+  /**
+   * Whether resolving the URL may prompt for authentication when a cached
+   * session is unavailable. Background rehydration should pass `false`.
+   */
+  readonly interactive?: boolean;
+}
+
+/**
  * A provider that discovers work items from an external source.
  *
  * Providers are registered via {@link DevDocketApi.registerProvider} and emit
@@ -112,7 +123,7 @@ export interface DevDocketProvider {
    * @param url - The raw URL entered by the user.
    * @param signal - Optional abort signal for cancellation.
    */
-  resolveUrl?(url: string, signal?: AbortSignal): Promise<ResolvedItem | undefined>;
+  resolveUrl?(url: string, signal?: AbortSignal, options?: ResolveUrlOptions): Promise<ResolvedItem | undefined>;
   /**
    * Check which of the given external items have been closed or completed.
    *

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -197,6 +197,22 @@ export interface ResolvedItem {
   externalId: string;
   group?: string;
   providerId: string;
+  /** Optional provider-declared item kind for synthetic provider items created from URL imports. */
+  itemType?: 'issue' | 'pr';
+  /** Optional metadata about who created the underlying item upstream. */
+  author?: ProviderItemAuthor;
+  /** Optional flag indicating the current user authored the item. */
+  authored?: boolean;
+  /** Optional badges, canonical identity, and state-like metadata for synthetic provider items. */
+  badges?: ProviderBadge[];
+  canonicalId?: string;
+  reason?: string;
+  relatedItems?: RelatedItemRef[];
+  resurfaceVersion?: string;
+  state?: string;
+  version?: string;
+  /** Optional capabilities for URL-imported items that are not yet live in provider discovery. */
+  capabilities?: ProviderItemCapabilities;
 }
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,4 +14,4 @@ export { combineSignals, createAbortError, raceWithAbort, getSessionWithAuthFall
 export { runWorkerPool, runWorkerPoolSettled } from './concurrency';
 export { WorkItemState } from './workItem';
 export type { WorkItem, WorkItemInput, ActivityLogEntry, ActivityType } from './workItem';
-export type { DevDocketProvider, DevDocketAction, DevDocketApi, StateTransitionEvent, ProviderRefreshOptions, ActivityDetailRender, ActivityDetailRenderer } from './apiTypes';
+export type { DevDocketProvider, DevDocketAction, DevDocketApi, StateTransitionEvent, ProviderRefreshOptions, ResolveUrlOptions, ActivityDetailRender, ActivityDetailRenderer } from './apiTypes';

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -43,7 +43,6 @@ function isValidCloneUrl(url: unknown): url is string {
       const parsed = new URL(url);
       return parsed.protocol === 'https:'
         && parsed.hostname.length > 0
-        && !parsed.username
         && !parsed.password
         && !parsed.search
         && !parsed.hash;

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -169,6 +169,15 @@ describe('StartWorkAction', () => {
       expect(action.canRun(item)).toBe(true);
     });
 
+    it('returns true for a URL-imported ADO PR when a synthetic provider item supplies gitWork', () => {
+      const item = createWorkItem({ providerId: 'ado-pr-reviews', externalId: 'myorg/MyProject/myrepo/42' });
+      const { action } = createAction(discovered('ado-pr-reviews', 'myorg/MyProject/myrepo/42', async () => ({
+        kind: 'pr', cloneUrl: 'https://myorg@dev.azure.com/myorg/MyProject/_git/myrepo', ref: 'users/me/fix', repoLabel: 'MyProject/myrepo',
+      })));
+
+      expect(action.canRun(item)).toBe(true);
+    });
+
     it('returns false when no capability is present', () => {
       const item = createWorkItem();
       const { action } = createAction(discovered('provider', 'item-1'));
@@ -804,6 +813,24 @@ describe('StartWorkAction', () => {
       expect(window.showErrorMessage).toHaveBeenCalledWith('DevDocket: Provider returned an invalid clone URL for this work item.');
       expect(window.showInputBox).not.toHaveBeenCalled();
       expect(execFile).not.toHaveBeenCalled();
+    });
+
+    it('accepts Azure DevOps HTTPS clone URLs that include a username', async () => {
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', async () => ({
+        kind: 'pr', cloneUrl: 'https://myorg@dev.azure.com/myorg/MyProject/_git/myrepo', ref: 'users/me/fix', repoLabel: 'MyProject/myrepo',
+      })));
+
+      await action.run(item);
+
+      expect(window.showErrorMessage).not.toHaveBeenCalledWith('DevDocket: Provider returned an invalid clone URL for this work item.');
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toEqual([
+        ['remote', '-v'],
+        ['remote', 'add', 'devdocket-fork-MyProject-myrepo', 'https://myorg@dev.azure.com/myorg/MyProject/_git/myrepo'],
+        ['fetch', 'devdocket-fork-MyProject-myrepo', '+refs/heads/users/me/fix:refs/remotes/devdocket-fork-MyProject-myrepo/users/me/fix'],
+        ['rev-parse', '--verify', 'refs/heads/users/me/fix'],
+        ['worktree', 'add', '--detach', path.join('/mock', 'myrepo-pr-1'), 'devdocket-fork-MyProject-myrepo/users/me/fix'],
+      ]);
     });
 
     it('rejects an invalid ref returned by a lazy resolver', async () => {


### PR DESCRIPTION
## Summary
- fix Azure DevOps pull requests imported by URL so Start Git Work gets provider-supplied `gitWork` metadata immediately
- rehydrate synthetic provider items on reload so URL-imported ADO PRs keep Start Git Work even when they are not in live provider discovery
- accept valid Azure DevOps HTTPS clone URLs that include the `org@dev.azure.com` username segment

## Root cause
### Symptom 1 — Start Git Work missing for URL-added ADO PRs
The Add by URL flow persisted a work item with `providerId` and `externalId`, but `StartWorkAction.canRun()` only looked at live `ProviderRegistry` items for `capabilities.gitWork`. `BaseAdoPrProvider.resolveUrl()` returned only basic `ResolvedItem` fields, so URL-imported ADO PRs never had a live or synthetic provider item carrying git-work capability metadata.

### Symptom 2 — invalid clone URL
ADO PR git work uses clone URLs shaped like `https://{org}@dev.azure.com/{org}/{project}/_git/{repo}`. `StartWorkAction` rejected any HTTPS clone URL with a username, so legitimate ADO clone URLs failed validation before checkout.

## Fix
- extend ADO PR URL resolution to return `itemType: 'pr'` plus `capabilities.gitWork`
- cache a synthetic provider item after Add by URL and rehydrate synthetic provider items from persisted work items when providers register
- extend `ResolvedItem` with optional metadata fields used by synthetic provider items
- relax clone URL validation to allow HTTPS usernames while still rejecting passwords, query strings, fragments, whitespace, and control characters
- add regression tests for URL-imported ADO PRs, startup rehydration, and ADO username-bearing clone URLs

## Notes
- This supersedes PR #652, which addressed the wrong problem by surfacing a no-repo UX for ADO work items instead of fixing Azure DevOps pull request git-work behavior.
- Closes #588.
