### PR TITLE
Cap inbox and read state store growth

### DIFF
--- a/.changeset/cap-state-store-growth.md
+++ b/.changeset/cap-state-store-growth.md
@@ -2,4 +2,4 @@
 "devdocket": patch
 ---
 
-Cap inbox-state and read-state persistence, trim only the excess oldest entries when the stores grow too large, and stamp persisted entries with eviction timestamps so oversized state can be trimmed safely.
+Cap inbox-state and read-state persistence with a shared age-based trimming helper, and apply the same bounded-storage protection to watch persistence so oversized watch snapshots only evict terminal runs and PRs.

--- a/.changeset/cap-state-store-growth.md
+++ b/.changeset/cap-state-store-growth.md
@@ -1,0 +1,5 @@
+---
+"devdocket": patch
+---
+
+Cap inbox-state and read-state persistence, evict the oldest entries when the stores grow too large, and stamp new entries with creation timestamps so oversized state can be trimmed safely.

--- a/.changeset/cap-state-store-growth.md
+++ b/.changeset/cap-state-store-growth.md
@@ -2,4 +2,4 @@
 "devdocket": patch
 ---
 
-Cap inbox-state and read-state persistence, evict the oldest entries when the stores grow too large, and stamp new entries with creation timestamps so oversized state can be trimmed safely.
+Cap inbox-state and read-state persistence, trim only the excess oldest entries when the stores grow too large, and stamp persisted entries with eviction timestamps so oversized state can be trimmed safely.

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -30,7 +30,7 @@ export interface InboxStateRecord {
 }
 
 interface PersistedInboxStateRecord extends InboxStateRecord {
-  /** Last-write timestamp used for eviction so recently updated inbox decisions survive capacity trimming. */
+  /** Legacy field name: stores the last-write timestamp used for eviction so recently updated inbox decisions survive trimming. */
   createdAt: number;
 }
 

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -30,6 +30,7 @@ export interface InboxStateRecord {
 }
 
 interface PersistedInboxStateRecord extends InboxStateRecord {
+  /** Last-write timestamp used for eviction so recently updated inbox decisions survive capacity trimming. */
   createdAt: number;
 }
 
