### PR TITLE
Add GitHub SSO recovery prompts

### DIFF
--- a/.changeset/add-github-sso-recovery.md
+++ b/.changeset/add-github-sso-recovery.md
@@ -1,6 +1,7 @@
 ---
+"@devdocket/shared": minor
 "devdocket-github": minor
 "devdocket": patch
 ---
 
-Add in-app GitHub SSO recovery prompts with authorize and retry actions for URL imports, and surface deduplicated authorization notifications during GitHub background refreshes.
+Add a shared recoverable-error contract so providers can supply recovery actions without teaching the core extension about provider-specific failures, and use it for GitHub SSO authorization prompts and deduplicated background refresh notifications.

--- a/.changeset/add-github-sso-recovery.md
+++ b/.changeset/add-github-sso-recovery.md
@@ -1,0 +1,6 @@
+---
+"devdocket-github": minor
+"devdocket": patch
+---
+
+Add in-app GitHub SSO recovery prompts with authorize and retry actions for URL imports, and surface deduplicated authorization notifications during GitHub background refreshes.

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -110,9 +110,7 @@ async function handleGitHubSsoError(
   retry: () => Promise<void>,
 ): Promise<void> {
   const authorizationUrl = getGitHubSsoAuthorizationUrl(err);
-  const safeAuthorizationUrl = authorizationUrl && isSafeUrl(authorizationUrl)
-    ? authorizationUrl
-    : undefined;
+  const safeAuthorizationUrl = authorizationUrl ? isSafeUrl(authorizationUrl) : null;
   const orgLabel = err.orgName
     ? `the "${err.orgName}" organization`
     : 'this organization';
@@ -127,7 +125,7 @@ async function handleGitHubSsoError(
 
   if (action === AUTHORIZE_IN_BROWSER_ACTION && safeAuthorizationUrl) {
     try {
-      await vscode.env.openExternal(vscode.Uri.parse(safeAuthorizationUrl));
+      await vscode.env.openExternal(vscode.Uri.parse(safeAuthorizationUrl.href));
     } catch (openError) {
       handleCommandError('Failed to open GitHub SSO authorization', openError);
     }

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -70,6 +70,14 @@ function formatItemTitle(item: { group?: string; title: string }): string {
  * drift apart silently.
  */
 const BROWSE_PROVIDER_EXTENSIONS_ACTION = 'Browse Provider Extensions';
+const AUTHORIZE_IN_BROWSER_ACTION = 'Authorize in browser';
+const RETRY_ACTION = 'Retry';
+const DISMISS_ACTION = 'Dismiss';
+
+type GitHubSsoLikeError = Error & {
+  ssoUrl?: string;
+  orgName?: string;
+};
 
 /**
  * Open the VS Code Extensions view filtered to extensions published by the
@@ -78,6 +86,38 @@ const BROWSE_PROVIDER_EXTENSIONS_ACTION = 'Browse Provider Extensions';
  */
 async function browseProviderExtensions(): Promise<void> {
   await vscode.commands.executeCommand('workbench.extensions.search', '@publisher:"devdocket"');
+}
+
+function isGitHubSsoError(err: unknown): err is GitHubSsoLikeError {
+  return typeof err === 'object'
+    && err !== null
+    && 'name' in err
+    && (err as { name?: unknown }).name === 'GitHubSsoError';
+}
+
+async function handleGitHubSsoError(
+  err: GitHubSsoLikeError,
+  retry: () => Promise<void>,
+): Promise<void> {
+  const orgLabel = err.orgName
+    ? `the "${err.orgName}" organization`
+    : 'this organization';
+  const message = `DevDocket: GitHub requires SSO authorization for ${orgLabel}\nbefore this item can be loaded.`;
+  const action = await vscode.window.showErrorMessage(
+    message,
+    AUTHORIZE_IN_BROWSER_ACTION,
+    RETRY_ACTION,
+    DISMISS_ACTION,
+  );
+
+  if (action === AUTHORIZE_IN_BROWSER_ACTION && err.ssoUrl) {
+    await vscode.env.openExternal(vscode.Uri.parse(err.ssoUrl));
+    return;
+  }
+
+  if (action === RETRY_ACTION) {
+    await retry();
+  }
 }
 
 /** Log the error and show a user-facing message. */
@@ -89,13 +129,20 @@ function handleCommandError(context: string, err: unknown): void {
 
 /** Wrap a command handler so unhandled errors are logged and shown to the user. */
 function wrapCommand<T extends unknown[]>(label: string, fn: (...args: T) => Promise<void> | void): (...args: T) => Promise<void> {
-  return async (...args: T) => {
+  const wrapped = async (...args: T): Promise<void> => {
     try {
       await fn(...args);
     } catch (err: unknown) {
+      if (isGitHubSsoError(err)) {
+        logger.error(label, err);
+        await handleGitHubSsoError(err, () => wrapped(...args));
+        return;
+      }
       handleCommandError(label, err);
     }
   };
+
+  return wrapped;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { isRecoverableError, type RecoverableError } from '@devdocket/shared';
 import { WorkItemState } from '../models/workItem';
 import { ACTIVITY_TYPES, type ActivityType } from '../models/activityLog';
 import { WorkGraph } from '../services/workGraph';
@@ -61,8 +62,6 @@ function formatItemTitle(item: { group?: string; title: string }): string {
   return item.title;
 }
 
-// isSafeUrl is imported from ../utils/url.
-
 /**
  * Label for the notification action button that opens the VS Code Extensions
  * view filtered to DevDocket-published extensions. Shared between the action
@@ -70,14 +69,8 @@ function formatItemTitle(item: { group?: string; title: string }): string {
  * drift apart silently.
  */
 const BROWSE_PROVIDER_EXTENSIONS_ACTION = 'Browse Provider Extensions';
-const AUTHORIZE_IN_BROWSER_ACTION = 'Authorize in browser';
 const RETRY_ACTION = 'Retry';
 const DISMISS_ACTION = 'Dismiss';
-
-type GitHubSsoLikeError = Error & {
-  ssoUrl?: string;
-  orgName?: string;
-};
 
 /**
  * Open the VS Code Extensions view filtered to extensions published by the
@@ -88,47 +81,37 @@ async function browseProviderExtensions(): Promise<void> {
   await vscode.commands.executeCommand('workbench.extensions.search', '@publisher:"devdocket"');
 }
 
-function isGitHubSsoError(err: unknown): err is GitHubSsoLikeError {
-  return typeof err === 'object'
-    && err !== null
-    && 'name' in err
-    && (err as { name?: unknown }).name === 'GitHubSsoError';
-}
-
-function getGitHubSsoAuthorizationUrl(err: GitHubSsoLikeError): string | undefined {
-  if (err.ssoUrl) {
-    return err.ssoUrl;
-  }
-  if (err.orgName) {
-    return `https://github.com/orgs/${encodeURIComponent(err.orgName)}/sso`;
-  }
-  return undefined;
-}
-
-async function handleGitHubSsoError(
-  err: GitHubSsoLikeError,
+async function handleRecoverableError(
+  err: RecoverableError,
   retry: () => Promise<void>,
 ): Promise<void> {
-  const authorizationUrl = getGitHubSsoAuthorizationUrl(err);
-  const safeAuthorizationUrl = authorizationUrl ? isSafeUrl(authorizationUrl) : null;
-  const orgLabel = err.orgName
-    ? `the "${err.orgName}" organization`
-    : 'this organization';
-  const actions = safeAuthorizationUrl
-    ? [AUTHORIZE_IN_BROWSER_ACTION, RETRY_ACTION, DISMISS_ACTION] as const
-    : [RETRY_ACTION, DISMISS_ACTION] as const;
-  const message = `DevDocket: GitHub requires SSO authorization for ${orgLabel}\nbefore this item can be loaded.`;
-  const action = await vscode.window.showErrorMessage(
-    message,
-    ...actions,
-  );
-
-  if (action === AUTHORIZE_IN_BROWSER_ACTION && safeAuthorizationUrl) {
+  const providerActions = err.actions ?? [];
+  const actions = [
+    ...providerActions.map(action => action.label),
+    ...(err.retryable !== false ? [RETRY_ACTION] : []),
+    DISMISS_ACTION,
+  ];
+  const action = await vscode.window.showErrorMessage(err.message, ...actions);
+  const providerAction = providerActions.find(candidate => candidate.label === action);
+  if (providerAction) {
     try {
-      await vscode.env.openExternal(vscode.Uri.parse(safeAuthorizationUrl.href));
-    } catch (openError) {
-      handleCommandError('Failed to open GitHub SSO authorization', openError);
+      await providerAction.run();
+    } catch (actionError) {
+      handleCommandError(`Recovery action failed: ${providerAction.label}`, actionError);
+      return;
     }
+
+    if (providerAction.retryAfterAction) {
+      try {
+        await retry();
+      } catch (retryError) {
+        handleCommandError('Retry failed', retryError);
+      }
+    }
+    return;
+  }
+
+  if (!action || action === DISMISS_ACTION) {
     return;
   }
 
@@ -136,7 +119,7 @@ async function handleGitHubSsoError(
     try {
       await retry();
     } catch (retryError) {
-      handleCommandError('Failed to retry after GitHub SSO authorization', retryError);
+      handleCommandError('Retry failed', retryError);
     }
   }
 }
@@ -154,9 +137,9 @@ function wrapCommand<T extends unknown[]>(label: string, fn: (...args: T) => Pro
     try {
       await fn(...args);
     } catch (err: unknown) {
-      if (isGitHubSsoError(err)) {
+      if (isRecoverableError(err)) {
         logger.error(label, err);
-        await handleGitHubSsoError(err, () => wrapped(...args));
+        await handleRecoverableError(err, () => wrapped(...args));
         return;
       }
       handleCommandError(label, err);
@@ -430,8 +413,8 @@ async function handleCreateItemFromUrl(
     if (error instanceof Error && error.name === 'AbortError') {
       return;
     }
-    if (isGitHubSsoError(error)) {
-      await handleGitHubSsoError(error, () => handleCreateItemFromUrl(
+    if (isRecoverableError(error)) {
+      await handleRecoverableError(error, () => handleCreateItemFromUrl(
         context,
         workGraph,
         providerRegistry,

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -95,23 +95,35 @@ function isGitHubSsoError(err: unknown): err is GitHubSsoLikeError {
     && (err as { name?: unknown }).name === 'GitHubSsoError';
 }
 
+function getGitHubSsoAuthorizationUrl(err: GitHubSsoLikeError): string | undefined {
+  if (err.ssoUrl) {
+    return err.ssoUrl;
+  }
+  if (err.orgName) {
+    return `https://github.com/orgs/${encodeURIComponent(err.orgName)}/sso`;
+  }
+  return undefined;
+}
+
 async function handleGitHubSsoError(
   err: GitHubSsoLikeError,
   retry: () => Promise<void>,
 ): Promise<void> {
+  const authorizationUrl = getGitHubSsoAuthorizationUrl(err);
   const orgLabel = err.orgName
     ? `the "${err.orgName}" organization`
     : 'this organization';
+  const actions = authorizationUrl
+    ? [AUTHORIZE_IN_BROWSER_ACTION, RETRY_ACTION, DISMISS_ACTION] as const
+    : [RETRY_ACTION, DISMISS_ACTION] as const;
   const message = `DevDocket: GitHub requires SSO authorization for ${orgLabel}\nbefore this item can be loaded.`;
   const action = await vscode.window.showErrorMessage(
     message,
-    AUTHORIZE_IN_BROWSER_ACTION,
-    RETRY_ACTION,
-    DISMISS_ACTION,
+    ...actions,
   );
 
-  if (action === AUTHORIZE_IN_BROWSER_ACTION && err.ssoUrl) {
-    await vscode.env.openExternal(vscode.Uri.parse(err.ssoUrl));
+  if (action === AUTHORIZE_IN_BROWSER_ACTION && authorizationUrl) {
+    await vscode.env.openExternal(vscode.Uri.parse(authorizationUrl));
     return;
   }
 

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -110,10 +110,13 @@ async function handleGitHubSsoError(
   retry: () => Promise<void>,
 ): Promise<void> {
   const authorizationUrl = getGitHubSsoAuthorizationUrl(err);
+  const safeAuthorizationUrl = authorizationUrl && isSafeUrl(authorizationUrl)
+    ? authorizationUrl
+    : undefined;
   const orgLabel = err.orgName
     ? `the "${err.orgName}" organization`
     : 'this organization';
-  const actions = authorizationUrl
+  const actions = safeAuthorizationUrl
     ? [AUTHORIZE_IN_BROWSER_ACTION, RETRY_ACTION, DISMISS_ACTION] as const
     : [RETRY_ACTION, DISMISS_ACTION] as const;
   const message = `DevDocket: GitHub requires SSO authorization for ${orgLabel}\nbefore this item can be loaded.`;
@@ -122,13 +125,21 @@ async function handleGitHubSsoError(
     ...actions,
   );
 
-  if (action === AUTHORIZE_IN_BROWSER_ACTION && authorizationUrl) {
-    await vscode.env.openExternal(vscode.Uri.parse(authorizationUrl));
+  if (action === AUTHORIZE_IN_BROWSER_ACTION && safeAuthorizationUrl) {
+    try {
+      await vscode.env.openExternal(vscode.Uri.parse(safeAuthorizationUrl));
+    } catch (openError) {
+      handleCommandError('Failed to open GitHub SSO authorization', openError);
+    }
     return;
   }
 
   if (action === RETRY_ACTION) {
-    await retry();
+    try {
+      await retry();
+    } catch (retryError) {
+      handleCommandError('Failed to retry after GitHub SSO authorization', retryError);
+    }
   }
 }
 

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -382,13 +382,15 @@ async function handleCreateItemFromUrl(
   providerRegistry: ProviderRegistry,
   labelCache: ProviderLabelCache,
   editorPanelDependencies: WorkItemEditorPanelDependencies,
+  initialUrl?: string,
 ): Promise<void> {
-  const url = await vscode.window.showInputBox({
+  const inputUrl = initialUrl ?? await vscode.window.showInputBox({
     prompt: 'Enter a URL to create a work item from',
   });
-  if (!url?.trim()) { return; }
+  const url = inputUrl?.trim();
+  if (!url) { return; }
 
-  if (!isSafeUrl(url.trim())) {
+  if (!isSafeUrl(url)) {
     void vscode.window.showErrorMessage('DevDocket: Please enter a valid HTTP or HTTPS URL');
     return;
   }
@@ -400,11 +402,22 @@ async function handleCreateItemFromUrl(
       (_progress, token) => {
         const controller = new AbortController();
         token.onCancellationRequested(() => controller.abort());
-        return providerRegistry.resolveUrl(url.trim(), controller.signal);
+        return providerRegistry.resolveUrl(url, controller.signal);
       },
     );
   } catch (error) {
     if (error instanceof Error && error.name === 'AbortError') {
+      return;
+    }
+    if (isGitHubSsoError(error)) {
+      await handleGitHubSsoError(error, () => handleCreateItemFromUrl(
+        context,
+        workGraph,
+        providerRegistry,
+        labelCache,
+        editorPanelDependencies,
+        url,
+      ));
       return;
     }
     throw error;

--- a/packages/core/src/commands/commands.ts
+++ b/packages/core/src/commands/commands.ts
@@ -85,23 +85,31 @@ async function handleRecoverableError(
   err: RecoverableError,
   retry: () => Promise<void>,
 ): Promise<void> {
-  const providerActions = err.actions ?? [];
-  const actions = [
-    ...providerActions.map(action => action.label),
-    ...(err.retryable !== false ? [RETRY_ACTION] : []),
-    DISMISS_ACTION,
+  const providerItems = (err.actions ?? []).map(action => ({
+    title: action.label,
+    action,
+  }));
+  const retryItem = err.retryable !== false
+    ? { title: RETRY_ACTION }
+    : undefined;
+  const dismissItem = { title: DISMISS_ACTION };
+  const items = [
+    ...providerItems,
+    ...(retryItem ? [retryItem] : []),
+    dismissItem,
   ];
-  const action = await vscode.window.showErrorMessage(err.message, ...actions);
-  const providerAction = providerActions.find(candidate => candidate.label === action);
-  if (providerAction) {
+  const selection = await vscode.window.showErrorMessage(err.message, ...items);
+
+  const providerItem = providerItems.find(item => item === selection);
+  if (providerItem) {
     try {
-      await providerAction.run();
+      await providerItem.action.run();
     } catch (actionError) {
-      handleCommandError(`Recovery action failed: ${providerAction.label}`, actionError);
+      handleCommandError(`Recovery action failed: ${providerItem.action.label}`, actionError);
       return;
     }
 
-    if (providerAction.retryAfterAction) {
+    if (providerItem.action.retryAfterAction) {
       try {
         await retry();
       } catch (retryError) {
@@ -111,11 +119,11 @@ async function handleRecoverableError(
     return;
   }
 
-  if (!action || action === DISMISS_ACTION) {
+  if (!selection || selection === dismissItem) {
     return;
   }
 
-  if (action === RETRY_ACTION) {
+  if (selection === retryItem) {
     try {
       await retry();
     } catch (retryError) {

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -69,6 +69,12 @@ function makeRecoverableError(overrides: Partial<RecoverableError> = {}): Recove
   return error;
 }
 
+function selectErrorAction(label: string): void {
+  (vscode.window.showErrorMessage as Mock).mockImplementationOnce(async (_message: string, ...items: any[]) =>
+    items.find(item => (typeof item === 'string' ? item : item.title) === label),
+  );
+}
+
 type UsedWorkGraphMethods = Pick<
   WorkGraph,
   'transitionState' | 'getItem' | 'createItem' | 'findItemByProvenance' | 'moveItem' | 'deleteItem' | 'clearOldHistory' | 'addActivity'
@@ -468,16 +474,16 @@ describe('registerCommands', () => {
       });
       providerRegistry.resolveUrl.mockRejectedValue(recoverableError);
       (vscode.window.showInputBox as Mock).mockResolvedValue('https://github.com/owner/repo/pull/42');
-      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Reconnect');
+      selectErrorAction('Reconnect');
       await invoke('devdocket.createItemFromUrl');
 
       expect(run).toHaveBeenCalledTimes(1);
       expect(providerRegistry.resolveUrl).toHaveBeenCalledTimes(1);
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
         'Recoverable error',
-        'Reconnect',
-        'Retry',
-        'Dismiss',
+        expect.objectContaining({ title: 'Reconnect' }),
+        expect.objectContaining({ title: 'Retry' }),
+        expect.objectContaining({ title: 'Dismiss' }),
       );
     });
 
@@ -495,7 +501,7 @@ describe('registerCommands', () => {
         .mockRejectedValueOnce(recoverableError)
         .mockResolvedValueOnce(fakeDetails);
       (vscode.window.showInputBox as Mock).mockResolvedValueOnce('https://github.com/owner/repo/pull/42');
-      (vscode.window.showErrorMessage as Mock).mockResolvedValueOnce('Authorize in browser');
+      selectErrorAction('Authorize in browser');
       await invoke('devdocket.createItemFromUrl');
 
       expect(authorize).toHaveBeenCalledTimes(1);
@@ -515,13 +521,13 @@ describe('registerCommands', () => {
       });
       providerRegistry.resolveUrl.mockRejectedValue(recoverableError);
       (vscode.window.showInputBox as Mock).mockResolvedValue('https://github.com/owner/repo/pull/42');
-      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Dismiss');
+      selectErrorAction('Dismiss');
       await invoke('devdocket.createItemFromUrl');
 
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
         'Recoverable error',
-        'Reconnect',
-        'Dismiss',
+        expect.objectContaining({ title: 'Reconnect' }),
+        expect.objectContaining({ title: 'Dismiss' }),
       );
     });
 
@@ -529,13 +535,13 @@ describe('registerCommands', () => {
       const recoverableError = makeRecoverableError({ message: 'Recoverable error' });
       providerRegistry.resolveUrl.mockRejectedValue(recoverableError);
       (vscode.window.showInputBox as Mock).mockResolvedValue('https://github.com/owner/repo/pull/42');
-      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Dismiss');
+      selectErrorAction('Dismiss');
       await invoke('devdocket.createItemFromUrl');
 
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
         'Recoverable error',
-        'Retry',
-        'Dismiss',
+        expect.objectContaining({ title: 'Retry' }),
+        expect.objectContaining({ title: 'Dismiss' }),
       );
     });
 
@@ -546,7 +552,7 @@ describe('registerCommands', () => {
         .mockResolvedValueOnce(fakeDetails);
       (vscode.window.showInputBox as Mock)
         .mockResolvedValueOnce('https://github.com/owner/repo/pull/42');
-      (vscode.window.showErrorMessage as Mock).mockResolvedValueOnce('Retry');
+      selectErrorAction('Retry');
       await invoke('devdocket.createItemFromUrl');
 
       expect(providerRegistry.resolveUrl).toHaveBeenCalledTimes(2);

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -482,6 +482,20 @@ describe('registerCommands', () => {
       expect(vscode.env.openExternal).toHaveBeenCalledWith(expect.objectContaining({ toString: expect.any(Function) }));
     });
 
+    it('falls back to the org SSO page when the error has no direct authorization URL', async () => {
+      const ssoError = Object.assign(new Error('GitHub SSO authorization required'), {
+        name: 'GitHubSsoError',
+        orgName: 'example-fallback',
+      });
+      providerRegistry.resolveUrl.mockRejectedValue(ssoError);
+      (vscode.window.showInputBox as Mock).mockResolvedValue('https://github.com/owner/repo/pull/42');
+      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Authorize in browser');
+      await invoke('devdocket.createItemFromUrl');
+
+      expect(vscode.Uri.parse).toHaveBeenCalledWith('https://github.com/orgs/example-fallback/sso');
+      expect(vscode.env.openExternal).toHaveBeenCalledWith(expect.objectContaining({ toString: expect.any(Function) }));
+    });
+
     it('retries the command when the user selects Retry from the SSO notification', async () => {
       const ssoError = Object.assign(new Error('GitHub SSO authorization required'), {
         name: 'GitHubSsoError',

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -496,6 +496,24 @@ describe('registerCommands', () => {
       expect(vscode.env.openExternal).toHaveBeenCalledWith(expect.objectContaining({ toString: expect.any(Function) }));
     });
 
+    it('omits authorize when the SSO URL is not safe to open', async () => {
+      const ssoError = Object.assign(new Error('GitHub SSO authorization required'), {
+        name: 'GitHubSsoError',
+        ssoUrl: 'file:///not-safe',
+      });
+      providerRegistry.resolveUrl.mockRejectedValue(ssoError);
+      (vscode.window.showInputBox as Mock).mockResolvedValue('https://github.com/owner/repo/pull/42');
+      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Dismiss');
+      await invoke('devdocket.createItemFromUrl');
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'DevDocket: GitHub requires SSO authorization for this organization\nbefore this item can be loaded.',
+        'Retry',
+        'Dismiss',
+      );
+      expect(vscode.env.openExternal).not.toHaveBeenCalled();
+    });
+
     it('retries the command when the user selects Retry from the SSO notification', async () => {
       const ssoError = Object.assign(new Error('GitHub SSO authorization required'), {
         name: 'GitHubSsoError',

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 import * as vscode from 'vscode';
+import { type RecoverableError } from '@devdocket/shared';
 import { WorkItemState, type WorkItem } from '../models/workItem';
 import { registerCommands } from '../commands/commands';
 import { isSafeUrl } from '../utils/url';
@@ -57,6 +58,15 @@ function makeSourceItem(overrides: Partial<SourceItemNode> = {}): SourceItemNode
     url: 'https://github.com/org/repo/issues/2',
     ...overrides,
   };
+}
+
+function makeRecoverableError(overrides: Partial<RecoverableError> = {}): RecoverableError {
+  const error = new Error('Recoverable error') as RecoverableError;
+  Object.assign(error, {
+    recoverable: true as const,
+    ...overrides,
+  });
+  return error;
 }
 
 type UsedWorkGraphMethods = Pick<
@@ -447,81 +457,92 @@ describe('registerCommands', () => {
       expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
     });
 
-    it('shows SSO recovery actions when URL resolution requires GitHub authorization', async () => {
-      const ssoError = Object.assign(new Error('GitHub SSO authorization required'), {
-        name: 'GitHubSsoError',
-        orgName: 'example',
-        ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
+    it('shows provider-supplied recovery actions and invokes the selected callback', async () => {
+      const run = vi.fn(async () => undefined);
+      const recoverableError = makeRecoverableError({
+        message: 'Recoverable error',
+        actions: [{
+          label: 'Reconnect',
+          run,
+        }],
       });
-      providerRegistry.resolveUrl.mockRejectedValue(ssoError);
+      providerRegistry.resolveUrl.mockRejectedValue(recoverableError);
       (vscode.window.showInputBox as Mock).mockResolvedValue('https://github.com/owner/repo/pull/42');
-      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Dismiss');
+      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Reconnect');
       await invoke('devdocket.createItemFromUrl');
 
-      expect(workGraph.createItem).not.toHaveBeenCalled();
+      expect(run).toHaveBeenCalledTimes(1);
+      expect(providerRegistry.resolveUrl).toHaveBeenCalledTimes(1);
       expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: GitHub requires SSO authorization for the "example" organization\nbefore this item can be loaded.',
-        'Authorize in browser',
+        'Recoverable error',
+        'Reconnect',
         'Retry',
         'Dismiss',
       );
     });
 
-    it('opens the GitHub SSO authorization URL in the browser when requested', async () => {
-      const ssoError = Object.assign(new Error('GitHub SSO authorization required'), {
-        name: 'GitHubSsoError',
-        orgName: 'example',
-        ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
-      });
-      providerRegistry.resolveUrl.mockRejectedValue(ssoError);
-      (vscode.window.showInputBox as Mock).mockResolvedValue('https://github.com/owner/repo/pull/42');
-      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Authorize in browser');
-      await invoke('devdocket.createItemFromUrl');
-
-      expect(vscode.Uri.parse).toHaveBeenCalledWith('https://github.com/orgs/example/sso?authorization_request=abc123');
-      expect(vscode.env.openExternal).toHaveBeenCalledWith(expect.objectContaining({ toString: expect.any(Function) }));
-    });
-
-    it('falls back to the org SSO page when the error has no direct authorization URL', async () => {
-      const ssoError = Object.assign(new Error('GitHub SSO authorization required'), {
-        name: 'GitHubSsoError',
-        orgName: 'example-fallback',
-      });
-      providerRegistry.resolveUrl.mockRejectedValue(ssoError);
-      (vscode.window.showInputBox as Mock).mockResolvedValue('https://github.com/owner/repo/pull/42');
-      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Authorize in browser');
-      await invoke('devdocket.createItemFromUrl');
-
-      expect(vscode.Uri.parse).toHaveBeenCalledWith('https://github.com/orgs/example-fallback/sso');
-      expect(vscode.env.openExternal).toHaveBeenCalledWith(expect.objectContaining({ toString: expect.any(Function) }));
-    });
-
-    it('omits authorize when the SSO URL is not safe to open', async () => {
-      const ssoError = Object.assign(new Error('GitHub SSO authorization required'), {
-        name: 'GitHubSsoError',
-        ssoUrl: 'file:///not-safe',
-      });
-      providerRegistry.resolveUrl.mockRejectedValue(ssoError);
-      (vscode.window.showInputBox as Mock).mockResolvedValue('https://github.com/owner/repo/pull/42');
-      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Dismiss');
-      await invoke('devdocket.createItemFromUrl');
-
-      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
-        'DevDocket: GitHub requires SSO authorization for this organization\nbefore this item can be loaded.',
-        'Retry',
-        'Dismiss',
-      );
-      expect(vscode.env.openExternal).not.toHaveBeenCalled();
-    });
-
-    it('retries the command when the user selects Retry from the SSO notification', async () => {
-      const ssoError = Object.assign(new Error('GitHub SSO authorization required'), {
-        name: 'GitHubSsoError',
-        orgName: 'example',
-        ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
+    it('retries after a recovery action when retryAfterAction is true', async () => {
+      const authorize = vi.fn(async () => undefined);
+      const recoverableError = makeRecoverableError({
+        message: 'Recoverable error',
+        actions: [{
+          label: 'Authorize in browser',
+          run: authorize,
+          retryAfterAction: true,
+        }],
       });
       providerRegistry.resolveUrl
-        .mockRejectedValueOnce(ssoError)
+        .mockRejectedValueOnce(recoverableError)
+        .mockResolvedValueOnce(fakeDetails);
+      (vscode.window.showInputBox as Mock).mockResolvedValueOnce('https://github.com/owner/repo/pull/42');
+      (vscode.window.showErrorMessage as Mock).mockResolvedValueOnce('Authorize in browser');
+      await invoke('devdocket.createItemFromUrl');
+
+      expect(authorize).toHaveBeenCalledTimes(1);
+      expect(providerRegistry.resolveUrl).toHaveBeenCalledTimes(2);
+      expect(vscode.window.showInputBox).toHaveBeenCalledTimes(1);
+      expect(workGraph.createItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('omits Retry when a recoverable error is not retryable', async () => {
+      const recoverableError = makeRecoverableError({
+        message: 'Recoverable error',
+        retryable: false,
+        actions: [{
+          label: 'Reconnect',
+          run: vi.fn(async () => undefined),
+        }],
+      });
+      providerRegistry.resolveUrl.mockRejectedValue(recoverableError);
+      (vscode.window.showInputBox as Mock).mockResolvedValue('https://github.com/owner/repo/pull/42');
+      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Dismiss');
+      await invoke('devdocket.createItemFromUrl');
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'Recoverable error',
+        'Reconnect',
+        'Dismiss',
+      );
+    });
+
+    it('falls back to Retry and Dismiss when a recoverable error has no actions', async () => {
+      const recoverableError = makeRecoverableError({ message: 'Recoverable error' });
+      providerRegistry.resolveUrl.mockRejectedValue(recoverableError);
+      (vscode.window.showInputBox as Mock).mockResolvedValue('https://github.com/owner/repo/pull/42');
+      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Dismiss');
+      await invoke('devdocket.createItemFromUrl');
+
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'Recoverable error',
+        'Retry',
+        'Dismiss',
+      );
+    });
+
+    it('retries the command when the user selects Retry from a recoverable error notification', async () => {
+      const recoverableError = makeRecoverableError({ message: 'Recoverable error' });
+      providerRegistry.resolveUrl
+        .mockRejectedValueOnce(recoverableError)
         .mockResolvedValueOnce(fakeDetails);
       (vscode.window.showInputBox as Mock)
         .mockResolvedValueOnce('https://github.com/owner/repo/pull/42');

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -492,12 +492,12 @@ describe('registerCommands', () => {
         .mockRejectedValueOnce(ssoError)
         .mockResolvedValueOnce(fakeDetails);
       (vscode.window.showInputBox as Mock)
-        .mockResolvedValueOnce('https://github.com/owner/repo/pull/42')
         .mockResolvedValueOnce('https://github.com/owner/repo/pull/42');
       (vscode.window.showErrorMessage as Mock).mockResolvedValueOnce('Retry');
       await invoke('devdocket.createItemFromUrl');
 
       expect(providerRegistry.resolveUrl).toHaveBeenCalledTimes(2);
+      expect(vscode.window.showInputBox).toHaveBeenCalledTimes(1);
       expect(workGraph.createItem).toHaveBeenCalledTimes(1);
       expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
         expect.stringContaining('Created'),

--- a/packages/core/src/test/commands.test.ts
+++ b/packages/core/src/test/commands.test.ts
@@ -447,6 +447,63 @@ describe('registerCommands', () => {
       expect(vscode.window.showErrorMessage).not.toHaveBeenCalled();
     });
 
+    it('shows SSO recovery actions when URL resolution requires GitHub authorization', async () => {
+      const ssoError = Object.assign(new Error('GitHub SSO authorization required'), {
+        name: 'GitHubSsoError',
+        orgName: 'example',
+        ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
+      });
+      providerRegistry.resolveUrl.mockRejectedValue(ssoError);
+      (vscode.window.showInputBox as Mock).mockResolvedValue('https://github.com/owner/repo/pull/42');
+      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Dismiss');
+      await invoke('devdocket.createItemFromUrl');
+
+      expect(workGraph.createItem).not.toHaveBeenCalled();
+      expect(vscode.window.showErrorMessage).toHaveBeenCalledWith(
+        'DevDocket: GitHub requires SSO authorization for the "example" organization\nbefore this item can be loaded.',
+        'Authorize in browser',
+        'Retry',
+        'Dismiss',
+      );
+    });
+
+    it('opens the GitHub SSO authorization URL in the browser when requested', async () => {
+      const ssoError = Object.assign(new Error('GitHub SSO authorization required'), {
+        name: 'GitHubSsoError',
+        orgName: 'example',
+        ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
+      });
+      providerRegistry.resolveUrl.mockRejectedValue(ssoError);
+      (vscode.window.showInputBox as Mock).mockResolvedValue('https://github.com/owner/repo/pull/42');
+      (vscode.window.showErrorMessage as Mock).mockResolvedValue('Authorize in browser');
+      await invoke('devdocket.createItemFromUrl');
+
+      expect(vscode.Uri.parse).toHaveBeenCalledWith('https://github.com/orgs/example/sso?authorization_request=abc123');
+      expect(vscode.env.openExternal).toHaveBeenCalledWith(expect.objectContaining({ toString: expect.any(Function) }));
+    });
+
+    it('retries the command when the user selects Retry from the SSO notification', async () => {
+      const ssoError = Object.assign(new Error('GitHub SSO authorization required'), {
+        name: 'GitHubSsoError',
+        orgName: 'example',
+        ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
+      });
+      providerRegistry.resolveUrl
+        .mockRejectedValueOnce(ssoError)
+        .mockResolvedValueOnce(fakeDetails);
+      (vscode.window.showInputBox as Mock)
+        .mockResolvedValueOnce('https://github.com/owner/repo/pull/42')
+        .mockResolvedValueOnce('https://github.com/owner/repo/pull/42');
+      (vscode.window.showErrorMessage as Mock).mockResolvedValueOnce('Retry');
+      await invoke('devdocket.createItemFromUrl');
+
+      expect(providerRegistry.resolveUrl).toHaveBeenCalledTimes(2);
+      expect(workGraph.createItem).toHaveBeenCalledTimes(1);
+      expect(vscode.window.showInformationMessage).toHaveBeenCalledWith(
+        expect.stringContaining('Created'),
+      );
+    });
+
     it('propagates non-abort fetch errors to wrapCommand handler', async () => {
       providerRegistry.resolveUrl.mockRejectedValue(new Error('GitHub PR owner/repo#42 not found. It may be private or deleted.'));
       (vscode.window.showInputBox as Mock).mockResolvedValue('https://github.com/owner/repo/pull/42');

--- a/packages/core/src/utils/url.ts
+++ b/packages/core/src/utils/url.ts
@@ -1,9 +1,1 @@
-/** Validate that a URL uses a safe scheme (http or https). */
-export function isSafeUrl(url: string): URL | null {
-  try {
-    const parsed = new URL(url);
-    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') ? parsed : null;
-  } catch {
-    return null;
-  }
-}
+export { isSafeUrl } from '@devdocket/shared';

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -1,14 +1,18 @@
 import * as vscode from 'vscode';
 import { BaseProvider, ProviderItem, createAbortError, runWorkerPool, type ProviderRefreshOptions, type RelatedItemRef } from '@devdocket/shared';
 import { fetchPrCrossReferencesBatch } from './githubGraphql';
-import { getGitHubSession } from './githubApiHelpers';
+import { GitHubSsoError, getGitHubSession } from './githubApiHelpers';
 import { logger } from './logger';
 import { matchesRepoPatterns, parseRepoPatterns, type RepoPattern } from './repoPattern';
 
 const RELATED_ITEMS_BATCH_SIZE = 10;
 const OPEN_SETTINGS = 'Open Settings';
 const SIGN_IN = 'Sign in';
+const AUTHORIZE_IN_BROWSER = 'Authorize in browser';
+const RETRY = 'Retry';
+const DISMISS = 'Dismiss';
 const GITHUB_SETTINGS_QUERY = '@ext:devdocket.devdocket-github';
+const notifiedGitHubSsoOrgs = new Set<string>();
 
 /**
  * Base class for GitHub providers that handles the common authentication
@@ -79,6 +83,9 @@ export abstract class BaseGitHubProvider extends BaseProvider {
       if (err instanceof Error && err.name === 'AbortError' && abortController.signal.aborted && token?.isCancellationRequested) {
         logger.debug(`${this.label} fetch aborted due to cancellation`);
       } else {
+        if (err instanceof GitHubSsoError) {
+          this.showGitHubSsoNotification(err, () => this.refresh(undefined, { interactive: true }));
+        }
         logger.error(`Failed to fetch ${this.label}`, err);
       }
     } finally {
@@ -103,7 +110,14 @@ export abstract class BaseGitHubProvider extends BaseProvider {
       return;
     }
 
-    await this.fetchAndPublish(session.accessToken, false);
+    try {
+      await this.fetchAndPublish(session.accessToken, false);
+    } catch (err) {
+      if (err instanceof GitHubSsoError) {
+        this.showGitHubSsoNotification(err, () => this.refreshInBackground(), true);
+      }
+      throw err;
+    }
   }
 
   /**
@@ -235,6 +249,46 @@ export abstract class BaseGitHubProvider extends BaseProvider {
       if (action === SIGN_IN) {
         void vscode.authentication.getSession('github', this.getAuthenticationScopes(), { createIfNone: true })
           .catch(err => logger.error('GitHub sign-in failed', err));
+      }
+    });
+  }
+
+  private showGitHubSsoNotification(error: GitHubSsoError, retry: (() => Promise<void> | void) | undefined, dedupeByOrg = false): void {
+    const dedupeKey = error.orgName ?? error.ssoUrl ?? error.message;
+    if (dedupeByOrg && notifiedGitHubSsoOrgs.has(dedupeKey)) {
+      return;
+    }
+    if (dedupeByOrg) {
+      notifiedGitHubSsoOrgs.add(dedupeKey);
+    }
+
+    const orgLabel = error.orgName
+      ? `the "${error.orgName}" organization`
+      : 'this organization';
+    const message = dedupeByOrg
+      ? `DevDocket: GitHub requires SSO authorization for ${orgLabel}\nbefore DevDocket can refresh items from it.`
+      : `DevDocket: GitHub requires SSO authorization for ${orgLabel}\nbefore this item can be loaded.`;
+    const actions = retry
+      ? [AUTHORIZE_IN_BROWSER, RETRY, DISMISS] as const
+      : [AUTHORIZE_IN_BROWSER, DISMISS] as const;
+
+    void Promise.resolve(vscode.window.showErrorMessage(message, ...actions)).then(async action => {
+      if (action === AUTHORIZE_IN_BROWSER && error.ssoUrl) {
+        if (dedupeByOrg) {
+          notifiedGitHubSsoOrgs.delete(dedupeKey);
+        }
+        await vscode.env.openExternal(vscode.Uri.parse(error.ssoUrl));
+        return;
+      }
+      if (action === RETRY && retry) {
+        if (dedupeByOrg) {
+          notifiedGitHubSsoOrgs.delete(dedupeKey);
+        }
+        try {
+          await retry();
+        } catch (retryError) {
+          logger.error('GitHub SSO retry failed', retryError);
+        }
       }
     });
   }

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -12,7 +12,13 @@ const AUTHORIZE_IN_BROWSER = 'Authorize in browser';
 const RETRY = 'Retry';
 const DISMISS = 'Dismiss';
 const GITHUB_SETTINGS_QUERY = '@ext:devdocket.devdocket-github';
+// Background refreshes are deduplicated per org for the lifetime of this session
+// so polling does not resurface the same SSO prompt every few minutes.
 const notifiedGitHubSsoOrgs = new Set<string>();
+
+export function resetGitHubSsoNotificationDedupeForTests(): void {
+  notifiedGitHubSsoOrgs.clear();
+}
 
 /**
  * Base class for GitHub providers that handles the common authentication

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -273,27 +273,34 @@ export abstract class BaseGitHubProvider extends BaseProvider {
       ? `the "${error.orgName}" organization`
       : 'this organization';
     const message = `DevDocket: GitHub requires SSO authorization for ${orgLabel}\nbefore DevDocket can refresh items from it.`;
-    const providerActions = error.actions ?? [];
-    const actions = [
-      ...providerActions.map(action => action.label),
-      ...(retry && error.retryable !== false ? [RETRY] : []),
-      DISMISS,
+    const providerItems = (error.actions ?? []).map(action => ({
+      title: action.label,
+      action,
+    }));
+    const retryItem = retry && error.retryable !== false
+      ? { title: RETRY }
+      : undefined;
+    const dismissItem = { title: DISMISS };
+    const items = [
+      ...providerItems,
+      ...(retryItem ? [retryItem] : []),
+      dismissItem,
     ];
 
-    void Promise.resolve(vscode.window.showErrorMessage(message, ...actions))
-      .then(async action => {
-        const providerAction = providerActions.find(candidate => candidate.label === action);
-        if (providerAction) {
+    void Promise.resolve(vscode.window.showErrorMessage(message, ...items))
+      .then(async selection => {
+        const providerItem = providerItems.find(item => item === selection);
+        if (providerItem) {
           if (dedupeByOrg) {
             notifiedGitHubSsoOrgs.delete(dedupeKey);
           }
           try {
-            await providerAction.run();
+            await providerItem.action.run();
           } catch (actionError) {
-            logger.error(`GitHub SSO action failed: ${providerAction.label}`, actionError);
+            logger.error(`GitHub SSO action failed: ${providerItem.action.label}`, actionError);
             return;
           }
-          if (providerAction.retryAfterAction && retry) {
+          if (providerItem.action.retryAfterAction && retry) {
             try {
               await retry();
             } catch (retryError) {
@@ -303,11 +310,11 @@ export abstract class BaseGitHubProvider extends BaseProvider {
           return;
         }
 
-        if (!action || action === DISMISS) {
+        if (!selection || selection === dismissItem) {
           return;
         }
 
-        if (action === RETRY && retry) {
+        if (selection === retryItem && retry) {
           if (dedupeByOrg) {
             notifiedGitHubSsoOrgs.delete(dedupeKey);
           }

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -268,6 +268,7 @@ export abstract class BaseGitHubProvider extends BaseProvider {
       notifiedGitHubSsoOrgs.add(dedupeKey);
     }
 
+    const authorizationUrl = getGitHubSsoAuthorizationUrl(error);
     const orgLabel = error.orgName
       ? `the "${error.orgName}" organization`
       : 'this organization';
@@ -278,25 +279,29 @@ export abstract class BaseGitHubProvider extends BaseProvider {
       ? [AUTHORIZE_IN_BROWSER, RETRY, DISMISS] as const
       : [AUTHORIZE_IN_BROWSER, DISMISS] as const;
 
-    void Promise.resolve(vscode.window.showErrorMessage(message, ...actions)).then(async action => {
-      if (action === AUTHORIZE_IN_BROWSER && error.ssoUrl) {
-        if (dedupeByOrg) {
-          notifiedGitHubSsoOrgs.delete(dedupeKey);
+    void Promise.resolve(vscode.window.showErrorMessage(message, ...actions))
+      .then(async action => {
+        if (action === AUTHORIZE_IN_BROWSER) {
+          if (dedupeByOrg) {
+            notifiedGitHubSsoOrgs.delete(dedupeKey);
+          }
+          if (authorizationUrl) {
+            await vscode.env.openExternal(vscode.Uri.parse(authorizationUrl));
+          }
+          return;
         }
-        await vscode.env.openExternal(vscode.Uri.parse(error.ssoUrl));
-        return;
-      }
-      if (action === RETRY && retry) {
-        if (dedupeByOrg) {
-          notifiedGitHubSsoOrgs.delete(dedupeKey);
+        if (action === RETRY && retry) {
+          if (dedupeByOrg) {
+            notifiedGitHubSsoOrgs.delete(dedupeKey);
+          }
+          try {
+            await retry();
+          } catch (retryError) {
+            logger.error('GitHub SSO retry failed', retryError);
+          }
         }
-        try {
-          await retry();
-        } catch (retryError) {
-          logger.error('GitHub SSO retry failed', retryError);
-        }
-      }
-    });
+      })
+      .catch(notificationError => logger.error('GitHub SSO notification failed', notificationError));
   }
 
   private showGitHubSettingsWarning(message: string): void {
@@ -307,6 +312,16 @@ export abstract class BaseGitHubProvider extends BaseProvider {
     });
   }
 
+}
+
+function getGitHubSsoAuthorizationUrl(error: Pick<GitHubSsoError, 'ssoUrl' | 'orgName'>): string | undefined {
+  if (error.ssoUrl) {
+    return error.ssoUrl;
+  }
+  if (error.orgName) {
+    return `https://github.com/orgs/${encodeURIComponent(error.orgName)}/sso`;
+  }
+  return undefined;
 }
 
 function chunkArray<T>(items: T[], size: number): T[][] {

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -12,8 +12,9 @@ const AUTHORIZE_IN_BROWSER = 'Authorize in browser';
 const RETRY = 'Retry';
 const DISMISS = 'Dismiss';
 const GITHUB_SETTINGS_QUERY = '@ext:devdocket.devdocket-github';
-// Background refreshes are deduplicated per org for the lifetime of this session
-// so polling does not resurface the same SSO prompt every few minutes.
+// Background refreshes are deduplicated per org until the user chooses
+// Authorize or Retry, so polling does not resurface the same SSO prompt
+// every few minutes while they have not acted on it.
 const notifiedGitHubSsoOrgs = new Set<string>();
 
 export function resetGitHubSsoNotificationDedupeForTests(): void {

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -275,9 +275,13 @@ export abstract class BaseGitHubProvider extends BaseProvider {
     const message = dedupeByOrg
       ? `DevDocket: GitHub requires SSO authorization for ${orgLabel}\nbefore DevDocket can refresh items from it.`
       : `DevDocket: GitHub requires SSO authorization for ${orgLabel}\nbefore this item can be loaded.`;
-    const actions = retry
-      ? [AUTHORIZE_IN_BROWSER, RETRY, DISMISS] as const
-      : [AUTHORIZE_IN_BROWSER, DISMISS] as const;
+    const actions = authorizationUrl
+      ? (retry
+        ? [AUTHORIZE_IN_BROWSER, RETRY, DISMISS] as const
+        : [AUTHORIZE_IN_BROWSER, DISMISS] as const)
+      : (retry
+        ? [RETRY, DISMISS] as const
+        : [DISMISS] as const);
 
     void Promise.resolve(vscode.window.showErrorMessage(message, ...actions))
       .then(async action => {

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -90,7 +90,7 @@ export abstract class BaseGitHubProvider extends BaseProvider {
         logger.debug(`${this.label} fetch aborted due to cancellation`);
       } else {
         if (err instanceof GitHubSsoError) {
-          this.showGitHubSsoNotification(err, () => this.refresh(undefined, { interactive: true }));
+          this.showGitHubSsoNotification(err, () => this.refresh(undefined, { interactive: true }), !interactive);
         }
         logger.error(`Failed to fetch ${this.label}`, err);
       }

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -261,7 +261,7 @@ export abstract class BaseGitHubProvider extends BaseProvider {
   }
 
   private showGitHubSsoNotification(error: GitHubSsoError, retry: (() => Promise<void> | void) | undefined, dedupeByOrg = false): void {
-    const dedupeKey = error.orgName ?? error.ssoUrl ?? error.message;
+    const dedupeKey = error.orgName ?? error.ssoUrl ?? `${this.id}:${error.message}`;
     if (dedupeByOrg && notifiedGitHubSsoOrgs.has(dedupeKey)) {
       return;
     }

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -8,7 +8,6 @@ import { matchesRepoPatterns, parseRepoPatterns, type RepoPattern } from './repo
 const RELATED_ITEMS_BATCH_SIZE = 10;
 const OPEN_SETTINGS = 'Open Settings';
 const SIGN_IN = 'Sign in';
-const AUTHORIZE_IN_BROWSER = 'Authorize in browser';
 const RETRY = 'Retry';
 const DISMISS = 'Dismiss';
 const GITHUB_SETTINGS_QUERY = '@ext:devdocket.devdocket-github';
@@ -270,33 +269,44 @@ export abstract class BaseGitHubProvider extends BaseProvider {
       notifiedGitHubSsoOrgs.add(dedupeKey);
     }
 
-    const authorizationUrl = getGitHubSsoAuthorizationUrl(error);
     const orgLabel = error.orgName
       ? `the "${error.orgName}" organization`
       : 'this organization';
-    const safeAuthorizationUrl = authorizationUrl && isSafeExternalUrl(authorizationUrl)
-      ? authorizationUrl
-      : undefined;
     const message = `DevDocket: GitHub requires SSO authorization for ${orgLabel}\nbefore DevDocket can refresh items from it.`;
-    const actions = safeAuthorizationUrl
-      ? (retry
-        ? [AUTHORIZE_IN_BROWSER, RETRY, DISMISS] as const
-        : [AUTHORIZE_IN_BROWSER, DISMISS] as const)
-      : (retry
-        ? [RETRY, DISMISS] as const
-        : [DISMISS] as const);
+    const providerActions = error.actions ?? [];
+    const actions = [
+      ...providerActions.map(action => action.label),
+      ...(retry && error.retryable !== false ? [RETRY] : []),
+      DISMISS,
+    ];
 
     void Promise.resolve(vscode.window.showErrorMessage(message, ...actions))
       .then(async action => {
-        if (action === AUTHORIZE_IN_BROWSER) {
+        const providerAction = providerActions.find(candidate => candidate.label === action);
+        if (providerAction) {
           if (dedupeByOrg) {
             notifiedGitHubSsoOrgs.delete(dedupeKey);
           }
-          if (safeAuthorizationUrl) {
-            await vscode.env.openExternal(vscode.Uri.parse(safeAuthorizationUrl));
+          try {
+            await providerAction.run();
+          } catch (actionError) {
+            logger.error(`GitHub SSO action failed: ${providerAction.label}`, actionError);
+            return;
+          }
+          if (providerAction.retryAfterAction && retry) {
+            try {
+              await retry();
+            } catch (retryError) {
+              logger.error('GitHub SSO retry failed', retryError);
+            }
           }
           return;
         }
+
+        if (!action || action === DISMISS) {
+          return;
+        }
+
         if (action === RETRY && retry) {
           if (dedupeByOrg) {
             notifiedGitHubSsoOrgs.delete(dedupeKey);
@@ -319,25 +329,6 @@ export abstract class BaseGitHubProvider extends BaseProvider {
     });
   }
 
-}
-
-function getGitHubSsoAuthorizationUrl(error: Pick<GitHubSsoError, 'ssoUrl' | 'orgName'>): string | undefined {
-  if (error.ssoUrl) {
-    return error.ssoUrl;
-  }
-  if (error.orgName) {
-    return `https://github.com/orgs/${encodeURIComponent(error.orgName)}/sso`;
-  }
-  return undefined;
-}
-
-function isSafeExternalUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
-  } catch {
-    return false;
-  }
 }
 
 function chunkArray<T>(items: T[], size: number): T[][] {

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -272,10 +272,11 @@ export abstract class BaseGitHubProvider extends BaseProvider {
     const orgLabel = error.orgName
       ? `the "${error.orgName}" organization`
       : 'this organization';
-    const message = dedupeByOrg
-      ? `DevDocket: GitHub requires SSO authorization for ${orgLabel}\nbefore DevDocket can refresh items from it.`
-      : `DevDocket: GitHub requires SSO authorization for ${orgLabel}\nbefore this item can be loaded.`;
-    const actions = authorizationUrl
+    const safeAuthorizationUrl = authorizationUrl && isSafeExternalUrl(authorizationUrl)
+      ? authorizationUrl
+      : undefined;
+    const message = `DevDocket: GitHub requires SSO authorization for ${orgLabel}\nbefore DevDocket can refresh items from it.`;
+    const actions = safeAuthorizationUrl
       ? (retry
         ? [AUTHORIZE_IN_BROWSER, RETRY, DISMISS] as const
         : [AUTHORIZE_IN_BROWSER, DISMISS] as const)
@@ -289,8 +290,8 @@ export abstract class BaseGitHubProvider extends BaseProvider {
           if (dedupeByOrg) {
             notifiedGitHubSsoOrgs.delete(dedupeKey);
           }
-          if (authorizationUrl) {
-            await vscode.env.openExternal(vscode.Uri.parse(authorizationUrl));
+          if (safeAuthorizationUrl) {
+            await vscode.env.openExternal(vscode.Uri.parse(safeAuthorizationUrl));
           }
           return;
         }
@@ -326,6 +327,15 @@ function getGitHubSsoAuthorizationUrl(error: Pick<GitHubSsoError, 'ssoUrl' | 'or
     return `https://github.com/orgs/${encodeURIComponent(error.orgName)}/sso`;
   }
   return undefined;
+}
+
+function isSafeExternalUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
 }
 
 function chunkArray<T>(items: T[], size: number): T[][] {

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -12,7 +12,8 @@ const AUTHORIZE_IN_BROWSER = 'Authorize in browser';
 const RETRY = 'Retry';
 const DISMISS = 'Dismiss';
 const GITHUB_SETTINGS_QUERY = '@ext:devdocket.devdocket-github';
-// Background refreshes are deduplicated per org until the user chooses
+// Background refreshes are deduplicated by the best available SSO identity
+// (org name first, then SSO URL, then message) until the user chooses
 // Authorize or Retry, so polling does not resurface the same SSO prompt
 // every few minutes while they have not acted on it.
 const notifiedGitHubSsoOrgs = new Set<string>();

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -69,7 +69,7 @@ export class GitHubSsoError extends Error implements RecoverableError {
     const safeAuthorizationUrl = authorizationUrl ? isSafeUrl(authorizationUrl) : null;
     super(typeof messageOrOpts === 'string' ? messageOrOpts : buildGitHubSsoMessage(resolvedOptions.orgName));
     this.name = 'GitHubSsoError';
-    this.ssoUrl = resolvedOptions.ssoUrl;
+    this.ssoUrl = safeAuthorizationUrl?.href;
     this.orgName = resolvedOptions.orgName;
     this.actions = safeAuthorizationUrl
       ? [createAuthorizeInBrowserAction(safeAuthorizationUrl.href)]

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -37,6 +37,19 @@ export interface GitHubPrMergeFields {
   merged?: boolean;
 }
 
+export class GitHubSsoError extends Error {
+  readonly ssoUrl: string | undefined;
+  readonly orgName: string | undefined;
+
+  constructor(message: string, opts: { ssoUrl?: string; orgName?: string } = {}) {
+    super(message);
+    this.name = 'GitHubSsoError';
+    this.ssoUrl = opts.ssoUrl;
+    this.orgName = opts.orgName;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
 export function isMergedGitHubPr(item: GitHubPrMergeFields): boolean {
   if (item.merged_at) {
     return true;
@@ -240,10 +253,12 @@ export async function throwApiError(response: Response, label: string): Promise<
     // Order matters: prefer the most specific signature so a coincidental
     // `remaining===0` doesn't mask SSO or secondary-rate-limit responses.
     if (sso) {
-      throw new Error(
+      const { ssoUrl, orgName } = parseGitHubSsoInfo(sso);
+      throw new GitHubSsoError(
         `GitHub SSO authorization required for ${label}` +
         `${apiMessage ? `: ${apiMessage}` : '.'}` +
         ' Authorize the token for the organization, then retry.',
+        { ssoUrl, orgName },
       );
     }
     if (isSecondaryRateLimited(retryAfter, apiMessage)) {
@@ -276,6 +291,34 @@ async function safeReadResponseBody(response: Response): Promise<string> {
     return text ?? '';
   } catch {
     return '';
+  }
+}
+
+function parseGitHubSsoInfo(headerValue: string | null): { ssoUrl?: string; orgName?: string } {
+  if (!headerValue) {
+    return {};
+  }
+
+  const ssoUrl = headerValue
+    .split(';')
+    .map(part => part.trim())
+    .find(part => part.toLowerCase().startsWith('url='))
+    ?.slice(4)
+    .trim();
+
+  if (!ssoUrl) {
+    return {};
+  }
+
+  try {
+    const parsed = new URL(ssoUrl);
+    const match = parsed.pathname.match(/^\/orgs\/([^/]+)\/sso\/?$/i);
+    return {
+      ssoUrl,
+      orgName: match?.[1] ? decodeURIComponent(match[1]) : undefined,
+    };
+  } catch {
+    return { ssoUrl };
   }
 }
 

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -67,12 +67,15 @@ export class GitHubSsoError extends Error implements RecoverableError {
     const resolvedOptions = typeof messageOrOpts === 'string' ? opts : messageOrOpts;
     const authorizationUrl = getGitHubSsoAuthorizationUrl(resolvedOptions);
     const safeAuthorizationUrl = authorizationUrl ? isSafeUrl(authorizationUrl) : null;
+    const trustedAuthorizationUrl = safeAuthorizationUrl && isTrustedGitHubSsoUrl(safeAuthorizationUrl)
+      ? safeAuthorizationUrl
+      : null;
     super(typeof messageOrOpts === 'string' ? messageOrOpts : buildGitHubSsoMessage(resolvedOptions.orgName));
     this.name = 'GitHubSsoError';
-    this.ssoUrl = safeAuthorizationUrl?.href;
+    this.ssoUrl = trustedAuthorizationUrl?.href;
     this.orgName = resolvedOptions.orgName;
-    this.actions = safeAuthorizationUrl
-      ? [createAuthorizeInBrowserAction(safeAuthorizationUrl.href)]
+    this.actions = trustedAuthorizationUrl
+      ? [createAuthorizeInBrowserAction(trustedAuthorizationUrl.href)]
       : undefined;
     Object.setPrototypeOf(this, new.target.prototype);
   }
@@ -103,6 +106,10 @@ function createAuthorizeInBrowserAction(authorizationUrl: string): RecoverableEr
       await vscode.env.openExternal(vscode.Uri.parse(authorizationUrl));
     },
   };
+}
+
+function isTrustedGitHubSsoUrl(url: URL): boolean {
+  return url.hostname === 'github.com';
 }
 
 export function isMergedGitHubPr(item: GitHubPrMergeFields): boolean {

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -1,5 +1,15 @@
 import * as vscode from 'vscode';
-import { isValidGitHubRepo, combineSignals, createAbortError, getSessionWithAuthFallback, runWorkerPoolSettled, type ProviderBadge } from '@devdocket/shared';
+import {
+  isSafeUrl,
+  isValidGitHubRepo,
+  combineSignals,
+  createAbortError,
+  getSessionWithAuthFallback,
+  runWorkerPoolSettled,
+  type ProviderBadge,
+  type RecoverableError,
+  type RecoverableErrorAction,
+} from '@devdocket/shared';
 import { logger } from './logger';
 
 export interface GitHubAuthOptions {
@@ -37,17 +47,62 @@ export interface GitHubPrMergeFields {
   merged?: boolean;
 }
 
-export class GitHubSsoError extends Error {
+const AUTHORIZE_IN_BROWSER = 'Authorize in browser';
+
+interface GitHubSsoErrorOptions {
+  ssoUrl?: string;
+  orgName?: string;
+}
+
+export class GitHubSsoError extends Error implements RecoverableError {
+  readonly recoverable = true as const;
+  readonly retryable = true as const;
   readonly ssoUrl: string | undefined;
   readonly orgName: string | undefined;
+  readonly actions?: ReadonlyArray<RecoverableErrorAction>;
 
-  constructor(message: string, opts: { ssoUrl?: string; orgName?: string } = {}) {
-    super(message);
+  constructor(opts?: GitHubSsoErrorOptions);
+  constructor(message: string, opts?: GitHubSsoErrorOptions);
+  constructor(messageOrOpts: string | GitHubSsoErrorOptions = {}, opts: GitHubSsoErrorOptions = {}) {
+    const resolvedOptions = typeof messageOrOpts === 'string' ? opts : messageOrOpts;
+    const authorizationUrl = getGitHubSsoAuthorizationUrl(resolvedOptions);
+    const safeAuthorizationUrl = authorizationUrl ? isSafeUrl(authorizationUrl) : null;
+    super(typeof messageOrOpts === 'string' ? messageOrOpts : buildGitHubSsoMessage(resolvedOptions.orgName));
     this.name = 'GitHubSsoError';
-    this.ssoUrl = opts.ssoUrl;
-    this.orgName = opts.orgName;
+    this.ssoUrl = resolvedOptions.ssoUrl;
+    this.orgName = resolvedOptions.orgName;
+    this.actions = safeAuthorizationUrl
+      ? [createAuthorizeInBrowserAction(safeAuthorizationUrl.href)]
+      : undefined;
     Object.setPrototypeOf(this, new.target.prototype);
   }
+}
+
+function buildGitHubSsoMessage(orgName?: string): string {
+  const orgLabel = orgName
+    ? `the "${orgName}" organization`
+    : 'this organization';
+  return `DevDocket: GitHub requires SSO authorization for ${orgLabel}\nbefore this item can be loaded.`;
+}
+
+function getGitHubSsoAuthorizationUrl(opts: GitHubSsoErrorOptions): string | undefined {
+  if (opts.ssoUrl) {
+    return opts.ssoUrl;
+  }
+  if (opts.orgName) {
+    return `https://github.com/orgs/${encodeURIComponent(opts.orgName)}/sso`;
+  }
+  return undefined;
+}
+
+function createAuthorizeInBrowserAction(authorizationUrl: string): RecoverableErrorAction {
+  return {
+    label: AUTHORIZE_IN_BROWSER,
+    retryAfterAction: true,
+    run: async () => {
+      await vscode.env.openExternal(vscode.Uri.parse(authorizationUrl));
+    },
+  };
 }
 
 export function isMergedGitHubPr(item: GitHubPrMergeFields): boolean {
@@ -254,12 +309,7 @@ export async function throwApiError(response: Response, label: string): Promise<
     // `remaining===0` doesn't mask SSO or secondary-rate-limit responses.
     if (sso) {
       const { ssoUrl, orgName } = parseGitHubSsoInfo(sso);
-      throw new GitHubSsoError(
-        `GitHub SSO authorization required for ${label}` +
-        `${apiMessage ? `: ${apiMessage}` : '.'}` +
-        ' Authorize the token for the organization, then retry.',
-        { ssoUrl, orgName },
-      );
+      throw new GitHubSsoError({ ssoUrl, orgName });
     }
     if (isSecondaryRateLimited(retryAfter, apiMessage)) {
       const wait = formatRetryAfter(retryAfter);

--- a/packages/github/src/githubMentionsProvider.ts
+++ b/packages/github/src/githubMentionsProvider.ts
@@ -700,6 +700,9 @@ export class GitHubMentionsProvider extends BaseGitHubProvider {
     }
 
     if (!response.ok) {
+      if (response.headers?.get?.('x-github-sso')) {
+        await throwApiError(response, 'GitHub mentions');
+      }
       logger.error(`Failed to fetch mentions: ${response.status}`);
       return { results: [], failures: ['all repositories'] };
     }

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -2,7 +2,7 @@ import { ProviderItem, ProviderBadge, combineSignals, createAbortError, runWorke
 import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
-import { getGitHubAuthHeaders, filterMergedGitHubPrs, type GitHubIssue, type GitHubPrMergeFields, type GitHubSearchResponse } from './githubApiHelpers';
+import { getGitHubAuthHeaders, filterMergedGitHubPrs, throwApiError, type GitHubIssue, type GitHubPrMergeFields, type GitHubSearchResponse } from './githubApiHelpers';
 import { matchesRepoPatterns } from './repoPattern';
 import { createGitHubPrGitWork } from './gitWorkCapabilities';
 
@@ -216,6 +216,9 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
     }
 
     if (!response.ok) {
+      if (response.headers?.get?.('x-github-sso')) {
+        await throwApiError(response, `GitHub ${label} PR search`);
+      }
       logger.error(`Failed to fetch ${label} PRs: ${response.status}`);
       return { prs: [], failures: [searchLabel] };
     }

--- a/packages/github/src/githubMyPrsProvider.ts
+++ b/packages/github/src/githubMyPrsProvider.ts
@@ -2,7 +2,7 @@ import { ProviderItem, ProviderBadge, combineSignals, createAbortError, runWorke
 import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
-import { getGitHubAuthHeaders, filterMergedGitHubPrs, throwApiError, type GitHubIssue, type GitHubPrMergeFields, type GitHubSearchResponse } from './githubApiHelpers';
+import { GitHubSsoError, getGitHubAuthHeaders, filterMergedGitHubPrs, throwApiError, type GitHubIssue, type GitHubPrMergeFields, type GitHubSearchResponse } from './githubApiHelpers';
 import { matchesRepoPatterns } from './repoPattern';
 import { createGitHubPrGitWork } from './gitWorkCapabilities';
 
@@ -67,14 +67,14 @@ export class GitHubMyPrsProvider extends BaseGitHubProvider {
 
     if (authoredSettled.status === 'rejected') {
       const err = authoredSettled.reason;
-      if (err instanceof Error && err.name === 'AbortError') {
+      if (err instanceof Error && (err.name === 'AbortError' || err instanceof GitHubSsoError)) {
         throw err;
       }
       logger.error('Failed to fetch authored PRs', err);
     }
     if (assignedSettled.status === 'rejected') {
       const err = assignedSettled.reason;
-      if (err instanceof Error && err.name === 'AbortError') {
+      if (err instanceof Error && (err.name === 'AbortError' || err instanceof GitHubSsoError)) {
         throw err;
       }
       logger.error('Failed to fetch assigned PRs', err);

--- a/packages/github/src/githubPrReviewProvider.ts
+++ b/packages/github/src/githubPrReviewProvider.ts
@@ -178,6 +178,9 @@ export class GitHubPrReviewProvider extends BaseGitHubProvider {
     );
 
     if (!response.ok) {
+      if (response.headers?.get?.('x-github-sso')) {
+        await throwApiError(response, 'GitHub PR review requests');
+      }
       logger.error(`Failed to fetch PR review requests: ${response.status}`);
       return { prs: [], failed: true };
     }

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -167,15 +167,15 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
       }
 
       if (!response.ok) {
+        if (response.headers?.get?.('x-github-sso')) {
+          await throwApiError(response, `GitHub ${label}`);
+        }
         if (allItems.length > 0) {
           logger.warn(
             `GitHub API returned ${response.status} on page ${page + 1}. ` +
             `Returning ${allItems.length} items from previous pages.`,
           );
           return allItems;
-        }
-        if (response.headers?.get?.('x-github-sso')) {
-          await throwApiError(response, `GitHub ${label}`);
         }
         throw new Error(`GitHub API returned ${response.status}`);
       }

--- a/packages/github/src/githubProvider.ts
+++ b/packages/github/src/githubProvider.ts
@@ -2,7 +2,7 @@ import { ProviderItem, combineSignals, createAbortError, safeDecodeComponent, ty
 import { BaseGitHubProvider } from './baseGithubProvider';
 import { logger } from './logger';
 import { parseRepoFromUrls } from './parseRepo';
-import { getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, looksLikeRateLimited403, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, type GitHubIssue } from './githubApiHelpers';
+import { GitHubSsoError, getHeaders, getGitHubAuthHeaders, retryWithAuth, throwApiError, looksLikeRateLimited403, parseCanonicalRepo, fetchClosedGitHubItems, buildIssueStateBadge, type GitHubIssue } from './githubApiHelpers';
 import { matchesRepoPatterns } from './repoPattern';
 import { createGitHubIssueGitWork } from './gitWorkCapabilities';
 
@@ -121,6 +121,7 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
       const items = await this.fetchPaginated<GitHubIssue>(
         'https://api.github.com/issues?filter=assigned&state=open&per_page=100',
         token,
+        'assigned issues',
         10,
         signal,
       );
@@ -129,12 +130,13 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
       return { issues, failed: false };
     } catch (err) {
       if (err instanceof Error && err.name === 'AbortError' && signal?.aborted) { throw err; }
+      if (err instanceof GitHubSsoError) { throw err; }
       logger.error('Failed to fetch assigned issues', err);
       return { issues: [], failed: true };
     }
   }
 
-  private async fetchPaginated<T>(url: string, token: string, maxPages: number = 10, signal?: AbortSignal): Promise<T[]> {
+  private async fetchPaginated<T>(url: string, token: string, label: string, maxPages: number = 10, signal?: AbortSignal): Promise<T[]> {
     const allItems: T[] = [];
     let nextUrl: string | null = url;
     let page = 0;
@@ -171,6 +173,9 @@ export class GitHubIssueProvider extends BaseGitHubProvider {
             `Returning ${allItems.length} items from previous pages.`,
           );
           return allItems;
+        }
+        if (response.headers?.get?.('x-github-sso')) {
+          await throwApiError(response, `GitHub ${label}`);
         }
         throw new Error(`GitHub API returned ${response.status}`);
       }

--- a/packages/github/src/test/baseGithubProvider.test.ts
+++ b/packages/github/src/test/baseGithubProvider.test.ts
@@ -173,6 +173,28 @@ describe('BaseGitHubProvider repository filtering', () => {
     provider.dispose();
   });
 
+  it('omits authorize when the SSO URL is not safe to open', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
+    vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
+    const provider = new TestGitHubProvider();
+    const error = new GitHubSsoError('GitHub SSO authorization required', {
+      ssoUrl: 'file:///not-safe',
+    });
+    provider.fetchImpl.mockRejectedValue(error);
+
+    await expect(provider.refreshInBackground()).rejects.toThrow(error);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      'DevDocket: GitHub requires SSO authorization for this organization\nbefore DevDocket can refresh items from it.',
+      'Retry',
+      'Dismiss',
+    );
+    expect(env.openExternal).not.toHaveBeenCalled();
+
+    provider.dispose();
+  });
+
   it('shows the refresh-oriented SSO message for user-triggered refreshes', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
     vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);

--- a/packages/github/src/test/baseGithubProvider.test.ts
+++ b/packages/github/src/test/baseGithubProvider.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
 import { authentication, commands, env, window, workspace } from 'vscode';
 import { type ProviderItem } from '@devdocket/shared';
-import { BaseGitHubProvider } from '../baseGithubProvider';
+import { BaseGitHubProvider, resetGitHubSsoNotificationDedupeForTests } from '../baseGithubProvider';
 import { GitHubSsoError } from '../githubApiHelpers';
 
 class TestGitHubProvider extends BaseGitHubProvider {
@@ -26,6 +26,7 @@ class TestGitHubProvider extends BaseGitHubProvider {
 
 describe('BaseGitHubProvider repository filtering', () => {
   afterEach(() => {
+    resetGitHubSsoNotificationDedupeForTests();
     vi.mocked(authentication.getSession).mockReset();
     vi.mocked(commands.executeCommand).mockReset();
     vi.mocked(env.openExternal).mockReset();
@@ -113,8 +114,8 @@ describe('BaseGitHubProvider repository filtering', () => {
     vi.mocked(window.showErrorMessage).mockResolvedValue('Authorize in browser' as any);
     const provider = new TestGitHubProvider();
     const error = new GitHubSsoError('GitHub SSO authorization required', {
-      orgName: 'example',
-      ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
+      orgName: 'example-open',
+      ssoUrl: 'https://github.com/orgs/example-open/sso?authorization_request=abc123',
     });
     provider.fetchImpl.mockRejectedValue(error);
 
@@ -122,7 +123,7 @@ describe('BaseGitHubProvider repository filtering', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(window.showErrorMessage).toHaveBeenCalledWith(
-      'DevDocket: GitHub requires SSO authorization for the "example" organization\nbefore DevDocket can refresh items from it.',
+      'DevDocket: GitHub requires SSO authorization for the "example-open" organization\nbefore DevDocket can refresh items from it.',
       'Authorize in browser',
       'Retry',
       'Dismiss',
@@ -137,8 +138,8 @@ describe('BaseGitHubProvider repository filtering', () => {
     vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
     const provider = new TestGitHubProvider();
     const error = new GitHubSsoError('GitHub SSO authorization required', {
-      orgName: 'example',
-      ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
+      orgName: 'example-dismiss',
+      ssoUrl: 'https://github.com/orgs/example-dismiss/sso?authorization_request=abc123',
     });
     provider.fetchImpl.mockRejectedValue(error);
 

--- a/packages/github/src/test/baseGithubProvider.test.ts
+++ b/packages/github/src/test/baseGithubProvider.test.ts
@@ -217,6 +217,24 @@ describe('BaseGitHubProvider repository filtering', () => {
     provider.dispose();
   });
 
+  it('deduplicates non-interactive refresh SSO prompts', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
+    vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
+    const provider = new TestGitHubProvider();
+    const error = new GitHubSsoError('GitHub SSO authorization required', {
+      orgName: 'example-noninteractive',
+    });
+    provider.fetchImpl.mockRejectedValue(error);
+
+    await provider.refresh(undefined, { interactive: false });
+    await provider.refresh(undefined, { interactive: false });
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(window.showErrorMessage).toHaveBeenCalledTimes(1);
+
+    provider.dispose();
+  });
+
   it('keeps background SSO prompts deduplicated after dismiss', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
     vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);

--- a/packages/github/src/test/baseGithubProvider.test.ts
+++ b/packages/github/src/test/baseGithubProvider.test.ts
@@ -24,6 +24,12 @@ class TestGitHubProvider extends BaseGitHubProvider {
   }
 }
 
+function selectErrorAction(label: string): void {
+  vi.mocked(window.showErrorMessage).mockImplementationOnce(async (_message: string, ...items: any[]) =>
+    items.find(item => (typeof item === 'string' ? item : item.title) === label) as any,
+  );
+}
+
 describe('BaseGitHubProvider repository filtering', () => {
   afterEach(() => {
     resetGitHubSsoNotificationDedupeForTests();
@@ -111,7 +117,7 @@ describe('BaseGitHubProvider repository filtering', () => {
 
   it('opens the organization SSO URL from background refresh errors', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
-    vi.mocked(window.showErrorMessage).mockResolvedValue('Authorize in browser' as any);
+    selectErrorAction('Authorize in browser');
     const provider = new TestGitHubProvider();
     const error = new GitHubSsoError({
       orgName: 'example-open',
@@ -126,9 +132,9 @@ describe('BaseGitHubProvider repository filtering', () => {
 
     expect(window.showErrorMessage).toHaveBeenCalledWith(
       'DevDocket: GitHub requires SSO authorization for the "example-open" organization\nbefore DevDocket can refresh items from it.',
-      'Authorize in browser',
-      'Retry',
-      'Dismiss',
+      expect.objectContaining({ title: 'Authorize in browser' }),
+      expect.objectContaining({ title: 'Retry' }),
+      expect.objectContaining({ title: 'Dismiss' }),
     );
     expect(env.openExternal).toHaveBeenCalledWith(expect.objectContaining({ toString: expect.any(Function) }));
     expect(provider.fetchImpl).toHaveBeenCalledTimes(2);
@@ -138,7 +144,7 @@ describe('BaseGitHubProvider repository filtering', () => {
 
   it('falls back to the org SSO page when the header omits a direct authorization URL', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
-    vi.mocked(window.showErrorMessage).mockResolvedValue('Authorize in browser' as any);
+    selectErrorAction('Authorize in browser');
     const provider = new TestGitHubProvider();
     const error = new GitHubSsoError({
       orgName: 'example-fallback',
@@ -160,7 +166,7 @@ describe('BaseGitHubProvider repository filtering', () => {
 
   it('omits authorize when no SSO URL can be derived', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
-    vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
+    selectErrorAction('Dismiss');
     const provider = new TestGitHubProvider();
     const error = new GitHubSsoError();
     provider.fetchImpl.mockRejectedValue(error);
@@ -170,8 +176,8 @@ describe('BaseGitHubProvider repository filtering', () => {
 
     expect(window.showErrorMessage).toHaveBeenCalledWith(
       'DevDocket: GitHub requires SSO authorization for this organization\nbefore DevDocket can refresh items from it.',
-      'Retry',
-      'Dismiss',
+      expect.objectContaining({ title: 'Retry' }),
+      expect.objectContaining({ title: 'Dismiss' }),
     );
     expect(env.openExternal).not.toHaveBeenCalled();
 
@@ -180,7 +186,7 @@ describe('BaseGitHubProvider repository filtering', () => {
 
   it('omits authorize when the SSO URL is not safe to open', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
-    vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
+    selectErrorAction('Dismiss');
     const provider = new TestGitHubProvider();
     const error = new GitHubSsoError({
       ssoUrl: 'file:///not-safe',
@@ -192,8 +198,8 @@ describe('BaseGitHubProvider repository filtering', () => {
 
     expect(window.showErrorMessage).toHaveBeenCalledWith(
       'DevDocket: GitHub requires SSO authorization for this organization\nbefore DevDocket can refresh items from it.',
-      'Retry',
-      'Dismiss',
+      expect.objectContaining({ title: 'Retry' }),
+      expect.objectContaining({ title: 'Dismiss' }),
     );
     expect(env.openExternal).not.toHaveBeenCalled();
 
@@ -202,7 +208,7 @@ describe('BaseGitHubProvider repository filtering', () => {
 
   it('shows the refresh-oriented SSO message for user-triggered refreshes', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
-    vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
+    selectErrorAction('Dismiss');
     const provider = new TestGitHubProvider();
     const error = new GitHubSsoError({
       orgName: 'example-refresh',
@@ -214,9 +220,9 @@ describe('BaseGitHubProvider repository filtering', () => {
 
     expect(window.showErrorMessage).toHaveBeenCalledWith(
       'DevDocket: GitHub requires SSO authorization for the "example-refresh" organization\nbefore DevDocket can refresh items from it.',
-      'Authorize in browser',
-      'Retry',
-      'Dismiss',
+      expect.objectContaining({ title: 'Authorize in browser' }),
+      expect.objectContaining({ title: 'Retry' }),
+      expect.objectContaining({ title: 'Dismiss' }),
     );
 
     provider.dispose();
@@ -224,7 +230,7 @@ describe('BaseGitHubProvider repository filtering', () => {
 
   it('deduplicates non-interactive refresh SSO prompts', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
-    vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
+    selectErrorAction('Dismiss');
     const provider = new TestGitHubProvider();
     const error = new GitHubSsoError({
       orgName: 'example-noninteractive',
@@ -242,7 +248,7 @@ describe('BaseGitHubProvider repository filtering', () => {
 
   it('keeps background SSO prompts deduplicated after dismiss', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
-    vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
+    selectErrorAction('Dismiss');
     const provider = new TestGitHubProvider();
     const error = new GitHubSsoError({
       orgName: 'example-dismiss',

--- a/packages/github/src/test/baseGithubProvider.test.ts
+++ b/packages/github/src/test/baseGithubProvider.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { authentication, commands, window, workspace } from 'vscode';
+import { authentication, commands, env, window, workspace } from 'vscode';
 import { type ProviderItem } from '@devdocket/shared';
 import { BaseGitHubProvider } from '../baseGithubProvider';
+import { GitHubSsoError } from '../githubApiHelpers';
 
 class TestGitHubProvider extends BaseGitHubProvider {
   readonly id = 'test-github';
   readonly label = 'Test GitHub';
+  readonly fetchImpl = vi.fn(async () => {
+    this.publishProviderItems([]);
+  });
 
   publishForTest(items: ProviderItem[]): void {
     this.publishProviderItems(items);
@@ -15,8 +19,8 @@ class TestGitHubProvider extends BaseGitHubProvider {
     this.warnOnFetchFailure(message, isUserTriggered);
   }
 
-  protected async fetchAndPublish(): Promise<void> {
-    this.publishProviderItems([]);
+  protected async fetchAndPublish(accessToken: string, isUserTriggered: boolean, signal?: AbortSignal): Promise<void> {
+    await this.fetchImpl(accessToken, isUserTriggered, signal);
   }
 }
 
@@ -24,6 +28,8 @@ describe('BaseGitHubProvider repository filtering', () => {
   afterEach(() => {
     vi.mocked(authentication.getSession).mockReset();
     vi.mocked(commands.executeCommand).mockReset();
+    vi.mocked(env.openExternal).mockReset();
+    vi.mocked(window.showErrorMessage).mockReset();
     vi.mocked(window.showWarningMessage).mockReset();
     vi.mocked(workspace.getConfiguration).mockReset();
   });
@@ -98,6 +104,49 @@ describe('BaseGitHubProvider repository filtering', () => {
       { createIfNone: true },
     );
     expect(commands.executeCommand).not.toHaveBeenCalledWith('github.signin');
+
+    provider.dispose();
+  });
+
+  it('opens the organization SSO URL from background refresh errors', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
+    vi.mocked(window.showErrorMessage).mockResolvedValue('Authorize in browser' as any);
+    const provider = new TestGitHubProvider();
+    const error = new GitHubSsoError('GitHub SSO authorization required', {
+      orgName: 'example',
+      ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
+    });
+    provider.fetchImpl.mockRejectedValue(error);
+
+    await expect(provider.refreshInBackground()).rejects.toThrow(error);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      'DevDocket: GitHub requires SSO authorization for the "example" organization\nbefore DevDocket can refresh items from it.',
+      'Authorize in browser',
+      'Retry',
+      'Dismiss',
+    );
+    expect(env.openExternal).toHaveBeenCalledWith(expect.objectContaining({ toString: expect.any(Function) }));
+
+    provider.dispose();
+  });
+
+  it('deduplicates background SSO prompts until the user takes an action', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
+    vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
+    const provider = new TestGitHubProvider();
+    const error = new GitHubSsoError('GitHub SSO authorization required', {
+      orgName: 'example',
+      ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
+    });
+    provider.fetchImpl.mockRejectedValue(error);
+
+    await expect(provider.refreshInBackground()).rejects.toThrow(error);
+    await expect(provider.refreshInBackground()).rejects.toThrow(error);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(window.showErrorMessage).toHaveBeenCalledTimes(1);
 
     provider.dispose();
   });

--- a/packages/github/src/test/baseGithubProvider.test.ts
+++ b/packages/github/src/test/baseGithubProvider.test.ts
@@ -133,6 +133,26 @@ describe('BaseGitHubProvider repository filtering', () => {
     provider.dispose();
   });
 
+  it('falls back to the org SSO page when the header omits a direct authorization URL', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
+    vi.mocked(window.showErrorMessage).mockResolvedValue('Authorize in browser' as any);
+    const provider = new TestGitHubProvider();
+    const error = new GitHubSsoError('GitHub SSO authorization required', {
+      orgName: 'example-fallback',
+    });
+    provider.fetchImpl.mockRejectedValue(error);
+
+    await expect(provider.refreshInBackground()).rejects.toThrow(error);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(env.openExternal).toHaveBeenCalledWith(expect.objectContaining({
+      toString: expect.any(Function),
+    }));
+    expect(env.openExternal.mock.calls[0][0].toString()).toBe('https://github.com/orgs/example-fallback/sso');
+
+    provider.dispose();
+  });
+
   it('deduplicates background SSO prompts until the user takes an action', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
     vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);

--- a/packages/github/src/test/baseGithubProvider.test.ts
+++ b/packages/github/src/test/baseGithubProvider.test.ts
@@ -113,11 +113,13 @@ describe('BaseGitHubProvider repository filtering', () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
     vi.mocked(window.showErrorMessage).mockResolvedValue('Authorize in browser' as any);
     const provider = new TestGitHubProvider();
-    const error = new GitHubSsoError('GitHub SSO authorization required', {
+    const error = new GitHubSsoError({
       orgName: 'example-open',
       ssoUrl: 'https://github.com/orgs/example-open/sso?authorization_request=abc123',
     });
-    provider.fetchImpl.mockRejectedValue(error);
+    provider.fetchImpl
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(undefined);
 
     await expect(provider.refreshInBackground()).rejects.toThrow(error);
     await new Promise(resolve => setTimeout(resolve, 0));
@@ -129,6 +131,7 @@ describe('BaseGitHubProvider repository filtering', () => {
       'Dismiss',
     );
     expect(env.openExternal).toHaveBeenCalledWith(expect.objectContaining({ toString: expect.any(Function) }));
+    expect(provider.fetchImpl).toHaveBeenCalledTimes(2);
 
     provider.dispose();
   });
@@ -137,10 +140,12 @@ describe('BaseGitHubProvider repository filtering', () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
     vi.mocked(window.showErrorMessage).mockResolvedValue('Authorize in browser' as any);
     const provider = new TestGitHubProvider();
-    const error = new GitHubSsoError('GitHub SSO authorization required', {
+    const error = new GitHubSsoError({
       orgName: 'example-fallback',
     });
-    provider.fetchImpl.mockRejectedValue(error);
+    provider.fetchImpl
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(undefined);
 
     await expect(provider.refreshInBackground()).rejects.toThrow(error);
     await new Promise(resolve => setTimeout(resolve, 0));
@@ -157,7 +162,7 @@ describe('BaseGitHubProvider repository filtering', () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
     vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
     const provider = new TestGitHubProvider();
-    const error = new GitHubSsoError('GitHub SSO authorization required');
+    const error = new GitHubSsoError();
     provider.fetchImpl.mockRejectedValue(error);
 
     await expect(provider.refreshInBackground()).rejects.toThrow(error);
@@ -177,7 +182,7 @@ describe('BaseGitHubProvider repository filtering', () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
     vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
     const provider = new TestGitHubProvider();
-    const error = new GitHubSsoError('GitHub SSO authorization required', {
+    const error = new GitHubSsoError({
       ssoUrl: 'file:///not-safe',
     });
     provider.fetchImpl.mockRejectedValue(error);
@@ -199,7 +204,7 @@ describe('BaseGitHubProvider repository filtering', () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
     vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
     const provider = new TestGitHubProvider();
-    const error = new GitHubSsoError('GitHub SSO authorization required', {
+    const error = new GitHubSsoError({
       orgName: 'example-refresh',
     });
     provider.fetchImpl.mockRejectedValue(error);
@@ -221,7 +226,7 @@ describe('BaseGitHubProvider repository filtering', () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
     vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
     const provider = new TestGitHubProvider();
-    const error = new GitHubSsoError('GitHub SSO authorization required', {
+    const error = new GitHubSsoError({
       orgName: 'example-noninteractive',
     });
     provider.fetchImpl.mockRejectedValue(error);
@@ -239,7 +244,7 @@ describe('BaseGitHubProvider repository filtering', () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
     vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
     const provider = new TestGitHubProvider();
-    const error = new GitHubSsoError('GitHub SSO authorization required', {
+    const error = new GitHubSsoError({
       orgName: 'example-dismiss',
       ssoUrl: 'https://github.com/orgs/example-dismiss/sso?authorization_request=abc123',
     });

--- a/packages/github/src/test/baseGithubProvider.test.ts
+++ b/packages/github/src/test/baseGithubProvider.test.ts
@@ -264,4 +264,29 @@ describe('BaseGitHubProvider repository filtering', () => {
 
     provider.dispose();
   });
+
+  it('does not deduplicate unrelated providers when an SSO error has no org or URL', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
+    selectErrorAction('Dismiss');
+    selectErrorAction('Dismiss');
+
+    class SecondTestGitHubProvider extends TestGitHubProvider {
+      override readonly id = 'test-github-second';
+    }
+
+    const firstProvider = new TestGitHubProvider();
+    const secondProvider = new SecondTestGitHubProvider();
+    const error = new GitHubSsoError();
+    firstProvider.fetchImpl.mockRejectedValue(error);
+    secondProvider.fetchImpl.mockRejectedValue(error);
+
+    await expect(firstProvider.refreshInBackground()).rejects.toThrow(error);
+    await expect(secondProvider.refreshInBackground()).rejects.toThrow(error);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(window.showErrorMessage).toHaveBeenCalledTimes(2);
+
+    firstProvider.dispose();
+    secondProvider.dispose();
+  });
 });

--- a/packages/github/src/test/baseGithubProvider.test.ts
+++ b/packages/github/src/test/baseGithubProvider.test.ts
@@ -153,7 +153,7 @@ describe('BaseGitHubProvider repository filtering', () => {
     provider.dispose();
   });
 
-  it('deduplicates background SSO prompts until the user takes an action', async () => {
+  it('keeps background SSO prompts deduplicated after dismiss', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
     vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
     const provider = new TestGitHubProvider();

--- a/packages/github/src/test/baseGithubProvider.test.ts
+++ b/packages/github/src/test/baseGithubProvider.test.ts
@@ -173,6 +173,28 @@ describe('BaseGitHubProvider repository filtering', () => {
     provider.dispose();
   });
 
+  it('shows the refresh-oriented SSO message for user-triggered refreshes', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
+    vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
+    const provider = new TestGitHubProvider();
+    const error = new GitHubSsoError('GitHub SSO authorization required', {
+      orgName: 'example-refresh',
+    });
+    provider.fetchImpl.mockRejectedValue(error);
+
+    await provider.refresh();
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      'DevDocket: GitHub requires SSO authorization for the "example-refresh" organization\nbefore DevDocket can refresh items from it.',
+      'Authorize in browser',
+      'Retry',
+      'Dismiss',
+    );
+
+    provider.dispose();
+  });
+
   it('keeps background SSO prompts deduplicated after dismiss', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
     vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);

--- a/packages/github/src/test/baseGithubProvider.test.ts
+++ b/packages/github/src/test/baseGithubProvider.test.ts
@@ -153,6 +153,26 @@ describe('BaseGitHubProvider repository filtering', () => {
     provider.dispose();
   });
 
+  it('omits authorize when no SSO URL can be derived', async () => {
+    vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
+    vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);
+    const provider = new TestGitHubProvider();
+    const error = new GitHubSsoError('GitHub SSO authorization required');
+    provider.fetchImpl.mockRejectedValue(error);
+
+    await expect(provider.refreshInBackground()).rejects.toThrow(error);
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    expect(window.showErrorMessage).toHaveBeenCalledWith(
+      'DevDocket: GitHub requires SSO authorization for this organization\nbefore DevDocket can refresh items from it.',
+      'Retry',
+      'Dismiss',
+    );
+    expect(env.openExternal).not.toHaveBeenCalled();
+
+    provider.dispose();
+  });
+
   it('keeps background SSO prompts deduplicated after dismiss', async () => {
     vi.mocked(authentication.getSession).mockResolvedValue({ accessToken: 'token' } as any);
     vi.mocked(window.showErrorMessage).mockResolvedValue('Dismiss' as any);

--- a/packages/github/src/test/githubApiHelpers.test.ts
+++ b/packages/github/src/test/githubApiHelpers.test.ts
@@ -73,6 +73,13 @@ describe('GitHubSsoError', () => {
     expect(new GitHubSsoError().actions).toBeUndefined();
     expect(new GitHubSsoError({ ssoUrl: 'file:///not-safe' }).actions).toBeUndefined();
   });
+
+  it('stores only safe SSO URLs on the error surface', () => {
+    expect(new GitHubSsoError({
+      ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
+    }).ssoUrl).toBe('https://github.com/orgs/example/sso?authorization_request=abc123');
+    expect(new GitHubSsoError({ ssoUrl: 'file:///not-safe' }).ssoUrl).toBeUndefined();
+  });
 });
 
 describe('isMergedGitHubPr', () => {

--- a/packages/github/src/test/githubApiHelpers.test.ts
+++ b/packages/github/src/test/githubApiHelpers.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { authentication } from 'vscode';
+import { authentication, env } from 'vscode';
+import { isRecoverableError } from '@devdocket/shared';
 import { GitHubSsoError, filterMergedGitHubPrs, isMergedGitHubPr, throwApiError, looksLikeRateLimited403, retryWithAuth, type GitHubIssue } from '../githubApiHelpers';
 import { setLogger } from '../logger';
 import { makeErrorResponse } from './responseMocks';
@@ -26,6 +27,52 @@ function createPr(number: number, state: string): GitHubIssue {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('GitHubSsoError', () => {
+  it('is recognized as a recoverable error', () => {
+    const error = new GitHubSsoError({
+      orgName: 'example',
+      ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
+    });
+
+    expect(isRecoverableError(error)).toBe(true);
+    expect(error.recoverable).toBe(true);
+  });
+
+  it('includes an authorize action when a direct SSO URL is present', async () => {
+    const error = new GitHubSsoError({
+      orgName: 'example',
+      ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
+    });
+
+    expect(error.actions).toHaveLength(1);
+    expect(error.actions?.[0]).toMatchObject({
+      label: 'Authorize in browser',
+      retryAfterAction: true,
+    });
+
+    await error.actions?.[0]?.run();
+
+    expect(env.openExternal).toHaveBeenCalledWith(expect.objectContaining({ toString: expect.any(Function) }));
+    expect(env.openExternal.mock.calls[0][0].toString()).toBe('https://github.com/orgs/example/sso?authorization_request=abc123');
+  });
+
+  it('falls back to the organization SSO URL when no direct URL is present', async () => {
+    const error = new GitHubSsoError({ orgName: 'example-fallback' });
+
+    expect(error.actions).toHaveLength(1);
+
+    await error.actions?.[0]?.run();
+
+    expect(env.openExternal.mock.calls[0][0].toString()).toBe('https://github.com/orgs/example-fallback/sso');
+  });
+
+  it('omits the authorize action when no safe URL is available', () => {
+    expect(new GitHubSsoError().actions).toBeUndefined();
+    expect(new GitHubSsoError({ ssoUrl: 'file:///not-safe' }).actions).toBeUndefined();
+  });
 });
 
 describe('isMergedGitHubPr', () => {
@@ -245,9 +292,14 @@ describe('throwApiError', () => {
 
     await expect(throwApiError(response, 'GitHub issue org/repo#1')).rejects.toMatchObject({
       name: 'GitHubSsoError',
-      message: expect.stringMatching(/SSO authorization required.*organization/i),
+      message: 'DevDocket: GitHub requires SSO authorization for the "example" organization\nbefore this item can be loaded.',
       ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
       orgName: 'example',
+      recoverable: true,
+      actions: [expect.objectContaining({
+        label: 'Authorize in browser',
+        retryAfterAction: true,
+      })],
     });
 
     await expect(throwApiError(makeErrorResponse({
@@ -267,7 +319,11 @@ describe('throwApiError', () => {
       bodyJson: { message: 'Resource protected by organization SAML enforcement.' },
     });
     await expect(throwApiError(response, 'GitHub issue org/repo#1'))
-      .rejects.toMatchObject({ name: 'GitHubSsoError', orgName: 'example' });
+      .rejects.toMatchObject({
+        name: 'GitHubSsoError',
+        orgName: 'example',
+        message: 'DevDocket: GitHub requires SSO authorization for the "example" organization\nbefore this item can be loaded.',
+      });
   });
 
   it('prefers secondary-rate-limit classification over a coincidental remaining=0', async () => {

--- a/packages/github/src/test/githubApiHelpers.test.ts
+++ b/packages/github/src/test/githubApiHelpers.test.ts
@@ -74,10 +74,11 @@ describe('GitHubSsoError', () => {
     expect(new GitHubSsoError({ ssoUrl: 'file:///not-safe' }).actions).toBeUndefined();
   });
 
-  it('stores only safe SSO URLs on the error surface', () => {
+  it('stores only trusted GitHub SSO URLs on the error surface', () => {
     expect(new GitHubSsoError({
       ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
     }).ssoUrl).toBe('https://github.com/orgs/example/sso?authorization_request=abc123');
+    expect(new GitHubSsoError({ ssoUrl: 'https://evil.example.com/orgs/example/sso' }).ssoUrl).toBeUndefined();
     expect(new GitHubSsoError({ ssoUrl: 'file:///not-safe' }).ssoUrl).toBeUndefined();
   });
 });

--- a/packages/github/src/test/githubApiHelpers.test.ts
+++ b/packages/github/src/test/githubApiHelpers.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { authentication } from 'vscode';
-import { filterMergedGitHubPrs, isMergedGitHubPr, throwApiError, looksLikeRateLimited403, retryWithAuth, type GitHubIssue } from '../githubApiHelpers';
+import { GitHubSsoError, filterMergedGitHubPrs, isMergedGitHubPr, throwApiError, looksLikeRateLimited403, retryWithAuth, type GitHubIssue } from '../githubApiHelpers';
 import { setLogger } from '../logger';
 import { makeErrorResponse } from './responseMocks';
 
@@ -236,14 +236,25 @@ describe('throwApiError', () => {
       .rejects.toThrow(/secondary rate limit.*Retry after \d+s/i);
   });
 
-  it('throws an SSO message for 403 with x-github-sso header', async () => {
+  it('throws a GitHubSsoError with org name and SSO URL from the response header', async () => {
     const response = makeErrorResponse({
       status: 403,
-      headers: { 'x-github-sso': 'required; url=https://github.com/orgs/example/sso' },
+      headers: { 'x-github-sso': 'required; url=https://github.com/orgs/example/sso?authorization_request=abc123' },
       bodyJson: { message: 'Resource protected by organization SAML enforcement. You must grant your OAuth token access to this organization.' },
     });
-    await expect(throwApiError(response, 'GitHub issue org/repo#1'))
-      .rejects.toThrow(/SSO authorization required.*organization/i);
+
+    await expect(throwApiError(response, 'GitHub issue org/repo#1')).rejects.toMatchObject({
+      name: 'GitHubSsoError',
+      message: expect.stringMatching(/SSO authorization required.*organization/i),
+      ssoUrl: 'https://github.com/orgs/example/sso?authorization_request=abc123',
+      orgName: 'example',
+    });
+
+    await expect(throwApiError(makeErrorResponse({
+      status: 403,
+      headers: { 'x-github-sso': 'required; url=https://github.com/orgs/example/sso?authorization_request=abc123' },
+      bodyJson: { message: 'Resource protected by organization SAML enforcement.' },
+    }), 'GitHub issue org/repo#1')).rejects.toBeInstanceOf(GitHubSsoError);
   });
 
   it('prefers SSO classification over a coincidental remaining=0', async () => {
@@ -256,7 +267,7 @@ describe('throwApiError', () => {
       bodyJson: { message: 'Resource protected by organization SAML enforcement.' },
     });
     await expect(throwApiError(response, 'GitHub issue org/repo#1'))
-      .rejects.toThrow(/SSO authorization required/i);
+      .rejects.toMatchObject({ name: 'GitHubSsoError', orgName: 'example' });
   });
 
   it('prefers secondary-rate-limit classification over a coincidental remaining=0', async () => {

--- a/packages/github/src/test/githubMentionsProvider.test.ts
+++ b/packages/github/src/test/githubMentionsProvider.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { authentication, workspace } from 'vscode';
 import { GitHubMentionsProvider } from '../githubMentionsProvider';
+import { GitHubSsoError } from '../githubApiHelpers';
 import { setLogger } from '../logger';
 
 const mockFetch = vi.fn();
@@ -106,6 +107,18 @@ describe('GitHubMentionsProvider', () => {
   it('has correct id and label', () => {
     expect(provider.id).toBe('github-mentions');
     expect(provider.label).toBe('GitHub Mentions');
+  });
+
+  it('propagates SSO errors during background refresh', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      headers: { get: (name: string) => name === 'x-github-sso' ? 'required; url=https://github.com/orgs/example-mentions/sso?authorization_request=abc123' : null },
+      text: async () => JSON.stringify({ message: 'Resource protected by organization SAML enforcement.' }),
+    });
+
+    await expect(provider.refreshInBackground()).rejects.toBeInstanceOf(GitHubSsoError);
   });
 
   it('requests read:org scope for team mention detection', async () => {

--- a/packages/github/src/test/githubMyPrsProvider.test.ts
+++ b/packages/github/src/test/githubMyPrsProvider.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { authentication, workspace } from 'vscode';
 import { GitHubMyPrsProvider, type PrDetail, type PrReview } from '../githubMyPrsProvider';
+import { GitHubSsoError } from '../githubApiHelpers';
 import { setLogger } from '../logger';
 
 const mockFetch = vi.fn();
@@ -87,6 +88,26 @@ describe('GitHubMyPrsProvider', () => {
 
     expect(listener).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('propagates SSO errors from PR searches during background refresh', async () => {
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.includes('search/issues') && url.includes('author:@me')) {
+        return {
+          ok: false,
+          status: 403,
+          statusText: 'Forbidden',
+          headers: { get: (name: string) => name === 'x-github-sso' ? 'required; url=https://github.com/orgs/example/sso?authorization_request=abc123' : null },
+          text: async () => JSON.stringify({ message: 'Resource protected by organization SAML enforcement.' }),
+        };
+      }
+      if (url.includes('search/issues') && url.includes('assignee:@me')) {
+        return mockSearchResponse([]);
+      }
+      return mockFailedResponse(404);
+    });
+
+    await expect(provider.refreshInBackground()).rejects.toBeInstanceOf(GitHubSsoError);
   });
 
   it('excludes merged PRs by fetching details for closed authored and assigned search results', async () => {

--- a/packages/github/src/test/githubPrReviewProvider.test.ts
+++ b/packages/github/src/test/githubPrReviewProvider.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { authentication, window, workspace } from 'vscode';
 import { GitHubPrReviewProvider } from '../githubPrReviewProvider';
+import { GitHubSsoError } from '../githubApiHelpers';
 import { setLogger } from '../logger';
 
 const mockFetch = vi.fn();
@@ -75,6 +76,18 @@ describe('GitHubPrReviewProvider', () => {
 
     expect(listener).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('propagates SSO errors during background refresh', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      headers: { get: (name: string) => name === 'x-github-sso' ? 'required; url=https://github.com/orgs/example-pr-reviews/sso?authorization_request=abc123' : null },
+      text: async () => JSON.stringify({ message: 'Resource protected by organization SAML enforcement.' }),
+    });
+
+    await expect(provider.refreshInBackground()).rejects.toBeInstanceOf(GitHubSsoError);
   });
 
   it('shows warning and logs error when auth throws on user-triggered refresh', async () => {

--- a/packages/github/src/test/githubProvider.test.ts
+++ b/packages/github/src/test/githubProvider.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import { authentication, workspace, window } from 'vscode';
 import { GitHubIssueProvider } from '../githubProvider';
+import { GitHubSsoError } from '../githubApiHelpers';
 import { setLogger } from '../logger';
 
 // Mock global fetch
@@ -56,6 +57,18 @@ describe('GitHubIssueProvider', () => {
 
     expect(listener).not.toHaveBeenCalled();
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('propagates SSO errors during background refresh', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      statusText: 'Forbidden',
+      headers: { get: (name: string) => name === 'x-github-sso' ? 'required; url=https://github.com/orgs/example-issues/sso?authorization_request=abc123' : null },
+      text: async () => JSON.stringify({ message: 'Resource protected by organization SAML enforcement.' }),
+    });
+
+    await expect(provider.refreshInBackground()).rejects.toBeInstanceOf(GitHubSsoError);
   });
 
   it('filters out configured repos via global fetch, keeps the rest', async () => {

--- a/packages/github/src/test/resolveUrl.test.ts
+++ b/packages/github/src/test/resolveUrl.test.ts
@@ -280,7 +280,7 @@ describe('resolveUrl', () => {
 
       await expect(
         provider.resolveUrl('https://github.com/owner/repo/issues/123'),
-      ).rejects.toThrow(/SSO authorization required/i);
+      ).rejects.toThrow('DevDocket: GitHub requires SSO authorization for the "example" organization\nbefore this item can be loaded.');
     });
 
     it('throws generic 403 error (not rate limit / SSO) with API message', async () => {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,7 +6,9 @@ export { createLoggerService, LogLevel, resolveLogLevel, serializeArg } from './
 export type { Logger, LogOutput, LoggerService } from './logger';
 export { BaseProvider } from './baseProvider';
 export type { ProviderItem, ProviderItemAuthor, ProviderItemCapabilities, Disposable, Event, EventEmitterLike, GitWorkInfo, ProviderBadge, RelatedItemRef, ResolvedItem, WindowStateProvider } from './baseProvider';
-export { isValidUrlSegment, isValidGitHubRepo, isValidRepoSlug, sanitizeUrlSegment, safeDecodeComponent } from './urlValidation';
+export { isSafeUrl, isValidUrlSegment, isValidGitHubRepo, isValidRepoSlug, sanitizeUrlSegment, safeDecodeComponent } from './urlValidation';
+export type { RecoverableError, RecoverableErrorAction } from './recoverableError';
+export { isRecoverableError } from './recoverableError';
 export { validateRefreshInterval } from './refreshInterval';
 export type { DevDocketRunWatcher, RunIdentifier, RunStatus, JobStatus, RunState, RunConclusion, CancellationTokenLike } from './runWatcher';
 export type { DevDocketPRWatcher, PRIdentifier, PRState, PRRunsSnapshot } from './prWatcher';

--- a/packages/shared/src/recoverableError.ts
+++ b/packages/shared/src/recoverableError.ts
@@ -18,5 +18,6 @@ export interface RecoverableError extends Error {
 export function isRecoverableError(error: unknown): error is RecoverableError {
   return typeof error === 'object'
     && error !== null
-    && (error as { recoverable?: unknown }).recoverable === true;
+    && (error as { recoverable?: unknown }).recoverable === true
+    && typeof (error as { message?: unknown }).message === 'string';
 }

--- a/packages/shared/src/recoverableError.ts
+++ b/packages/shared/src/recoverableError.ts
@@ -1,0 +1,22 @@
+export interface RecoverableErrorAction {
+  readonly label: string;
+  readonly run: () => Promise<void>;
+  readonly retryAfterAction?: boolean;
+}
+
+/**
+ * An error a provider or action can throw to surface recovery options in the UI.
+ * Consumers will usually render `message` directly, but may substitute more
+ * context-specific copy when the same recovery action is reused elsewhere.
+ */
+export interface RecoverableError extends Error {
+  readonly recoverable: true;
+  readonly actions?: ReadonlyArray<RecoverableErrorAction>;
+  readonly retryable?: boolean;
+}
+
+export function isRecoverableError(error: unknown): error is RecoverableError {
+  return typeof error === 'object'
+    && error !== null
+    && (error as { recoverable?: unknown }).recoverable === true;
+}

--- a/packages/shared/src/recoverableError.ts
+++ b/packages/shared/src/recoverableError.ts
@@ -16,8 +16,30 @@ export interface RecoverableError extends Error {
 }
 
 export function isRecoverableError(error: unknown): error is RecoverableError {
-  return typeof error === 'object'
-    && error !== null
-    && (error as { recoverable?: unknown }).recoverable === true
-    && typeof (error as { message?: unknown }).message === 'string';
+  if (typeof error !== 'object' || error === null) {
+    return false;
+  }
+
+  const candidate = error as {
+    recoverable?: unknown;
+    message?: unknown;
+    actions?: unknown;
+    retryable?: unknown;
+  };
+
+  const hasValidActions = candidate.actions === undefined || (
+    Array.isArray(candidate.actions)
+    && candidate.actions.every(action => typeof action === 'object'
+      && action !== null
+      && typeof (action as { label?: unknown }).label === 'string'
+      && typeof (action as { run?: unknown }).run === 'function'
+      && ((action as { retryAfterAction?: unknown }).retryAfterAction === undefined
+        || typeof (action as { retryAfterAction?: unknown }).retryAfterAction === 'boolean'))
+  );
+  const hasValidRetryable = candidate.retryable === undefined || typeof candidate.retryable === 'boolean';
+
+  return candidate.recoverable === true
+    && typeof candidate.message === 'string'
+    && hasValidActions
+    && hasValidRetryable;
 }

--- a/packages/shared/src/test/recoverableError.test.ts
+++ b/packages/shared/src/test/recoverableError.test.ts
@@ -28,6 +28,8 @@ describe('isRecoverableError', () => {
   it('returns false for non-recoverable values', () => {
     expect(isRecoverableError(new Error('nope'))).toBe(false);
     expect(isRecoverableError({ recoverable: false })).toBe(false);
+    expect(isRecoverableError({ recoverable: true })).toBe(false);
+    expect(isRecoverableError({ recoverable: true, message: 42 })).toBe(false);
     expect(isRecoverableError(null)).toBe(false);
     expect(isRecoverableError('recoverable')).toBe(false);
   });

--- a/packages/shared/src/test/recoverableError.test.ts
+++ b/packages/shared/src/test/recoverableError.test.ts
@@ -30,6 +30,9 @@ describe('isRecoverableError', () => {
     expect(isRecoverableError({ recoverable: false })).toBe(false);
     expect(isRecoverableError({ recoverable: true })).toBe(false);
     expect(isRecoverableError({ recoverable: true, message: 42 })).toBe(false);
+    expect(isRecoverableError({ recoverable: true, message: 'oops', actions: 'bad' })).toBe(false);
+    expect(isRecoverableError({ recoverable: true, message: 'oops', actions: [{ label: 'Retry' }] })).toBe(false);
+    expect(isRecoverableError({ recoverable: true, message: 'oops', retryable: 'sometimes' })).toBe(false);
     expect(isRecoverableError(null)).toBe(false);
     expect(isRecoverableError('recoverable')).toBe(false);
   });

--- a/packages/shared/src/test/recoverableError.test.ts
+++ b/packages/shared/src/test/recoverableError.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { isRecoverableError, type RecoverableError } from '../recoverableError';
+
+describe('isRecoverableError', () => {
+  it('returns true for recoverable errors', () => {
+    const error = Object.assign(new Error('Recover me'), {
+      recoverable: true as const,
+      actions: [{
+        label: 'Open settings',
+        run: vi.fn(async () => undefined),
+      }],
+    }) satisfies RecoverableError;
+
+    expect(isRecoverableError(error)).toBe(true);
+  });
+
+  it('returns true for plain objects from another extension bundle', () => {
+    const crossBoundaryError = {
+      name: 'RemoteRecoverableError',
+      message: 'Needs recovery',
+      recoverable: true as const,
+      retryable: false,
+    };
+
+    expect(isRecoverableError(crossBoundaryError)).toBe(true);
+  });
+
+  it('returns false for non-recoverable values', () => {
+    expect(isRecoverableError(new Error('nope'))).toBe(false);
+    expect(isRecoverableError({ recoverable: false })).toBe(false);
+    expect(isRecoverableError(null)).toBe(false);
+    expect(isRecoverableError('recoverable')).toBe(false);
+  });
+});

--- a/packages/shared/src/urlValidation.ts
+++ b/packages/shared/src/urlValidation.ts
@@ -93,3 +93,13 @@ export function sanitizeUrlSegment(segment: string): string {
 export function safeDecodeComponent(value: string): string {
   try { return decodeURIComponent(value); } catch { return value; }
 }
+
+/** Validate that a URL uses a safe scheme (http or https). */
+export function isSafeUrl(url: string): URL | null {
+  try {
+    const parsed = new URL(url);
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:') ? parsed : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared `RecoverableError` contract in `@devdocket/shared` so providers can supply recovery actions without teaching core about provider-specific failures
- move GitHub SSO messaging, authorize action construction, and fallback SSO URL handling into `devdocket-github`
- generalize core command recovery handling so URL imports render provider-supplied actions and retries with zero GitHub-specific logic in `packages/core`
- keep GitHub background-refresh SSO notifications deduplicated while reusing the same recoverable-action model

## Testing
- npm run build
- npm run test

Closes #598
