### PR TITLE
Parallelize run and PR watcher polling

### DIFF
--- a/.changeset/parallel-watch-polling.md
+++ b/.changeset/parallel-watch-polling.md
@@ -1,0 +1,5 @@
+---
+"devdocket": patch
+---
+
+Poll CI runs and PR watches concurrently so large watch lists refresh faster without waiting for each provider call to finish in series.

--- a/packages/core/src/services/prWatchPool.ts
+++ b/packages/core/src/services/prWatchPool.ts
@@ -250,6 +250,10 @@ export class PRWatchPool implements vscode.Disposable {
       group,
       async ({ prWatch, index }) => {
         const key = this.getPRWatchKey(prWatch.identifier);
+        if (this.isDisposed()) {
+          fetchResults[index] = { key, error: new Error('Watcher service disposed') };
+          return;
+        }
         try {
           const prWatcher = this.prWatcherRegistry.get(prWatch.identifier.providerId);
           if (!prWatcher) {

--- a/packages/core/src/services/prWatchPool.ts
+++ b/packages/core/src/services/prWatchPool.ts
@@ -307,8 +307,8 @@ export class PRWatchPool implements vscode.Disposable {
 
       const currentRunKeys = new Set(prWatch.childRunKeys);
       const newRunKeys = new Set<string>();
-      for (const runId of snapshot.runs) {
-        const resolved = this.runControl.resolveRunIdentifier(runId);
+      for (const runIdentifier of snapshot.runs) {
+        const resolved = this.runControl.resolveRunIdentifier(runIdentifier);
         const runKey = this.runControl.getWatchKey(resolved);
         newRunKeys.add(runKey);
         if (!currentRunKeys.has(runKey)) {

--- a/packages/core/src/services/prWatchPool.ts
+++ b/packages/core/src/services/prWatchPool.ts
@@ -1,8 +1,16 @@
 import * as vscode from 'vscode';
-import type { PRIdentifier, RunIdentifier } from '@devdocket/shared';
+import { runWorkerPool, type PRIdentifier, type PRRunsSnapshot, type RunIdentifier } from '@devdocket/shared';
 import { PRWatcherRegistry } from './prWatcherRegistry';
 import type { WatchedPR, WatchedRun } from './watcherService';
 import type { StartWatchOptions, WatchStartResult } from './runWatchPool';
+
+const POLL_CONCURRENCY_PER_PROVIDER = 4;
+
+type PRPollFetchResult = {
+  key: string;
+  snapshot?: PRRunsSnapshot;
+  error?: unknown;
+};
 
 type WatcherLogger = {
   info: (msg: string) => void;
@@ -237,84 +245,100 @@ export class PRWatchPool implements vscode.Disposable {
     );
     if (activePRs.length === 0) return { prChanged: false, childRunChanged: false };
 
+    const fetchResults = new Array<PRPollFetchResult>(activePRs.length);
+    await Promise.all(this.groupPRsByProvider(activePRs).map(group => runWorkerPool(
+      group,
+      async ({ prWatch, index }) => {
+        const key = this.getPRWatchKey(prWatch.identifier);
+        try {
+          const prWatcher = this.prWatcherRegistry.get(prWatch.identifier.providerId);
+          if (!prWatcher) {
+            throw new Error(`PR watcher '${prWatch.identifier.providerId}' is no longer registered`);
+          }
+
+          fetchResults[index] = {
+            key,
+            snapshot: await prWatcher.getPRRunsSnapshot(prWatch.identifier),
+          };
+        } catch (error) {
+          fetchResults[index] = { key, error };
+        }
+      },
+      POLL_CONCURRENCY_PER_PROVIDER,
+    )));
+
     let prChanged = false;
     let childRunChanged = false;
 
-    for (const prWatch of activePRs) {
-      const key = this.getPRWatchKey(prWatch.identifier);
-      try {
-        const prWatcher = this.prWatcherRegistry.get(prWatch.identifier.providerId);
-        if (!prWatcher) {
-          throw new Error(`PR watcher '${prWatch.identifier.providerId}' is no longer registered`);
-        }
+    for (let index = 0; index < activePRs.length; index += 1) {
+      const prWatch = activePRs[index];
+      const result = fetchResults[index];
+      const key = result?.key ?? this.getPRWatchKey(prWatch.identifier);
 
-        const snapshot = await prWatcher.getPRRunsSnapshot(prWatch.identifier);
-        if (this.isDisposed()) return { prChanged, childRunChanged };
-        if (this.prWatches.get(key) !== prWatch || prWatch.dismissed) {
-          continue;
-        }
-        prWatch.lastPolledAt = new Date().toISOString();
+      if (this.isDisposed()) return { prChanged, childRunChanged };
+      if (this.prWatches.get(key) !== prWatch || prWatch.dismissed) {
+        continue;
+      }
 
-        if (snapshot.displayName && snapshot.displayName !== prWatch.identifier.displayName) {
-          prWatch.identifier.displayName = snapshot.displayName;
-          prChanged = true;
-        }
+      if (result?.error !== undefined) {
+        prChanged = this.handlePollFailure(prWatch, key, result.error) || prChanged;
+        continue;
+      }
 
-        this.consecutiveFailures.delete(key);
-        prWatch.hasWarning = false;
-        prWatch.errorMessage = undefined;
+      const snapshot = result?.snapshot;
+      if (!snapshot) {
+        continue;
+      }
 
-        const currentRunKeys = new Set(prWatch.childRunKeys);
-        const newRunKeys = new Set<string>();
-        for (const runId of snapshot.runs) {
-          const resolved = this.runControl.resolveRunIdentifier(runId);
-          const runKey = this.runControl.getWatchKey(resolved);
-          newRunKeys.add(runKey);
-          if (!currentRunKeys.has(runKey)) {
-            const added = await this.addChildRun(key, prWatch, resolved);
-            if (this.isDisposed()) return { prChanged, childRunChanged };
-            if (added) {
-              childRunChanged = true;
-            }
+      prWatch.lastPolledAt = new Date().toISOString();
+
+      if (snapshot.displayName && snapshot.displayName !== prWatch.identifier.displayName) {
+        prWatch.identifier.displayName = snapshot.displayName;
+        prChanged = true;
+      }
+
+      this.consecutiveFailures.delete(key);
+      prWatch.hasWarning = false;
+      prWatch.errorMessage = undefined;
+
+      const currentRunKeys = new Set(prWatch.childRunKeys);
+      const newRunKeys = new Set<string>();
+      for (const runId of snapshot.runs) {
+        const resolved = this.runControl.resolveRunIdentifier(runId);
+        const runKey = this.runControl.getWatchKey(resolved);
+        newRunKeys.add(runKey);
+        if (!currentRunKeys.has(runKey)) {
+          const added = await this.addChildRun(key, prWatch, resolved, { deferStatusFetch: true });
+          if (this.isDisposed()) return { prChanged, childRunChanged };
+          if (added) {
+            childRunChanged = true;
           }
         }
+      }
 
-        const hadObservedChildren = currentRunKeys.size > 0 || this.hasObservedChildRun(key, prWatch);
-        for (const childKey of currentRunKeys) {
-          if (!newRunKeys.has(childKey)) {
-            if (this.runControl.dismissOwnedChildRun(childKey, key, { clearAcknowledgement: false })) {
-              childRunChanged = true;
-            }
-            prWatch.childRunKeys = prWatch.childRunKeys.filter(k => k !== childKey);
+      const hadObservedChildren = currentRunKeys.size > 0 || this.hasObservedChildRun(key, prWatch);
+      for (const childKey of currentRunKeys) {
+        if (!newRunKeys.has(childKey)) {
+          if (this.runControl.dismissOwnedChildRun(childKey, key, { clearAcknowledgement: false })) {
+            childRunChanged = true;
           }
+          prWatch.childRunKeys = prWatch.childRunKeys.filter(k => k !== childKey);
         }
-        if (
-          hadObservedChildren
-          && this.getActiveChildRunKeys(key).length === 0
-          && this.dismissChildlessPRWatches([key], { assumeObserved: true }) > 0
-        ) {
-          prChanged = true;
-          continue;
-        }
+      }
+      if (
+        hadObservedChildren
+        && this.getActiveChildRunKeys(key).length === 0
+        && this.dismissChildlessPRWatches([key], { assumeObserved: true }) > 0
+      ) {
+        prChanged = true;
+        continue;
+      }
 
-        if (snapshot.prState !== prWatch.prState) {
-          prWatch.prState = snapshot.prState;
-          prChanged = true;
-          if (snapshot.prState === 'merged' || snapshot.prState === 'closed') {
-            this._onDidCompletePR.fire(prWatch);
-          }
-        }
-      } catch (err) {
-        const failures = (this.consecutiveFailures.get(key) || 0) + 1;
-        this.consecutiveFailures.set(key, failures);
-
-        if (failures >= 3) {
-          prWatch.hasWarning = true;
-          prWatch.errorMessage = err instanceof Error ? err.message : String(err);
-          prChanged = true;
-          this.logger.warn(`3 consecutive failures for PR ${prWatch.identifier.displayName}, marking with warning`);
-        } else {
-          this.logger.warn(`PR poll failed for ${prWatch.identifier.displayName} (attempt ${failures}/3): ${err}`);
+      if (snapshot.prState !== prWatch.prState) {
+        prWatch.prState = snapshot.prState;
+        prChanged = true;
+        if (snapshot.prState === 'merged' || snapshot.prState === 'closed') {
+          this._onDidCompletePR.fire(prWatch);
         }
       }
     }
@@ -474,6 +498,31 @@ export class PRWatchPool implements vscode.Disposable {
       }
     }
     return runToPRKeys;
+  }
+
+  private groupPRsByProvider(prWatches: WatchedPR[]): Array<Array<{ prWatch: WatchedPR; index: number }>> {
+    const grouped = new Map<string, Array<{ prWatch: WatchedPR; index: number }>>();
+    for (const [index, prWatch] of prWatches.entries()) {
+      const providerGroup = grouped.get(prWatch.identifier.providerId) ?? [];
+      providerGroup.push({ prWatch, index });
+      grouped.set(prWatch.identifier.providerId, providerGroup);
+    }
+    return Array.from(grouped.values());
+  }
+
+  private handlePollFailure(prWatch: WatchedPR, key: string, err: unknown): boolean {
+    const failures = (this.consecutiveFailures.get(key) || 0) + 1;
+    this.consecutiveFailures.set(key, failures);
+
+    if (failures >= 3) {
+      prWatch.hasWarning = true;
+      prWatch.errorMessage = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`3 consecutive failures for PR ${prWatch.identifier.displayName}, marking with warning`);
+      return true;
+    }
+
+    this.logger.warn(`PR poll failed for ${prWatch.identifier.displayName} (attempt ${failures}/3): ${err}`);
+    return false;
   }
 
   private hasObservedChildRun(prKey: string, prWatch: WatchedPR): boolean {

--- a/packages/core/src/services/runWatchPool.ts
+++ b/packages/core/src/services/runWatchPool.ts
@@ -1,8 +1,16 @@
 import * as vscode from 'vscode';
-import type { JobStatus, RunIdentifier, RunStatus } from '@devdocket/shared';
+import { runWorkerPool, type JobStatus, type RunIdentifier, type RunStatus } from '@devdocket/shared';
 import { WatcherRegistry } from './watcherRegistry';
 import type { WatchedRun } from './watcherService';
 import { isFailedConclusion } from '../webview/shared/runConclusionLabels';
+
+const POLL_CONCURRENCY_PER_PROVIDER = 4;
+
+type RunPollFetchResult = {
+  key: string;
+  status?: RunStatus;
+  error?: unknown;
+};
 
 type WatcherLogger = {
   info: (msg: string) => void;
@@ -222,81 +230,96 @@ export class RunWatchPool implements vscode.Disposable {
     );
     if (pollableWatches.length === 0) return false;
 
+    const fetchResults = new Array<RunPollFetchResult>(pollableWatches.length);
+    await Promise.all(this.groupWatchesByProvider(pollableWatches).map(group => runWorkerPool(
+      group,
+      async ({ watch, index }) => {
+        const key = this.getWatchKey(watch.identifier);
+        try {
+          const watcher = this.watcherRegistry.get(watch.identifier.providerId);
+          if (!watcher) {
+            throw new Error(`Watcher '${watch.identifier.providerId}' is no longer registered`);
+          }
+
+          fetchResults[index] = {
+            key,
+            status: await watcher.getRunStatus(watch.identifier),
+          };
+        } catch (error) {
+          fetchResults[index] = { key, error };
+        }
+      },
+      POLL_CONCURRENCY_PER_PROVIDER,
+    )));
+
     let anyChanged = false;
 
-    for (const watch of pollableWatches) {
-      try {
-        const watcher = this.watcherRegistry.get(watch.identifier.providerId);
-        if (!watcher) {
-          throw new Error(`Watcher '${watch.identifier.providerId}' is no longer registered`);
-        }
+    for (let index = 0; index < pollableWatches.length; index += 1) {
+      const watch = pollableWatches[index];
+      const result = fetchResults[index];
+      const key = result?.key ?? this.getWatchKey(watch.identifier);
 
-        const newStatus = await watcher.getRunStatus(watch.identifier);
-        const key = this.getWatchKey(watch.identifier);
-        if (this.isDisposed()) return anyChanged;
-        if (this.watches.get(key) !== watch || watch.dismissed) {
-          continue;
-        }
-        watch.lastPolledAt = new Date().toISOString();
+      if (this.isDisposed()) return anyChanged;
+      if (this.watches.get(key) !== watch || watch.dismissed) {
+        continue;
+      }
 
-        const suppressStatusEvents = watch.suppressNextStatusEvents === true;
-        if (suppressStatusEvents) {
-          delete watch.suppressNextStatusEvents;
-          anyChanged = true;
-        }
+      if (result?.error !== undefined) {
+        anyChanged = this.handlePollFailure(watch, key, result.error) || anyChanged;
+        continue;
+      }
 
-        this.consecutiveFailures.delete(key);
-        watch.hasWarning = false;
-        watch.errorMessage = undefined;
+      const newStatus = result?.status;
+      if (!newStatus) {
+        continue;
+      }
 
-        const oldStatus = watch.status;
-        const statusChanged = oldStatus.overallState !== newStatus.overallState
-          || oldStatus.conclusion !== newStatus.conclusion
-          || oldStatus.jobs.length !== newStatus.jobs.length
-          || newStatus.jobs.some(newJob => {
+      watch.lastPolledAt = new Date().toISOString();
+
+      const suppressStatusEvents = watch.suppressNextStatusEvents === true;
+      if (suppressStatusEvents) {
+        delete watch.suppressNextStatusEvents;
+        anyChanged = true;
+      }
+
+      this.consecutiveFailures.delete(key);
+      watch.hasWarning = false;
+      watch.errorMessage = undefined;
+
+      const oldStatus = watch.status;
+      const statusChanged = oldStatus.overallState !== newStatus.overallState
+        || oldStatus.conclusion !== newStatus.conclusion
+        || oldStatus.jobs.length !== newStatus.jobs.length
+        || newStatus.jobs.some(newJob => {
+          const oldJob = newJob.id
+            ? oldStatus.jobs.find(j => j.id === newJob.id)
+            : oldStatus.jobs.find(j => j.name === newJob.name);
+          return !oldJob || oldJob.state !== newJob.state || oldJob.conclusion !== newJob.conclusion;
+        });
+      watch.status = newStatus;
+      if (newStatus.displayName && newStatus.displayName !== watch.identifier.displayName) {
+        watch.identifier.displayName = newStatus.displayName;
+        anyChanged = true;
+      }
+      if (statusChanged) {
+        anyChanged = true;
+      }
+
+      if (!suppressStatusEvents && newStatus.overallState !== 'completed') {
+        for (const newJob of newStatus.jobs) {
+          if (newJob.state === 'completed' && newJob.conclusion === 'failure') {
             const oldJob = newJob.id
               ? oldStatus.jobs.find(j => j.id === newJob.id)
               : oldStatus.jobs.find(j => j.name === newJob.name);
-            return !oldJob || oldJob.state !== newJob.state || oldJob.conclusion !== newJob.conclusion;
-          });
-        watch.status = newStatus;
-        if (newStatus.displayName && newStatus.displayName !== watch.identifier.displayName) {
-          watch.identifier.displayName = newStatus.displayName;
-          anyChanged = true;
-        }
-        if (statusChanged) {
-          anyChanged = true;
-        }
-
-        if (!suppressStatusEvents && newStatus.overallState !== 'completed') {
-          for (const newJob of newStatus.jobs) {
-            if (newJob.state === 'completed' && newJob.conclusion === 'failure') {
-              const oldJob = newJob.id
-                ? oldStatus.jobs.find(j => j.id === newJob.id)
-                : oldStatus.jobs.find(j => j.name === newJob.name);
-              if (!oldJob || oldJob.state !== 'completed' || oldJob.conclusion !== 'failure') {
-                this._onDidDetectJobFailure.fire({ run: watch, job: newJob });
-              }
+            if (!oldJob || oldJob.state !== 'completed' || oldJob.conclusion !== 'failure') {
+              this._onDidDetectJobFailure.fire({ run: watch, job: newJob });
             }
           }
         }
+      }
 
-        if (!suppressStatusEvents && oldStatus.overallState !== 'completed' && newStatus.overallState === 'completed') {
-          this._onDidCompleteRun.fire(watch);
-        }
-      } catch (err) {
-        const key = this.getWatchKey(watch.identifier);
-        const failures = (this.consecutiveFailures.get(key) || 0) + 1;
-        this.consecutiveFailures.set(key, failures);
-
-        if (failures >= 3) {
-          watch.hasWarning = true;
-          watch.errorMessage = err instanceof Error ? err.message : String(err);
-          anyChanged = true;
-          this.logger.warn(`3 consecutive failures for ${watch.identifier.displayName}, marking with warning`);
-        } else {
-          this.logger.warn(`Poll failed for ${watch.identifier.displayName} (attempt ${failures}/3): ${err}`);
-        }
+      if (!suppressStatusEvents && oldStatus.overallState !== 'completed' && newStatus.overallState === 'completed') {
+        this._onDidCompleteRun.fire(watch);
       }
     }
 
@@ -328,6 +351,31 @@ export class RunWatchPool implements vscode.Disposable {
     }
 
     return identifier;
+  }
+
+  private groupWatchesByProvider(watches: WatchedRun[]): Array<Array<{ watch: WatchedRun; index: number }>> {
+    const grouped = new Map<string, Array<{ watch: WatchedRun; index: number }>>();
+    for (const [index, watch] of watches.entries()) {
+      const providerGroup = grouped.get(watch.identifier.providerId) ?? [];
+      providerGroup.push({ watch, index });
+      grouped.set(watch.identifier.providerId, providerGroup);
+    }
+    return Array.from(grouped.values());
+  }
+
+  private handlePollFailure(watch: WatchedRun, key: string, err: unknown): boolean {
+    const failures = (this.consecutiveFailures.get(key) || 0) + 1;
+    this.consecutiveFailures.set(key, failures);
+
+    if (failures >= 3) {
+      watch.hasWarning = true;
+      watch.errorMessage = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`3 consecutive failures for ${watch.identifier.displayName}, marking with warning`);
+      return true;
+    }
+
+    this.logger.warn(`Poll failed for ${watch.identifier.displayName} (attempt ${failures}/3): ${err}`);
+    return false;
   }
 
   private static isFailedRun(watch: WatchedRun): boolean {

--- a/packages/core/src/services/runWatchPool.ts
+++ b/packages/core/src/services/runWatchPool.ts
@@ -235,6 +235,10 @@ export class RunWatchPool implements vscode.Disposable {
       group,
       async ({ watch, index }) => {
         const key = this.getWatchKey(watch.identifier);
+        if (this.isDisposed()) {
+          fetchResults[index] = { key, error: new Error('Watcher service disposed') };
+          return;
+        }
         try {
           const watcher = this.watcherRegistry.get(watch.identifier.providerId);
           if (!watcher) {

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -51,6 +51,16 @@ function createMockWatchStore(): WatchStore {
   } as unknown as WatchStore;
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 describe('WatcherService', () => {
   it('keeps host-specific run URL routing out of watcher services', () => {
     const serviceFiles = [
@@ -291,6 +301,60 @@ describe('WatcherService', () => {
       expect(completeSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('polls many run watches in parallel across providers', async () => {
+      const pollDelayMs = 1000;
+      const createParallelWatcher = (providerId: string) => createMockWatcher(
+        providerId,
+        async () => ({ overallState: 'running', conclusion: undefined, jobs: [] }),
+      );
+
+      const providerA = createParallelWatcher('provider-a');
+      const providerB = createParallelWatcher('provider-b');
+      for (const watcher of [providerA, providerB]) {
+        (watcher.getRunStatus as ReturnType<typeof vi.fn>).mockImplementation((identifier: RunIdentifier) => {
+          const key = `${watcher.id}:${identifier.runId}`;
+          const callCount = (((watcher as unknown as { _counts?: Map<string, number> })._counts ??= new Map<string, number>()).get(key) ?? 0) + 1;
+          (watcher as unknown as { _counts: Map<string, number> })._counts.set(key, callCount);
+          if (callCount === 1) {
+            return Promise.resolve({ overallState: 'running', conclusion: undefined, jobs: [] });
+          }
+          return new Promise(resolve => {
+            setTimeout(() => resolve({
+              overallState: 'running',
+              conclusion: undefined,
+              displayName: `Polled ${identifier.runId}`,
+              jobs: [],
+            }), pollDelayMs);
+          });
+        });
+        registry.register(watcher);
+      }
+
+      for (let index = 0; index < 4; index += 1) {
+        await service.startWatch({ ...createIdentifier('provider-a'), runId: `a-${index}`, displayName: `A ${index}` });
+        await service.startWatch({ ...createIdentifier('provider-b'), runId: `b-${index}`, displayName: `B ${index}` });
+      }
+      await service.flushPersistence();
+      (watchStore.saveAll as ReturnType<typeof vi.fn>).mockClear();
+
+      let completed = false;
+      const pollPromise = (service as any).pollAllWatches().then(() => {
+        completed = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(pollDelayMs - 1);
+      expect(completed).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await pollPromise;
+
+      expect(completed).toBe(true);
+      expect(service.getActiveWatches()).toHaveLength(8);
+      expect(service.getActiveWatches().every(watch => watch.identifier.displayName?.startsWith('Polled '))).toBe(true);
+      expect(providerA.getRunStatus).toHaveBeenCalledTimes(8);
+      expect(providerB.getRunStatus).toHaveBeenCalledTimes(8);
+    });
+
     it('sets hasWarning after 3 consecutive failures and skips run', async () => {
       let initialCall = true;
       const watcher = createMockWatcher('test');
@@ -373,6 +437,31 @@ describe('WatcherService', () => {
       await Promise.resolve();
       await Promise.resolve();
       expect(watchStore.saveAll).not.toHaveBeenCalled();
+    });
+
+    it('skips overlapping polls while one is already in flight', async () => {
+      let callCount = 0;
+      const deferredPoll = createDeferred<RunStatus>();
+      const watcher = createMockWatcher('test');
+      (watcher.getRunStatus as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        callCount += 1;
+        if (callCount === 1) {
+          return Promise.resolve({ overallState: 'running', conclusion: undefined, jobs: [] });
+        }
+        return deferredPoll.promise;
+      });
+      registry.register(watcher);
+      await service.startWatch(createIdentifier());
+
+      const firstPollPromise = (service as any).pollAllWatches();
+      await vi.waitFor(() => expect(watcher.getRunStatus).toHaveBeenCalledTimes(2));
+
+      await (service as any).pollAllWatches();
+      expect(logger.warn).toHaveBeenCalledWith('Poll already in flight, skipping tick');
+      expect(watcher.getRunStatus).toHaveBeenCalledTimes(2);
+
+      deferredPoll.resolve({ overallState: 'completed', conclusion: 'success', jobs: [] });
+      await firstPollPromise;
     });
   });
 
@@ -1029,6 +1118,98 @@ describe('WatcherService', () => {
 
       expect(completeSpy).toHaveBeenCalledTimes(1);
       expect(service.getActivePRWatches()[0].prState).toBe('merged');
+    });
+
+    it('keeps per-PR child run mutations correct after parallel polling', async () => {
+      const runWatcher = createMockWatcher('github-actions');
+      const runCallCounts = new Map<string, number>();
+      (runWatcher.getRunStatus as ReturnType<typeof vi.fn>).mockImplementation((identifier: RunIdentifier) => {
+        const callCount = (runCallCounts.get(identifier.runId) ?? 0) + 1;
+        runCallCounts.set(identifier.runId, callCount);
+        if (callCount === 1) {
+          return Promise.resolve({ overallState: 'running', conclusion: undefined, jobs: [] });
+        }
+        return Promise.resolve({
+          overallState: identifier.runId === 'run-3' ? 'queued' : 'running',
+          conclusion: undefined,
+          displayName: `Updated ${identifier.runId}`,
+          jobs: [],
+        });
+      });
+      registry.register(runWatcher);
+
+      const prPollCounts = new Map<string, number>();
+      const prWatcher = createMockPRWatcher('test-pr', async () => ({ prState: 'open', runs: [] }));
+      (prWatcher.getPRRunsSnapshot as ReturnType<typeof vi.fn>).mockImplementation((identifier: import('@devdocket/shared').PRIdentifier) => {
+        const callCount = (prPollCounts.get(identifier.prId) ?? 0) + 1;
+        prPollCounts.set(identifier.prId, callCount);
+        if (callCount === 1) {
+          return Promise.resolve({
+            prState: 'open',
+            runs: [{
+              providerId: 'github-actions',
+              runId: identifier.prId === '42' ? 'run-1' : 'run-2',
+              displayName: `Initial ${identifier.prId}`,
+              url: `https://example.com/run/${identifier.prId}`,
+              repo: 'owner/repo',
+            }],
+          });
+        }
+
+        return new Promise(resolve => {
+          const delay = identifier.prId === '42' ? 300 : 100;
+          setTimeout(() => resolve(identifier.prId === '42'
+            ? {
+                prState: 'open',
+                displayName: 'PR #42 renamed',
+                runs: [
+                  {
+                    providerId: 'github-actions',
+                    runId: 'run-1',
+                    displayName: 'Run 1',
+                    url: 'https://example.com/run/1',
+                    repo: 'owner/repo',
+                  },
+                  {
+                    providerId: 'github-actions',
+                    runId: 'run-3',
+                    displayName: 'Run 3',
+                    url: 'https://example.com/run/3',
+                    repo: 'owner/repo',
+                  },
+                ],
+              }
+            : {
+                prState: 'open',
+                runs: [],
+              }), delay);
+        });
+      });
+      prRegistry.register(prWatcher);
+
+      const firstPR = await service.startPRWatch(createPRIdentifier('test-pr'));
+      const secondPR = await service.startPRWatch({ ...createPRIdentifier('test-pr'), prId: '99', displayName: 'PR #99' });
+
+      expect(service.getChildRuns(service.getPRWatchKey(firstPR.identifier)).map(run => run.identifier.runId)).toEqual(['run-1']);
+      expect(service.getChildRuns(service.getPRWatchKey(secondPR.identifier)).map(run => run.identifier.runId)).toEqual(['run-2']);
+
+      const pollPromise = (service as any).pollAllWatches();
+      await vi.advanceTimersByTimeAsync(300);
+      await pollPromise;
+
+      expect(service.isPRActive(secondPR.identifier)).toBe(false);
+      expect(service.getActivePRWatches()).toHaveLength(1);
+      expect(service.getActivePRWatches()[0].identifier.displayName).toBe('PR #42 renamed');
+      expect(service.getChildRuns(service.getPRWatchKey(firstPR.identifier)).map(run => run.identifier.runId).sort()).toEqual(['run-1', 'run-3']);
+      expect(service.getActiveWatches().map(run => run.identifier.runId).sort()).toEqual(['run-1', 'run-3']);
+      expect(service.getActiveWatches().map(run => ({
+        runId: run.identifier.runId,
+        displayName: run.identifier.displayName,
+        overallState: run.status.overallState,
+      })).sort((left, right) => left.runId.localeCompare(right.runId))).toEqual([
+        { runId: 'run-1', displayName: 'Updated run-1', overallState: 'running' },
+        { runId: 'run-3', displayName: 'Run 3', overallState: 'running' },
+      ]);
     });
 
     it('loads persisted PR watches', async () => {


### PR DESCRIPTION
## Summary
- parallelize run watch polling with bounded per-provider worker pools
- parallelize PR watch snapshot polling and defer new child-run status fetches to the run poll phase
- add regression coverage for poll latency, PR child-run mutation correctness, and the in-flight poll guard

## Why
Watcher polling previously awaited each watch in series, so a tick took the sum of all request latencies. This change reduces recurring poll ticks to roughly bounded parallel latency per provider instead of linear wall-clock growth as watch counts increase.

## Testing
- npm run build
- npm run test

Closes #632
