### PR TITLE
Record before and after values in updated activity log entries

### DIFF
--- a/.changeset/activity-log-field-diffs.md
+++ b/.changeset/activity-log-field-diffs.md
@@ -1,0 +1,5 @@
+---
+"devdocket": patch
+---
+
+Record per-field before/after values for updated activity log entries and render structured diffs in the work item editor. Provider-synced description updates now use a generic changed marker to avoid storing large mirrored bodies in the activity log.

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -29,6 +29,7 @@ import { isSafeUrl } from './utils/url';
 import { logger, setLogger } from './services/logger';
 import { syncProviderTitles } from './services/titleSync';
 import { syncProviderDescriptions } from './services/descriptionSync';
+import { renderUpdatedActivityDetail } from './services/updateDetail';
 import { isFailedConclusion, toRunCompletionLabel } from './webview/shared/runConclusionLabels';
 import { performance } from 'perf_hooks';
 
@@ -498,6 +499,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   );
   const ar = new ActionRegistry();
   const adrr = new ActivityDetailRendererRegistry();
+  adrr.register('updated', renderUpdatedActivityDetail);
   const wr = new WatcherRegistry(logger);
   const pwr = new PRWatcherRegistry(logger);
   const watchStore = new WatchStore(createUserIntentStore(useFileBackedStorage, context.globalState, context.globalStorageUri, 'devdocket.watches', 'watches.json'));