@@ -183,19 +184,27 @@ export class InboxStateStore {
     if (!this.loaded) { await this.load(); }
     const k = this.key(providerId, externalId);
     const previousValue = this.cache.get(k);
+    const nextVersion = version ?? previousValue?.version;
+    const nextResurfaceVersion = previousValue?.resurfaceVersion;
+    if (
+      previousValue
+      && previousValue.inboxState === state
+      && previousValue.version === nextVersion
+      && previousValue.resurfaceVersion === nextResurfaceVersion
+    ) {
+      return;
+    }
     const newRecord: PersistedInboxStateRecord = {
       providerId,
       externalId,
       inboxState: state,
-      createdAt: previousValue?.createdAt ?? Date.now(),
+      createdAt: Date.now(),
     };
-    if (version !== undefined) {
-      newRecord.version = version;
-    } else if (previousValue?.version !== undefined) {
-      newRecord.version = previousValue.version;
+    if (nextVersion !== undefined) {
+      newRecord.version = nextVersion;
     }
-    if (previousValue?.resurfaceVersion !== undefined) {
-      newRecord.resurfaceVersion = previousValue.resurfaceVersion;
+    if (nextResurfaceVersion !== undefined) {
+      newRecord.resurfaceVersion = nextResurfaceVersion;
     }
     this.cache.set(k, newRecord);
     this.dirtyKeys.add(k);
@@ -210,29 +219,38 @@ export class InboxStateStore {
   async setStates(items: Array<{ providerId: string; externalId: string; state: InboxState; version?: string; resurfaceVersion?: string }>): Promise<void> {
     if (!this.loaded) { await this.load(); }
     if (items.length === 0) { return; }
+    let changed = false;
     for (const item of items) {
       const k = this.key(item.providerId, item.externalId);
       const previousRecord = this.cache.get(k);
+      const nextVersion = item.version ?? previousRecord?.version;
+      const nextResurfaceVersion = item.resurfaceVersion ?? previousRecord?.resurfaceVersion;
+      if (
+        previousRecord
+        && previousRecord.inboxState === item.state
+        && previousRecord.version === nextVersion
+        && previousRecord.resurfaceVersion === nextResurfaceVersion
+      ) {
+        continue;
+      }
       const newRecord: PersistedInboxStateRecord = {
         providerId: item.providerId,
         externalId: item.externalId,
         inboxState: item.state,
-        createdAt: previousRecord?.createdAt ?? Date.now(),
+        createdAt: Date.now(),
       };
-      if (item.version !== undefined) {
-        newRecord.version = item.version;
-      } else if (previousRecord?.version !== undefined) {
-        newRecord.version = previousRecord.version;
+      if (nextVersion !== undefined) {
+        newRecord.version = nextVersion;
       }
-      if (item.resurfaceVersion !== undefined) {
-        newRecord.resurfaceVersion = item.resurfaceVersion;
-      } else if (previousRecord?.resurfaceVersion !== undefined) {
-        newRecord.resurfaceVersion = previousRecord.resurfaceVersion;
+      if (nextResurfaceVersion !== undefined) {
+        newRecord.resurfaceVersion = nextResurfaceVersion;
       }
       this.cache.set(k, newRecord);
       this.dirtyKeys.add(k);
       this.removedKeys.delete(k);
+      changed = true;
     }
+    if (!changed) { return; }
     await this.persist();
     this._onDidChange.fire();
   }

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -13,7 +13,6 @@ import {
 /** Possible states for a provider-discovered item in the inbox workflow. */
 const inboxStates = ['unseen', 'accepted', 'dismissed'] as const;
 const MAX_TOTAL_ENTRIES = 5_000;
-const EVICTION_FRACTION = 0.2;
 
 export type InboxState = (typeof inboxStates)[number];
 
@@ -39,10 +38,7 @@ function trimInboxStateRecords(records: PersistedInboxStateRecord[]): PersistedI
     return records;
   }
 
-  const evictedCount = Math.max(
-    records.length - MAX_TOTAL_ENTRIES,
-    Math.ceil(records.length * EVICTION_FRACTION),
-  );
+  const evictedCount = records.length - MAX_TOTAL_ENTRIES;
   const keysToEvict = new Set(
     records
       .map((record, index) => ({

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -7,10 +7,13 @@ import {
   requiredString,
   optionalString,
   requiredEnum,
+  optionalFiniteNumber,
 } from './validation';
 
 /** Possible states for a provider-discovered item in the inbox workflow. */
 const inboxStates = ['unseen', 'accepted', 'dismissed'] as const;
+const MAX_TOTAL_ENTRIES = 5_000;
+const EVICTION_FRACTION = 0.2;
 
 export type InboxState = (typeof inboxStates)[number];
 
@@ -27,6 +30,39 @@ export interface InboxStateRecord {
   resurfaceVersion?: string;
 }
 
+interface PersistedInboxStateRecord extends InboxStateRecord {
+  createdAt: number;
+}
+
+function trimInboxStateRecords(records: PersistedInboxStateRecord[]): PersistedInboxStateRecord[] {
+  if (records.length <= MAX_TOTAL_ENTRIES) {
+    return records;
+  }
+
+  const evictedCount = Math.max(
+    records.length - MAX_TOTAL_ENTRIES,
+    Math.ceil(records.length * EVICTION_FRACTION),
+  );
+  const keysToEvict = new Set(
+    records
+      .map((record, index) => ({
+        key: `${record.providerId}::${record.externalId}`,
+        createdAt: record.createdAt,
+        index,
+      }))
+      .sort((a, b) => a.createdAt - b.createdAt || a.index - b.index)
+      .slice(0, evictedCount)
+      .map(record => record.key),
+  );
+
+  return records.filter(record => !keysToEvict.has(`${record.providerId}::${record.externalId}`));
+}
+
+function toInboxStateRecord(record: PersistedInboxStateRecord): InboxStateRecord {
+  const { createdAt: _createdAt, ...publicRecord } = record;
+  return publicRecord;
+}
+
 /**
  * Validates that a parsed JSON value has the required shape of an InboxStateRecord.
  * Returns a descriptive error string if invalid, or undefined if valid.
@@ -40,7 +76,8 @@ function validateInboxStateRecord(value: unknown, index: number): string | undef
     ?? requiredString(result, 'externalId', ctx)
     ?? requiredEnum(result, 'inboxState', validInboxStates, ctx)
     ?? optionalString(result, 'version', ctx)
-    ?? optionalString(result, 'resurfaceVersion', ctx);
+    ?? optionalString(result, 'resurfaceVersion', ctx)
+    ?? optionalFiniteNumber(result, 'createdAt', ctx);
 }
 
 /**
@@ -51,7 +88,7 @@ function validateInboxStateRecord(value: unknown, index: number): string | undef
  * always read live from the provider.
  */
 export class InboxStateStore {
-  private readonly cache = new Map<string, InboxStateRecord>();
+  private readonly cache = new Map<string, PersistedInboxStateRecord>();
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   readonly onDidChange = this._onDidChange.event;
   private loaded = false;
@@ -93,7 +130,7 @@ export class InboxStateStore {
    * keys win, and locally removed keys stay removed.
    */
   private async persist(): Promise<void> {
-    const merged = new Map<string, InboxStateRecord>();
+    const merged = new Map<string, PersistedInboxStateRecord>();
 
     for (const remote of await this.parseFromFileStore()) {
       merged.set(this.key(remote.providerId, remote.externalId), remote);
@@ -110,27 +147,32 @@ export class InboxStateStore {
       }
     }
 
-    await this.fileStore.write(Array.from(merged.values()));
+    const trimmed = trimInboxStateRecords(Array.from(merged.values()));
+    await this.fileStore.write(trimmed);
     this.cache.clear();
-    for (const [k, record] of merged) {
-      this.cache.set(k, record);
+    for (const record of trimmed) {
+      this.cache.set(this.key(record.providerId, record.externalId), record);
     }
     this.dirtyKeys.clear();
     this.removedKeys.clear();
   }
 
   /** Parse and validate inbox state records from the backing JSON file. */
-  private async parseFromFileStore(): Promise<InboxStateRecord[]> {
+  private async parseFromFileStore(): Promise<PersistedInboxStateRecord[]> {
     const parsed = await this.fileStore.read();
     if (!Array.isArray(parsed)) { return []; }
-    const records: InboxStateRecord[] = [];
+    const records: PersistedInboxStateRecord[] = [];
     for (let i = 0; i < parsed.length; i++) {
       const error = validateInboxStateRecord(parsed[i], i);
       if (error) {
         logger.warn(`Skipping invalid inbox state record: ${error}`);
         continue;
       }
-      records.push(parsed[i] as InboxStateRecord);
+      const record = parsed[i] as InboxStateRecord & { createdAt?: number };
+      records.push({
+        ...record,
+        createdAt: record.createdAt ?? i,
+      });
     }
     return records;
   }
@@ -145,7 +187,12 @@ export class InboxStateStore {
     if (!this.loaded) { await this.load(); }
     const k = this.key(providerId, externalId);
     const previousValue = this.cache.get(k);
-    const newRecord: InboxStateRecord = { providerId, externalId, inboxState: state };
+    const newRecord: PersistedInboxStateRecord = {
+      providerId,
+      externalId,
+      inboxState: state,
+      createdAt: previousValue?.createdAt ?? Date.now(),
+    };
     if (version !== undefined) {
       newRecord.version = version;
     } else if (previousValue?.version !== undefined) {
@@ -170,7 +217,12 @@ export class InboxStateStore {
     for (const item of items) {
       const k = this.key(item.providerId, item.externalId);
       const previousRecord = this.cache.get(k);
-      const newRecord: InboxStateRecord = { providerId: item.providerId, externalId: item.externalId, inboxState: item.state };
+      const newRecord: PersistedInboxStateRecord = {
+        providerId: item.providerId,
+        externalId: item.externalId,
+        inboxState: item.state,
+        createdAt: previousRecord?.createdAt ?? Date.now(),
+      };
       if (item.version !== undefined) {
         newRecord.version = item.version;
       } else if (previousRecord?.version !== undefined) {
@@ -194,7 +246,7 @@ export class InboxStateStore {
    */
   async loadAll(): Promise<InboxStateRecord[]> {
     await this.load();
-    return Array.from(this.cache.values());
+    return Array.from(this.cache.values(), record => toInboxStateRecord(record));
   }
 
   /**
@@ -204,12 +256,17 @@ export class InboxStateStore {
     if (this.loaded) { return; }
     this.cache.clear();
     const records = await this.parseFromFileStore();
-    for (const record of records) {
+    const trimmedRecords = trimInboxStateRecords(records);
+    if (trimmedRecords.length !== records.length) {
+      await this.fileStore.write(trimmedRecords);
+      logger.info(`Trimmed inbox-state.json from ${records.length} to ${trimmedRecords.length} entries while loading to enforce the ${MAX_TOTAL_ENTRIES}-entry cap`);
+    }
+    for (const record of trimmedRecords) {
       this.cache.set(this.key(record.providerId, record.externalId), record);
     }
     this.dirtyKeys.clear();
     this.removedKeys.clear();
-    if (records.length > 0) {
+    if (trimmedRecords.length > 0) {
       logger.debug(`Loaded inbox state: ${this.cache.size} entries`);
     }
     this.loaded = true;

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -175,9 +175,11 @@ export class InboxStateStore {
       return { records: [], available: false };
     }
     const records: PersistedInboxStateRecord[] = [];
+    let invalidCount = 0;
     for (let i = 0; i < parsed.length; i++) {
       const error = validateInboxStateRecord(parsed[i], i);
       if (error) {
+        invalidCount++;
         logger.warn(`Skipping invalid inbox state record: ${error}`);
         continue;
       }
@@ -188,6 +190,7 @@ export class InboxStateStore {
       });
     }
 
+    const available = invalidCount === 0;
     const deduped = new Map<string, PersistedInboxStateRecord>();
     for (const record of records) {
       const key = this.key(record.providerId, record.externalId);
@@ -197,7 +200,7 @@ export class InboxStateStore {
       }
     }
 
-    return { records: Array.from(deduped.values()), available: true };
+    return { records: Array.from(deduped.values()), available };
   }
 
   /**

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -296,8 +296,12 @@ export class InboxStateStore {
     const records = snapshot.records;
     const trimmedRecords = trimInboxStateRecords(records);
     if (trimmedRecords.length !== records.length) {
-      await this.fileStore.write(trimmedRecords);
-      logger.info(`Trimmed inbox-state.json from ${records.length} to ${trimmedRecords.length} entries while loading to enforce the ${MAX_TOTAL_ENTRIES}-entry cap`);
+      try {
+        await this.fileStore.write(trimmedRecords);
+        logger.info(`Trimmed inbox-state.json from ${records.length} to ${trimmedRecords.length} entries while loading to enforce the ${MAX_TOTAL_ENTRIES}-entry cap`);
+      } catch (err) {
+        logger.warn(`Failed to persist trimmed inbox state while loading; continuing with ${trimmedRecords.length} in-memory entries`, err);
+      }
     }
     for (const record of trimmedRecords) {
       this.cache.set(this.key(record.providerId, record.externalId), record);

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -34,6 +34,11 @@ interface PersistedInboxStateRecord extends InboxStateRecord {
   createdAt: number;
 }
 
+interface InboxStateSnapshot {
+  records: PersistedInboxStateRecord[];
+  available: boolean;
+}
+
 function trimInboxStateRecords(records: PersistedInboxStateRecord[]): PersistedInboxStateRecord[] {
   if (records.length <= MAX_TOTAL_ENTRIES) {
     return records;
@@ -127,10 +132,17 @@ export class InboxStateStore {
    * keys win, and locally removed keys stay removed.
    */
   private async persist(): Promise<void> {
+    const snapshot = await this.parseFromFileStore();
     const merged = new Map<string, PersistedInboxStateRecord>();
 
-    for (const remote of await this.parseFromFileStore()) {
-      merged.set(this.key(remote.providerId, remote.externalId), remote);
+    if (snapshot.available) {
+      for (const remote of snapshot.records) {
+        merged.set(this.key(remote.providerId, remote.externalId), remote);
+      }
+    } else {
+      for (const [key, record] of this.cache) {
+        merged.set(key, record);
+      }
     }
 
     for (const k of this.removedKeys) {
@@ -155,9 +167,10 @@ export class InboxStateStore {
   }
 
   /** Parse and validate inbox state records from the backing JSON file. */
-  private async parseFromFileStore(): Promise<PersistedInboxStateRecord[]> {
+  private async parseFromFileStore(): Promise<InboxStateSnapshot> {
     const parsed = await this.fileStore.read();
-    if (!Array.isArray(parsed)) { return []; }
+    if (parsed === undefined) { return { records: [], available: false }; }
+    if (!Array.isArray(parsed)) { return { records: [], available: true }; }
     const records: PersistedInboxStateRecord[] = [];
     for (let i = 0; i < parsed.length; i++) {
       const error = validateInboxStateRecord(parsed[i], i);
@@ -181,7 +194,7 @@ export class InboxStateStore {
       }
     }
 
-    return Array.from(deduped.values());
+    return { records: Array.from(deduped.values()), available: true };
   }
 
   /**
@@ -279,7 +292,8 @@ export class InboxStateStore {
   async load(): Promise<void> {
     if (this.loaded) { return; }
     this.cache.clear();
-    const records = await this.parseFromFileStore();
+    const snapshot = await this.parseFromFileStore();
+    const records = snapshot.records;
     const trimmedRecords = trimInboxStateRecords(records);
     if (trimmedRecords.length !== records.length) {
       await this.fileStore.write(trimmedRecords);

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -170,7 +170,10 @@ export class InboxStateStore {
   private async parseFromFileStore(): Promise<InboxStateSnapshot> {
     const parsed = await this.fileStore.read();
     if (parsed === undefined) { return { records: [], available: false }; }
-    if (!Array.isArray(parsed)) { return { records: [], available: true }; }
+    if (!Array.isArray(parsed)) {
+      logger.warn('Inbox state snapshot is not an array; falling back to the in-memory snapshot');
+      return { records: [], available: false };
+    }
     const records: PersistedInboxStateRecord[] = [];
     for (let i = 0; i < parsed.length; i++) {
       const error = validateInboxStateRecord(parsed[i], i);

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -9,6 +9,7 @@ import {
   requiredEnum,
   optionalFiniteNumber,
 } from './validation';
+import { trimByAge } from './trimByAge';
 
 /** Possible states for a provider-discovered item in the inbox workflow. */
 const inboxStates = ['unseen', 'accepted', 'dismissed'] as const;
@@ -37,27 +38,6 @@ interface PersistedInboxStateRecord extends InboxStateRecord {
 interface InboxStateSnapshot {
   records: PersistedInboxStateRecord[];
   available: boolean;
-}
-
-function trimInboxStateRecords(records: PersistedInboxStateRecord[]): PersistedInboxStateRecord[] {
-  if (records.length <= MAX_TOTAL_ENTRIES) {
-    return records;
-  }
-
-  const evictedCount = records.length - MAX_TOTAL_ENTRIES;
-  const keysToEvict = new Set(
-    records
-      .map((record, index) => ({
-        key: `${record.providerId}::${record.externalId}`,
-        createdAt: record.createdAt,
-        index,
-      }))
-      .sort((a, b) => a.createdAt - b.createdAt || a.index - b.index)
-      .slice(0, evictedCount)
-      .map(record => record.key),
-  );
-
-  return records.filter(record => !keysToEvict.has(`${record.providerId}::${record.externalId}`));
 }
 
 function toInboxStateRecord(record: PersistedInboxStateRecord): InboxStateRecord {
@@ -156,7 +136,11 @@ export class InboxStateStore {
       }
     }
 
-    const trimmed = trimInboxStateRecords(Array.from(merged.values()));
+    const trimmed = trimByAge(Array.from(merged.values()), {
+      maxEntries: MAX_TOTAL_ENTRIES,
+      getTimestamp: record => record.createdAt,
+      getKey: record => this.key(record.providerId, record.externalId),
+    });
     await this.fileStore.write(trimmed);
     this.cache.clear();
     for (const record of trimmed) {
@@ -300,7 +284,11 @@ export class InboxStateStore {
     this.cache.clear();
     const snapshot = await this.parseFromFileStore();
     const records = snapshot.records;
-    const trimmedRecords = trimInboxStateRecords(records);
+    const trimmedRecords = trimByAge(records, {
+      maxEntries: MAX_TOTAL_ENTRIES,
+      getTimestamp: record => record.createdAt,
+      getKey: record => this.key(record.providerId, record.externalId),
+    });
     if (trimmedRecords.length !== records.length) {
       try {
         await this.fileStore.write(trimmedRecords);

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -171,7 +171,17 @@ export class InboxStateStore {
         createdAt: record.createdAt ?? i,
       });
     }
-    return records;
+
+    const deduped = new Map<string, PersistedInboxStateRecord>();
+    for (const record of records) {
+      const key = this.key(record.providerId, record.externalId);
+      const existing = deduped.get(key);
+      if (!existing || record.createdAt >= existing.createdAt) {
+        deduped.set(key, record);
+      }
+    }
+
+    return Array.from(deduped.values());
   }
 
   /**

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -4,7 +4,6 @@ import { logger } from '../services/logger';
 import type { FileStore } from './fileStore';
 
 const MAX_TOTAL_ENTRIES = 5_000;
-const EVICTION_FRACTION = 0.2;
 
 interface PersistedReadStateRecord {
   key: string;
@@ -16,10 +15,7 @@ function trimReadStateRecords(records: PersistedReadStateRecord[]): PersistedRea
     return records;
   }
 
-  const evictedCount = Math.max(
-    records.length - MAX_TOTAL_ENTRIES,
-    Math.ceil(records.length * EVICTION_FRACTION),
-  );
+  const evictedCount = records.length - MAX_TOTAL_ENTRIES;
   const keysToEvict = new Set(
     records
       .map((record, index) => ({ ...record, index }))

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -120,7 +120,15 @@ export class ReadStateStore {
       logger.warn(`Skipped ${invalidCount} invalid read state entries (expected strings or { key, createdAt })`);
     }
 
-    return records;
+    const deduped = new Map<string, PersistedReadStateRecord>();
+    for (const record of records) {
+      const existing = deduped.get(record.key);
+      if (!existing || record.createdAt < existing.createdAt) {
+        deduped.set(record.key, record);
+      }
+    }
+
+    return Array.from(deduped.values());
   }
 
   /** Returns true only when the key is newly added. Persists automatically. */

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import type { ProviderItem } from '../api/types';
 import { logger } from '../services/logger';
 import type { FileStore } from './fileStore';
+import { trimByAge } from './trimByAge';
 
 const MAX_TOTAL_ENTRIES = 5_000;
 
@@ -14,23 +15,6 @@ interface PersistedReadStateRecord {
 interface ReadStateSnapshot {
   records: PersistedReadStateRecord[];
   available: boolean;
-}
-
-function trimReadStateRecords(records: PersistedReadStateRecord[]): PersistedReadStateRecord[] {
-  if (records.length <= MAX_TOTAL_ENTRIES) {
-    return records;
-  }
-
-  const evictedCount = records.length - MAX_TOTAL_ENTRIES;
-  const keysToEvict = new Set(
-    records
-      .map((record, index) => ({ ...record, index }))
-      .sort((a, b) => a.createdAt - b.createdAt || a.index - b.index)
-      .slice(0, evictedCount)
-      .map(record => record.key),
-  );
-
-  return records.filter(record => !keysToEvict.has(record.key));
 }
 
 /**
@@ -86,8 +70,13 @@ export class ReadStateStore {
       }
     }
 
-    const trimmed = trimReadStateRecords(
+    const trimmed = trimByAge(
       Array.from(merged, ([key, createdAt]) => ({ key, createdAt })),
+      {
+        maxEntries: MAX_TOTAL_ENTRIES,
+        getTimestamp: record => record.createdAt,
+        getKey: record => record.key,
+      },
     );
     await this.fileStore.write(trimmed);
     this.items.clear();
@@ -250,7 +239,11 @@ export class ReadStateStore {
     if (this.loaded) { return; }
     const snapshot = await this.parseFromFileStore();
     const records = snapshot.records;
-    const trimmedRecords = trimReadStateRecords(records);
+    const trimmedRecords = trimByAge(records, {
+      maxEntries: MAX_TOTAL_ENTRIES,
+      getTimestamp: record => record.createdAt,
+      getKey: record => record.key,
+    });
     this.items.clear();
     if (trimmedRecords.length !== records.length) {
       try {

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -3,14 +3,42 @@ import type { ProviderItem } from '../api/types';
 import { logger } from '../services/logger';
 import type { FileStore } from './fileStore';
 
+const MAX_TOTAL_ENTRIES = 5_000;
+const EVICTION_FRACTION = 0.2;
+
+interface PersistedReadStateRecord {
+  key: string;
+  createdAt: number;
+}
+
+function trimReadStateRecords(records: PersistedReadStateRecord[]): PersistedReadStateRecord[] {
+  if (records.length <= MAX_TOTAL_ENTRIES) {
+    return records;
+  }
+
+  const evictedCount = Math.max(
+    records.length - MAX_TOTAL_ENTRIES,
+    Math.ceil(records.length * EVICTION_FRACTION),
+  );
+  const keysToEvict = new Set(
+    records
+      .map((record, index) => ({ ...record, index }))
+      .sort((a, b) => a.createdAt - b.createdAt || a.index - b.index)
+      .slice(0, evictedCount)
+      .map(record => record.key),
+  );
+
+  return records.filter(record => !keysToEvict.has(record.key));
+}
+
 /**
  * Persists the set of inbox item IDs that the user has viewed ("read")
  * so read/unread state survives across VS Code restarts.
  *
- * Stored as a string array in a JSON file under globalStorageUri.
+ * Stored as timestamped records in a JSON file under globalStorageUri.
  */
 export class ReadStateStore {
-  private readonly items = new Set<string>();
+  private readonly items = new Map<string, number>();
   private loaded = false;
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   /** Fires whenever the set of read keys changes (add, addMany, deleteMany, prune). */
@@ -29,28 +57,68 @@ export class ReadStateStore {
    * keys, and writes the merged result.
    */
   private async persist(): Promise<void> {
-    const remoteParsed = await this.fileStore.read();
-    const merged = new Set(this.items);
-    if (Array.isArray(remoteParsed)) {
-      for (const item of remoteParsed) {
-        if (typeof item === 'string' && !this.removedSinceLoad.has(item)) {
-          merged.add(item);
-        }
+    const merged = new Map(this.items);
+    for (const remote of await this.parseFromFileStore()) {
+      if (!this.removedSinceLoad.has(remote.key) && !merged.has(remote.key)) {
+        merged.set(remote.key, remote.createdAt);
       }
     }
-    await this.fileStore.write([...merged]);
+
+    const trimmed = trimReadStateRecords(
+      Array.from(merged, ([key, createdAt]) => ({ key, createdAt })),
+    );
+    await this.fileStore.write(trimmed);
     this.items.clear();
-    for (const key of merged) {
-      this.items.add(key);
+    for (const record of trimmed) {
+      this.items.set(record.key, record.createdAt);
     }
     this.removedSinceLoad.clear();
+  }
+
+  private async parseFromFileStore(): Promise<PersistedReadStateRecord[]> {
+    const parsed = await this.fileStore.read();
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+
+    const records: PersistedReadStateRecord[] = [];
+    let invalidCount = 0;
+    for (let i = 0; i < parsed.length; i++) {
+      const item = parsed[i];
+      if (typeof item === 'string') {
+        records.push({ key: item, createdAt: i });
+        continue;
+      }
+
+      if (
+        typeof item === 'object'
+        && item !== null
+        && !Array.isArray(item)
+        && typeof (item as { key?: unknown }).key === 'string'
+        && ((item as { createdAt?: unknown }).createdAt === undefined
+          || (typeof (item as { createdAt?: unknown }).createdAt === 'number'
+            && Number.isFinite((item as { createdAt?: number }).createdAt)))
+      ) {
+        const record = item as { key: string; createdAt?: number };
+        records.push({ key: record.key, createdAt: record.createdAt ?? i });
+        continue;
+      }
+
+      invalidCount++;
+    }
+
+    if (invalidCount > 0) {
+      logger.warn(`Skipped ${invalidCount} invalid read state entries (expected strings or { key, createdAt })`);
+    }
+
+    return records;
   }
 
   /** Returns true only when the key is newly added. Persists automatically. */
   async add(key: string): Promise<boolean> {
     if (!this.loaded) { await this.load(); }
     if (this.items.has(key)) { return false; }
-    this.items.add(key);
+    this.items.set(key, Date.now());
     await this.persist();
     this._onDidChange.fire();
     return true;
@@ -63,7 +131,7 @@ export class ReadStateStore {
     const newlyAdded: string[] = [];
     for (const key of keys) {
       if (!this.items.has(key)) {
-        this.items.add(key);
+        this.items.set(key, Date.now());
         newlyAdded.push(key);
       }
     }
@@ -75,7 +143,7 @@ export class ReadStateStore {
   }
 
   keys(): IterableIterator<string> {
-    return this.items.values();
+    return this.items.keys();
   }
 
   async deleteMany(keys: string[]): Promise<void> {
@@ -116,7 +184,7 @@ export class ReadStateStore {
     if (activeProviderIds.size === 0) { return 0; }
 
     const staleKeys: string[] = [];
-    for (const key of this.items) {
+    for (const key of this.items.keys()) {
       const delimiterIndex = key.indexOf('::');
       if (delimiterIndex === -1) { continue; }
       const providerId = key.slice(0, delimiterIndex);
@@ -139,20 +207,17 @@ export class ReadStateStore {
 
   async load(): Promise<void> {
     if (this.loaded) { return; }
-    const parsed = await this.fileStore.read();
+    const records = await this.parseFromFileStore();
+    const trimmedRecords = trimReadStateRecords(records);
     this.items.clear();
-    if (Array.isArray(parsed)) {
-      let invalidCount = 0;
-      for (const item of parsed) {
-        if (typeof item === 'string') {
-          this.items.add(item);
-        } else {
-          invalidCount++;
-        }
-      }
-      if (invalidCount > 0) {
-        logger.warn(`Skipped ${invalidCount} invalid read state entries (expected strings)`);
-      }
+    if (trimmedRecords.length !== records.length) {
+      await this.fileStore.write(trimmedRecords);
+      logger.info(`Trimmed read-state.json from ${records.length} to ${trimmedRecords.length} entries while loading to enforce the ${MAX_TOTAL_ENTRIES}-entry cap`);
+    }
+    for (const record of trimmedRecords) {
+      this.items.set(record.key, record.createdAt);
+    }
+    if (trimmedRecords.length > 0) {
       logger.debug(`Loaded read state: ${this.items.size} entries`);
     }
     this.removedSinceLoad.clear();

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -250,8 +250,12 @@ export class ReadStateStore {
     const trimmedRecords = trimReadStateRecords(records);
     this.items.clear();
     if (trimmedRecords.length !== records.length) {
-      await this.fileStore.write(trimmedRecords);
-      logger.info(`Trimmed read-state.json from ${records.length} to ${trimmedRecords.length} entries while loading to enforce the ${MAX_TOTAL_ENTRIES}-entry cap`);
+      try {
+        await this.fileStore.write(trimmedRecords);
+        logger.info(`Trimmed read-state.json from ${records.length} to ${trimmedRecords.length} entries while loading to enforce the ${MAX_TOTAL_ENTRIES}-entry cap`);
+      } catch (err) {
+        logger.warn(`Failed to persist trimmed read state while loading; continuing with ${trimmedRecords.length} in-memory entries`, err);
+      }
     }
     for (const record of trimmedRecords) {
       this.items.set(record.key, record.createdAt);

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -43,6 +43,8 @@ export class ReadStateStore {
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   /** Fires whenever the set of read keys changes (add, addMany, deleteMany, prune). */
   readonly onDidChange = this._onDidChange.event;
+  /** Keys added locally since last load — ensures local additions survive remote merges. */
+  private readonly addedSinceLoad = new Set<string>();
   /** Keys removed locally since last load — prevents re-adding from stale remote data. */
   private readonly removedSinceLoad = new Set<string>();
 
@@ -57,10 +59,19 @@ export class ReadStateStore {
    * keys, and writes the merged result.
    */
   private async persist(): Promise<void> {
-    const merged = new Map(this.items);
-    for (const remote of await this.parseFromFileStore()) {
-      if (!this.removedSinceLoad.has(remote.key) && !merged.has(remote.key)) {
+    const remoteRecords = await this.parseFromFileStore();
+    const remoteKeys = new Set(remoteRecords.map(record => record.key));
+    const merged = new Map<string, number>();
+
+    for (const remote of remoteRecords) {
+      if (!this.removedSinceLoad.has(remote.key)) {
         merged.set(remote.key, remote.createdAt);
+      }
+    }
+
+    for (const [key, createdAt] of this.items) {
+      if (!this.removedSinceLoad.has(key) && (this.addedSinceLoad.has(key) || remoteKeys.has(key))) {
+        merged.set(key, createdAt);
       }
     }
 
@@ -72,6 +83,7 @@ export class ReadStateStore {
     for (const record of trimmed) {
       this.items.set(record.key, record.createdAt);
     }
+    this.addedSinceLoad.clear();
     this.removedSinceLoad.clear();
   }
 
@@ -119,6 +131,8 @@ export class ReadStateStore {
     if (!this.loaded) { await this.load(); }
     if (this.items.has(key)) { return false; }
     this.items.set(key, Date.now());
+    this.addedSinceLoad.add(key);
+    this.removedSinceLoad.delete(key);
     await this.persist();
     this._onDidChange.fire();
     return true;
@@ -132,6 +146,8 @@ export class ReadStateStore {
     for (const key of keys) {
       if (!this.items.has(key)) {
         this.items.set(key, Date.now());
+        this.addedSinceLoad.add(key);
+        this.removedSinceLoad.delete(key);
         newlyAdded.push(key);
       }
     }
@@ -152,6 +168,7 @@ export class ReadStateStore {
     for (const key of keys) {
       if (this.items.delete(key)) {
         changed = true;
+        this.addedSinceLoad.delete(key);
         this.removedSinceLoad.add(key);
       }
     }
@@ -220,6 +237,7 @@ export class ReadStateStore {
     if (trimmedRecords.length > 0) {
       logger.debug(`Loaded read state: ${this.items.size} entries`);
     }
+    this.addedSinceLoad.clear();
     this.removedSinceLoad.clear();
     this.loaded = true;
   }
@@ -234,6 +252,7 @@ export class ReadStateStore {
    */
   invalidateCache(): void {
     this.items.clear();
+    this.addedSinceLoad.clear();
     this.removedSinceLoad.clear();
     this.loaded = false;
   }

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -7,6 +7,7 @@ const MAX_TOTAL_ENTRIES = 5_000;
 
 interface PersistedReadStateRecord {
   key: string;
+  /** First-seen timestamp used for FIFO eviction of persisted read-state entries. */
   createdAt: number;
 }
 
@@ -39,9 +40,9 @@ export class ReadStateStore {
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   /** Fires whenever the set of read keys changes (add, addMany, deleteMany, prune). */
   readonly onDidChange = this._onDidChange.event;
-  /** Keys added locally since last load — ensures local additions survive remote merges. */
+  /** Keys added locally since the last load or persist — ensures local additions survive remote merges. */
   private readonly addedSinceLoad = new Set<string>();
-  /** Keys removed locally since last load — prevents re-adding from stale remote data. */
+  /** Keys removed locally since the last load or persist — prevents re-adding from stale remote data. */
   private readonly removedSinceLoad = new Set<string>();
 
   constructor(private readonly fileStore: FileStore<unknown[]>) {}

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -81,7 +81,8 @@ export class ReadStateStore {
 
     for (const [key, createdAt] of this.items) {
       if (!this.removedSinceLoad.has(key) && (!snapshot.available || this.addedSinceLoad.has(key) || remoteKeys.has(key))) {
-        merged.set(key, createdAt);
+        const existingCreatedAt = merged.get(key);
+        merged.set(key, existingCreatedAt === undefined ? createdAt : Math.min(existingCreatedAt, createdAt));
       }
     }
 
@@ -133,6 +134,7 @@ export class ReadStateStore {
       invalidCount++;
     }
 
+    const available = invalidCount === 0;
     if (invalidCount > 0) {
       logger.warn(`Skipped ${invalidCount} invalid read state entries (expected strings or { key, createdAt })`);
     }
@@ -145,7 +147,7 @@ export class ReadStateStore {
       }
     }
 
-    return { records: Array.from(deduped.values()), available: true };
+    return { records: Array.from(deduped.values()), available };
   }
 
   /** Returns true only when the key is newly added. Persists automatically. */

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -134,7 +134,7 @@ export class ReadStateStore {
     return true;
   }
 
-  /** Adds multiple keys in a single write. Returns keys that were newly added. */
+  /** Adds multiple keys in a single write. Returns newly added keys that remain persisted after capacity trimming. */
   async addMany(keys: string[]): Promise<string[]> {
     if (keys.length === 0) { return []; }
     if (!this.loaded) { await this.load(); }
@@ -151,7 +151,7 @@ export class ReadStateStore {
       await this.persist();
       this._onDidChange.fire();
     }
-    return newlyAdded;
+    return newlyAdded.filter(key => this.items.has(key));
   }
 
   keys(): IterableIterator<string> {

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -11,6 +11,11 @@ interface PersistedReadStateRecord {
   createdAt: number;
 }
 
+interface ReadStateSnapshot {
+  records: PersistedReadStateRecord[];
+  available: boolean;
+}
+
 function trimReadStateRecords(records: PersistedReadStateRecord[]): PersistedReadStateRecord[] {
   if (records.length <= MAX_TOTAL_ENTRIES) {
     return records;
@@ -56,18 +61,26 @@ export class ReadStateStore {
    * keys, and writes the merged result.
    */
   private async persist(): Promise<void> {
-    const remoteRecords = await this.parseFromFileStore();
-    const remoteKeys = new Set(remoteRecords.map(record => record.key));
+    const snapshot = await this.parseFromFileStore();
+    const remoteKeys = new Set(snapshot.records.map(record => record.key));
     const merged = new Map<string, number>();
 
-    for (const remote of remoteRecords) {
-      if (!this.removedSinceLoad.has(remote.key)) {
-        merged.set(remote.key, remote.createdAt);
+    if (snapshot.available) {
+      for (const remote of snapshot.records) {
+        if (!this.removedSinceLoad.has(remote.key)) {
+          merged.set(remote.key, remote.createdAt);
+        }
+      }
+    } else {
+      for (const [key, createdAt] of this.items) {
+        if (!this.removedSinceLoad.has(key)) {
+          merged.set(key, createdAt);
+        }
       }
     }
 
     for (const [key, createdAt] of this.items) {
-      if (!this.removedSinceLoad.has(key) && (this.addedSinceLoad.has(key) || remoteKeys.has(key))) {
+      if (!this.removedSinceLoad.has(key) && (!snapshot.available || this.addedSinceLoad.has(key) || remoteKeys.has(key))) {
         merged.set(key, createdAt);
       }
     }
@@ -84,10 +97,13 @@ export class ReadStateStore {
     this.removedSinceLoad.clear();
   }
 
-  private async parseFromFileStore(): Promise<PersistedReadStateRecord[]> {
+  private async parseFromFileStore(): Promise<ReadStateSnapshot> {
     const parsed = await this.fileStore.read();
+    if (parsed === undefined) {
+      return { records: [], available: false };
+    }
     if (!Array.isArray(parsed)) {
-      return [];
+      return { records: [], available: true };
     }
 
     const records: PersistedReadStateRecord[] = [];
@@ -128,7 +144,7 @@ export class ReadStateStore {
       }
     }
 
-    return Array.from(deduped.values());
+    return { records: Array.from(deduped.values()), available: true };
   }
 
   /** Returns true only when the key is newly added. Persists automatically. */
@@ -229,7 +245,8 @@ export class ReadStateStore {
 
   async load(): Promise<void> {
     if (this.loaded) { return; }
-    const records = await this.parseFromFileStore();
+    const snapshot = await this.parseFromFileStore();
+    const records = snapshot.records;
     const trimmedRecords = trimReadStateRecords(records);
     this.items.clear();
     if (trimmedRecords.length !== records.length) {

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -103,7 +103,8 @@ export class ReadStateStore {
       return { records: [], available: false };
     }
     if (!Array.isArray(parsed)) {
-      return { records: [], available: true };
+      logger.warn('Read state snapshot is not an array; falling back to the in-memory snapshot');
+      return { records: [], available: false };
     }
 
     const records: PersistedReadStateRecord[] = [];

--- a/packages/core/src/storage/trimByAge.ts
+++ b/packages/core/src/storage/trimByAge.ts
@@ -1,0 +1,51 @@
+import { logger } from '../services/logger';
+
+export function trimByAge<T>(
+  records: T[],
+  options: {
+    maxEntries: number;
+    getTimestamp: (record: T) => number;
+    getKey: (record: T) => string;
+    /** Records for which this returns true are NEVER evicted. */
+    isProtected?: (record: T) => boolean;
+  },
+): T[] {
+  if (records.length <= options.maxEntries) {
+    return records;
+  }
+
+  const metadata = records.map((record, index) => {
+    const key = options.getKey(record);
+    return {
+      record,
+      index,
+      key,
+      evictionId: `${key}\u0000${index}`,
+      timestamp: options.getTimestamp(record),
+      isProtected: options.isProtected?.(record) ?? false,
+    };
+  });
+
+  const protectedCount = metadata.filter(entry => entry.isProtected).length;
+  if (protectedCount > options.maxEntries) {
+    logger.warn(
+      `trimByAge retained ${protectedCount} protected records, exceeding the ${options.maxEntries}-entry cap because protected records cannot be evicted`,
+    );
+    return metadata
+      .filter(entry => entry.isProtected)
+      .map(entry => entry.record);
+  }
+
+  const unprotectedToEvict = records.length - options.maxEntries;
+  const recordsToEvict = new Set(
+    metadata
+      .filter(entry => !entry.isProtected)
+      .sort((a, b) => a.timestamp - b.timestamp || a.index - b.index)
+      .slice(0, unprotectedToEvict)
+      .map(entry => entry.evictionId),
+  );
+
+  return metadata
+    .filter(entry => !recordsToEvict.has(entry.evictionId))
+    .map(entry => entry.record);
+}

--- a/packages/core/src/storage/watchStore.ts
+++ b/packages/core/src/storage/watchStore.ts
@@ -1,7 +1,8 @@
 import type { PRIdentifier } from '@devdocket/shared';
 import { logger } from '../services/logger';
+import type { WatchedPR, WatchedRun } from '../services/watcherService';
 import type { FileStore } from './fileStore';
-import type { WatchedRun, WatchedPR } from '../services/watcherService';
+import { trimByAge } from './trimByAge';
 
 /**
  * Persisted shape: either a legacy plain array of WatchedRun, or the
@@ -12,12 +13,69 @@ interface WatchStoreData {
   prs: WatchedPR[];
 }
 
+// 1,000 per watch type is far above typical manual watch usage, but still keeps
+// pathological accumulation bounded without evicting active watches.
+const MAX_WATCHED_RUNS = 1_000;
+const MAX_WATCHED_PRS = 1_000;
+
 function getRunKey(run: WatchedRun): string {
   return `${run.identifier.providerId}::${run.identifier.repo}::${run.identifier.runId}`;
 }
 
 function getPRKey(pr: WatchedPR): string {
   return `${pr.identifier.providerId}::${pr.identifier.repo}::${pr.identifier.prId}`;
+}
+
+function getWatchedAtTimestamp(value: string | undefined): number {
+  if (!value) {
+    return 0;
+  }
+
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : 0;
+}
+
+function isActiveRun(run: WatchedRun): boolean {
+  return run.status.overallState !== 'completed';
+}
+
+function isActivePR(pr: WatchedPR): boolean {
+  return pr.prState === 'open';
+}
+
+function isWatchedRun(value: unknown): value is WatchedRun {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const obj = value as Record<string, unknown>;
+  return obj.identifier !== undefined && obj.status !== undefined;
+}
+
+function isWatchedPR(value: unknown): value is WatchedPR {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const obj = value as Record<string, unknown>;
+  return obj.identifier !== undefined && typeof obj.prState === 'string';
+}
+
+function trimWatchStoreData(data: WatchStoreData): WatchStoreData {
+  return {
+    runs: trimByAge(data.runs, {
+      maxEntries: MAX_WATCHED_RUNS,
+      getTimestamp: run => getWatchedAtTimestamp((run as Partial<WatchedRun>).watchedAt),
+      getKey: getRunKey,
+      isProtected: isActiveRun,
+    }),
+    prs: trimByAge(data.prs, {
+      maxEntries: MAX_WATCHED_PRS,
+      getTimestamp: pr => getWatchedAtTimestamp((pr as Partial<WatchedPR>).watchedAt),
+      getKey: getPRKey,
+      isProtected: isActivePR,
+    }),
+  };
 }
 
 /**
@@ -40,12 +98,10 @@ export class WatchStore {
 
     // Legacy migration: plain array → envelope
     if (Array.isArray(parsed)) {
-      const runs = parsed.filter((item: unknown) => {
-        if (typeof item !== 'object' || item === null) return false;
-        const obj = item as Record<string, unknown>;
-        return obj.identifier && obj.status && typeof obj.watchedAt === 'string';
-      }) as WatchedRun[];
-      return { runs, prs: [] };
+      return {
+        runs: parsed.filter(isWatchedRun),
+        prs: [],
+      };
     }
 
     if (typeof parsed !== 'object' || parsed === null) {
@@ -55,19 +111,11 @@ export class WatchStore {
 
     const data = parsed as Record<string, unknown>;
     const runs = Array.isArray(data.runs)
-      ? (data.runs as unknown[]).filter((item: unknown) => {
-          if (typeof item !== 'object' || item === null) return false;
-          const obj = item as Record<string, unknown>;
-          return obj.identifier && obj.status && typeof obj.watchedAt === 'string';
-        }) as WatchedRun[]
+      ? (data.runs as unknown[]).filter(isWatchedRun)
       : [];
 
     const prs = Array.isArray(data.prs)
-      ? (data.prs as unknown[]).filter((item: unknown) => {
-          if (typeof item !== 'object' || item === null) return false;
-          const obj = item as Record<string, unknown>;
-          return obj.identifier && typeof obj.watchedAt === 'string' && typeof obj.prState === 'string';
-        }) as WatchedPR[]
+      ? (data.prs as unknown[]).filter(isWatchedPR)
       : [];
 
     return { runs, prs };
@@ -80,9 +128,27 @@ export class WatchStore {
    */
   async loadAll(): Promise<WatchStoreData> {
     const data = await this.readFromFile();
-    this.lastSeenRunKeys = new Set(data.runs.map(getRunKey));
-    this.lastSeenPRKeys = new Set(data.prs.map(getPRKey));
-    return data;
+    const trimmedData = trimWatchStoreData(data);
+    const droppedRuns = data.runs.length - trimmedData.runs.length;
+    const droppedPRs = data.prs.length - trimmedData.prs.length;
+
+    if (droppedRuns > 0 || droppedPRs > 0) {
+      try {
+        await this.fileStore.write(trimmedData);
+        logger.warn(
+          `Trimmed watches.json while loading to enforce caps: dropped ${droppedRuns} run watch(es) and ${droppedPRs} PR watch(es); caps are ${MAX_WATCHED_RUNS} runs and ${MAX_WATCHED_PRS} PRs`,
+        );
+      } catch (err) {
+        logger.warn(
+          `Failed to persist trimmed watches while loading; continuing with ${trimmedData.runs.length} run watch(es) and ${trimmedData.prs.length} PR watch(es) in memory`,
+          err,
+        );
+      }
+    }
+
+    this.lastSeenRunKeys = new Set(trimmedData.runs.map(getRunKey));
+    this.lastSeenPRKeys = new Set(trimmedData.prs.map(getPRKey));
+    return trimmedData;
   }
 
   /**
@@ -126,11 +192,13 @@ export class WatchStore {
       mergedPRs.set(getPRKey(pr), pr);
     }
 
-    await this.fileStore.write({
+    const trimmedData = trimWatchStoreData({
       runs: Array.from(mergedRuns.values()),
       prs: Array.from(mergedPRs.values()),
     });
-    this.lastSeenRunKeys = runKeys;
-    this.lastSeenPRKeys = prKeys;
+
+    await this.fileStore.write(trimmedData);
+    this.lastSeenRunKeys = new Set(trimmedData.runs.map(getRunKey));
+    this.lastSeenPRKeys = new Set(trimmedData.prs.map(getPRKey));
   }
 }

--- a/packages/core/src/test/extension.test.ts
+++ b/packages/core/src/test/extension.test.ts
@@ -54,6 +54,11 @@ function getMainProvider(): MainViewProvider {
   return registerWebviewViewProvider.mock.calls[0][1] as MainViewProvider;
 }
 
+function readReadStateKeys(fileSystem: MockFileSystem, fileUri: vscode.Uri): string[] {
+  const records = fileSystem.readJson<Array<string | { key: string }>>(fileUri) ?? [];
+  return records.map(record => typeof record === 'string' ? record : record.key);
+}
+
 describe('activate()', () => {
   let context: vscode.ExtensionContext;
   let fileSystem: MockFileSystem;
@@ -291,7 +296,7 @@ describe('activate()', () => {
 
       await vi.waitFor(() => {
         expect(pruneSpy).toHaveBeenCalled();
-        expect(fileSystem.readJson<string[]>(vscode.Uri.joinPath(context.globalStorageUri, 'read-state.json'))).toEqual([
+        expect(readReadStateKeys(fileSystem, vscode.Uri.joinPath(context.globalStorageUri, 'read-state.json'))).toEqual([
           'prune-provider::keep',
           'other-provider::stale',
         ]);
@@ -336,7 +341,7 @@ describe('activate()', () => {
 
       const active = pruneSpy.mock.calls.at(-1)?.[0] as Map<string, unknown[]>;
       expect(active.get('empty-provider')).toEqual([]);
-      expect(fileSystem.readJson<string[]>(vscode.Uri.joinPath(context.globalStorageUri, 'read-state.json'))).toEqual(['empty-provider::stale']);
+      expect(readReadStateKeys(fileSystem, vscode.Uri.joinPath(context.globalStorageUri, 'read-state.json'))).toEqual(['empty-provider::stale']);
       expect(fileSystem.readJson<Array<{ providerId: string; externalId: string }>>(vscode.Uri.joinPath(context.globalStorageUri, 'inbox-state.json'))).toEqual([
         { providerId: 'empty-provider', externalId: 'stale', inboxState: 'accepted' },
       ]);
@@ -425,7 +430,7 @@ describe('activate()', () => {
       await flushMicrotasks();
 
       expect(pruneSpy).not.toHaveBeenCalled();
-      expect(fileSystem.readJson<string[]>(vscode.Uri.joinPath(context.globalStorageUri, 'read-state.json'))).toEqual(['truncated-provider::stale']);
+      expect(readReadStateKeys(fileSystem, vscode.Uri.joinPath(context.globalStorageUri, 'read-state.json'))).toEqual(['truncated-provider::stale']);
       const discoveredRecords = fileSystem.readJson<Array<{ providerId: string; externalId: string }>>(vscode.Uri.joinPath(context.globalStorageUri, 'inbox-state.json')) ?? [];
       expect(discoveredRecords.some(record => record.providerId === 'truncated-provider' && record.externalId === 'stale')).toBe(true);
     } finally {

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -212,6 +212,23 @@ describe('InboxStateStore', () => {
     store2.dispose();
   });
 
+  it('keeps cached inbox records when the remote snapshot is temporarily unavailable', async () => {
+    fileSystem.writeJson(fileUri, [
+      { providerId: 'gh', externalId: 'keep', inboxState: 'accepted', createdAt: 1 },
+    ]);
+
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    await store2.load();
+    await vscode.workspace.fs.delete(fileUri);
+    await store2.setState('gh', 'fresh', 'dismissed');
+
+    expect((await store2.loadAll()).sort((a, b) => a.externalId.localeCompare(b.externalId))).toEqual([
+      { providerId: 'gh', externalId: 'fresh', inboxState: 'dismissed' },
+      { providerId: 'gh', externalId: 'keep', inboxState: 'accepted' },
+    ]);
+    store2.dispose();
+  });
+
   // ── Schema validation ─────────────────────────────────────────────
 
   describe('schema validation', () => {

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -193,6 +193,25 @@ describe('InboxStateStore', () => {
     store2.dispose();
   });
 
+  it('deduplicates persisted inbox-state records while keeping the newest timestamp', async () => {
+    fileSystem.writeJson(fileUri, [
+      { providerId: 'gh', externalId: 'dup', inboxState: 'accepted', createdAt: 1 },
+      { providerId: 'gh', externalId: 'dup', inboxState: 'dismissed', createdAt: 5 },
+      { providerId: 'gh', externalId: 'other', inboxState: 'unseen', createdAt: 3 },
+    ]);
+
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    const records = await store2.loadAll();
+
+    expect(records).toEqual([
+      { providerId: 'gh', externalId: 'dup', inboxState: 'dismissed' },
+      { providerId: 'gh', externalId: 'other', inboxState: 'unseen' },
+    ]);
+    expect(store2.getState('gh', 'dup')).toBe('dismissed');
+    expect(store2.getState('gh', 'other')).toBe('unseen');
+    store2.dispose();
+  });
+
   // ── Schema validation ─────────────────────────────────────────────
 
   describe('schema validation', () => {

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -2,12 +2,22 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { InboxStateStore } from '../storage/inboxStateStore';
 import { JsonFileStore } from '../storage/fileStore';
+import { logger } from '../services/logger';
 import { useMockFileSystem, type MockFileSystem } from './testFileSystem';
 
 describe('InboxStateStore', () => {
   const fileUri = vscode.Uri.file('C:\\test\\inbox-state.json');
   let fileSystem: MockFileSystem;
   let store: InboxStateStore;
+
+  const persistedRecords = () => fileSystem.readJson<Array<{
+    providerId: string;
+    externalId: string;
+    inboxState: string;
+    version?: string;
+    resurfaceVersion?: string;
+    createdAt?: number;
+  }>>(fileUri) ?? [];
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -30,13 +40,14 @@ describe('InboxStateStore', () => {
   it('should create a record and persist on setState', async () => {
     await store.setState('gh', 'issue-1', 'unseen');
 
-    const persisted = fileSystem.readJson<unknown[]>(fileUri);
+    const persisted = persistedRecords();
     expect(persisted).toHaveLength(1);
-    expect(persisted![0]).toEqual({
+    expect(persisted[0]).toEqual(expect.objectContaining({
       providerId: 'gh',
       externalId: 'issue-1',
       inboxState: 'unseen',
-    });
+      createdAt: expect.any(Number),
+    }));
   });
 
   it('should return state for a known item from getState', async () => {
@@ -101,6 +112,59 @@ describe('InboxStateStore', () => {
 
     expect(store2.getState('gh', 'issue-1')).toBe('accepted');
     expect(store2.getState('gh', 'issue-2')).toBe('dismissed');
+    store2.dispose();
+  });
+
+  it('persists createdAt timestamps for new records', async () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(1_234);
+
+    try {
+      await store.setState('gh', 'issue-1', 'accepted');
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(persistedRecords()[0]).toEqual(expect.objectContaining({
+      providerId: 'gh',
+      externalId: 'issue-1',
+      inboxState: 'accepted',
+      createdAt: 1_234,
+    }));
+  });
+
+  it('preserves createdAt timestamps across reload and rewrite', async () => {
+    fileSystem.writeJson(fileUri, [
+      { providerId: 'gh', externalId: 'issue-1', inboxState: 'accepted', createdAt: 321 },
+    ]);
+
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    await store2.load();
+    await store2.setState('gh', 'issue-1', 'dismissed');
+
+    expect(persistedRecords()[0]).toEqual(expect.objectContaining({
+      providerId: 'gh',
+      externalId: 'issue-1',
+      inboxState: 'dismissed',
+      createdAt: 321,
+    }));
+    expect(await store2.loadAll()).toEqual([
+      { providerId: 'gh', externalId: 'issue-1', inboxState: 'dismissed' },
+    ]);
+    store2.dispose();
+  });
+
+  it('loads legacy records that do not have createdAt timestamps', async () => {
+    fileSystem.writeJson(fileUri, [
+      { providerId: 'gh', externalId: 'legacy', inboxState: 'accepted' },
+    ]);
+
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    const records = await store2.loadAll();
+
+    expect(records).toEqual([
+      { providerId: 'gh', externalId: 'legacy', inboxState: 'accepted' },
+    ]);
+    expect(store2.getState('gh', 'legacy')).toBe('accepted');
     store2.dispose();
   });
 
@@ -670,6 +734,52 @@ describe('InboxStateStore', () => {
   });
 
   // ── prune ──────────────────────────────────────────────────────────
+
+  describe('capacity management', () => {
+    it('caps persisted records and evicts the oldest records first on write', async () => {
+      let currentTime = 0;
+      const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => currentTime++);
+
+      try {
+        await store.setStates(Array.from({ length: 6_000 }, (_, i) => ({
+          providerId: 'gh',
+          externalId: `issue-${i}`,
+          state: 'accepted' as const,
+        })));
+      } finally {
+        nowSpy.mockRestore();
+      }
+
+      const records = await store.loadAll();
+      expect(records).toHaveLength(4_800);
+      expect(persistedRecords()).toHaveLength(4_800);
+      expect(store.getState('gh', 'issue-0')).toBeUndefined();
+      expect(store.getState('gh', 'issue-1199')).toBeUndefined();
+      expect(store.getState('gh', 'issue-1200')).toBe('accepted');
+      expect(store.getState('gh', 'issue-5999')).toBe('accepted');
+    });
+
+    it('trims oversized persisted state on load and logs once', async () => {
+      const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+      fileSystem.writeJson(fileUri, Array.from({ length: 6_000 }, (_, i) => ({
+        providerId: 'gh',
+        externalId: `issue-${i}`,
+        inboxState: 'dismissed',
+        createdAt: i,
+      })));
+
+      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      await store2.load();
+
+      expect(await store2.loadAll()).toHaveLength(4_800);
+      expect(persistedRecords()).toHaveLength(4_800);
+      expect(store2.getState('gh', 'issue-0')).toBeUndefined();
+      expect(store2.getState('gh', 'issue-1200')).toBe('dismissed');
+      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Trimmed inbox-state.json from 6000 to 4800 entries while loading'));
+      store2.dispose();
+      infoSpy.mockRestore();
+    });
+  });
 
   describe('prune', () => {
     it('should remove stale records for providers that have active items', async () => {

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -79,18 +79,22 @@ describe('InboxStateStore', () => {
 
     const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
     store2.onDidChange(listener);
-    await store2.load();
-    await store2.setState('gh', 'issue-1', 'accepted');
 
-    expect(listener).not.toHaveBeenCalled();
-    expect(persistedRecords()[0]).toEqual(expect.objectContaining({
-      providerId: 'gh',
-      externalId: 'issue-1',
-      inboxState: 'accepted',
-      createdAt: 321,
-    }));
-    nowSpy.mockRestore();
-    store2.dispose();
+    try {
+      await store2.load();
+      await store2.setState('gh', 'issue-1', 'accepted');
+
+      expect(listener).not.toHaveBeenCalled();
+      expect(persistedRecords()[0]).toEqual(expect.objectContaining({
+        providerId: 'gh',
+        externalId: 'issue-1',
+        inboxState: 'accepted',
+        createdAt: 321,
+      }));
+    } finally {
+      nowSpy.mockRestore();
+      store2.dispose();
+    }
   });
 
   it('should return all records from loadAll', async () => {

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -249,6 +249,26 @@ describe('InboxStateStore', () => {
     store2.dispose();
   });
 
+  it('keeps cached inbox records when the remote snapshot is an invalid array', async () => {
+    fileSystem.writeJson(fileUri, [
+      { providerId: 'gh', externalId: 'keep', inboxState: 'accepted', createdAt: 1 },
+    ]);
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    await store2.load();
+    fileSystem.writeJson(fileUri, [42]);
+    await store2.setState('gh', 'fresh', 'dismissed');
+
+    expect((await store2.loadAll()).sort((a, b) => a.externalId.localeCompare(b.externalId))).toEqual([
+      { providerId: 'gh', externalId: 'fresh', inboxState: 'dismissed' },
+      { providerId: 'gh', externalId: 'keep', inboxState: 'accepted' },
+    ]);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Skipping invalid inbox state record:'));
+    warnSpy.mockRestore();
+    store2.dispose();
+  });
+
   // ── Schema validation ─────────────────────────────────────────────
 
   describe('schema validation', () => {

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -751,11 +751,11 @@ describe('InboxStateStore', () => {
       }
 
       const records = await store.loadAll();
-      expect(records).toHaveLength(4_800);
-      expect(persistedRecords()).toHaveLength(4_800);
+      expect(records).toHaveLength(5_000);
+      expect(persistedRecords()).toHaveLength(5_000);
       expect(store.getState('gh', 'issue-0')).toBeUndefined();
-      expect(store.getState('gh', 'issue-1199')).toBeUndefined();
-      expect(store.getState('gh', 'issue-1200')).toBe('accepted');
+      expect(store.getState('gh', 'issue-999')).toBeUndefined();
+      expect(store.getState('gh', 'issue-1000')).toBe('accepted');
       expect(store.getState('gh', 'issue-5999')).toBe('accepted');
     });
 
@@ -771,11 +771,11 @@ describe('InboxStateStore', () => {
       const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
       await store2.load();
 
-      expect(await store2.loadAll()).toHaveLength(4_800);
-      expect(persistedRecords()).toHaveLength(4_800);
+      expect(await store2.loadAll()).toHaveLength(5_000);
+      expect(persistedRecords()).toHaveLength(5_000);
       expect(store2.getState('gh', 'issue-0')).toBeUndefined();
-      expect(store2.getState('gh', 'issue-1200')).toBe('dismissed');
-      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Trimmed inbox-state.json from 6000 to 4800 entries while loading'));
+      expect(store2.getState('gh', 'issue-1000')).toBe('dismissed');
+      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Trimmed inbox-state.json from 6000 to 5000 entries while loading'));
       store2.dispose();
       infoSpy.mockRestore();
     });

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -70,6 +70,29 @@ describe('InboxStateStore', () => {
     expect(records[0].inboxState).toBe('accepted');
   });
 
+  it('skips no-op setState writes', async () => {
+    fileSystem.writeJson(fileUri, [
+      { providerId: 'gh', externalId: 'issue-1', inboxState: 'accepted', createdAt: 321 },
+    ]);
+    const listener = vi.fn();
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(999);
+
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    store2.onDidChange(listener);
+    await store2.load();
+    await store2.setState('gh', 'issue-1', 'accepted');
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(persistedRecords()[0]).toEqual(expect.objectContaining({
+      providerId: 'gh',
+      externalId: 'issue-1',
+      inboxState: 'accepted',
+      createdAt: 321,
+    }));
+    nowSpy.mockRestore();
+    store2.dispose();
+  });
+
   it('should return all records from loadAll', async () => {
     await store.setState('gh', 'issue-1', 'unseen');
     await store.setState('gh', 'issue-2', 'accepted');
@@ -132,10 +155,11 @@ describe('InboxStateStore', () => {
     }));
   });
 
-  it('preserves createdAt timestamps across reload and rewrite', async () => {
+  it('refreshes createdAt timestamps when an existing record is updated', async () => {
     fileSystem.writeJson(fileUri, [
       { providerId: 'gh', externalId: 'issue-1', inboxState: 'accepted', createdAt: 321 },
     ]);
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(654);
 
     const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
     await store2.load();
@@ -145,11 +169,12 @@ describe('InboxStateStore', () => {
       providerId: 'gh',
       externalId: 'issue-1',
       inboxState: 'dismissed',
-      createdAt: 321,
+      createdAt: 654,
     }));
     expect(await store2.loadAll()).toEqual([
       { providerId: 'gh', externalId: 'issue-1', inboxState: 'dismissed' },
     ]);
+    nowSpy.mockRestore();
     store2.dispose();
   });
 
@@ -608,6 +633,27 @@ describe('InboxStateStore', () => {
       expect(store.getVersion('gh', 'pr-1')).toBe('sha-new');
     });
 
+    it('refreshes createdAt when only the version changes via setState', async () => {
+      fileSystem.writeJson(fileUri, [
+        { providerId: 'gh', externalId: 'pr-1', inboxState: 'accepted', version: 'sha-old', createdAt: 10 },
+      ]);
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(20);
+
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      await freshStore.load();
+      await freshStore.setState('gh', 'pr-1', 'accepted', 'sha-new');
+
+      expect(persistedRecords()[0]).toEqual(expect.objectContaining({
+        providerId: 'gh',
+        externalId: 'pr-1',
+        inboxState: 'accepted',
+        version: 'sha-new',
+        createdAt: 20,
+      }));
+      nowSpy.mockRestore();
+      freshStore.dispose();
+    });
+
     it('should persist version to the backing JSON file', async () => {
       await store.setState('gh', 'pr-1', 'unseen', 'sha-abc');
 
@@ -632,6 +678,55 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'pr-1', state: 'accepted' },
       ]);
       expect(store.getVersion('gh', 'pr-1')).toBe('sha-abc');
+    });
+
+    it('refreshes createdAt when setStates updates an existing record', async () => {
+      fileSystem.writeJson(fileUri, [
+        { providerId: 'gh', externalId: 'pr-1', inboxState: 'accepted', createdAt: 50 },
+      ]);
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(75);
+
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      await freshStore.load();
+      await freshStore.setStates([
+        { providerId: 'gh', externalId: 'pr-1', state: 'dismissed' },
+      ]);
+
+      expect(persistedRecords()[0]).toEqual(expect.objectContaining({
+        providerId: 'gh',
+        externalId: 'pr-1',
+        inboxState: 'dismissed',
+        createdAt: 75,
+      }));
+      nowSpy.mockRestore();
+      freshStore.dispose();
+    });
+
+    it('skips no-op setStates writes', async () => {
+      fileSystem.writeJson(fileUri, [
+        { providerId: 'gh', externalId: 'pr-1', inboxState: 'accepted', version: 'sha-1', resurfaceVersion: 'rv-1', createdAt: 44 },
+      ]);
+      const listener = vi.fn();
+      const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(99);
+
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      freshStore.onDidChange(listener);
+      await freshStore.load();
+      await freshStore.setStates([
+        { providerId: 'gh', externalId: 'pr-1', state: 'accepted', version: 'sha-1', resurfaceVersion: 'rv-1' },
+      ]);
+
+      expect(listener).not.toHaveBeenCalled();
+      expect(persistedRecords()[0]).toEqual(expect.objectContaining({
+        providerId: 'gh',
+        externalId: 'pr-1',
+        inboxState: 'accepted',
+        version: 'sha-1',
+        resurfaceVersion: 'rv-1',
+        createdAt: 44,
+      }));
+      nowSpy.mockRestore();
+      freshStore.dispose();
     });
 
     it('should update version in setStates when provided', async () => {

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -910,6 +910,22 @@ describe('InboxStateStore', () => {
       store2.dispose();
       infoSpy.mockRestore();
     });
+
+    it('keeps trimmed inbox entries in memory when persisting the load-time trim fails', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const failingStore = new InboxStateStore({
+        read: vi.fn(async () => Array.from({ length: 6_000 }, (_, i) => ({ providerId: 'gh', externalId: `issue-${i}`, inboxState: 'accepted', createdAt: i }))),
+        write: vi.fn(async () => { throw new Error('disk full'); }),
+      });
+
+      await expect(failingStore.load()).resolves.toBeUndefined();
+      expect((await failingStore.loadAll())).toHaveLength(5_000);
+      expect(failingStore.getState('gh', 'issue-0')).toBeUndefined();
+      expect(failingStore.getState('gh', 'issue-1000')).toBe('accepted');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to persist trimmed inbox state while loading; continuing with 5000 in-memory entries'), expect.any(Error));
+      warnSpy.mockRestore();
+      failingStore.dispose();
+    });
   });
 
   describe('prune', () => {

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -229,6 +229,26 @@ describe('InboxStateStore', () => {
     store2.dispose();
   });
 
+  it('keeps cached inbox records when the remote snapshot is malformed', async () => {
+    fileSystem.writeJson(fileUri, [
+      { providerId: 'gh', externalId: 'keep', inboxState: 'accepted', createdAt: 1 },
+    ]);
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    await store2.load();
+    fileSystem.writeJson(fileUri, { invalid: true });
+    await store2.setState('gh', 'fresh', 'dismissed');
+
+    expect((await store2.loadAll()).sort((a, b) => a.externalId.localeCompare(b.externalId))).toEqual([
+      { providerId: 'gh', externalId: 'fresh', inboxState: 'dismissed' },
+      { providerId: 'gh', externalId: 'keep', inboxState: 'accepted' },
+    ]);
+    expect(warnSpy).toHaveBeenCalledWith('Inbox state snapshot is not an array; falling back to the in-memory snapshot');
+    warnSpy.mockRestore();
+    store2.dispose();
+  });
+
   // ── Schema validation ─────────────────────────────────────────────
 
   describe('schema validation', () => {

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -289,6 +289,29 @@ describe('ReadStateStore', () => {
       store2.dispose();
       infoSpy.mockRestore();
     });
+
+    it('does not resurrect keys evicted by another window', async () => {
+      const windowA = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      const windowB = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+
+      fileSystem.writeJson(fileUri, Array.from({ length: 6_000 }, (_, i) => ({
+        key: `gh::issue-${i}`,
+        createdAt: i,
+      })));
+
+      await windowA.load();
+      await windowB.load();
+      await windowA.add('gh::fresh');
+      await windowB.add('gh::another-fresh');
+
+      expect(persistedKeys()).not.toContain('gh::issue-0');
+      expect(persistedKeys()).not.toContain('gh::issue-1199');
+      expect(persistedKeys()).toContain('gh::fresh');
+      expect(persistedKeys()).toContain('gh::another-fresh');
+
+      windowA.dispose();
+      windowB.dispose();
+    });
   });
 
   describe('prune', () => {

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -130,6 +130,26 @@ describe('ReadStateStore', () => {
     store2.dispose();
   });
 
+  it('deduplicates persisted read-state keys while keeping the oldest timestamp', async () => {
+    fileSystem.writeJson(fileUri, [
+      { key: 'gh::dup', createdAt: 5 },
+      { key: 'gh::dup', createdAt: 1 },
+      { key: 'gh::other', createdAt: 3 },
+    ]);
+
+    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+    await store2.load();
+    await store2.add('gh::fresh');
+
+    expect([...store2.keys()].sort()).toEqual(['gh::dup', 'gh::fresh', 'gh::other']);
+    expect(persistedRecords()).toEqual([
+      { key: 'gh::dup', createdAt: 1 },
+      { key: 'gh::other', createdAt: 3 },
+      { key: 'gh::fresh', createdAt: expect.any(Number) },
+    ]);
+    store2.dispose();
+  });
+
   it('should skip non-string elements in the array', async () => {
     fileSystem.writeJson(fileUri, ['valid::1', 42, null, true, 'valid::2', { obj: true }]);
 

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -377,6 +377,21 @@ describe('ReadStateStore', () => {
       expect(persistedKeys().sort()).toEqual(['gh::fresh', 'gh::keep']);
       store2.dispose();
     });
+
+    it('keeps cached keys when the remote snapshot is malformed', async () => {
+      fileSystem.writeJson(fileUri, ['gh::keep']);
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      await store2.load();
+      fileSystem.writeJson(fileUri, { invalid: true });
+
+      await store2.add('gh::fresh');
+
+      expect(persistedKeys().sort()).toEqual(['gh::fresh', 'gh::keep']);
+      expect(warnSpy).toHaveBeenCalledWith('Read state snapshot is not an array; falling back to the in-memory snapshot');
+      warnSpy.mockRestore();
+      store2.dispose();
+    });
   });
 
   describe('prune', () => {

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -392,6 +392,21 @@ describe('ReadStateStore', () => {
       warnSpy.mockRestore();
       store2.dispose();
     });
+
+    it('keeps cached keys when the remote snapshot is an invalid array', async () => {
+      fileSystem.writeJson(fileUri, ['gh::keep']);
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      await store2.load();
+      fileSystem.writeJson(fileUri, [42]);
+
+      await store2.add('gh::fresh');
+
+      expect(persistedKeys().sort()).toEqual(['gh::fresh', 'gh::keep']);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Skipped 1 invalid read state entries'));
+      warnSpy.mockRestore();
+      store2.dispose();
+    });
   });
 
   describe('prune', () => {

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -349,6 +349,18 @@ describe('ReadStateStore', () => {
       windowA.dispose();
       windowB.dispose();
     });
+
+    it('keeps cached keys when the remote snapshot is temporarily unavailable', async () => {
+      fileSystem.writeJson(fileUri, ['gh::keep']);
+      const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      await store2.load();
+      await vscode.workspace.fs.delete(fileUri);
+
+      await store2.add('gh::fresh');
+
+      expect(persistedKeys().sort()).toEqual(['gh::fresh', 'gh::keep']);
+      store2.dispose();
+    });
   });
 
   describe('prune', () => {

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -263,11 +263,11 @@ describe('ReadStateStore', () => {
         nowSpy.mockRestore();
       }
 
-      expect([...store.keys()]).toHaveLength(4_800);
-      expect(persistedRecords()).toHaveLength(4_800);
+      expect([...store.keys()]).toHaveLength(5_000);
+      expect(persistedRecords()).toHaveLength(5_000);
       expect(store.has('gh::issue-0')).toBe(false);
-      expect(store.has('gh::issue-1199')).toBe(false);
-      expect(store.has('gh::issue-1200')).toBe(true);
+      expect(store.has('gh::issue-999')).toBe(false);
+      expect(store.has('gh::issue-1000')).toBe(true);
       expect(store.has('gh::issue-5999')).toBe(true);
     });
 
@@ -281,11 +281,11 @@ describe('ReadStateStore', () => {
       const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
       await store2.load();
 
-      expect([...store2.keys()]).toHaveLength(4_800);
-      expect(persistedRecords()).toHaveLength(4_800);
+      expect([...store2.keys()]).toHaveLength(5_000);
+      expect(persistedRecords()).toHaveLength(5_000);
       expect(store2.has('gh::issue-0')).toBe(false);
-      expect(store2.has('gh::issue-1200')).toBe(true);
-      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Trimmed read-state.json from 6000 to 4800 entries while loading'));
+      expect(store2.has('gh::issue-1000')).toBe(true);
+      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Trimmed read-state.json from 6000 to 5000 entries while loading'));
       store2.dispose();
       infoSpy.mockRestore();
     });
@@ -305,7 +305,7 @@ describe('ReadStateStore', () => {
       await windowB.add('gh::another-fresh');
 
       expect(persistedKeys()).not.toContain('gh::issue-0');
-      expect(persistedKeys()).not.toContain('gh::issue-1199');
+      expect(persistedKeys()).not.toContain('gh::issue-999');
       expect(persistedKeys()).toContain('gh::fresh');
       expect(persistedKeys()).toContain('gh::another-fresh');
 

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -3,12 +3,16 @@ import * as vscode from 'vscode';
 import type { ProviderItem } from '../api/types';
 import { ReadStateStore } from '../storage/readStateStore';
 import { JsonFileStore } from '../storage/fileStore';
+import { logger } from '../services/logger';
 import { useMockFileSystem, type MockFileSystem } from './testFileSystem';
 
 describe('ReadStateStore', () => {
   const fileUri = vscode.Uri.file('C:\\test\\read-state.json');
   let fileSystem: MockFileSystem;
   let store: ReadStateStore;
+
+  const persistedRecords = () => fileSystem.readJson<Array<{ key: string; createdAt?: number }>>(fileUri) ?? [];
+  const persistedKeys = () => persistedRecords().map(record => record.key);
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -25,12 +29,12 @@ describe('ReadStateStore', () => {
     expect(store.has('gh::1')).toBe(false);
   });
 
-  it('should add a key and persist to globalState', async () => {
+  it('should add a key and persist to the file store', async () => {
     await store.load();
     expect(await store.add('gh::issue-1')).toBe(true);
 
-    const persisted = fileSystem.readJson<string[]>(fileUri);
-    expect(persisted).toEqual(['gh::issue-1']);
+    const persisted = persistedRecords();
+    expect(persisted).toEqual([{ key: 'gh::issue-1', createdAt: expect.any(Number) }]);
   });
 
   it('should return false when adding a duplicate key', async () => {
@@ -57,8 +61,8 @@ describe('ReadStateStore', () => {
     expect(store.has('gh::2')).toBe(true);
     expect(store.has('gh::3')).toBe(false);
 
-    const persisted = fileSystem.readJson<string[]>(fileUri);
-    expect(persisted).toEqual(['gh::2']);
+    const persisted = persistedRecords();
+    expect(persisted).toEqual([{ key: 'gh::2', createdAt: expect.any(Number) }]);
   });
 
   it('should ignore non-existent keys in deleteMany', async () => {
@@ -87,6 +91,43 @@ describe('ReadStateStore', () => {
     expect(store2.has('gh::1')).toBe(true);
     expect(store2.has('jira::2')).toBe(true);
     expect(store2.has('gh::3')).toBe(false);
+  });
+
+  it('persists createdAt timestamps for new keys', async () => {
+    const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(4_321);
+
+    try {
+      await store.load();
+      await store.add('gh::timed');
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(persistedRecords()).toEqual([{ key: 'gh::timed', createdAt: 4_321 }]);
+  });
+
+  it('preserves createdAt timestamps across reload and rewrite', async () => {
+    fileSystem.writeJson(fileUri, [{ key: 'gh::legacy', createdAt: 123 }]);
+
+    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+    await store2.load();
+    await store2.add('gh::new');
+
+    expect(persistedRecords()).toEqual(expect.arrayContaining([
+      expect.objectContaining({ key: 'gh::legacy', createdAt: 123 }),
+      expect.objectContaining({ key: 'gh::new', createdAt: expect.any(Number) }),
+    ]));
+    store2.dispose();
+  });
+
+  it('loads legacy string entries without createdAt timestamps', async () => {
+    fileSystem.writeJson(fileUri, ['gh::legacy']);
+
+    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+    await store2.load();
+
+    expect(store2.has('gh::legacy')).toBe(true);
+    store2.dispose();
   });
 
   it('should skip non-string elements in the array', async () => {
@@ -154,7 +195,7 @@ describe('ReadStateStore', () => {
       await windowB.add('gh::remote');
       await windowA.add('gh::local');
 
-      expect(fileSystem.readJson<string[]>(fileUri)?.sort()).toEqual(['gh::local', 'gh::remote']);
+      expect(persistedKeys().sort()).toEqual(['gh::local', 'gh::remote']);
 
       windowA.dispose();
       windowB.dispose();
@@ -172,7 +213,7 @@ describe('ReadStateStore', () => {
       await windowA.deleteMany(['gh::remove']);
 
       expect([...windowA.keys()].sort()).toEqual(['gh::keep', 'gh::remote']);
-      expect(fileSystem.readJson<string[]>(fileUri)?.sort()).toEqual(['gh::keep', 'gh::remote']);
+      expect(persistedKeys().sort()).toEqual(['gh::keep', 'gh::remote']);
 
       windowA.dispose();
       windowB.dispose();
@@ -192,7 +233,7 @@ describe('ReadStateStore', () => {
 
       await windowA.add('gh::local');
 
-      expect(fileSystem.readJson<string[]>(fileUri)?.sort()).toEqual(['gh::local', 'gh::shared']);
+      expect(persistedKeys().sort()).toEqual(['gh::local', 'gh::shared']);
 
       windowA.dispose();
       windowB.dispose();
@@ -207,6 +248,46 @@ describe('ReadStateStore', () => {
       await store.load();
 
       expect([...store.keys()]).toEqual(['gh::issue-2']);
+    });
+  });
+
+  describe('capacity management', () => {
+    it('caps persisted keys and evicts the oldest keys first on write', async () => {
+      let currentTime = 0;
+      const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => currentTime++);
+
+      try {
+        await store.load();
+        await store.addMany(Array.from({ length: 6_000 }, (_, i) => `gh::issue-${i}`));
+      } finally {
+        nowSpy.mockRestore();
+      }
+
+      expect([...store.keys()]).toHaveLength(4_800);
+      expect(persistedRecords()).toHaveLength(4_800);
+      expect(store.has('gh::issue-0')).toBe(false);
+      expect(store.has('gh::issue-1199')).toBe(false);
+      expect(store.has('gh::issue-1200')).toBe(true);
+      expect(store.has('gh::issue-5999')).toBe(true);
+    });
+
+    it('trims oversized persisted read state on load and logs once', async () => {
+      const infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => undefined);
+      fileSystem.writeJson(fileUri, Array.from({ length: 6_000 }, (_, i) => ({
+        key: `gh::issue-${i}`,
+        createdAt: i,
+      })));
+
+      const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      await store2.load();
+
+      expect([...store2.keys()]).toHaveLength(4_800);
+      expect(persistedRecords()).toHaveLength(4_800);
+      expect(store2.has('gh::issue-0')).toBe(false);
+      expect(store2.has('gh::issue-1200')).toBe(true);
+      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('Trimmed read-state.json from 6000 to 4800 entries while loading'));
+      store2.dispose();
+      infoSpy.mockRestore();
     });
   });
 
@@ -303,7 +384,7 @@ describe('ReadStateStore', () => {
       expect(pruned).toBe(1);
       expect(freshStore.has('gh::keep')).toBe(true);
       expect(freshStore.has('gh::stale')).toBe(false);
-      expect(fileSystem.readJson<string[]>(fileUri)).toEqual(['gh::keep']);
+      expect(persistedKeys()).toEqual(['gh::keep']);
       freshStore.dispose();
     });
 
@@ -319,7 +400,7 @@ describe('ReadStateStore', () => {
 
       expect(pruned).toBe(1);
       expect([...freshStore.keys()]).toEqual(['legacy-key']);
-      expect(fileSystem.readJson<string[]>(fileUri)).toEqual(['legacy-key']);
+      expect(persistedKeys()).toEqual(['legacy-key']);
       freshStore.dispose();
     });
 

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -327,6 +327,22 @@ describe('ReadStateStore', () => {
       infoSpy.mockRestore();
     });
 
+    it('keeps trimmed entries in memory when persisting the load-time trim fails', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      const failingStore = new ReadStateStore({
+        read: vi.fn(async () => Array.from({ length: 6_000 }, (_, i) => ({ key: `gh::issue-${i}`, createdAt: i }))),
+        write: vi.fn(async () => { throw new Error('disk full'); }),
+      });
+
+      await expect(failingStore.load()).resolves.toBeUndefined();
+      expect([...failingStore.keys()]).toHaveLength(5_000);
+      expect(failingStore.has('gh::issue-0')).toBe(false);
+      expect(failingStore.has('gh::issue-1000')).toBe(true);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to persist trimmed read state while loading; continuing with 5000 in-memory entries'), expect.any(Error));
+      warnSpy.mockRestore();
+      failingStore.dispose();
+    });
+
     it('does not resurrect keys evicted by another window', async () => {
       const windowA = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
       const windowB = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -186,6 +186,21 @@ describe('ReadStateStore', () => {
     expect(result).toEqual([]);
   });
 
+  it('addMany only returns newly added keys that remain after capacity trimming', async () => {
+    let currentTime = 0;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => currentTime++);
+
+    try {
+      await store.load();
+      await store.addMany(Array.from({ length: 4_999 }, (_, i) => `gh::seed-${i}`));
+      const retained = await store.addMany(Array.from({ length: 10 }, (_, i) => `gh::new-${i}`));
+
+      expect(retained).toEqual(Array.from({ length: 10 }, (_, i) => `gh::new-${i}`));
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+
   describe('merge-on-write', () => {
     it('preserves remote additions while persisting local changes', async () => {
       const windowA = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
@@ -258,7 +273,9 @@ describe('ReadStateStore', () => {
 
       try {
         await store.load();
-        await store.addMany(Array.from({ length: 6_000 }, (_, i) => `gh::issue-${i}`));
+        const retained = await store.addMany(Array.from({ length: 6_000 }, (_, i) => `gh::issue-${i}`));
+
+        expect(retained).toEqual(Array.from({ length: 5_000 }, (_, i) => `gh::issue-${i + 1_000}`));
       } finally {
         nowSpy.mockRestore();
       }

--- a/packages/core/src/test/trimByAge.test.ts
+++ b/packages/core/src/test/trimByAge.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { logger } from '../services/logger';
+import { trimByAge } from '../storage/trimByAge';
+
+type RecordShape = {
+  key: string;
+  timestamp: number;
+  protected?: boolean;
+};
+
+describe('trimByAge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes records through unchanged when under the cap', () => {
+    const records: RecordShape[] = [
+      { key: 'a', timestamp: 1 },
+      { key: 'b', timestamp: 2 },
+    ];
+
+    const trimmed = trimByAge(records, {
+      maxEntries: 2,
+      getTimestamp: record => record.timestamp,
+      getKey: record => record.key,
+    });
+
+    expect(trimmed).toBe(records);
+  });
+
+  it('evicts the oldest records first when over the cap', () => {
+    const trimmed = trimByAge([
+      { key: 'a', timestamp: 1 },
+      { key: 'b', timestamp: 2 },
+      { key: 'c', timestamp: 3 },
+      { key: 'd', timestamp: 4 },
+    ], {
+      maxEntries: 2,
+      getTimestamp: record => record.timestamp,
+      getKey: record => record.key,
+    });
+
+    expect(trimmed.map(record => record.key)).toEqual(['c', 'd']);
+  });
+
+  it('uses original index as a stable tiebreaker for equal timestamps', () => {
+    const trimmed = trimByAge([
+      { key: 'a', timestamp: 1 },
+      { key: 'b', timestamp: 1 },
+      { key: 'c', timestamp: 2 },
+    ], {
+      maxEntries: 2,
+      getTimestamp: record => record.timestamp,
+      getKey: record => record.key,
+    });
+
+    expect(trimmed.map(record => record.key)).toEqual(['b', 'c']);
+  });
+
+  it('never evicts protected records', () => {
+    const trimmed = trimByAge([
+      { key: 'protected-oldest', timestamp: 1, protected: true },
+      { key: 'oldest-unprotected', timestamp: 2 },
+      { key: 'newest', timestamp: 3 },
+    ], {
+      maxEntries: 2,
+      getTimestamp: record => record.timestamp,
+      getKey: record => record.key,
+      isProtected: record => record.protected === true,
+    });
+
+    expect(trimmed.map(record => record.key)).toEqual(['protected-oldest', 'newest']);
+  });
+
+  it('returns all protected records and logs once when protected entries alone exceed the cap', () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+
+    const trimmed = trimByAge([
+      { key: 'a', timestamp: 1, protected: true },
+      { key: 'b', timestamp: 2, protected: true },
+      { key: 'c', timestamp: 3, protected: true },
+      { key: 'd', timestamp: 4 },
+    ], {
+      maxEntries: 2,
+      getTimestamp: record => record.timestamp,
+      getKey: record => record.key,
+      isProtected: record => record.protected === true,
+    });
+
+    expect(trimmed.map(record => record.key)).toEqual(['a', 'b', 'c']);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('protected records'));
+  });
+});

--- a/packages/core/src/test/watchStore.test.ts
+++ b/packages/core/src/test/watchStore.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as vscode from 'vscode';
-import { WatchStore } from '../storage/watchStore';
+import { logger } from '../services/logger';
 import { JsonFileStore } from '../storage/fileStore';
-import { useMockFileSystem, type MockFileSystem } from './testFileSystem';
-import type { WatchedRun, WatchedPR } from '../services/watcherService';
+import { WatchStore } from '../storage/watchStore';
+import type { WatchedPR, WatchedRun } from '../services/watcherService';
+import { type MockFileSystem, useMockFileSystem } from './testFileSystem';
 
 vi.mock('../services/logger', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
@@ -42,6 +43,70 @@ function createTestPRWatch(overrides?: Partial<WatchedPR>): WatchedPR {
     dismissed: false,
     ...overrides,
   };
+}
+
+function isoOffset(baseMs: number, offset: number): string {
+  return new Date(baseMs + offset * 1000).toISOString();
+}
+
+function createCompletedRun(index: number, watchedAt = isoOffset(Date.UTC(2026, 0, 1), index)): WatchedRun {
+  return createTestWatch({
+    identifier: {
+      providerId: 'github-actions',
+      runId: String(index),
+      displayName: `Run ${index}`,
+      url: `https://github.com/owner/repo/actions/runs/${index}`,
+      repo: 'owner/repo',
+    },
+    status: { overallState: 'completed', conclusion: 'success', jobs: [] },
+    watchedAt,
+    lastPolledAt: watchedAt,
+  });
+}
+
+function createActiveRun(index: number, watchedAt = isoOffset(Date.UTC(2026, 1, 1), index)): WatchedRun {
+  return createTestWatch({
+    identifier: {
+      providerId: 'github-actions',
+      runId: String(index),
+      displayName: `Run ${index}`,
+      url: `https://github.com/owner/repo/actions/runs/${index}`,
+      repo: 'owner/repo',
+    },
+    status: { overallState: 'running', jobs: [] },
+    watchedAt,
+    lastPolledAt: watchedAt,
+  });
+}
+
+function createClosedPR(index: number, watchedAt = isoOffset(Date.UTC(2026, 0, 1), index)): WatchedPR {
+  return createTestPRWatch({
+    identifier: {
+      providerId: 'github-pr',
+      prId: String(index),
+      displayName: `PR #${index}`,
+      url: `https://github.com/owner/repo/pull/${index}`,
+      repo: 'owner/repo',
+    },
+    prState: 'closed',
+    watchedAt,
+    lastPolledAt: watchedAt,
+  });
+}
+
+function createOpenPR(index: number, watchedAt = isoOffset(Date.UTC(2026, 1, 1), index)): WatchedPR {
+  return createTestPRWatch({
+    identifier: {
+      providerId: 'github-pr',
+      prId: String(index),
+      displayName: `PR #${index}`,
+      url: `https://github.com/owner/repo/pull/${index}`,
+      repo: 'owner/repo',
+    },
+    prState: 'open',
+    watchedAt,
+    lastPolledAt: watchedAt,
+  });
 }
 
 describe('WatchStore', () => {
@@ -98,6 +163,44 @@ describe('WatchStore', () => {
       const result = await store.loadAll();
       expect(result.runs).toHaveLength(1);
     });
+
+    it('treats legacy entries without watchedAt as the oldest and evicts them first', async () => {
+      const legacyRun = {
+        ...createCompletedRun(-1),
+        watchedAt: undefined,
+      } as unknown as WatchedRun;
+      const legacyPR = {
+        ...createClosedPR(-1),
+        watchedAt: undefined,
+      } as unknown as WatchedPR;
+      const runs = [legacyRun, ...Array.from({ length: 1_000 }, (_, i) => createCompletedRun(i, isoOffset(Date.UTC(2026, 0, 2), i)))];
+      const prs = [legacyPR, ...Array.from({ length: 1_000 }, (_, i) => createClosedPR(i, isoOffset(Date.UTC(2026, 0, 3), i)))];
+      fileSystem.writeJson(fileUri, { runs, prs });
+
+      const loaded = await store.loadAll();
+
+      expect(loaded.runs).toHaveLength(1_000);
+      expect(loaded.prs).toHaveLength(1_000);
+      expect(loaded.runs.some(run => run.identifier.runId === '-1')).toBe(false);
+      expect(loaded.prs.some(pr => pr.identifier.prId === '-1')).toBe(false);
+    });
+
+    it('trims oversized persisted watches on load and logs once', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+      fileSystem.writeJson(fileUri, {
+        runs: Array.from({ length: 1_001 }, (_, i) => createCompletedRun(i, isoOffset(Date.UTC(2026, 0, 4), i))),
+        prs: Array.from({ length: 1_001 }, (_, i) => createClosedPR(i, isoOffset(Date.UTC(2026, 0, 5), i))),
+      });
+
+      const loaded = await store.loadAll();
+      const persisted = fileSystem.readJson<{ runs: WatchedRun[]; prs: WatchedPR[] }>(fileUri)!;
+
+      expect(loaded.runs).toHaveLength(1_000);
+      expect(loaded.prs).toHaveLength(1_000);
+      expect(persisted.runs).toHaveLength(1_000);
+      expect(persisted.prs).toHaveLength(1_000);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Trimmed watches.json while loading to enforce caps'));
+    });
   });
 
   describe('hasPRWatch', () => {
@@ -116,7 +219,7 @@ describe('WatchStore', () => {
   });
 
   describe('saveAll', () => {
-    it('saves watches to globalState in envelope format', async () => {
+    it('saves watches in envelope format', async () => {
       const watch = createTestWatch();
       const prWatch = createTestPRWatch();
       await store.saveAll([watch], [prWatch]);
@@ -126,6 +229,45 @@ describe('WatchStore', () => {
       expect(persisted!.runs[0].identifier.runId).toBe('123');
       expect(persisted!.prs).toHaveLength(1);
       expect(persisted!.prs[0].identifier.prId).toBe('42');
+    });
+
+    it('does not evict active runs or PRs when the total exceeds the cap', async () => {
+      const runs = [
+        ...Array.from({ length: 1_000 }, (_, i) => createActiveRun(i, isoOffset(Date.UTC(2026, 1, 2), i))),
+        createCompletedRun(10_001, '2026-01-01T00:00:00Z'),
+        createCompletedRun(10_002, '2026-01-01T00:00:01Z'),
+      ];
+      const prs = [
+        ...Array.from({ length: 1_000 }, (_, i) => createOpenPR(i, isoOffset(Date.UTC(2026, 1, 3), i))),
+        createClosedPR(10_001, '2026-01-01T00:00:00Z'),
+        createClosedPR(10_002, '2026-01-01T00:00:01Z'),
+      ];
+
+      await store.saveAll(runs, prs);
+      const persisted = fileSystem.readJson<{ runs: WatchedRun[]; prs: WatchedPR[] }>(fileUri)!;
+
+      expect(persisted.runs).toHaveLength(1_000);
+      expect(persisted.prs).toHaveLength(1_000);
+      expect(persisted.runs.every(run => run.status.overallState !== 'completed')).toBe(true);
+      expect(persisted.prs.every(pr => pr.prState === 'open')).toBe(true);
+    });
+
+    it('evicts terminal runs and PRs oldest-first', async () => {
+      await store.saveAll(
+        Array.from({ length: 1_002 }, (_, i) => createCompletedRun(i, isoOffset(Date.UTC(2026, 0, 6), i))),
+        Array.from({ length: 1_002 }, (_, i) => createClosedPR(i, isoOffset(Date.UTC(2026, 0, 7), i))),
+      );
+
+      const persisted = fileSystem.readJson<{ runs: WatchedRun[]; prs: WatchedPR[] }>(fileUri)!;
+
+      expect(persisted.runs).toHaveLength(1_000);
+      expect(persisted.prs).toHaveLength(1_000);
+      expect(persisted.runs.some(run => run.identifier.runId === '0')).toBe(false);
+      expect(persisted.runs.some(run => run.identifier.runId === '1')).toBe(false);
+      expect(persisted.runs.some(run => run.identifier.runId === '2')).toBe(true);
+      expect(persisted.prs.some(pr => pr.identifier.prId === '0')).toBe(false);
+      expect(persisted.prs.some(pr => pr.identifier.prId === '1')).toBe(false);
+      expect(persisted.prs.some(pr => pr.identifier.prId === '2')).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary
- cap inbox-state and read-state stores at 5,000 entries with oldest-first eviction
- stamp new persisted entries with createdAt metadata and preserve legacy entries without timestamps
- trim oversized persisted state on load, keep the zero-items prune guard, and cover the cap behavior with tests

## Testing
- npm run build
- npm run test

Closes #582

Additional scope in this PR: the inbox/read cap logic now uses a shared trimByAge helper, and WatchStore now applies the same bounded-growth protection with active-state preservation. Watch persistence caps runs and PRs at 1,000 entries each, reuses watchedAt timestamps for age-based trimming, and only evicts terminal entries so active runs and open PR watches are never trimmed out from under the user.
