### PR TITLE
Make Start Git Work cancellation-aware

### DIFF
--- a/.changeset/add-cancellable-start-git-work.md
+++ b/.changeset/add-cancellable-start-git-work.md
@@ -1,0 +1,6 @@
+---
+"@devdocket/shared": minor
+"devdocket-start-git-work": patch
+---
+
+Add a shared `abortFromToken` helper and let Start Git Work flows be cancelled while surfacing cleanup guidance for partially created worktrees.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,7 +10,7 @@ export { isValidUrlSegment, isValidGitHubRepo, isValidRepoSlug, sanitizeUrlSegme
 export { validateRefreshInterval } from './refreshInterval';
 export type { DevDocketRunWatcher, RunIdentifier, RunStatus, JobStatus, RunState, RunConclusion, CancellationTokenLike } from './runWatcher';
 export type { DevDocketPRWatcher, PRIdentifier, PRState, PRRunsSnapshot } from './prWatcher';
-export { combineSignals, createAbortError, raceWithAbort, getSessionWithAuthFallback } from './signalUtils';
+export { abortFromToken, combineSignals, createAbortError, raceWithAbort, getSessionWithAuthFallback } from './signalUtils';
 export { runWorkerPool, runWorkerPoolSettled } from './concurrency';
 export { WorkItemState } from './workItem';
 export type { WorkItem, WorkItemInput, ActivityLogEntry, ActivityType } from './workItem';

--- a/packages/shared/src/signalUtils.ts
+++ b/packages/shared/src/signalUtils.ts
@@ -1,3 +1,5 @@
+import type { CancellationTokenLike } from './runWatcher';
+
 /**
  * Creates an AbortError with the standard 'The operation was aborted.' message.
  * Use this instead of the three-line pattern for consistency:
@@ -11,6 +13,10 @@ export function createAbortError(): Error {
   return error;
 }
 
+type CancellationTokenWithEvents = CancellationTokenLike & {
+  readonly onCancellationRequested?: (listener: () => void) => { dispose(): void };
+};
+
 /**
  * Bridges a VS Code-style cancellation token to an AbortController.
  *
@@ -19,10 +25,7 @@ export function createAbortError(): Error {
  * later fires. If the controller is aborted externally, the token subscription
  * is disposed to avoid leaking listeners.
  */
-export function abortFromToken(token?: {
-  readonly isCancellationRequested: boolean;
-  readonly onCancellationRequested?: (listener: () => void) => { dispose(): void };
-}): AbortController {
+export function abortFromToken(token?: CancellationTokenWithEvents): AbortController {
   const controller = new AbortController();
   if (!token) {
     return controller;

--- a/packages/shared/src/signalUtils.ts
+++ b/packages/shared/src/signalUtils.ts
@@ -11,6 +11,41 @@ export function createAbortError(): Error {
   return error;
 }
 
+/**
+ * Bridges a VS Code-style cancellation token to an AbortController.
+ *
+ * The returned controller is aborted immediately when the token is already
+ * cancelled, and otherwise aborts with a standard AbortError when the token
+ * later fires. If the controller is aborted externally, the token subscription
+ * is disposed to avoid leaking listeners.
+ */
+export function abortFromToken(token?: {
+  readonly isCancellationRequested: boolean;
+  readonly onCancellationRequested?: (listener: () => void) => { dispose(): void };
+}): AbortController {
+  const controller = new AbortController();
+  if (!token) {
+    return controller;
+  }
+
+  if (token.isCancellationRequested) {
+    controller.abort(createAbortError());
+    return controller;
+  }
+
+  const subscription = token.onCancellationRequested?.(() => {
+    if (!controller.signal.aborted) {
+      controller.abort(createAbortError());
+    }
+  });
+
+  if (subscription) {
+    controller.signal.addEventListener('abort', () => subscription.dispose(), { once: true });
+  }
+
+  return controller;
+}
+
 function getAbortReason(signal: AbortSignal): Error {
   return signal.reason instanceof Error ? signal.reason : createAbortError();
 }

--- a/packages/shared/src/test/signalUtils.test.ts
+++ b/packages/shared/src/test/signalUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { combineSignals, getSessionWithAuthFallback, raceWithAbort } from '../signalUtils';
+import { abortFromToken, combineSignals, createAbortError, getSessionWithAuthFallback, raceWithAbort } from '../signalUtils';
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -10,6 +10,44 @@ function deferred<T>() {
   });
   return { promise, resolve, reject };
 }
+
+describe('abortFromToken', () => {
+  it('aborts immediately when the token is already cancelled', () => {
+    const controller = abortFromToken({ isCancellationRequested: true });
+    expect(controller.signal.aborted).toBe(true);
+    expect(controller.signal.reason).toMatchObject({ name: 'AbortError', message: 'The operation was aborted.' });
+  });
+
+  it('aborts when the token later requests cancellation', () => {
+    let listener: (() => void) | undefined;
+    const dispose = vi.fn();
+    const controller = abortFromToken({
+      isCancellationRequested: false,
+      onCancellationRequested: (registeredListener) => {
+        listener = registeredListener;
+        return { dispose };
+      },
+    });
+
+    listener?.();
+
+    expect(controller.signal.aborted).toBe(true);
+    expect(controller.signal.reason).toMatchObject({ name: 'AbortError', message: 'The operation was aborted.' });
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('disposes the token subscription when aborted externally', () => {
+    const dispose = vi.fn();
+    const controller = abortFromToken({
+      isCancellationRequested: false,
+      onCancellationRequested: () => ({ dispose }),
+    });
+
+    controller.abort(createAbortError());
+
+    expect(dispose).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('combineSignals', () => {
   afterEach(() => {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -1027,7 +1027,7 @@ export class StartWorkAction implements DevDocketAction {
 
     const detail = `Start Git Work cancelled during ${cancellationState.currentStep}.`;
     try {
-      await this.addActivity(item.id, 'updated', detail);
+      await this.addActivity(item.id, 'action-executed', detail);
     } catch (activityErr) {
       logger.warn('Failed to log cancellation activity', activityErr);
     }

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -323,7 +323,7 @@ export class StartWorkAction implements DevDocketAction {
     } catch (worktreeErr) {
       if (this.isAbortError(worktreeErr)) {
         try {
-          await execFileAsync('git', ['branch', '-d', '--', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+          await this.rollbackCreatedBranch(branchName, baseBranch, repoPath);
           cancellationState.cleanupActivity = undefined;
         } catch (rollbackErr) {
           const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
@@ -333,7 +333,7 @@ export class StartWorkAction implements DevDocketAction {
       }
 
       try {
-        await execFileAsync('git', ['branch', '-d', '--', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+        await this.rollbackCreatedBranch(branchName, baseBranch, repoPath);
       } catch (rollbackErr) {
         const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
         void vscode.window.showWarningMessage(`DevDocket: Failed to delete branch during rollback — ${rollbackMessage}`);
@@ -976,6 +976,24 @@ export class StartWorkAction implements DevDocketAction {
           `DevDocket: Command "${cmd.command}" failed — ${cmdMessage}`,
         );
       }
+    }
+  }
+
+  private async rollbackCreatedBranch(branchName: string, baseBranch: string, repoPath: string): Promise<void> {
+    try {
+      await execFileAsync('git', ['branch', '-d', '--', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+      return;
+    } catch (deleteErr) {
+      const branchRef = `refs/heads/${branchName}`;
+      const [{ stdout: branchHead }, { stdout: baseHead }] = await Promise.all([
+        execFileAsync('git', ['rev-parse', '--verify', branchRef], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT }),
+        execFileAsync('git', ['rev-parse', '--verify', baseBranch], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT }),
+      ]);
+      if (branchHead.trim() === baseHead.trim()) {
+        await execFileAsync('git', ['branch', '-D', '--', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+        return;
+      }
+      throw deleteErr;
     }
   }
 

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -1016,14 +1016,16 @@ export class StartWorkAction implements DevDocketAction {
 
     if (cancellationState.cleanupActivity) {
       const cleanupInfo = decodeWorkStartedDetail(cancellationState.cleanupActivity.detail);
-      const cleanupTarget = cleanupInfo?.worktreePath
+      const hasWorktree = !!cleanupInfo?.worktreePath;
+      const cleanupTarget = hasWorktree
         ? 'The created worktree may need cleanup.'
         : 'A partially created branch may need cleanup.';
+      const cleanupAction = hasWorktree ? 'Remove worktree' : 'Clean up';
       const choice = await vscode.window.showWarningMessage(
         `DevDocket: ${detail} ${cleanupTarget}`,
-        'Remove worktree',
+        cleanupAction,
       );
-      if (choice === 'Remove worktree') {
+      if (choice === cleanupAction) {
         await promptGitCleanup(
           {
             ...item,

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -986,8 +986,8 @@ export class StartWorkAction implements DevDocketAction {
     } catch (deleteErr) {
       const branchRef = `refs/heads/${branchName}`;
       const [{ stdout: branchHead }, { stdout: baseHead }] = await Promise.all([
-        execFileAsync('git', ['rev-parse', '--verify', branchRef], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT }),
-        execFileAsync('git', ['rev-parse', '--verify', baseBranch], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT }),
+        execFileAsync('git', ['rev-parse', '--verify', '--', branchRef], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT }),
+        execFileAsync('git', ['rev-parse', '--verify', '--', baseBranch], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT }),
       ]);
       if (branchHead.trim() === baseHead.trim()) {
         await execFileAsync('git', ['branch', '-D', '--', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -323,7 +323,7 @@ export class StartWorkAction implements DevDocketAction {
     } catch (worktreeErr) {
       if (this.isAbortError(worktreeErr)) {
         try {
-          await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+          await execFileAsync('git', ['branch', '-d', '--', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
           cancellationState.cleanupActivity = undefined;
         } catch (rollbackErr) {
           const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
@@ -333,7 +333,7 @@ export class StartWorkAction implements DevDocketAction {
       }
 
       try {
-        await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+        await execFileAsync('git', ['branch', '-d', '--', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
       } catch (rollbackErr) {
         const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
         void vscode.window.showWarningMessage(`DevDocket: Failed to delete branch during rollback — ${rollbackMessage}`);

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -15,7 +15,7 @@ import {
   type DevDocketAction,
 } from '@devdocket/shared';
 import { promptGitCleanup } from './gitCleanup';
-import { encodeWorkStartedDetail } from './workStartedDetail';
+import { decodeWorkStartedDetail, encodeWorkStartedDetail } from './workStartedDetail';
 
 const execFileAsync = promisify(execFile);
 
@@ -1015,8 +1015,8 @@ export class StartWorkAction implements DevDocketAction {
     }
 
     if (cancellationState.cleanupActivity) {
-      const cleanupDetail = cancellationState.cleanupActivity.detail;
-      const cleanupTarget = cleanupDetail && cleanupDetail.includes('"worktreePath"')
+      const cleanupInfo = decodeWorkStartedDetail(cancellationState.cleanupActivity.detail);
+      const cleanupTarget = cleanupInfo?.worktreePath
         ? 'The created worktree may need cleanup.'
         : 'A partially created branch may need cleanup.';
       const choice = await vscode.window.showWarningMessage(

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -4,7 +4,17 @@ import { promisify } from 'util';
 import * as path from 'path';
 import * as fs from 'fs';
 import { logger } from './logger';
-import { WorkItemState, type ProviderItem, type GitWorkInfo, type WorkItem, type DevDocketAction } from '@devdocket/shared';
+import {
+  abortFromToken,
+  WorkItemState,
+  type ActivityLogEntry,
+  type ActivityType,
+  type ProviderItem,
+  type GitWorkInfo,
+  type WorkItem,
+  type DevDocketAction,
+} from '@devdocket/shared';
+import { promptGitCleanup } from './gitCleanup';
 import { encodeWorkStartedDetail } from './workStartedDetail';
 
 const execFileAsync = promisify(execFile);
@@ -85,6 +95,11 @@ interface PrBranchInfo {
   sourceRef: string;
   /** Remote tracking ref when branch is on a non-origin remote (e.g. "devdocket-fork-contributor/fix-bug"). */
   trackingRef?: string;
+}
+
+interface FlowCancellationState {
+  currentStep: string;
+  cleanupActivity?: ActivityLogEntry;
 }
 
 /**
@@ -219,6 +234,8 @@ export class StartWorkAction implements DevDocketAction {
 
     const promptForNames = this.shouldPromptForNames();
 
+    const cancellationState: FlowCancellationState = { currentStep: workMode === 'worktree' ? 'creating worktree' : 'checking out branch' };
+
     try {
       let worktreePath: string | undefined;
       if (promptForNames) {
@@ -240,17 +257,21 @@ export class StartWorkAction implements DevDocketAction {
         {
           location: vscode.ProgressLocation.Notification,
           title: 'Starting git work for issue',
-          cancellable: false,
+          cancellable: true,
         },
-        async (progress) => {
+        async (progress, token) => {
+          const abortController = abortFromToken(token);
           if (workMode === 'worktree') {
-            await this.issueWorktreeFlow(item, gitWork, repoPath, branchName, baseBranch, progress, worktreePath);
+            await this.issueWorktreeFlow(item, gitWork, repoPath, branchName, baseBranch, progress, abortController.signal, cancellationState, worktreePath);
           } else {
-            await this.issueCheckoutFlow(item, repoPath, branchName, baseBranch, progress);
+            await this.issueCheckoutFlow(item, repoPath, branchName, baseBranch, progress, abortController.signal, cancellationState);
           }
         },
       );
     } catch (err: unknown) {
+      if (await this.handleFlowCancellation(item, err, cancellationState)) {
+        return;
+      }
       logger.error('Failed to start work', err);
       const message = err instanceof Error ? err.message : String(err);
       void vscode.window.showErrorMessage(`DevDocket: Failed to start work — ${message}`);
@@ -264,6 +285,8 @@ export class StartWorkAction implements DevDocketAction {
     branchName: string,
     baseBranch: string,
     progress: vscode.Progress<{ message?: string }>,
+    signal: AbortSignal,
+    cancellationState: FlowCancellationState,
     promptedWorktreePath?: string,
   ): Promise<void> {
     const worktreePath = promptedWorktreePath ?? this.getDefaultWorktreePath(repoPath, branchName, item, gitWork);
@@ -273,27 +296,28 @@ export class StartWorkAction implements DevDocketAction {
       return;
     }
 
-    progress.report({ message: 'Creating branch...' });
+    this.reportStep(progress, cancellationState, 'Creating branch...', 'creating branch');
 
-    const { stdout: branchList } = await execFileAsync('git', ['branch', '--list', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+    const { stdout: branchList } = await execFileAsync('git', ['branch', '--list', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT, signal });
     if (branchList.trim()) {
       void vscode.window.showErrorMessage(`DevDocket: Branch "${branchName}" already exists.`);
       return;
     }
 
-    await execFileAsync('git', ['branch', branchName, baseBranch], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+    await execFileAsync('git', ['branch', branchName, baseBranch], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT, signal });
     logger.info(`Starting work: creating branch ${branchName}`);
 
-    progress.report({ message: 'Creating worktree...' });
+    this.reportStep(progress, cancellationState, 'Creating worktree...', 'creating worktree');
 
     try {
       await execFileAsync('git', ['worktree', 'add', worktreePath, branchName], {
         cwd: repoPath,
         timeout: GIT_CHECKOUT_TIMEOUT,
+        signal,
       });
     } catch (worktreeErr) {
       try {
-        await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+        await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT, signal });
       } catch (rollbackErr) {
         const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
         void vscode.window.showWarningMessage(`DevDocket: Failed to delete branch during rollback — ${rollbackMessage}`);
@@ -310,9 +334,10 @@ export class StartWorkAction implements DevDocketAction {
 
     logger.info(`Created worktree at ${worktreePath}`);
 
+    const detail = encodeWorkStartedDetail({ branchName, worktreePath, repoPath });
+    cancellationState.cleanupActivity = { timestamp: Date.now(), type: 'work-started', detail };
     try {
-      const detail = encodeWorkStartedDetail({ branchName, worktreePath, repoPath });
-      await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-started', detail);
+      await this.addActivity(item.id, 'work-started', detail);
     } catch (activityErr) {
       logger.error('Failed to log work-started activity', activityErr);
       void vscode.window.showWarningMessage(
@@ -320,7 +345,7 @@ export class StartWorkAction implements DevDocketAction {
       );
     }
 
-    await this.runPostWorktreeCommands(worktreePath, progress);
+    await this.runPostWorktreeCommands(worktreePath, progress, signal, cancellationState);
 
     void vscode.window.showInformationMessage(
       `DevDocket: Created worktree for ${branchName}`,
@@ -333,20 +358,22 @@ export class StartWorkAction implements DevDocketAction {
     branchName: string,
     baseBranch: string,
     progress: vscode.Progress<{ message?: string }>,
+    signal: AbortSignal,
+    cancellationState: FlowCancellationState,
   ): Promise<void> {
-    const canProceed = await this.checkDirtyTree(repoPath);
+    const canProceed = await this.checkDirtyTree(repoPath, signal);
     if (!canProceed) {
       return;
     }
 
-    progress.report({ message: 'Creating and checking out branch...' });
+    this.reportStep(progress, cancellationState, 'Creating and checking out branch...', 'creating and checking out branch');
 
-    await execFileAsync('git', ['checkout', '-b', branchName, baseBranch], { cwd: repoPath, timeout: GIT_CHECKOUT_TIMEOUT });
+    await execFileAsync('git', ['checkout', '-b', branchName, baseBranch], { cwd: repoPath, timeout: GIT_CHECKOUT_TIMEOUT, signal });
     logger.info(`Starting work: checked out new branch ${branchName}`);
 
     try {
       const detail = encodeWorkStartedDetail({ branchName, repoPath });
-      await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-started', detail);
+      await this.addActivity(item.id, 'work-started', detail);
     } catch (activityErr) {
       logger.error('Failed to log work-started activity', activityErr);
       void vscode.window.showWarningMessage(
@@ -388,29 +415,35 @@ export class StartWorkAction implements DevDocketAction {
       }
     }
 
+    const cancellationState: FlowCancellationState = { currentStep: 'fetching PR branch' };
+
     try {
       await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
           title: 'Starting git work for PR',
-          cancellable: false,
+          cancellable: true,
         },
-        async (progress) => {
-          progress.report({ message: 'Fetching PR branch...' });
+        async (progress, token) => {
+          const abortController = abortFromToken(token);
+          this.reportStep(progress, cancellationState, 'Fetching PR branch...', 'fetching PR branch');
 
-          const branchInfo = await this.fetchPrBranch(gitWork, repoPath, branchName);
+          const branchInfo = await this.fetchPrBranch(gitWork, repoPath, branchName, abortController.signal);
           if (!branchInfo) {
             return;
           }
 
           if (workMode === 'worktree') {
-            await this.prWorktreeFlow(item, gitWork, repoPath, branchInfo, progress, worktreePath);
+            await this.prWorktreeFlow(item, gitWork, repoPath, branchInfo, progress, abortController.signal, cancellationState, worktreePath);
           } else {
-            await this.prCheckoutFlow(item, repoPath, branchInfo, progress);
+            await this.prCheckoutFlow(item, repoPath, branchInfo, progress, abortController.signal, cancellationState);
           }
         },
       );
     } catch (err: unknown) {
+      if (await this.handleFlowCancellation(item, err, cancellationState)) {
+        return;
+      }
       logger.error('Failed to start work', err);
       const message = err instanceof Error ? err.message : String(err);
       void vscode.window.showErrorMessage(`DevDocket: Failed to start work — ${message}`);
@@ -421,13 +454,14 @@ export class StartWorkAction implements DevDocketAction {
     gitWork: ResolvedGitWork,
     repoPath: string,
     localBranchName?: string,
+    signal?: AbortSignal,
   ): Promise<PrBranchInfo | undefined> {
     const upstreamBranchName = this.normalizeBranchName(gitWork.ref);
     const branchName = localBranchName ?? upstreamBranchName;
     const cloneUrl = gitWork.headCloneUrl ?? gitWork.cloneUrl;
 
     logger.info(`Fetching provider-supplied PR branch "${upstreamBranchName}"`);
-    const remoteName = await this.findOrAddRemote(cloneUrl, gitWork.repoLabel, repoPath);
+    const remoteName = await this.findOrAddRemote(cloneUrl, gitWork.repoLabel, repoPath, signal);
     const sourceRef = `${remoteName}/${upstreamBranchName}`;
 
     try {
@@ -435,9 +469,12 @@ export class StartWorkAction implements DevDocketAction {
         'fetch',
         remoteName,
         `+refs/heads/${upstreamBranchName}:refs/remotes/${remoteName}/${upstreamBranchName}`,
-      ], { cwd: repoPath, timeout: GIT_CHECKOUT_TIMEOUT });
+      ], { cwd: repoPath, timeout: GIT_CHECKOUT_TIMEOUT, signal });
       logger.debug(`Fetch complete for branch "${upstreamBranchName}" from remote "${remoteName}"`);
     } catch (err) {
+      if (this.isAbortError(err)) {
+        throw err;
+      }
       const details = this.formatGitError(err);
       logger.info(`Failed to fetch branch "${upstreamBranchName}" from ${remoteName}: ${details}`);
       void vscode.window.showErrorMessage(
@@ -456,8 +493,8 @@ export class StartWorkAction implements DevDocketAction {
    * Finds a local remote whose fetch URL matches {@link cloneUrl}, or adds a
    * new DevDocket-managed remote pointing to it.
    */
-  private async findOrAddRemote(cloneUrl: string, repoLabel: string | undefined, repoPath: string): Promise<string> {
-    const { stdout } = await execFileAsync('git', ['remote', '-v'], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+  private async findOrAddRemote(cloneUrl: string, repoLabel: string | undefined, repoPath: string, signal?: AbortSignal): Promise<string> {
+    const { stdout } = await execFileAsync('git', ['remote', '-v'], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT, signal });
     for (const line of stdout.split('\n')) {
       const match = line.match(/^(\S+)\t(\S+)\s+\(fetch\)$/);
       if (match && match[2] === cloneUrl) {
@@ -475,14 +512,17 @@ export class StartWorkAction implements DevDocketAction {
     logger.debug(`No remote found for ${cloneUrl}, adding "${remoteName}"`);
 
     try {
-      await execFileAsync('git', ['remote', 'add', remoteName, cloneUrl], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+      await execFileAsync('git', ['remote', 'add', remoteName, cloneUrl], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT, signal });
       logger.info(`Added remote "${remoteName}" → ${cloneUrl}`);
     } catch (err) {
+      if (this.isAbortError(err)) {
+        throw err;
+      }
       try {
-        const { stdout: existingUrl } = await execFileAsync('git', ['remote', 'get-url', remoteName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+        const { stdout: existingUrl } = await execFileAsync('git', ['remote', 'get-url', remoteName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT, signal });
         if (existingUrl.trim() !== cloneUrl) {
           logger.info(`Remote "${remoteName}" exists with different URL, updating to "${cloneUrl}".`);
-          await execFileAsync('git', ['remote', 'set-url', remoteName, cloneUrl], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+          await execFileAsync('git', ['remote', 'set-url', remoteName, cloneUrl], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT, signal });
         } else {
           logger.debug(`Remote "${remoteName}" already exists with correct URL`);
         }
@@ -500,6 +540,8 @@ export class StartWorkAction implements DevDocketAction {
     repoPath: string,
     branchInfo: PrBranchInfo,
     progress: vscode.Progress<{ message?: string }>,
+    signal: AbortSignal,
+    cancellationState: FlowCancellationState,
     promptedWorktreePath?: string,
   ): Promise<void> {
     const { branchName, sourceRef, trackingRef } = branchInfo;
@@ -510,20 +552,20 @@ export class StartWorkAction implements DevDocketAction {
       return;
     }
 
-    progress.report({ message: 'Creating worktree...' });
+    this.reportStep(progress, cancellationState, 'Creating worktree...', 'creating worktree');
 
     // Determine worktree strategy based on whether a local branch already exists.
     // For fork PRs, always create from the remote tracking ref (detached if local branch
     // exists, to avoid using a stale/unrelated same-named local branch).
     // For same-repo PRs, the branch may only exist as origin/<branch> after fetch.
-    const hasLocalBranch = await this.localBranchExists(branchName, repoPath);
+    const hasLocalBranch = await this.localBranchExists(branchName, repoPath, signal);
     const worktreeSourceRef = sourceRef;
     // Only relevant when we'd otherwise run `git worktree add <path> <branch>`
     // (the local-branch path that's neither --detach nor -b). For trackingRef
     // and no-local-branch paths, the porcelain pre-check would be wasted work.
     const conflictingWorktree =
       hasLocalBranch && !trackingRef
-        ? await this.findWorktreeHoldingBranch(branchName, repoPath)
+        ? await this.findWorktreeHoldingBranch(branchName, repoPath, undefined, signal)
         : undefined;
     let createdBranch = false;
 
@@ -533,31 +575,35 @@ export class StartWorkAction implements DevDocketAction {
       logger.info(
         `Local branch ${branchName} exists, but PR uses tracking ref ${trackingRef}; creating detached worktree from tracking ref`,
       );
-      progress.report({ message: 'Creating detached worktree from PR tracking ref...' });
+      this.reportStep(progress, cancellationState, 'Creating detached worktree from PR tracking ref...', 'creating detached worktree');
 
       await execFileAsync('git', ['worktree', 'add', '--detach', worktreePath, trackingRef], {
         cwd: repoPath,
         timeout: GIT_CHECKOUT_TIMEOUT,
+        signal,
       });
     } else if (hasLocalBranch && conflictingWorktree) {
       logger.info(
         `Branch ${branchName} is already held by worktree at ${conflictingWorktree}; creating detached worktree from ${worktreeSourceRef}`,
       );
-      progress.report({ message: 'Branch in use elsewhere; creating detached worktree...' });
+      this.reportStep(progress, cancellationState, 'Branch in use elsewhere; creating detached worktree...', 'creating detached worktree');
 
       await execFileAsync('git', ['worktree', 'add', '--detach', worktreePath, worktreeSourceRef], {
         cwd: repoPath,
         timeout: GIT_CHECKOUT_TIMEOUT,
+        signal,
       });
     } else if (hasLocalBranch) {
       await execFileAsync('git', ['worktree', 'add', worktreePath, branchName], {
         cwd: repoPath,
         timeout: GIT_CHECKOUT_TIMEOUT,
+        signal,
       });
     } else {
       await execFileAsync('git', ['worktree', 'add', '-b', branchName, worktreePath, worktreeSourceRef], {
         cwd: repoPath,
         timeout: GIT_CHECKOUT_TIMEOUT,
+        signal,
       });
       createdBranch = true;
     }
@@ -572,7 +618,8 @@ export class StartWorkAction implements DevDocketAction {
         worktreePath,
         repoPath,
       });
-      await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-started', detail);
+      cancellationState.cleanupActivity = { timestamp: Date.now(), type: 'work-started', detail };
+      await this.addActivity(item.id, 'work-started', detail);
     } catch (activityErr) {
       logger.error('Failed to log work-started activity', activityErr);
       void vscode.window.showWarningMessage(
@@ -580,7 +627,7 @@ export class StartWorkAction implements DevDocketAction {
       );
     }
 
-    await this.runPostWorktreeCommands(worktreePath, progress);
+    await this.runPostWorktreeCommands(worktreePath, progress, signal, cancellationState);
 
     void vscode.window.showInformationMessage(
       `DevDocket: Created worktree for ${branchName}`,
@@ -592,28 +639,30 @@ export class StartWorkAction implements DevDocketAction {
     repoPath: string,
     branchInfo: PrBranchInfo,
     progress: vscode.Progress<{ message?: string }>,
+    signal: AbortSignal,
+    cancellationState: FlowCancellationState,
   ): Promise<void> {
     const { branchName, sourceRef, trackingRef } = branchInfo;
-    const canProceed = await this.checkDirtyTree(repoPath);
+    const canProceed = await this.checkDirtyTree(repoPath, signal);
     if (!canProceed) {
       return;
     }
 
-    progress.report({ message: 'Checking out branch...' });
+    this.reportStep(progress, cancellationState, 'Checking out branch...', 'checking out branch');
 
     // Check if the branch already exists locally to pick the right checkout strategy.
     // For fork PRs without a local branch, create from the remote tracking ref.
     // For same-repo PRs without a local branch, create from origin/<branch>.
     // When a fork trackingRef is set and a local branch exists, use a detached checkout
     // to avoid destructively modifying the user's existing branch.
-    const hasLocalBranch = await this.localBranchExists(branchName, repoPath);
+    const hasLocalBranch = await this.localBranchExists(branchName, repoPath, signal);
 
     // Pre-check: if `git checkout <branch>` would collide with another worktree
     // that already holds the branch, surface a clear error before attempting it.
     // The current worktree (`repoPath`) is excluded — when it's the holder, the
     // branch is already HEAD and `git checkout <branch>` is a successful no-op.
     if (hasLocalBranch && !trackingRef) {
-      const conflictingWorktree = await this.findWorktreeHoldingBranch(branchName, repoPath, repoPath);
+      const conflictingWorktree = await this.findWorktreeHoldingBranch(branchName, repoPath, repoPath, signal);
       if (conflictingWorktree) {
         void vscode.window.showErrorMessage(
           `DevDocket: Branch "${branchName}" is already checked out by the worktree at "${conflictingWorktree}". Use worktree mode instead, or remove the conflicting worktree first.`,
@@ -639,7 +688,7 @@ export class StartWorkAction implements DevDocketAction {
       createdBranch = true;
     }
 
-    await execFileAsync('git', checkoutArgs, { cwd: repoPath, timeout: GIT_CHECKOUT_TIMEOUT });
+    await execFileAsync('git', checkoutArgs, { cwd: repoPath, timeout: GIT_CHECKOUT_TIMEOUT, signal });
     logger.info(`Checked out PR branch ${branchName}`);
 
     try {
@@ -649,7 +698,7 @@ export class StartWorkAction implements DevDocketAction {
         ...(createdBranch ? { branchName } : {}),
         repoPath,
       });
-      await vscode.commands.executeCommand('devdocket.addActivity', item.id, 'work-started', detail);
+      await this.addActivity(item.id, 'work-started', detail);
     } catch (activityErr) {
       logger.error('Failed to log work-started activity', activityErr);
       void vscode.window.showWarningMessage(
@@ -666,8 +715,8 @@ export class StartWorkAction implements DevDocketAction {
    * Checks if the working tree is dirty and prompts the user for confirmation.
    * Returns true if work can proceed (clean tree or user confirmed).
    */
-  private async checkDirtyTree(repoPath: string): Promise<boolean> {
-    const { stdout: statusOutput } = await execFileAsync('git', ['status', '--porcelain'], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+  private async checkDirtyTree(repoPath: string, signal?: AbortSignal): Promise<boolean> {
+    const { stdout: statusOutput } = await execFileAsync('git', ['status', '--porcelain'], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT, signal });
     if (statusOutput.trim()) {
       const answer = await vscode.window.showWarningMessage(
         'Working tree has uncommitted changes. Checkout anyway?',
@@ -682,11 +731,14 @@ export class StartWorkAction implements DevDocketAction {
   }
 
   /** Checks whether a local branch with the given name already exists. */
-  private async localBranchExists(branchName: string, repoPath: string): Promise<boolean> {
+  private async localBranchExists(branchName: string, repoPath: string, signal?: AbortSignal): Promise<boolean> {
     try {
-      await execFileAsync('git', ['rev-parse', '--verify', `refs/heads/${branchName}`], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+      await execFileAsync('git', ['rev-parse', '--verify', `refs/heads/${branchName}`], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT, signal });
       return true;
-    } catch {
+    } catch (err) {
+      if (this.isAbortError(err)) {
+        throw err;
+      }
       return false;
     }
   }
@@ -707,14 +759,19 @@ export class StartWorkAction implements DevDocketAction {
     branchName: string,
     repoPath: string,
     excludeWorktreePath?: string,
+    signal?: AbortSignal,
   ): Promise<string | undefined> {
     let stdout: string;
     try {
       ({ stdout } = await execFileAsync('git', ['worktree', 'list', '--porcelain'], {
         cwd: repoPath,
         timeout: GIT_METADATA_TIMEOUT,
+        signal,
       }));
     } catch (err) {
+      if (this.isAbortError(err)) {
+        throw err;
+      }
       // Pre-check is best-effort — if it fails, fall through and let the actual
       // git operation surface any real error.
       logger.debug(`git worktree list --porcelain failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -860,18 +917,23 @@ export class StartWorkAction implements DevDocketAction {
   private async runPostWorktreeCommands(
     worktreePath: string,
     progress: vscode.Progress<{ message?: string }>,
+    signal: AbortSignal,
+    cancellationState: FlowCancellationState,
   ): Promise<void> {
     const commands = vscode.workspace.getConfiguration('devDocketStartGitWork')
       .get<{ command: string; args?: string[] }[]>('commands', []);
 
     for (const cmd of commands) {
-      progress.report({ message: `Running ${cmd.command}...` });
+      this.reportStep(progress, cancellationState, `Running ${cmd.command}...`, `running ${cmd.command}`);
       const resolvedArgs = (cmd.args ?? []).map(
         arg => arg.replace(/\{path\}/g, worktreePath),
       );
       try {
-        await execFileAsync(cmd.command, resolvedArgs, { cwd: worktreePath, timeout: 60_000 });
+        await execFileAsync(cmd.command, resolvedArgs, { cwd: worktreePath, timeout: 60_000, signal });
       } catch (cmdErr) {
+        if (this.isAbortError(cmdErr)) {
+          throw cmdErr;
+        }
         const cmdMessage = cmdErr instanceof Error ? cmdErr.message : String(cmdErr);
         logger.error(`Post-worktree command failed: ${cmd.command}`, cmdErr);
         void vscode.window.showWarningMessage(
@@ -879,6 +941,62 @@ export class StartWorkAction implements DevDocketAction {
         );
       }
     }
+  }
+
+  private async addActivity(itemId: string, type: ActivityType, detail?: string): Promise<void> {
+    await vscode.commands.executeCommand('devdocket.addActivity', itemId, type, detail);
+  }
+
+  private reportStep(
+    progress: vscode.Progress<{ message?: string }>,
+    cancellationState: FlowCancellationState,
+    message: string,
+    step: string,
+  ): void {
+    cancellationState.currentStep = step;
+    progress.report({ message });
+  }
+
+  private isAbortError(err: unknown): boolean {
+    const abortError = err as { name?: string; code?: string };
+    return abortError?.name === 'AbortError' || abortError?.code === 'ABORT_ERR';
+  }
+
+  private async handleFlowCancellation(
+    item: Readonly<WorkItem>,
+    err: unknown,
+    cancellationState: FlowCancellationState,
+  ): Promise<boolean> {
+    if (!this.isAbortError(err)) {
+      return false;
+    }
+
+    const detail = `Start Git Work cancelled during ${cancellationState.currentStep}.`;
+    try {
+      await this.addActivity(item.id, 'updated', detail);
+    } catch (activityErr) {
+      logger.warn('Failed to log cancellation activity', activityErr);
+    }
+
+    if (cancellationState.cleanupActivity) {
+      const choice = await vscode.window.showWarningMessage(
+        `DevDocket: ${detail} The created worktree may need cleanup.`,
+        'Remove worktree',
+      );
+      if (choice === 'Remove worktree') {
+        await promptGitCleanup(
+          {
+            ...item,
+            activityLog: [...(item.activityLog ?? []), cancellationState.cleanupActivity],
+          },
+          async (itemId, type, activityDetail) => this.addActivity(itemId, type, activityDetail),
+        );
+      }
+      return true;
+    }
+
+    void vscode.window.showInformationMessage(`DevDocket: ${detail}`);
+    return true;
   }
 
   private normalizeBranchName(ref: string): string {

--- a/packages/start-git-work/src/startWorkAction.ts
+++ b/packages/start-git-work/src/startWorkAction.ts
@@ -306,6 +306,11 @@ export class StartWorkAction implements DevDocketAction {
 
     await execFileAsync('git', ['branch', branchName, baseBranch], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT, signal });
     logger.info(`Starting work: creating branch ${branchName}`);
+    cancellationState.cleanupActivity = {
+      timestamp: Date.now(),
+      type: 'work-started',
+      detail: encodeWorkStartedDetail({ branchName, repoPath }),
+    };
 
     this.reportStep(progress, cancellationState, 'Creating worktree...', 'creating worktree');
 
@@ -316,8 +321,19 @@ export class StartWorkAction implements DevDocketAction {
         signal,
       });
     } catch (worktreeErr) {
+      if (this.isAbortError(worktreeErr)) {
+        try {
+          await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
+          cancellationState.cleanupActivity = undefined;
+        } catch (rollbackErr) {
+          const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
+          void vscode.window.showWarningMessage(`DevDocket: Failed to delete branch during rollback — ${rollbackMessage}`);
+        }
+        throw worktreeErr;
+      }
+
       try {
-        await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT, signal });
+        await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoPath, timeout: GIT_METADATA_TIMEOUT });
       } catch (rollbackErr) {
         const rollbackMessage = rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr);
         void vscode.window.showWarningMessage(`DevDocket: Failed to delete branch during rollback — ${rollbackMessage}`);
@@ -570,6 +586,11 @@ export class StartWorkAction implements DevDocketAction {
     let createdBranch = false;
 
     if (hasLocalBranch && trackingRef) {
+      cancellationState.cleanupActivity = {
+        timestamp: Date.now(),
+        type: 'work-started',
+        detail: encodeWorkStartedDetail({ worktreePath, repoPath }),
+      };
       // PR with an existing local branch — the local branch may be stale or
       // tracking a different remote. Create a detached worktree from the PR ref.
       logger.info(
@@ -583,6 +604,11 @@ export class StartWorkAction implements DevDocketAction {
         signal,
       });
     } else if (hasLocalBranch && conflictingWorktree) {
+      cancellationState.cleanupActivity = {
+        timestamp: Date.now(),
+        type: 'work-started',
+        detail: encodeWorkStartedDetail({ worktreePath, repoPath }),
+      };
       logger.info(
         `Branch ${branchName} is already held by worktree at ${conflictingWorktree}; creating detached worktree from ${worktreeSourceRef}`,
       );
@@ -594,12 +620,22 @@ export class StartWorkAction implements DevDocketAction {
         signal,
       });
     } else if (hasLocalBranch) {
+      cancellationState.cleanupActivity = {
+        timestamp: Date.now(),
+        type: 'work-started',
+        detail: encodeWorkStartedDetail({ worktreePath, repoPath }),
+      };
       await execFileAsync('git', ['worktree', 'add', worktreePath, branchName], {
         cwd: repoPath,
         timeout: GIT_CHECKOUT_TIMEOUT,
         signal,
       });
     } else {
+      cancellationState.cleanupActivity = {
+        timestamp: Date.now(),
+        type: 'work-started',
+        detail: encodeWorkStartedDetail({ branchName, worktreePath, repoPath }),
+      };
       await execFileAsync('git', ['worktree', 'add', '-b', branchName, worktreePath, worktreeSourceRef], {
         cwd: repoPath,
         timeout: GIT_CHECKOUT_TIMEOUT,
@@ -979,8 +1015,12 @@ export class StartWorkAction implements DevDocketAction {
     }
 
     if (cancellationState.cleanupActivity) {
+      const cleanupDetail = cancellationState.cleanupActivity.detail;
+      const cleanupTarget = cleanupDetail && cleanupDetail.includes('"worktreePath"')
+        ? 'The created worktree may need cleanup.'
+        : 'A partially created branch may need cleanup.';
       const choice = await vscode.window.showWarningMessage(
-        `DevDocket: ${detail} The created worktree may need cleanup.`,
+        `DevDocket: ${detail} ${cleanupTarget}`,
         'Remove worktree',
       );
       if (choice === 'Remove worktree') {

--- a/packages/start-git-work/src/test/__mocks__/vscode.ts
+++ b/packages/start-git-work/src/test/__mocks__/vscode.ts
@@ -51,7 +51,13 @@ const window = {
   showErrorMessage: vi.fn(),
   showQuickPick: vi.fn(),
   showOpenDialog: vi.fn(),
-  withProgress: vi.fn(async (_options: any, task: Function) => task({ report: vi.fn() })),
+  withProgress: vi.fn(async (_options: any, task: Function) => task(
+    { report: vi.fn() },
+    {
+      isCancellationRequested: false,
+      onCancellationRequested: () => ({ dispose: vi.fn() }),
+    },
+  )),
   registerTreeDataProvider: vi.fn(() => ({ dispose: vi.fn() })),
   createWebviewPanel: vi.fn(),
   createOutputChannel: vi.fn(() => ({

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -1147,7 +1147,7 @@ describe('StartWorkAction', () => {
       expect(vi.mocked(commands.executeCommand).mock.calls).toContainEqual([
         'devdocket.addActivity',
         'wc-test-1',
-        'updated',
+        'action-executed',
         'Start Git Work cancelled during running npm.',
       ]);
     });

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -1214,11 +1214,11 @@ describe('StartWorkAction', () => {
           cb(new Error('not fully merged'), '', 'error: the branch is not fully merged');
           return;
         }
-        if (args[0] === 'rev-parse' && args[2] === 'refs/heads/issue123') {
+        if (args[0] === 'rev-parse' && args[3] === 'refs/heads/issue123') {
           cb(null, 'abc123\n', '');
           return;
         }
-        if (args[0] === 'rev-parse' && args[2] === 'origin/dev') {
+        if (args[0] === 'rev-parse' && args[3] === 'origin/dev') {
           cb(null, 'abc123\n', '');
           return;
         }

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -1185,8 +1185,9 @@ describe('StartWorkAction', () => {
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual(['branch', '-D', 'issue123']);
       const rollbackCall = vi.mocked(execFile).mock.calls.find(call => call[1][0] === 'branch' && call[1][1] === '-D');
       expect(rollbackCall?.[2]).toEqual({ cwd: '/mock/workspace', timeout: 30_000 });
-      expect(window.showInformationMessage).toHaveBeenCalledWith(
-        'DevDocket: Start Git Work cancelled during creating worktree.',
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Start Git Work cancelled during creating worktree.'),
+        'Clean up',
       );
     });
 

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { window, workspace } from 'vscode';
+import { commands, window, workspace } from 'vscode';
 import { StartWorkAction } from '../startWorkAction';
 import * as path from 'path';
 import type { ProviderItemCapabilities } from '@devdocket/shared';
@@ -767,6 +767,31 @@ describe('StartWorkAction', () => {
       ]);
     });
 
+    it('propagates AbortError when PR fetch is cancelled', async () => {
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'remote' && args[1] === '-v') {
+          cb(null, ORIGIN_REMOTE_V, '');
+          return;
+        }
+        if (args[0] === 'fetch') {
+          const err = new Error('The operation was aborted.');
+          err.name = 'AbortError';
+          cb(err, '', '');
+          return;
+        }
+        cb(null, '', '');
+      }) as any);
+      const { action } = createAction();
+
+      await expect((action as any).fetchPrBranch(
+        { kind: 'pr', cloneUrl: 'https://example.com/acme/repo.git', ref: 'feature/topic', repoLabel: 'acme/repo' },
+        '/mock/workspace',
+        undefined,
+        new AbortController().signal,
+      )).rejects.toMatchObject({ name: 'AbortError', message: 'The operation was aborted.' });
+      expect(window.showErrorMessage).not.toHaveBeenCalled();
+    });
+
     it('rejects an invalid cloneUrl returned by a lazy resolver', async () => {
       const item = createWorkItem();
       const { action } = createAction(discovered('provider', 'item-1', async () => ({
@@ -1037,6 +1062,31 @@ describe('StartWorkAction', () => {
       ]);
     });
 
+    it('keeps start-work progress cancellable and passes abort signals to git commands', async () => {
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(window.withProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ cancellable: true, title: 'Starting git work for issue' }),
+        expect.any(Function),
+      );
+      const gitOptions = vi.mocked(execFile).mock.calls
+        .filter(call => call[0] === 'git')
+        .map(call => call[2]);
+      expect(gitOptions).toHaveLength(3);
+      expect(gitOptions.every(options => options.signal instanceof AbortSignal)).toBe(true);
+      expect(vi.mocked(commands.executeCommand).mock.calls).toContainEqual([
+        'devdocket.addActivity',
+        'wc-test-1',
+        'work-started',
+        expect.any(String),
+      ]);
+    });
+
     it('runs configured post-worktree commands with the created worktree path', async () => {
       vi.mocked(workspace.getConfiguration).mockReturnValue({
         get: vi.fn((key: string, defaultValue?: any) => key === 'commands'
@@ -1051,7 +1101,54 @@ describe('StartWorkAction', () => {
       await action.run(item);
 
       expect(vi.mocked(execFile).mock.calls.map(call => [call[0], call[1], call[2]])).toContainEqual([
-        'npm', ['install', '--prefix', path.join('/mock', 'repo-issue-1')], { cwd: path.join('/mock', 'repo-issue-1'), timeout: 60_000 },
+        'npm', ['install', '--prefix', path.join('/mock', 'repo-issue-1')], expect.objectContaining({ cwd: path.join('/mock', 'repo-issue-1'), timeout: 60_000, signal: expect.any(AbortSignal) }),
+      ]);
+    });
+
+    it('logs cancellation and offers worktree cleanup when cancelled after worktree creation', async () => {
+      vi.mocked(workspace.getConfiguration).mockReturnValue({
+        get: vi.fn((key: string, defaultValue?: any) => key === 'commands'
+          ? [{ command: 'npm', args: ['install'] }]
+          : defaultValue),
+      } as any);
+      const cancellationListeners: Array<() => void> = [];
+      vi.mocked(window.withProgress).mockImplementation(async (_options: any, task: Function) => task(
+        { report: vi.fn() },
+        {
+          isCancellationRequested: false,
+          onCancellationRequested: (listener: () => void) => {
+            cancellationListeners.push(listener);
+            return { dispose: vi.fn() };
+          },
+        },
+      ));
+      vi.mocked(window.showWarningMessage).mockResolvedValue(undefined as any);
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (cmd === 'npm') {
+          cancellationListeners.forEach(listener => listener());
+          const err = new Error('The operation was aborted.');
+          err.name = 'AbortError';
+          cb(err, '', '');
+          return;
+        }
+        cb(null, '', '');
+      }) as any);
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Start Git Work cancelled during running npm.'),
+        'Remove worktree',
+      );
+      expect(vi.mocked(commands.executeCommand).mock.calls).toContainEqual([
+        'devdocket.addActivity',
+        'wc-test-1',
+        'updated',
+        'Start Git Work cancelled during running npm.',
       ]);
     });
 

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -1182,8 +1182,8 @@ describe('StartWorkAction', () => {
 
       await action.run(item);
 
-      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual(['branch', '-D', 'issue123']);
-      const rollbackCall = vi.mocked(execFile).mock.calls.find(call => call[1][0] === 'branch' && call[1][1] === '-D');
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual(['branch', '-d', '--', 'issue123']);
+      const rollbackCall = vi.mocked(execFile).mock.calls.find(call => call[1][0] === 'branch' && call[1][1] === '-d');
       expect(rollbackCall?.[2]).toEqual({ cwd: '/mock/workspace', timeout: 30_000 });
       expect(window.showWarningMessage).toHaveBeenCalledWith(
         expect.stringContaining('Start Git Work cancelled during creating worktree.'),

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -1152,6 +1152,44 @@ describe('StartWorkAction', () => {
       ]);
     });
 
+    it('offers cleanup and rolls back the branch when issue worktree creation is cancelled', async () => {
+      const cancellationListeners: Array<() => void> = [];
+      vi.mocked(window.withProgress).mockImplementation(async (_options: any, task: Function) => task(
+        { report: vi.fn() },
+        {
+          isCancellationRequested: false,
+          onCancellationRequested: (listener: () => void) => {
+            cancellationListeners.push(listener);
+            return { dispose: vi.fn() };
+          },
+        },
+      ));
+      vi.mocked(window.showWarningMessage).mockResolvedValue(undefined as any);
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'worktree' && args[1] === 'add') {
+          cancellationListeners.forEach(listener => listener());
+          const err = new Error('The operation was aborted.');
+          err.name = 'AbortError';
+          cb(err, '', '');
+          return;
+        }
+        cb(null, '', '');
+      }) as any);
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual(['branch', '-D', 'issue123']);
+      const rollbackCall = vi.mocked(execFile).mock.calls.find(call => call[1][0] === 'branch' && call[1][1] === '-D');
+      expect(rollbackCall?.[2]).toEqual({ cwd: '/mock/workspace', timeout: 30_000 });
+      expect(window.showInformationMessage).toHaveBeenCalledWith(
+        'DevDocket: Start Git Work cancelled during creating worktree.',
+      );
+    });
+
     it('accepts and routes a third-party provider without host or provider-id knowledge', async () => {
       const item = createWorkItem({ providerId: 'fake-vendor', externalId: 'work-42' });
       const { action } = createAction(discovered('fake-vendor', 'work-42', {

--- a/packages/start-git-work/src/test/startWorkAction.test.ts
+++ b/packages/start-git-work/src/test/startWorkAction.test.ts
@@ -1185,10 +1185,53 @@ describe('StartWorkAction', () => {
       expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual(['branch', '-d', '--', 'issue123']);
       const rollbackCall = vi.mocked(execFile).mock.calls.find(call => call[1][0] === 'branch' && call[1][1] === '-d');
       expect(rollbackCall?.[2]).toEqual({ cwd: '/mock/workspace', timeout: 30_000 });
-      expect(window.showWarningMessage).toHaveBeenCalledWith(
-        expect.stringContaining('Start Git Work cancelled during creating worktree.'),
-        'Clean up',
+      expect(window.showInformationMessage).toHaveBeenCalledWith(
+        'DevDocket: Start Git Work cancelled during creating worktree.',
       );
+    });
+
+    it('force deletes rollback branches that still point at the base branch tip', async () => {
+      const cancellationListeners: Array<() => void> = [];
+      vi.mocked(window.withProgress).mockImplementation(async (_options: any, task: Function) => task(
+        { report: vi.fn() },
+        {
+          isCancellationRequested: false,
+          onCancellationRequested: (listener: () => void) => {
+            cancellationListeners.push(listener);
+            return { dispose: vi.fn() };
+          },
+        },
+      ));
+      vi.mocked(execFile).mockImplementation(((cmd: string, args: string[], opts: any, cb: Function) => {
+        if (args[0] === 'worktree' && args[1] === 'add') {
+          cancellationListeners.forEach(listener => listener());
+          const err = new Error('The operation was aborted.');
+          err.name = 'AbortError';
+          cb(err, '', '');
+          return;
+        }
+        if (args[0] === 'branch' && args[1] === '-d') {
+          cb(new Error('not fully merged'), '', 'error: the branch is not fully merged');
+          return;
+        }
+        if (args[0] === 'rev-parse' && args[2] === 'refs/heads/issue123') {
+          cb(null, 'abc123\n', '');
+          return;
+        }
+        if (args[0] === 'rev-parse' && args[2] === 'origin/dev') {
+          cb(null, 'abc123\n', '');
+          return;
+        }
+        cb(null, '', '');
+      }) as any);
+      const item = createWorkItem();
+      const { action } = createAction(discovered('provider', 'item-1', {
+        kind: 'issue', cloneUrl: 'https://example.com/acme/repo.git', ref: 'issue123', repoLabel: 'acme/repo',
+      }));
+
+      await action.run(item);
+
+      expect(vi.mocked(execFile).mock.calls.map(call => call[1])).toContainEqual(['branch', '-D', '--', 'issue123']);
     });
 
     it('accepts and routes a third-party provider without host or provider-id knowledge', async () => {


### PR DESCRIPTION
## Summary
- make Start Git Work progress notifications cancellable for both issue and PR flows
- bridge VS Code cancellation tokens to child-process AbortSignals and log the interrupted step
- offer follow-up cleanup when cancellation happens after a worktree may have been created
- add a shared `abortFromToken` helper in `@devdocket/shared` for this branch and the companion #577 work

## Testing
- `npm run build`
- `npm run test`

Closes #578

Note: this PR introduces the shared `abortFromToken` helper in `@devdocket/shared`; issue #577 is expected to pick up the same helper when that branch rebases.