--- a/packages/core/src/services/descriptionSync.ts
+++ b/packages/core/src/services/descriptionSync.ts
@@ -24,7 +24,7 @@ export async function syncProviderDescriptions(
     const workItem = workGraph.findItemByProvenance(providerId, discovered.externalId);
     if (workItem && 'description' in discovered && workItem.description !== discovered.description) {
       try {
-        await workGraph.updateItem(workItem.id, { description: discovered.description });
+        await workGraph.updateItem(workItem.id, { description: discovered.description }, { source: 'provider-sync' });
         logger.debug(`Synced description for ${providerId}/${discovered.externalId}`);
       } catch (err) {
         logger.error(`Failed to sync description for ${providerId}/${discovered.externalId}`, err);

--- a/packages/core/src/services/updateDetail.ts
+++ b/packages/core/src/services/updateDetail.ts
@@ -1,0 +1,204 @@
+import type { ActivityDetailRender } from '@devdocket/shared';
+import { logger } from './logger';
+
+/** Supported work-item fields that can appear in an `'updated'` activity entry. */
+export const UPDATED_DETAIL_FIELDS = ['title', 'notes', 'description', 'url'] as const;
+
+export type UpdatedDetailField = typeof UPDATED_DETAIL_FIELDS[number];
+
+export interface UpdatedFieldDiffV1 {
+  from?: string;
+  to?: string;
+}
+
+/**
+ * Versioned schema for the `detail` field of an `'updated'` activity log entry.
+ *
+ * Legacy entries stored a plain comma-separated list of changed field names.
+ * New entries store per-field before/after values so the activity log can answer
+ * historical questions like “what did the title used to be?”. Any incompatible
+ * change to this payload must bump `v` and extend {@link decodeUpdatedDetail}.
+ */
+export interface UpdatedDetailV1 {
+  v: 1;
+  changes: Partial<Record<UpdatedDetailField, UpdatedFieldDiffV1>>;
+}
+
+export type UpdatedDetailInput = Partial<Record<UpdatedDetailField, UpdatedFieldDiffV1>>;
+
+export interface LegacyUpdatedDetail {
+  kind: 'legacy';
+  fields: string[];
+}
+
+export interface VersionedUpdatedDetail {
+  kind: 'v1';
+  detail: UpdatedDetailV1;
+}
+
+export type DecodedUpdatedDetail = LegacyUpdatedDetail | VersionedUpdatedDetail;
+
+export const UPDATED_DETAIL_VERSION = 1 as const;
+export const UPDATED_DETAIL_VALUE_MAX_LENGTH = 500;
+
+export function encodeUpdatedDetail(input: Readonly<UpdatedDetailInput>): string {
+  const changes: UpdatedDetailV1['changes'] = {};
+
+  for (const field of UPDATED_DETAIL_FIELDS) {
+    const change = input[field];
+    if (!change) {
+      continue;
+    }
+
+    const encodedChange: UpdatedFieldDiffV1 = {};
+    if (change.from !== undefined) {
+      encodedChange.from = truncateUpdatedDetailValue(change.from);
+    }
+    if (change.to !== undefined) {
+      encodedChange.to = truncateUpdatedDetailValue(change.to);
+    }
+    changes[field] = encodedChange;
+  }
+
+  return JSON.stringify({ v: UPDATED_DETAIL_VERSION, changes } satisfies UpdatedDetailV1);
+}
+
+export function decodeUpdatedDetail(detail: string | undefined): DecodedUpdatedDetail | undefined {
+  if (!detail) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(detail);
+  } catch {
+    return decodeLegacyUpdatedDetail(detail);
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return undefined;
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const version = obj.v;
+  if (version !== UPDATED_DETAIL_VERSION) {
+    logger.warn(`Unknown updated activity detail version: ${String(version)}; structured diff rendering will be skipped for this entry.`);
+    return undefined;
+  }
+
+  if (typeof obj.changes !== 'object' || obj.changes === null || Array.isArray(obj.changes)) {
+    logger.warn('updated activity detail is missing an object "changes" field; structured diff rendering will be skipped for this entry.');
+    return undefined;
+  }
+
+  const rawChanges = obj.changes as Record<string, unknown>;
+  const changes: UpdatedDetailV1['changes'] = {};
+
+  for (const field of UPDATED_DETAIL_FIELDS) {
+    const rawChange = rawChanges[field];
+    if (typeof rawChange !== 'object' || rawChange === null || Array.isArray(rawChange)) {
+      continue;
+    }
+
+    const changeObject = rawChange as Record<string, unknown>;
+    const from = typeof changeObject.from === 'string' ? changeObject.from : undefined;
+    const to = typeof changeObject.to === 'string' ? changeObject.to : undefined;
+
+    const change: UpdatedFieldDiffV1 = {};
+    if (from !== undefined) {
+      change.from = from;
+    }
+    if (to !== undefined) {
+      change.to = to;
+    }
+    changes[field] = change;
+  }
+
+  if (Object.keys(changes).length === 0) {
+    logger.warn('updated activity detail did not contain any recognized field diffs; structured diff rendering will be skipped for this entry.');
+    return undefined;
+  }
+
+  return { kind: 'v1', detail: { v: UPDATED_DETAIL_VERSION, changes } };
+}
+
+function decodeLegacyUpdatedDetail(detail: string): LegacyUpdatedDetail | undefined {
+  if (!/^[a-z]+(?:\s*,\s*[a-z]+)*$/i.test(detail.trim())) {
+    return undefined;
+  }
+
+  const fields = detail
+    .split(',')
+    .map(field => field.trim())
+    .filter((field): field is string => field.length > 0);
+
+  return fields.length > 0 ? { kind: 'legacy', fields } : undefined;
+}
+
+export function renderUpdatedActivityDetail(detail: string | undefined): ActivityDetailRender | undefined {
+  const decoded = decodeUpdatedDetail(detail);
+  if (!decoded) {
+    return renderUnknownUpdatedActivityDetail(detail);
+  }
+  if (decoded.kind === 'legacy') {
+    return { kind: 'text', text: `fields changed: ${decoded.fields.join(', ')}` };
+  }
+
+  const rows = UPDATED_DETAIL_FIELDS
+    .map((field) => {
+      const change = decoded.detail.changes[field];
+      return change
+        ? { label: updatedFieldLabel(field), value: formatUpdatedFieldDiff(change) }
+        : undefined;
+    })
+    .filter((row): row is { label: string; value: string } => row !== undefined);
+
+  return rows.length > 0 ? { kind: 'fields', rows } : { kind: 'text', text: 'fields updated' };
+}
+
+function renderUnknownUpdatedActivityDetail(detail: string | undefined): ActivityDetailRender | undefined {
+  if (!detail) {
+    return undefined;
+  }
+
+  try {
+    const parsed = JSON.parse(detail) as { v?: unknown };
+    if (typeof parsed === 'object' && parsed !== null && 'v' in parsed) {
+      return { kind: 'text', text: 'fields updated' };
+    }
+  } catch {
+    // Non-JSON details are handled by the legacy decoder path above.
+  }
+
+  return undefined;
+}
+
+function truncateUpdatedDetailValue(value: string): string {
+  return value.length <= UPDATED_DETAIL_VALUE_MAX_LENGTH
+    ? value
+    : `${value.slice(0, UPDATED_DETAIL_VALUE_MAX_LENGTH - 1)}…`;
+}
+
+function updatedFieldLabel(field: UpdatedDetailField): string {
+  switch (field) {
+    case 'title':
+      return 'Title';
+    case 'notes':
+      return 'Notes';
+    case 'description':
+      return 'Description';
+    case 'url':
+      return 'URL';
+  }
+}
+
+function formatUpdatedFieldDiff(change: UpdatedFieldDiffV1): string {
+  if (change.from === undefined && change.to === undefined) {
+    return 'value changed';
+  }
+  return `${formatUpdatedFieldValue(change.from)} → ${formatUpdatedFieldValue(change.to)}`;
+}
+
+function formatUpdatedFieldValue(value: string | undefined): string {
+  return value === undefined ? 'unknown' : `'${value}'`;
+}

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -5,6 +5,11 @@ import { type ActivityLogEntry, type ActivityType, MAX_ACTIVITY_LOG_ENTRIES } fr
 import { ITaskStore } from '../storage/taskStore';
 import { logger } from './logger';
 import { isSafeUrl } from '../utils/url';
+import { encodeUpdatedDetail, type UpdatedDetailInput } from './updateDetail';
+
+interface UpdateItemOptions {
+  source?: 'user' | 'provider-sync';
+}
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -242,29 +247,49 @@ export class WorkGraph {
   }
 
   /** Apply a partial update (title, notes, description, and/or url) to an existing work item. */
-  async updateItem(id: string, patch: Partial<WorkItemInput>): Promise<void> {
-    return this.withLock(() => this.doUpdateItem(id, patch));
+  async updateItem(id: string, patch: Partial<WorkItemInput>, options?: UpdateItemOptions): Promise<void> {
+    return this.withLock(() => this.doUpdateItem(id, patch, options));
   }
 
-  private async doUpdateItem(id: string, patch: Partial<WorkItemInput>): Promise<void> {
+  private async doUpdateItem(id: string, patch: Partial<WorkItemInput>, options?: UpdateItemOptions): Promise<void> {
     const item = this.items.get(id);
     if (!item) {
       throw new Error(`Work item not found: ${id}`);
     }
-    const changes: string[] = [];
-    if (patch.title !== undefined && patch.title !== item.title) { changes.push('title'); }
+
+    const detailChanges: UpdatedDetailInput = {};
+    if (patch.title !== undefined && patch.title !== item.title) {
+      detailChanges.title = { from: item.title, to: patch.title };
+    }
     // Detect notes changes including clearing (patch.notes === undefined with key present)
-    if ('notes' in patch && patch.notes !== item.notes) { changes.push('notes'); }
-    // Detect description changes including clearing
-    if ('description' in patch && patch.description !== item.description) { changes.push('description'); }
+    if ('notes' in patch) {
+      const currentNotes = item.notes ?? '';
+      const nextNotes = patch.notes ?? '';
+      if (nextNotes !== currentNotes) {
+        detailChanges.notes = { from: currentNotes, to: nextNotes };
+      }
+    }
+    if ('description' in patch) {
+      const currentDescription = item.description ?? '';
+      const nextDescription = patch.description ?? '';
+      if (nextDescription !== currentDescription) {
+        detailChanges.description = options?.source === 'provider-sync'
+          ? {}
+          : { from: currentDescription, to: nextDescription };
+      }
+    }
     // Detect url changes including clearing (patch.url === undefined with key present)
     if ('url' in patch) {
       const sanitized = patch.url ? isSafeUrl(patch.url.trim())?.href : undefined;
       if (sanitized !== patch.url) { patch = { ...patch, url: sanitized }; }
-      if (sanitized !== item.url) { changes.push('url'); }
+      const currentUrl = item.url ?? '';
+      const nextUrl = sanitized ?? '';
+      if (nextUrl !== currentUrl) {
+        detailChanges.url = { from: currentUrl, to: nextUrl };
+      }
     }
     // Skip save/event when no fields actually changed (e.g. autosave with identical values)
-    if (changes.length === 0) {
+    if (Object.keys(detailChanges).length === 0) {
       return;
     }
     const now = Date.now();
@@ -274,7 +299,7 @@ export class WorkGraph {
       activityLog: WorkGraph.appendLogEntry(item.activityLog, {
         timestamp: now,
         type: 'updated' as const,
-        detail: changes.join(', '),
+        detail: encodeUpdatedDetail(detailChanges),
       }),
       updatedAt: now,
     };

--- a/packages/core/src/test/activityLog.test.ts
+++ b/packages/core/src/test/activityLog.test.ts
@@ -76,6 +76,45 @@ describe('ActivityLog', () => {
     expect(detail!.textContent).toBe(rawDetail);
   });
 
+  it('renders updated diffs supplied through displayDetail.fields', () => {
+    renderActivityLog([{
+      timestamp: Date.now(),
+      type: 'updated',
+      detail: 'ignored raw payload',
+      displayDetail: {
+        kind: 'fields',
+        rows: [
+          { label: 'Title', value: "'Fix login bug' → 'Fix SSO login bug on Safari'" },
+          { label: 'Notes', value: "'' → 'Repro on Safari 17.4'" },
+        ],
+      },
+    }]);
+
+    expandActivityLog();
+
+    const detail = container!.querySelector('.activity-entry-detail--structured');
+    expect(detail).toBeInstanceOf(HTMLDListElement);
+    expect(detail!.textContent).toContain('Title:');
+    expect(detail!.textContent).toContain("'Fix login bug' → 'Fix SSO login bug on Safari'");
+    expect(detail!.textContent).toContain('Notes:');
+    expect(detail!.textContent).toContain("'' → 'Repro on Safari 17.4'");
+  });
+
+  it('renders updated legacy summaries supplied through displayDetail.text', () => {
+    renderActivityLog([{
+      timestamp: Date.now(),
+      type: 'updated',
+      detail: 'ignored raw payload',
+      displayDetail: { kind: 'text', text: 'fields changed: title, notes' },
+    }]);
+
+    expandActivityLog();
+
+    const detail = container!.querySelector('.activity-entry-detail');
+    expect(detail).toBeInstanceOf(HTMLSpanElement);
+    expect(detail!.textContent).toBe('fields changed: title, notes');
+  });
+
   it('renders plain detail strings verbatim', () => {
     renderActivityLog([{ timestamp: Date.now(), type: 'state-changed', detail: 'New → InProgress' }]);
 

--- a/packages/core/src/test/descriptionSync.test.ts
+++ b/packages/core/src/test/descriptionSync.test.ts
@@ -33,7 +33,7 @@ describe('syncProviderDescriptions', () => {
     await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.findItemByProvenance).toHaveBeenCalledWith('github', '42');
-    expect(workGraph.updateItem).toHaveBeenCalledWith('item-1', { description: 'New description' });
+    expect(workGraph.updateItem).toHaveBeenCalledWith('item-1', { description: 'New description' }, { source: 'provider-sync' });
   });
 
   it('does not update when descriptions match', async () => {
@@ -73,7 +73,7 @@ describe('syncProviderDescriptions', () => {
     await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.updateItem).toHaveBeenCalledTimes(1);
-    expect(workGraph.updateItem).toHaveBeenCalledWith('gh-1', { description: 'Updated GH desc' });
+    expect(workGraph.updateItem).toHaveBeenCalledWith('gh-1', { description: 'Updated GH desc' }, { source: 'provider-sync' });
     expect(workGraph.findItemByProvenance).not.toHaveBeenCalledWith('ado', expect.anything());
   });
 
@@ -91,7 +91,7 @@ describe('syncProviderDescriptions', () => {
     await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.updateItem).toHaveBeenCalledTimes(1);
-    expect(workGraph.updateItem).toHaveBeenCalledWith('gh-1', { description: 'Updated GH desc' });
+    expect(workGraph.updateItem).toHaveBeenCalledWith('gh-1', { description: 'Updated GH desc' }, { source: 'provider-sync' });
   });
 
   it('continues syncing other items when one update fails', async () => {
@@ -111,7 +111,7 @@ describe('syncProviderDescriptions', () => {
     await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
 
     expect(workGraph.updateItem).toHaveBeenCalledTimes(2);
-    expect(workGraph.updateItem).toHaveBeenCalledWith('item-2', { description: 'Updated' });
+    expect(workGraph.updateItem).toHaveBeenCalledWith('item-2', { description: 'Updated' }, { source: 'provider-sync' });
   });
 
   it('does nothing when provider has no items', async () => {
@@ -131,7 +131,7 @@ describe('syncProviderDescriptions', () => {
 
     await syncProviderDescriptions('github', providerRegistry as any, workGraph as any);
 
-    expect(workGraph.updateItem).toHaveBeenCalledWith('item-1', { description: undefined });
+    expect(workGraph.updateItem).toHaveBeenCalledWith('item-1', { description: undefined }, { source: 'provider-sync' });
   });
 
   it('does not update when both descriptions are undefined', async () => {

--- a/packages/core/src/test/updateDetail.test.ts
+++ b/packages/core/src/test/updateDetail.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import {
+  decodeUpdatedDetail,
+  encodeUpdatedDetail,
+  renderUpdatedActivityDetail,
+  UPDATED_DETAIL_VALUE_MAX_LENGTH,
+} from '../services/updateDetail';
+
+describe('encodeUpdatedDetail', () => {
+  it('stamps v1 and preserves per-field diffs', () => {
+    const encoded = encodeUpdatedDetail({
+      title: { from: 'Old title', to: 'New title' },
+      notes: { from: '', to: 'Added repro steps' },
+    });
+
+    expect(JSON.parse(encoded)).toEqual({
+      v: 1,
+      changes: {
+        title: { from: 'Old title', to: 'New title' },
+        notes: { from: '', to: 'Added repro steps' },
+      },
+    });
+  });
+
+  it('truncates oversized values', () => {
+    const oversized = 'x'.repeat(UPDATED_DETAIL_VALUE_MAX_LENGTH + 25);
+    const encoded = encodeUpdatedDetail({ title: { from: oversized, to: oversized } });
+    const decoded = decodeUpdatedDetail(encoded);
+
+    expect(decoded).toEqual({
+      kind: 'v1',
+      detail: {
+        v: 1,
+        changes: {
+          title: {
+            from: `${'x'.repeat(UPDATED_DETAIL_VALUE_MAX_LENGTH - 1)}…`,
+            to: `${'x'.repeat(UPDATED_DETAIL_VALUE_MAX_LENGTH - 1)}…`,
+          },
+        },
+      },
+    });
+  });
+});
+
+describe('renderUpdatedActivityDetail', () => {
+  it('renders legacy entries as a summary line', () => {
+    expect(renderUpdatedActivityDetail('title, notes')).toEqual({ kind: 'text', text: 'fields changed: title, notes' });
+  });
+
+  it('renders v1 entries as structured rows', () => {
+    expect(renderUpdatedActivityDetail('{"v":1,"changes":{"title":{"from":"Old","to":"New"},"description":{}}}')).toEqual({
+      kind: 'fields',
+      rows: [
+        { label: 'Title', value: "'Old' → 'New'" },
+        { label: 'Description', value: 'value changed' },
+      ],
+    });
+  });
+
+  it('renders unknown future versions as a generic summary', () => {
+    expect(renderUpdatedActivityDetail('{"v":2,"changes":{"title":{"from":"Old","to":"New"}}}')).toEqual({ kind: 'text', text: 'fields updated' });
+  });
+});
+
+describe('decodeUpdatedDetail', () => {
+  it('accepts legacy comma-separated field lists', () => {
+    expect(decodeUpdatedDetail('title, notes')).toEqual({ kind: 'legacy', fields: ['title', 'notes'] });
+  });
+
+  it('accepts current v1 payloads', () => {
+    expect(decodeUpdatedDetail('{"v":1,"changes":{"title":{"from":"Old","to":"New"}}}')).toEqual({
+      kind: 'v1',
+      detail: {
+        v: 1,
+        changes: {
+          title: { from: 'Old', to: 'New' },
+        },
+      },
+    });
+  });
+
+  it('returns undefined for unknown future versions', () => {
+    expect(decodeUpdatedDetail('{"v":2,"changes":{"title":{"from":"Old","to":"New"}}}')).toBeUndefined();
+  });
+});

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -6,6 +6,7 @@ import { JsonTaskStore } from '../storage/jsonTaskStore';
 import { JsonFileStore } from '../storage/fileStore';
 import { ITaskStore } from '../storage/taskStore';
 import { useMockFileSystem } from './testFileSystem';
+import { decodeUpdatedDetail, UPDATED_DETAIL_VALUE_MAX_LENGTH, renderUpdatedActivityDetail } from '../services/updateDetail';
 
 function createMockStore(): ITaskStore {
   const items: Map<string, any> = new Map();
@@ -986,7 +987,15 @@ describe('WorkGraph', () => {
       const updated = graph.getItem(item.id);
       expect(updated?.activityLog).toHaveLength(2);
       expect(updated!.activityLog![1].type).toBe('updated');
-      expect(updated!.activityLog![1].detail).toBe('title');
+      expect(decodeUpdatedDetail(updated!.activityLog![1].detail)).toEqual({
+        kind: 'v1',
+        detail: {
+          v: 1,
+          changes: {
+            title: { from: 'Original', to: 'Updated' },
+          },
+        },
+      });
     });
 
     it('records changed fields in update detail', async () => {
@@ -994,7 +1003,70 @@ describe('WorkGraph', () => {
       await graph.updateItem(item.id, { title: 'New title', notes: 'new notes' });
 
       const updated = graph.getItem(item.id);
-      expect(updated!.activityLog![1].detail).toBe('title, notes');
+      expect(decodeUpdatedDetail(updated!.activityLog![1].detail)).toEqual({
+        kind: 'v1',
+        detail: {
+          v: 1,
+          changes: {
+            title: { from: 'Original', to: 'New title' },
+            notes: { from: 'some notes', to: 'new notes' },
+          },
+        },
+      });
+    });
+
+    it('truncates oversized field diffs in update detail', async () => {
+      const originalNotes = 'a'.repeat(UPDATED_DETAIL_VALUE_MAX_LENGTH + 10);
+      const updatedNotes = 'b'.repeat(UPDATED_DETAIL_VALUE_MAX_LENGTH + 25);
+      const item = await graph.createItem({ title: 'Original', notes: originalNotes });
+      await graph.updateItem(item.id, { notes: updatedNotes });
+
+      const updated = graph.getItem(item.id);
+      expect(decodeUpdatedDetail(updated!.activityLog![1].detail)).toEqual({
+        kind: 'v1',
+        detail: {
+          v: 1,
+          changes: {
+            notes: {
+              from: `${'a'.repeat(UPDATED_DETAIL_VALUE_MAX_LENGTH - 1)}…`,
+              to: `${'b'.repeat(UPDATED_DETAIL_VALUE_MAX_LENGTH - 1)}…`,
+            },
+          },
+        },
+      });
+    });
+
+    it('omits provider-synced description values from update detail', async () => {
+      const item = await graph.createItem({ title: 'Original', description: 'Old provider description' });
+      await graph.updateItem(item.id, { description: 'New provider description' }, { source: 'provider-sync' });
+
+      const updated = graph.getItem(item.id);
+      expect(decodeUpdatedDetail(updated!.activityLog![1].detail)).toEqual({
+        kind: 'v1',
+        detail: {
+          v: 1,
+          changes: {
+            description: {},
+          },
+        },
+      });
+      expect(renderUpdatedActivityDetail(updated!.activityLog![1].detail)).toEqual({
+        kind: 'fields',
+        rows: [{ label: 'Description', value: 'value changed' }],
+      });
+    });
+
+    it('does not record empty-to-empty changes when clearing optional fields', async () => {
+      const item = await graph.createItem({ title: 'Original' });
+      const listener = vi.fn();
+      graph.onDidChange(listener);
+      (store.save as ReturnType<typeof vi.fn>).mockClear();
+
+      await graph.updateItem(item.id, { notes: '' });
+
+      expect(graph.getItem(item.id)?.activityLog).toHaveLength(1);
+      expect(store.save).not.toHaveBeenCalled();
+      expect(listener).not.toHaveBeenCalled();
     });
 
     it('does not record update entry when no fields actually changed', async () => {


### PR DESCRIPTION
## Summary
- store structured versioned per-field diffs for `updated` activity entries
- render updated activity details through the activity detail renderer registry, including legacy entries and unknown future versions
- avoid bloating provider-synced description updates by recording a generic changed marker instead of mirrored bodies
- add coverage for legacy decoding, v1 decoding/rendering, truncation, provider-sync behavior, and unknown versions

## Validation
- npm run build
- npm run test

Closes #587
