### PR TITLE
Add rate-limit backoff for watches and refreshes

### DIFF
--- a/.changeset/rate-limit-backoff-polls.md
+++ b/.changeset/rate-limit-backoff-polls.md
@@ -1,0 +1,8 @@
+---
+"@devdocket/shared": minor
+"devdocket": minor
+"devdocket-github": minor
+"devdocket-ado": minor
+---
+
+Add shared polling backoff support and teach DevDocket watches/providers to honor throttling signals like Retry-After, GitHub rate-limit resets, and temporary upstream outages before retrying.

--- a/packages/ado/src/adoAuth.ts
+++ b/packages/ado/src/adoAuth.ts
@@ -51,8 +51,11 @@ export async function throwAdoApiError(response: Response, label: string, backof
   if (response.status === 404) { throw new Error(`${label} not found. It may be private or deleted.`); }
   if (response.status === 429 || response.status === 503) {
     const waitMessage = retryAfterMs !== undefined ? ` Retry after ${Math.ceil(retryAfterMs / 1000)}s.` : '';
+    const message = response.status === 429
+      ? `Azure DevOps throttled ${label}.${waitMessage}`
+      : `Azure DevOps is temporarily unavailable for ${label}.${waitMessage}`;
     throw new PollingBackoffError({
-      message: `Azure DevOps throttled ${label}.${waitMessage}`,
+      message,
       backoffKey,
       statusCode: response.status,
       retryAfterMs,

--- a/packages/ado/src/adoAuth.ts
+++ b/packages/ado/src/adoAuth.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { combineSignals, getSessionWithAuthFallback } from '@devdocket/shared';
+import { combineSignals, getSessionWithAuthFallback, parseRetryAfterHeader, PollingBackoffError } from '@devdocket/shared';
 
 export const ADO_AUTH_SCOPE = '499b84ac-1321-427f-aa17-267ca6975798/.default';
 
@@ -46,8 +46,18 @@ export async function retryAdoWithAuth(
 }
 
 /** Throw a descriptive error for a non-ok ADO API response. */
-export function throwAdoApiError(response: Response, label: string): never {
+export async function throwAdoApiError(response: Response, label: string, backoffKey = 'dev.azure.com'): Promise<never> {
+  const retryAfterMs = parseRetryAfterHeader(response.headers?.get?.('retry-after') ?? null);
   if (response.status === 404) { throw new Error(`${label} not found. It may be private or deleted.`); }
+  if (response.status === 429 || response.status === 503) {
+    const waitMessage = retryAfterMs !== undefined ? ` Retry after ${Math.ceil(retryAfterMs / 1000)}s.` : '';
+    throw new PollingBackoffError({
+      message: `Azure DevOps throttled ${label}.${waitMessage}`,
+      backoffKey,
+      statusCode: response.status,
+      retryAfterMs,
+    });
+  }
   if (response.status === 401 || response.status === 403) { throw new Error(`ADO authentication required for ${label}. Sign in to Azure DevOps in VS Code.`); }
   throw new Error(`Azure DevOps API error: ${response.status} ${response.statusText}`);
 }

--- a/packages/ado/src/adoPRWatcher.ts
+++ b/packages/ado/src/adoPRWatcher.ts
@@ -66,6 +66,7 @@ export class AdoPRWatcher implements DevDocketPRWatcher {
       displayName: `PR #${prId}`,
       url,
       repo: `${org}/${project}/${repo}`,
+      backoffKey: `dev.azure.com/${org}`,
     };
   }
 
@@ -101,7 +102,7 @@ export class AdoPRWatcher implements DevDocketPRWatcher {
       throw err;
     }
     if (!prResponse.ok) {
-      throwAdoApiError(prResponse, `PR ${identifier.prId}`);
+      await throwAdoApiError(prResponse, `PR ${identifier.prId}`, `dev.azure.com/${org}`);
     }
     const prData = await prResponse.json() as AdoPullRequest;
 
@@ -147,6 +148,7 @@ export class AdoPRWatcher implements DevDocketPRWatcher {
           displayName,
           url: `https://dev.azure.com/${encodeURIComponent(org)}/${encodeURIComponent(project)}/_build/results?buildId=${build.id}`,
           repo: `${org}/${project}`,
+          backoffKey: `dev.azure.com/${org}`,
         });
       }
     } else {

--- a/packages/ado/src/adoPipelineWatcher.ts
+++ b/packages/ado/src/adoPipelineWatcher.ts
@@ -70,6 +70,7 @@ export class AdoPipelineWatcher implements DevDocketRunWatcher {
       displayName: `Build ${buildId}`,
       url,
       repo: `${org}/${project}`,
+      backoffKey: `dev.azure.com/${org}`,
     };
   }
 
@@ -101,7 +102,7 @@ export class AdoPipelineWatcher implements DevDocketRunWatcher {
       throw err;
     }
     if (!buildResponse.ok) {
-      throwAdoApiError(buildResponse, `Build ${identifier.runId}`);
+      await throwAdoApiError(buildResponse, `Build ${identifier.runId}`, `dev.azure.com/${org}`);
     }
     const buildData = await buildResponse.json() as AdoBuild;
 

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -701,7 +701,7 @@ export class AdoWorkItemProvider extends BaseProvider {
     }
 
     if (!response.ok) {
-      throwAdoApiError(response, `ADO work item ${org}/${project}#${id}`);
+      await throwAdoApiError(response, `ADO work item ${org}/${project}#${id}`, `dev.azure.com/${org}`);
     }
 
     const data = await response.json() as AdoWorkItem;

--- a/packages/ado/src/baseAdoPrProvider.ts
+++ b/packages/ado/src/baseAdoPrProvider.ts
@@ -375,7 +375,7 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
     }
 
     if (!response.ok) {
-      throwAdoApiError(response, `ADO PR ${org}/${project}/${repo}#${id}`);
+      await throwAdoApiError(response, `ADO PR ${org}/${project}/${repo}#${id}`, `dev.azure.com/${org}`);
     }
 
     const data = await response.json() as AdoPullRequest & {

--- a/packages/ado/src/test/adoAuth.test.ts
+++ b/packages/ado/src/test/adoAuth.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { authentication } from 'vscode';
-import { retryAdoWithAuth } from '../adoAuth';
+import { PollingBackoffError } from '@devdocket/shared';
+import { retryAdoWithAuth, throwAdoApiError } from '../adoAuth';
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -77,5 +78,24 @@ describe('retryAdoWithAuth', () => {
       { createIfNone: true },
     );
     expect(fetchMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe('throwAdoApiError', () => {
+  it('uses an availability message for 503 responses', async () => {
+    const response = {
+      status: 503,
+      statusText: 'Service Unavailable',
+      headers: { get: (name: string) => name === 'retry-after' ? '30' : null },
+    } as unknown as Response;
+
+    await expect(throwAdoApiError(response, 'Build 123', 'dev.azure.com/org')).rejects.toMatchObject({
+      name: 'PollingBackoffError',
+      message: 'Azure DevOps is temporarily unavailable for Build 123. Retry after 30s.',
+      backoffKey: 'dev.azure.com/org',
+      statusCode: 503,
+      retryAfterMs: 30_000,
+    });
+    await expect(throwAdoApiError(response, 'Build 123', 'dev.azure.com/org')).rejects.toBeInstanceOf(PollingBackoffError);
   });
 });

--- a/packages/ado/src/test/adoPRWatcher.test.ts
+++ b/packages/ado/src/test/adoPRWatcher.test.ts
@@ -73,6 +73,7 @@ describe('AdoPRWatcher', () => {
     it('sets repo to org/project/repo', () => {
       const result = watcher.parsePRUrl(validUrl);
       expect(result.repo).toBe('myorg/myproject/myrepo');
+      expect(result.backoffKey).toBe('dev.azure.com/myorg');
     });
 
     it('throws for invalid URL format', () => {

--- a/packages/ado/src/test/adoPipelineWatcher.test.ts
+++ b/packages/ado/src/test/adoPipelineWatcher.test.ts
@@ -46,6 +46,7 @@ describe('AdoPipelineWatcher', () => {
       expect(result.repo).toBe('dnceng/internal');
       expect(result.url).toBe('https://dev.azure.com/dnceng/internal/_build/results?buildId=2955324');
       expect(result.displayName).toBe('Build 2955324');
+      expect(result.backoffKey).toBe('dev.azure.com/dnceng');
     });
 
     it('throws for URL without buildId', () => {

--- a/packages/core/src/services/pollingBackoffRegistry.ts
+++ b/packages/core/src/services/pollingBackoffRegistry.ts
@@ -8,11 +8,17 @@ export interface PollingBackoffSnapshot {
 
 export class PollingBackoffRegistry {
   private readonly policies = new Map<string, BackoffPolicy>();
+  private readonly jitterRatio: number;
+  private readonly random: () => number;
 
   constructor(
     private readonly getBaseDelayMs: () => number,
     private readonly maxDelayMs = 60 * 60 * 1000,
-  ) {}
+    options: { jitterRatio?: number; random?: () => number } = {},
+  ) {
+    this.jitterRatio = options.jitterRatio ?? 0.1;
+    this.random = options.random ?? Math.random;
+  }
 
   isCoolingDown(backoffKey: string | undefined, nowMs = Date.now()): boolean {
     if (!backoffKey) {
@@ -56,7 +62,8 @@ export class PollingBackoffRegistry {
       policy = new BackoffPolicy({
         baseDelayMs,
         maxDelayMs: this.maxDelayMs,
-        jitterRatio: 0,
+        jitterRatio: this.jitterRatio,
+        random: this.random,
       });
       this.policies.set(backoffKey, policy);
       return policy;

--- a/packages/core/src/services/pollingBackoffRegistry.ts
+++ b/packages/core/src/services/pollingBackoffRegistry.ts
@@ -18,30 +18,30 @@ export class PollingBackoffRegistry {
     if (!backoffKey) {
       return false;
     }
-    return (this.policies.get(backoffKey)?.isCoolingDown(nowMs)) ?? false;
+    return this.getPolicy(backoffKey, nowMs).isCoolingDown(nowMs);
   }
 
   getRemainingMs(backoffKey: string | undefined, nowMs = Date.now()): number {
     if (!backoffKey) {
       return 0;
     }
-    return this.policies.get(backoffKey)?.getRemainingMs(nowMs) ?? 0;
+    return this.getPolicy(backoffKey, nowMs).getRemainingMs(nowMs);
   }
 
-  recordSuccess(backoffKey: string | undefined): void {
+  recordSuccess(backoffKey: string | undefined, nowMs = Date.now()): void {
     if (!backoffKey) {
       return;
     }
-    this.policies.get(backoffKey)?.recordSuccess();
+    this.getPolicy(backoffKey, nowMs).recordSuccess();
   }
 
-  recordFailure(error: unknown): PollingBackoffSnapshot | undefined {
+  recordFailure(error: unknown, nowMs = Date.now()): PollingBackoffSnapshot | undefined {
     if (!isPollingBackoffError(error)) {
       return undefined;
     }
 
-    const policy = this.getPolicy(error.backoffKey);
-    const state = policy.recordFailure({ retryAfterMs: error.retryAfterMs });
+    const policy = this.getPolicy(error.backoffKey, nowMs);
+    const state = policy.recordFailure({ nowMs, retryAfterMs: error.retryAfterMs });
     return {
       key: error.backoffKey,
       delayMs: state.delayMs,
@@ -49,16 +49,23 @@ export class PollingBackoffRegistry {
     };
   }
 
-  private getPolicy(backoffKey: string): BackoffPolicy {
+  private getPolicy(backoffKey: string, nowMs = Date.now()): BackoffPolicy {
+    const baseDelayMs = this.getBaseDelayMs();
     let policy = this.policies.get(backoffKey);
     if (!policy) {
       policy = new BackoffPolicy({
-        baseDelayMs: this.getBaseDelayMs(),
+        baseDelayMs,
         maxDelayMs: this.maxDelayMs,
         jitterRatio: 0,
       });
       this.policies.set(backoffKey, policy);
+      return policy;
     }
+
+    policy.reconfigure({
+      baseDelayMs,
+      maxDelayMs: this.maxDelayMs,
+    }, nowMs);
     return policy;
   }
 }

--- a/packages/core/src/services/pollingBackoffRegistry.ts
+++ b/packages/core/src/services/pollingBackoffRegistry.ts
@@ -62,10 +62,12 @@ export class PollingBackoffRegistry {
       return policy;
     }
 
-    policy.reconfigure({
-      baseDelayMs,
-      maxDelayMs: this.maxDelayMs,
-    }, nowMs);
+    if (policy.getBaseDelayMs() !== baseDelayMs) {
+      policy.reconfigure({
+        baseDelayMs,
+        maxDelayMs: this.maxDelayMs,
+      }, nowMs);
+    }
     return policy;
   }
 }

--- a/packages/core/src/services/pollingBackoffRegistry.ts
+++ b/packages/core/src/services/pollingBackoffRegistry.ts
@@ -1,0 +1,64 @@
+import { BackoffPolicy, isPollingBackoffError } from '@devdocket/shared';
+
+export interface PollingBackoffSnapshot {
+  key: string;
+  delayMs: number;
+  cooldownUntilMs: number;
+}
+
+export class PollingBackoffRegistry {
+  private readonly policies = new Map<string, BackoffPolicy>();
+
+  constructor(
+    private readonly getBaseDelayMs: () => number,
+    private readonly maxDelayMs = 60 * 60 * 1000,
+  ) {}
+
+  isCoolingDown(backoffKey: string | undefined, nowMs = Date.now()): boolean {
+    if (!backoffKey) {
+      return false;
+    }
+    return (this.policies.get(backoffKey)?.isCoolingDown(nowMs)) ?? false;
+  }
+
+  getRemainingMs(backoffKey: string | undefined, nowMs = Date.now()): number {
+    if (!backoffKey) {
+      return 0;
+    }
+    return this.policies.get(backoffKey)?.getRemainingMs(nowMs) ?? 0;
+  }
+
+  recordSuccess(backoffKey: string | undefined): void {
+    if (!backoffKey) {
+      return;
+    }
+    this.policies.get(backoffKey)?.recordSuccess();
+  }
+
+  recordFailure(error: unknown): PollingBackoffSnapshot | undefined {
+    if (!isPollingBackoffError(error)) {
+      return undefined;
+    }
+
+    const policy = this.getPolicy(error.backoffKey);
+    const state = policy.recordFailure({ retryAfterMs: error.retryAfterMs });
+    return {
+      key: error.backoffKey,
+      delayMs: state.delayMs,
+      cooldownUntilMs: state.cooldownUntilMs,
+    };
+  }
+
+  private getPolicy(backoffKey: string): BackoffPolicy {
+    let policy = this.policies.get(backoffKey);
+    if (!policy) {
+      policy = new BackoffPolicy({
+        baseDelayMs: this.getBaseDelayMs(),
+        maxDelayMs: this.maxDelayMs,
+        jitterRatio: 0,
+      });
+      this.policies.set(backoffKey, policy);
+    }
+    return policy;
+  }
+}

--- a/packages/core/src/services/prWatchPool.ts
+++ b/packages/core/src/services/prWatchPool.ts
@@ -68,6 +68,7 @@ export class PRWatchPool implements vscode.Disposable {
   restore(prs: WatchedPR[]): number {
     let restored = 0;
     for (const pr of prs.filter(pr => !pr.dismissed)) {
+      pr.identifier = this.rehydrateRestoredPRIdentifier(pr.identifier);
       const key = this.getPRWatchKey(pr.identifier);
       if (this.prWatches.has(key)) {
         continue;
@@ -480,6 +481,28 @@ export class PRWatchPool implements vscode.Disposable {
 
   getPRWatchKey(identifier: PRIdentifier): string {
     return `pr:${identifier.providerId}:${identifier.repo}:${identifier.prId}`;
+  }
+
+  private rehydrateRestoredPRIdentifier(identifier: PRIdentifier): PRIdentifier {
+    if (identifier.backoffKey) {
+      return identifier;
+    }
+
+    const watcher = this.prWatcherRegistry.get(identifier.providerId) ?? this.prWatcherRegistry.findWatcherForUrl(identifier.url);
+    if (!watcher) {
+      return identifier;
+    }
+
+    try {
+      const parsed = watcher.parsePRUrl(identifier.url);
+      return {
+        ...identifier,
+        backoffKey: parsed.backoffKey ?? identifier.backoffKey,
+      };
+    } catch (err) {
+      this.logger.warn(`PR URL matched watcher '${watcher.id}' but parsePRUrl failed for ${identifier.url}: ${err}`);
+      return identifier;
+    }
   }
 
   buildActiveChildRunIndex(): Map<string, Set<string>> {

--- a/packages/core/src/services/prWatchPool.ts
+++ b/packages/core/src/services/prWatchPool.ts
@@ -108,6 +108,7 @@ export class PRWatchPool implements vscode.Disposable {
       this.pollingBackoffRegistry.recordFailure(error);
       throw error;
     }
+    this.pollingBackoffRegistry.recordSuccess(identifier.backoffKey);
     if (snapshot.displayName) {
       identifier.displayName = snapshot.displayName;
     }

--- a/packages/core/src/services/prWatchPool.ts
+++ b/packages/core/src/services/prWatchPool.ts
@@ -1,7 +1,8 @@
 import * as vscode from 'vscode';
-import type { PRIdentifier, RunIdentifier } from '@devdocket/shared';
+import type { PRIdentifier, PRRunsSnapshot, RunIdentifier } from '@devdocket/shared';
 import { PRWatcherRegistry } from './prWatcherRegistry';
 import type { WatchedPR, WatchedRun } from './watcherService';
+import { PollingBackoffRegistry } from './pollingBackoffRegistry';
 import type { StartWatchOptions, WatchStartResult } from './runWatchPool';
 
 type WatcherLogger = {
@@ -57,6 +58,7 @@ export class PRWatchPool implements vscode.Disposable {
   constructor(
     private readonly prWatcherRegistry: PRWatcherRegistry,
     private readonly runControl: RunWatchControl,
+    private readonly pollingBackoffRegistry: PollingBackoffRegistry,
     private readonly logger: WatcherLogger,
     private readonly isDisposed: () => boolean,
     private readonly onPollingNeeded: () => void,
@@ -98,7 +100,13 @@ export class PRWatchPool implements vscode.Disposable {
       throw new Error(`No PR watcher registered for provider: ${identifier.providerId}`);
     }
 
-    const snapshot = await prWatcher.getPRRunsSnapshot(identifier);
+    let snapshot: PRRunsSnapshot;
+    try {
+      snapshot = await prWatcher.getPRRunsSnapshot(identifier);
+    } catch (error) {
+      this.pollingBackoffRegistry.recordFailure(error);
+      throw error;
+    }
     if (snapshot.displayName) {
       identifier.displayName = snapshot.displayName;
     }
@@ -241,6 +249,10 @@ export class PRWatchPool implements vscode.Disposable {
     let childRunChanged = false;
 
     for (const prWatch of activePRs) {
+      if (this.pollingBackoffRegistry.isCoolingDown(prWatch.identifier.backoffKey)) {
+        continue;
+      }
+
       const key = this.getPRWatchKey(prWatch.identifier);
       try {
         const prWatcher = this.prWatcherRegistry.get(prWatch.identifier.providerId);
@@ -254,6 +266,7 @@ export class PRWatchPool implements vscode.Disposable {
           continue;
         }
         prWatch.lastPolledAt = new Date().toISOString();
+        this.pollingBackoffRegistry.recordSuccess(prWatch.identifier.backoffKey);
 
         if (snapshot.displayName && snapshot.displayName !== prWatch.identifier.displayName) {
           prWatch.identifier.displayName = snapshot.displayName;
@@ -305,6 +318,12 @@ export class PRWatchPool implements vscode.Disposable {
           }
         }
       } catch (err) {
+        const backoff = this.pollingBackoffRegistry.recordFailure(err);
+        if (backoff) {
+          this.logger.warn(`PR poll backoff active for ${prWatch.identifier.displayName} until ${new Date(backoff.cooldownUntilMs).toISOString()}`);
+          continue;
+        }
+
         const failures = (this.consecutiveFailures.get(key) || 0) + 1;
         this.consecutiveFailures.set(key, failures);
 

--- a/packages/core/src/services/runWatchPool.ts
+++ b/packages/core/src/services/runWatchPool.ts
@@ -93,6 +93,9 @@ export class RunWatchPool implements vscode.Disposable {
       this.pollingBackoffRegistry.recordFailure(error);
       throw error;
     }
+    if (!options?.deferStatusFetch) {
+      this.pollingBackoffRegistry.recordSuccess(identifier.backoffKey);
+    }
     if (status.displayName) {
       identifier.displayName = status.displayName;
     }

--- a/packages/core/src/services/runWatchPool.ts
+++ b/packages/core/src/services/runWatchPool.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import type { JobStatus, RunIdentifier, RunStatus } from '@devdocket/shared';
 import { WatcherRegistry } from './watcherRegistry';
 import type { WatchedRun } from './watcherService';
+import { PollingBackoffRegistry } from './pollingBackoffRegistry';
 import { isFailedConclusion } from '../webview/shared/runConclusionLabels';
 
 type WatcherLogger = {
@@ -45,6 +46,7 @@ export class RunWatchPool implements vscode.Disposable {
 
   constructor(
     private readonly watcherRegistry: WatcherRegistry,
+    private readonly pollingBackoffRegistry: PollingBackoffRegistry,
     private readonly logger: WatcherLogger,
     private readonly isDisposed: () => boolean,
     private readonly onPollingNeeded: () => void,
@@ -81,9 +83,15 @@ export class RunWatchPool implements vscode.Disposable {
       throw new Error(`No watcher registered for provider: ${identifier.providerId}`);
     }
 
-    const status: RunStatus = options?.deferStatusFetch
-      ? { overallState: 'queued', jobs: [] }
-      : await watcher.getRunStatus(identifier);
+    let status: RunStatus;
+    try {
+      status = options?.deferStatusFetch
+        ? { overallState: 'queued', jobs: [] }
+        : await watcher.getRunStatus(identifier);
+    } catch (error) {
+      this.pollingBackoffRegistry.recordFailure(error);
+      throw error;
+    }
     if (status.displayName) {
       identifier.displayName = status.displayName;
     }
@@ -225,6 +233,10 @@ export class RunWatchPool implements vscode.Disposable {
     let anyChanged = false;
 
     for (const watch of pollableWatches) {
+      if (this.pollingBackoffRegistry.isCoolingDown(watch.identifier.backoffKey)) {
+        continue;
+      }
+
       try {
         const watcher = this.watcherRegistry.get(watch.identifier.providerId);
         if (!watcher) {
@@ -245,6 +257,7 @@ export class RunWatchPool implements vscode.Disposable {
           anyChanged = true;
         }
 
+        this.pollingBackoffRegistry.recordSuccess(watch.identifier.backoffKey);
         this.consecutiveFailures.delete(key);
         watch.hasWarning = false;
         watch.errorMessage = undefined;
@@ -285,6 +298,12 @@ export class RunWatchPool implements vscode.Disposable {
           this._onDidCompleteRun.fire(watch);
         }
       } catch (err) {
+        const backoff = this.pollingBackoffRegistry.recordFailure(err);
+        if (backoff) {
+          this.logger.warn(`Poll backoff active for ${watch.identifier.displayName} until ${new Date(backoff.cooldownUntilMs).toISOString()}`);
+          continue;
+        }
+
         const key = this.getWatchKey(watch.identifier);
         const failures = (this.consecutiveFailures.get(key) || 0) + 1;
         this.consecutiveFailures.set(key, failures);

--- a/packages/core/src/services/runWatchPool.ts
+++ b/packages/core/src/services/runWatchPool.ts
@@ -56,6 +56,7 @@ export class RunWatchPool implements vscode.Disposable {
   restore(watches: WatchedRun[]): number {
     let restored = 0;
     for (const watch of watches.filter(w => !w.dismissed)) {
+      watch.identifier = this.rehydrateRestoredRunIdentifier(watch.identifier);
       const key = this.getWatchKey(watch.identifier);
       if (this.watches.has(key)) {
         continue;
@@ -347,6 +348,31 @@ export class RunWatchPool implements vscode.Disposable {
     }
 
     return identifier;
+  }
+
+  private rehydrateRestoredRunIdentifier(identifier: RunIdentifier): RunIdentifier {
+    if (identifier.backoffKey) {
+      return identifier;
+    }
+
+    const watcher = identifier.providerId
+      ? this.watcherRegistry.get(identifier.providerId) ?? this.watcherRegistry.findWatcherForUrl(identifier.url)
+      : this.watcherRegistry.findWatcherForUrl(identifier.url);
+    if (!watcher) {
+      return identifier;
+    }
+
+    try {
+      const parsed = watcher.parseRunUrl(identifier.url);
+      return {
+        ...identifier,
+        ...parsed,
+        displayName: identifier.displayName || parsed.displayName,
+      };
+    } catch (err) {
+      this.logger.warn(`URL matched watcher '${watcher.id}' but parseRunUrl failed for ${identifier.url}: ${err}`);
+      return identifier;
+    }
   }
 
   private static isFailedRun(watch: WatchedRun): boolean {

--- a/packages/core/src/services/runWatchPool.ts
+++ b/packages/core/src/services/runWatchPool.ts
@@ -364,10 +364,16 @@ export class RunWatchPool implements vscode.Disposable {
 
     try {
       const parsed = watcher.parseRunUrl(identifier.url);
+      if (!identifier.providerId) {
+        return {
+          ...parsed,
+          displayName: identifier.displayName || parsed.displayName,
+        };
+      }
+
       return {
         ...identifier,
-        ...parsed,
-        displayName: identifier.displayName || parsed.displayName,
+        backoffKey: parsed.backoffKey ?? identifier.backoffKey,
       };
     } catch (err) {
       this.logger.warn(`URL matched watcher '${watcher.id}' but parseRunUrl failed for ${identifier.url}: ${err}`);

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -4,6 +4,7 @@ import { WatcherRegistry } from './watcherRegistry';
 import { PRWatcherRegistry } from './prWatcherRegistry';
 import { RunWatchPool } from './runWatchPool';
 import { PRWatchPool } from './prWatchPool';
+import { PollingBackoffRegistry } from './pollingBackoffRegistry';
 import { WatchPersistence } from './watchPersistence';
 import { WatchStore } from '../storage/watchStore';
 
@@ -72,6 +73,7 @@ export class WatcherService implements vscode.Disposable {
   private configSubscription: vscode.Disposable | undefined;
   private readonly runPool: RunWatchPool;
   private readonly prPool: PRWatchPool;
+  private readonly pollingBackoffRegistry: PollingBackoffRegistry;
   private readonly persistence: WatchPersistence;
   private readonly poolSubscriptions: vscode.Disposable[];
 
@@ -97,8 +99,10 @@ export class WatcherService implements vscode.Disposable {
     private logger: { info: (msg: string) => void; warn: (msg: string) => void; error: (msg: string) => void }
   ) {
     this.persistence = new WatchPersistence(watchStore, logger);
+    this.pollingBackoffRegistry = new PollingBackoffRegistry(() => this.getPollingInterval() * 1000);
     this.runPool = new RunWatchPool(
       watcherRegistry,
+      this.pollingBackoffRegistry,
       logger,
       () => this.disposed,
       () => this.ensurePollingActive(),
@@ -107,6 +111,7 @@ export class WatcherService implements vscode.Disposable {
     this.prPool = new PRWatchPool(
       prWatcherRegistry,
       this.runPool,
+      this.pollingBackoffRegistry,
       logger,
       () => this.disposed,
       () => this.ensurePollingActive(),

--- a/packages/core/src/test/pollingBackoffRegistry.test.ts
+++ b/packages/core/src/test/pollingBackoffRegistry.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PollingBackoffError } from '@devdocket/shared';
+import { PollingBackoffRegistry } from '../services/pollingBackoffRegistry';
+
+describe('PollingBackoffRegistry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('adopts updated base delays for existing backoff buckets while preserving cooldowns', () => {
+    let baseDelayMs = 15_000;
+    const registry = new PollingBackoffRegistry(() => baseDelayMs, 120_000);
+    const error = new PollingBackoffError({
+      message: 'Rate limited',
+      backoffKey: 'api.github.com',
+      statusCode: 429,
+      retryAfterMs: 60_000,
+    });
+
+    const first = registry.recordFailure(error);
+    expect(first?.delayMs).toBe(60_000);
+
+    vi.advanceTimersByTime(30_000);
+    expect(registry.getRemainingMs('api.github.com')).toBe(30_000);
+
+    baseDelayMs = 30_000;
+    expect(registry.getRemainingMs('api.github.com')).toBe(30_000);
+
+    registry.recordSuccess('api.github.com');
+    const second = registry.recordFailure(new PollingBackoffError({
+      message: 'Rate limited again',
+      backoffKey: 'api.github.com',
+      statusCode: 429,
+    }));
+
+    expect(second?.delayMs).toBe(60_000);
+  });
+});

--- a/packages/core/src/test/pollingBackoffRegistry.test.ts
+++ b/packages/core/src/test/pollingBackoffRegistry.test.ts
@@ -14,7 +14,7 @@ describe('PollingBackoffRegistry', () => {
 
   it('adopts updated base delays for existing backoff buckets while preserving cooldowns', () => {
     let baseDelayMs = 15_000;
-    const registry = new PollingBackoffRegistry(() => baseDelayMs, 120_000);
+    const registry = new PollingBackoffRegistry(() => baseDelayMs, 120_000, { jitterRatio: 0, random: () => 0 });
     const error = new PollingBackoffError({
       message: 'Rate limited',
       backoffKey: 'api.github.com',

--- a/packages/core/src/test/watchPoolBackoff.test.ts
+++ b/packages/core/src/test/watchPoolBackoff.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PollingBackoffError, type DevDocketRunWatcher, type RunIdentifier } from '@devdocket/shared';
+import { WatcherRegistry } from '../services/watcherRegistry';
+import { PRWatcherRegistry } from '../services/prWatcherRegistry';
+import { PollingBackoffRegistry } from '../services/pollingBackoffRegistry';
+import { RunWatchPool } from '../services/runWatchPool';
+
+function createLogger() {
+  return { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+describe('watch pool backoff resets', () => {
+  it('clears stale run cooldowns after a successful startWatch fetch', async () => {
+    const logger = createLogger();
+    const watcherRegistry = new WatcherRegistry(logger);
+    const backoffRegistry = new PollingBackoffRegistry(() => 15_000);
+    const watcher: DevDocketRunWatcher = {
+      id: 'test',
+      label: 'Test watcher',
+      canWatch: vi.fn().mockReturnValue(true),
+      parseRunUrl: vi.fn().mockReturnValue({
+        providerId: 'test',
+        runId: 'run-1',
+        displayName: 'Run 1',
+        url: 'https://example.com/run/1',
+        backoffKey: 'api.example.com',
+      }),
+      getRunStatus: vi.fn().mockResolvedValue({ overallState: 'running', jobs: [] }),
+    };
+    watcherRegistry.register(watcher);
+
+    backoffRegistry.recordFailure(new PollingBackoffError({
+      message: 'Rate limited',
+      backoffKey: 'api.example.com',
+      statusCode: 429,
+      retryAfterMs: 60_000,
+    }), 0);
+    expect(backoffRegistry.isCoolingDown('api.example.com', 30_000)).toBe(true);
+
+    const pool = new RunWatchPool(
+      watcherRegistry,
+      backoffRegistry,
+      logger,
+      () => false,
+      () => {},
+      () => 0,
+    );
+
+    const identifier: RunIdentifier = {
+      providerId: 'test',
+      runId: 'run-1',
+      displayName: 'Run 1',
+      url: 'https://example.com/run/1',
+      backoffKey: 'api.example.com',
+    };
+
+    await pool.startWatch(identifier);
+
+    expect(backoffRegistry.isCoolingDown('api.example.com', 30_000)).toBe(false);
+  });
+});

--- a/packages/core/src/test/watchPoolBackoff.test.ts
+++ b/packages/core/src/test/watchPoolBackoff.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
-import { PollingBackoffError, type DevDocketRunWatcher, type RunIdentifier } from '@devdocket/shared';
+import { PollingBackoffError, type DevDocketPRWatcher, type DevDocketRunWatcher, type PRIdentifier, type RunIdentifier } from '@devdocket/shared';
 import { WatcherRegistry } from '../services/watcherRegistry';
 import { PRWatcherRegistry } from '../services/prWatcherRegistry';
 import { PollingBackoffRegistry } from '../services/pollingBackoffRegistry';
+import { PRWatchPool } from '../services/prWatchPool';
 import { RunWatchPool } from '../services/runWatchPool';
 
 function createLogger() {
@@ -55,6 +56,67 @@ describe('watch pool backoff resets', () => {
     };
 
     await pool.startWatch(identifier);
+
+    expect(backoffRegistry.isCoolingDown('api.example.com', 30_000)).toBe(false);
+  });
+
+  it('clears stale PR cooldowns after a successful startPRWatch snapshot', async () => {
+    const logger = createLogger();
+    const watcherRegistry = new WatcherRegistry(logger);
+    const prWatcherRegistry = new PRWatcherRegistry(logger);
+    const backoffRegistry = new PollingBackoffRegistry(() => 15_000);
+    const runPool = new RunWatchPool(
+      watcherRegistry,
+      backoffRegistry,
+      logger,
+      () => false,
+      () => {},
+      () => 0,
+    );
+    const prWatcher: DevDocketPRWatcher = {
+      id: 'test-pr',
+      label: 'Test PR watcher',
+      canWatch: vi.fn().mockReturnValue(true),
+      parsePRUrl: vi.fn().mockReturnValue({
+        providerId: 'test-pr',
+        prId: '42',
+        displayName: 'PR #42',
+        url: 'https://example.com/pr/42',
+        repo: 'owner/repo',
+        backoffKey: 'api.example.com',
+      }),
+      getPRRunsSnapshot: vi.fn().mockResolvedValue({ prState: 'open', runs: [] }),
+    };
+    prWatcherRegistry.register(prWatcher);
+
+    backoffRegistry.recordFailure(new PollingBackoffError({
+      message: 'Rate limited',
+      backoffKey: 'api.example.com',
+      statusCode: 429,
+      retryAfterMs: 60_000,
+    }), 0);
+    expect(backoffRegistry.isCoolingDown('api.example.com', 30_000)).toBe(true);
+
+    const prPool = new PRWatchPool(
+      prWatcherRegistry,
+      runPool,
+      backoffRegistry,
+      logger,
+      () => false,
+      () => {},
+      () => {},
+    );
+
+    const identifier: PRIdentifier = {
+      providerId: 'test-pr',
+      prId: '42',
+      displayName: 'PR #42',
+      url: 'https://example.com/pr/42',
+      repo: 'owner/repo',
+      backoffKey: 'api.example.com',
+    };
+
+    await prPool.startPRWatch(identifier);
 
     expect(backoffRegistry.isCoolingDown('api.example.com', 30_000)).toBe(false);
   });

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -479,6 +479,32 @@ describe('WatcherService', () => {
       expect(service.getActiveWatches()[0].identifier.runId).toBe('run-1');
     });
 
+    it('backfills backoff keys for persisted run watches', async () => {
+      const watcher = createMockWatcher('test');
+      (watcher.parseRunUrl as ReturnType<typeof vi.fn>).mockReturnValue({
+        providerId: 'test',
+        runId: 'run-1',
+        displayName: 'Test Run',
+        url: 'https://example.com/run/1',
+        backoffKey: 'api.example.com',
+      });
+      registry.register(watcher);
+
+      const persistedWatch: WatchedRun = {
+        identifier: createIdentifier(),
+        status: { overallState: 'running', jobs: [] },
+        watchedAt: new Date().toISOString(),
+        lastPolledAt: new Date().toISOString(),
+        dismissed: false,
+      };
+      delete persistedWatch.identifier.backoffKey;
+      (watchStore.loadAll as ReturnType<typeof vi.fn>).mockResolvedValue({ runs: [persistedWatch], prs: [] });
+
+      await service.loadPersistedWatches();
+
+      expect(service.getActiveWatches()[0].identifier.backoffKey).toBe('api.example.com');
+    });
+
     it('does not clobber a run watch started while persisted watches load', async () => {
       const identifier = { ...createIdentifier(), displayName: 'Live Run' };
       const persistedWatch: WatchedRun = {

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -596,6 +596,34 @@ describe('WatcherService', () => {
       expect(watchStore.loadAll).toHaveBeenCalledTimes(1);
     });
 
+    it('backfills backoff keys for persisted PR watches', async () => {
+      const prWatcher = createMockPRWatcher();
+      (prWatcher.parsePRUrl as ReturnType<typeof vi.fn>).mockReturnValue({
+        providerId: 'test-pr',
+        prId: '42',
+        displayName: 'PR #42',
+        url: 'https://example.com/pr/42',
+        repo: 'owner/repo',
+        backoffKey: 'api.example.com',
+      });
+      prRegistry.register(prWatcher);
+
+      const persistedPR = {
+        identifier: createPRIdentifier(),
+        prState: 'open' as const,
+        childRunKeys: [],
+        watchedAt: new Date().toISOString(),
+        lastPolledAt: new Date().toISOString(),
+        dismissed: false,
+      };
+      delete persistedPR.identifier.backoffKey;
+      (watchStore.loadAll as ReturnType<typeof vi.fn>).mockResolvedValue({ runs: [], prs: [persistedPR] });
+
+      await service.loadPersistedWatches();
+
+      expect(service.getAllPRWatches()[0].identifier.backoffKey).toBe('api.example.com');
+    });
+
     it('caches persisted PR watch lookups across repeated checks', async () => {
       const identifier = createPRIdentifier();
       (watchStore.loadAll as ReturnType<typeof vi.fn>).mockResolvedValue({

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -76,9 +76,11 @@ describe('WatcherService', () => {
   let prRegistry: PRWatcherRegistry;
   let logger: ReturnType<typeof createMockLogger>;
   let watchStore: WatchStore;
+  let mathRandomSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.useFakeTimers();
+    mathRandomSpy = vi.spyOn(Math, 'random').mockReturnValue(0);
     logger = createMockLogger();
     registry = new WatcherRegistry(logger);
     prRegistry = new PRWatcherRegistry(logger);
@@ -88,6 +90,7 @@ describe('WatcherService', () => {
 
   afterEach(() => {
     service.dispose();
+    mathRandomSpy.mockRestore();
     vi.useRealTimers();
   });
 

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -5,7 +5,7 @@ import { WatcherService, WatchedRun } from '../services/watcherService';
 import { WatcherRegistry } from '../services/watcherRegistry';
 import { PRWatcherRegistry } from '../services/prWatcherRegistry';
 import { WatchStore } from '../storage/watchStore';
-import type { DevDocketRunWatcher, RunIdentifier, RunStatus } from '@devdocket/shared';
+import { PollingBackoffError, type DevDocketRunWatcher, type RunIdentifier, type RunStatus } from '@devdocket/shared';
 
 function createMockLogger() {
   return {
@@ -318,6 +318,57 @@ describe('WatcherService', () => {
       await vi.advanceTimersByTimeAsync(60000);
       const callCountAfter = (watcher.getRunStatus as ReturnType<typeof vi.fn>).mock.calls.length;
       expect(callCountAfter).toBe(callCountBefore); // No new calls
+    });
+
+    it('backs off run polling until Retry-After expires', async () => {
+      const { workspace } = await import('../test/__mocks__/vscode');
+      workspace.getConfiguration.mockReturnValue({
+        get: vi.fn((key: string, defaultValue?: any) => {
+          if (key === 'pollingIntervalSeconds') { return 15; }
+          return defaultValue;
+        }),
+        update: vi.fn().mockResolvedValue(undefined),
+        inspect: vi.fn(() => undefined),
+      });
+
+      let callCount = 0;
+      const watcher = createMockWatcher('test');
+      (watcher.getRunStatus as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          return { overallState: 'running' as const, conclusion: undefined, jobs: [] };
+        }
+        if (callCount === 2) {
+          throw new PollingBackoffError({
+            message: 'Rate limited',
+            backoffKey: 'api.github.com',
+            statusCode: 429,
+            retryAfterMs: 60_000,
+          });
+        }
+        return { overallState: 'running' as const, conclusion: undefined, jobs: [] };
+      });
+      registry.register(watcher);
+
+      await service.startWatch({ ...createIdentifier(), backoffKey: 'api.github.com' });
+      expect(watcher.getRunStatus).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(watcher.getRunStatus).toHaveBeenCalledTimes(2);
+      expect(service.getActiveWatches()[0].hasWarning).not.toBe(true);
+
+      await vi.advanceTimersByTimeAsync(45_000);
+      expect(watcher.getRunStatus).toHaveBeenCalledTimes(2);
+
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(watcher.getRunStatus).toHaveBeenCalledTimes(3);
+      expect(service.getActiveWatches()[0].hasWarning).not.toBe(true);
+
+      workspace.getConfiguration.mockReturnValue({
+        get: vi.fn((_: string, defaultValue?: any) => defaultValue),
+        update: vi.fn().mockResolvedValue(undefined),
+        inspect: vi.fn(() => undefined),
+      });
     });
 
     it('stops polling when no active watches remain', async () => {

--- a/packages/github/src/githubActionsWatcher.ts
+++ b/packages/github/src/githubActionsWatcher.ts
@@ -8,6 +8,7 @@ import type {
   RunConclusion,
   CancellationTokenLike 
 } from '@devdocket/shared';
+import { throwApiError } from './githubApiHelpers';
 import { logger } from './logger';
 
 
@@ -62,6 +63,7 @@ export class GitHubActionsWatcher implements DevDocketRunWatcher {
       displayName: 'CI Build', // We'll update this with the real name when we fetch status
       url,
       repo: `${owner}/${repo}`,
+      backoffKey: 'api.github.com',
     };
   }
 
@@ -78,13 +80,15 @@ export class GitHubActionsWatcher implements DevDocketRunWatcher {
     // Fetch run details
     const runData = await this.fetchApi<GitHubWorkflowRun>(
       `https://api.github.com/repos/${encodedOwner}/${encodedRepo}/actions/runs/${encodedRunId}`,
-      token
+      token,
+      `GitHub Actions run ${identifier.runId}`,
     );
 
     // Fetch jobs for this run (request max page size to avoid omitting jobs on larger workflows)
     const jobsData = await this.fetchApi<{ jobs: GitHubWorkflowJob[] }>(
       `https://api.github.com/repos/${encodedOwner}/${encodedRepo}/actions/runs/${encodedRunId}/jobs?per_page=100`,
-      token
+      token,
+      `GitHub Actions jobs for run ${identifier.runId}`,
     );
 
     const overallState = this.mapState(runData.status);
@@ -134,7 +138,7 @@ export class GitHubActionsWatcher implements DevDocketRunWatcher {
 
   private static readonly FETCH_TIMEOUT_MS = 30_000;
 
-  private async fetchApi<T>(url: string, token?: CancellationTokenLike): Promise<T> {
+  private async fetchApi<T>(url: string, token: CancellationTokenLike | undefined, label: string): Promise<T> {
     // Background polling must not trigger interactive sign-in prompts.
     // Reuse an existing session if available; fail gracefully if not.
     const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: false });
@@ -164,20 +168,7 @@ export class GitHubActionsWatcher implements DevDocketRunWatcher {
     }
 
     if (!response.ok) {
-      if (response.status === 404) {
-        throw new Error('Run not found or access denied');
-      }
-      if (response.status === 401) {
-        throw new Error('GitHub authentication failed. Please re-authenticate.');
-      }
-      if (response.status === 403) {
-        const rateLimitRemaining = response.headers.get('x-ratelimit-remaining');
-        if (rateLimitRemaining === '0') {
-          throw new Error('GitHub API rate limit exceeded. Please wait and try again.');
-        }
-        throw new Error('GitHub access denied. Check repository permissions.');
-      }
-      throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+      await throwApiError(response, label);
     }
 
     return await response.json() as T;

--- a/packages/github/src/githubApiHelpers.ts
+++ b/packages/github/src/githubApiHelpers.ts
@@ -5,6 +5,9 @@ import {
   combineSignals,
   createAbortError,
   getSessionWithAuthFallback,
+  parseRateLimitResetHeader,
+  parseRetryAfterHeader,
+  PollingBackoffError,
   runWorkerPoolSettled,
   type ProviderBadge,
   type RecoverableError,
@@ -48,6 +51,7 @@ export interface GitHubPrMergeFields {
 }
 
 const AUTHORIZE_IN_BROWSER = 'Authorize in browser';
+const GITHUB_API_BACKOFF_KEY = 'api.github.com';
 
 interface GitHubSsoErrorOptions {
   ssoUrl?: string;
@@ -283,10 +287,16 @@ export async function throwApiError(response: Response, label: string): Promise<
   const bodyText = await safeReadResponseBody(response);
   const apiMessage = extractGitHubApiMessage(bodyText);
 
-  const remaining = response.headers.get('x-ratelimit-remaining');
-  const reset = response.headers.get('x-ratelimit-reset');
-  const retryAfter = response.headers.get('retry-after');
-  const sso = response.headers.get('x-github-sso');
+  const remaining = response.headers?.get?.('x-ratelimit-remaining') ?? null;
+  const reset = response.headers?.get?.('x-ratelimit-reset') ?? null;
+  const retryAfter = response.headers?.get?.('retry-after') ?? null;
+  const sso = response.headers?.get?.('x-github-sso') ?? null;
+  const retryAfterMs = parseRetryAfterHeader(retryAfter);
+  const rateLimitResetAtMs = parseRateLimitResetHeader(reset);
+  const resetDelayMs = rateLimitResetAtMs !== undefined
+    ? Math.max(0, rateLimitResetAtMs - Date.now())
+    : undefined;
+  const enforcedRetryAfterMs = Math.max(retryAfterMs ?? 0, resetDelayMs ?? 0) || undefined;
 
   const bodySnippet = bodyText ? truncateForLog(bodyText) : null;
   const diag = [
@@ -320,20 +330,46 @@ export async function throwApiError(response: Response, label: string): Promise<
     }
     if (isSecondaryRateLimited(retryAfter, apiMessage)) {
       const wait = formatRetryAfter(retryAfter);
-      throw new Error(`GitHub secondary rate limit hit for ${label}.${wait ? ` ${wait}` : ''}`);
+      throw new PollingBackoffError({
+        message: `GitHub secondary rate limit hit for ${label}.${wait ? ` ${wait}` : ''}`,
+        backoffKey: GITHUB_API_BACKOFF_KEY,
+        statusCode: status,
+        retryAfterMs: enforcedRetryAfterMs,
+      });
     }
     if (isPrimaryRateLimited(remaining, apiMessage)) {
       const resetHint = formatRateLimitReset(reset);
-      throw new Error(
-        `GitHub API rate limit exceeded for ${label}.` +
-        `${resetHint ? ` ${resetHint}` : ''}` +
-        ' Sign in to GitHub in VS Code for a higher quota.',
-      );
+      throw new PollingBackoffError({
+        message: `GitHub API rate limit exceeded for ${label}.`
+          + `${resetHint ? ` ${resetHint}` : ''}`
+          + ' Sign in to GitHub in VS Code for a higher quota.',
+        backoffKey: GITHUB_API_BACKOFF_KEY,
+        statusCode: status,
+        retryAfterMs: enforcedRetryAfterMs,
+      });
     }
     throw new Error(
       `GitHub denied access to ${label} (HTTP 403)` +
       `${apiMessage ? `: ${apiMessage}` : '. The token may lack required permissions, or the resource may be private.'}`,
     );
+  }
+  if (status === 429) {
+    const wait = formatRetryAfter(retryAfter);
+    throw new PollingBackoffError({
+      message: `GitHub rate limit hit for ${label}.${wait ? ` ${wait}` : ''}`,
+      backoffKey: GITHUB_API_BACKOFF_KEY,
+      statusCode: status,
+      retryAfterMs: enforcedRetryAfterMs,
+    });
+  }
+  if (status === 503) {
+    const wait = formatRetryAfter(retryAfter);
+    throw new PollingBackoffError({
+      message: `GitHub API temporarily unavailable for ${label}.${wait ? ` ${wait}` : ''}`,
+      backoffKey: GITHUB_API_BACKOFF_KEY,
+      statusCode: status,
+      retryAfterMs: enforcedRetryAfterMs,
+    });
   }
   throw new Error(
     `GitHub API error for ${label}: HTTP ${status}` +

--- a/packages/github/src/githubPRWatcher.ts
+++ b/packages/github/src/githubPRWatcher.ts
@@ -7,6 +7,7 @@ import type {
   RunIdentifier,
   CancellationTokenLike,
 } from '@devdocket/shared';
+import { throwApiError } from './githubApiHelpers';
 
 interface GitHubPR {
   number: number;
@@ -62,6 +63,7 @@ export class GitHubPRWatcher implements DevDocketPRWatcher {
       displayName: `PR #${prNumber}`,
       url,
       repo: `${owner}/${repo}`,
+      backoffKey: 'api.github.com',
     };
   }
 
@@ -82,6 +84,7 @@ export class GitHubPRWatcher implements DevDocketPRWatcher {
     const prData = await this.fetchApi<GitHubPR>(
       `https://api.github.com/repos/${encodedOwner}/${encodedRepo}/pulls/${encodedPrNumber}`,
       token,
+      `GitHub PR ${identifier.prId}`,
     );
 
     const prState: PRState = prData.merged
@@ -98,6 +101,7 @@ export class GitHubPRWatcher implements DevDocketPRWatcher {
     const checkRunsData = await this.fetchApi<{ check_runs: GitHubCheckRun[] }>(
       `https://api.github.com/repos/${encodedOwner}/${encodedRepo}/commits/${prData.head.sha}/check-runs?per_page=100`,
       token,
+      `GitHub check runs for PR ${identifier.prId}`,
     );
 
     const runs: RunIdentifier[] = [];
@@ -121,6 +125,7 @@ export class GitHubPRWatcher implements DevDocketPRWatcher {
           displayName: cr.name,
           url: `https://github.com/${owner}/${repo}/actions/runs/${runId}`,
           repo: `${owner}/${repo}`,
+          backoffKey: 'api.github.com',
         });
         continue;
       }
@@ -133,13 +138,14 @@ export class GitHubPRWatcher implements DevDocketPRWatcher {
         displayName: cr.name,
         url: checkUrl,
         repo: `${owner}/${repo}`,
+        backoffKey: 'api.github.com',
       });
     }
 
     return { prState, runs, displayName: updatedDisplayName };
   }
 
-  private async fetchApi<T>(url: string, token?: CancellationTokenLike): Promise<T> {
+  private async fetchApi<T>(url: string, token: CancellationTokenLike | undefined, label: string): Promise<T> {
     const session = await vscode.authentication.getSession('github', ['repo'], { createIfNone: false });
     if (!session) {
       throw new Error('No GitHub authentication session available. Sign in to GitHub to watch PR pipelines.');
@@ -167,20 +173,7 @@ export class GitHubPRWatcher implements DevDocketPRWatcher {
     }
 
     if (!response.ok) {
-      if (response.status === 404) {
-        throw new Error('PR not found or access denied');
-      }
-      if (response.status === 401) {
-        throw new Error('GitHub authentication failed. Please re-authenticate.');
-      }
-      if (response.status === 403) {
-        const rateLimitRemaining = response.headers.get('x-ratelimit-remaining');
-        if (rateLimitRemaining === '0') {
-          throw new Error('GitHub API rate limit exceeded. Please wait and try again.');
-        }
-        throw new Error('GitHub access denied. Check repository permissions.');
-      }
-      throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
+      await throwApiError(response, label);
     }
 
     return await response.json() as T;

--- a/packages/github/src/test/githubActionsWatcher.test.ts
+++ b/packages/github/src/test/githubActionsWatcher.test.ts
@@ -42,6 +42,7 @@ describe('GitHubActionsWatcher', () => {
       expect(result.repo).toBe('myorg/myrepo');
       expect(result.url).toBe('https://github.com/myorg/myrepo/actions/runs/999');
       expect(result.displayName).toBe('CI Build');
+      expect(result.backoffKey).toBe('api.github.com');
     });
 
     it('throws for invalid URL format', () => {
@@ -172,7 +173,7 @@ describe('GitHubActionsWatcher', () => {
         repo: 'owner/repo',
       };
 
-      await expect(watcher.getRunStatus(identifier)).rejects.toThrow('Run not found');
+      await expect(watcher.getRunStatus(identifier)).rejects.toThrow('not found');
 
       fetchSpy.mockRestore();
     });

--- a/packages/github/src/test/githubApiHelpers.test.ts
+++ b/packages/github/src/test/githubApiHelpers.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { authentication, env } from 'vscode';
-import { isRecoverableError } from '@devdocket/shared';
+import { isRecoverableError, PollingBackoffError } from '@devdocket/shared';
 import { GitHubSsoError, filterMergedGitHubPrs, isMergedGitHubPr, throwApiError, looksLikeRateLimited403, retryWithAuth, type GitHubIssue } from '../githubApiHelpers';
 import { setLogger } from '../logger';
 import { makeErrorResponse } from './responseMocks';
@@ -278,6 +278,22 @@ describe('throwApiError', () => {
     });
     await expect(throwApiError(response, 'GitHub issue org/repo#1'))
       .rejects.toThrow(/secondary rate limit.*Retry after 30s/i);
+  });
+
+  it('throws a PollingBackoffError for HTTP 429 responses', async () => {
+    const response = makeErrorResponse({
+      status: 429,
+      statusText: 'Too Many Requests',
+      headers: { 'retry-after': '60' },
+      bodyJson: { message: 'Too many requests' },
+    });
+
+    await expect(throwApiError(response, 'GitHub issue org/repo#1')).rejects.toMatchObject({
+      name: 'PollingBackoffError',
+      backoffKey: 'api.github.com',
+      retryAfterMs: 60_000,
+    });
+    await expect(throwApiError(response, 'GitHub issue org/repo#1')).rejects.toBeInstanceOf(PollingBackoffError);
   });
 
   it('throws a secondary-rate-limit message with an HTTP-date Retry-After', async () => {

--- a/packages/github/src/test/githubPRWatcher.test.ts
+++ b/packages/github/src/test/githubPRWatcher.test.ts
@@ -67,6 +67,7 @@ describe('GitHubPRWatcher', () => {
     it('sets repo to owner/repo', () => {
       const result = watcher.parsePRUrl('https://github.com/owner/repo/pull/7');
       expect(result.repo).toBe('owner/repo');
+      expect(result.backoffKey).toBe('api.github.com');
     });
 
     it('throws for invalid URL format', () => {

--- a/packages/shared/src/backoffPolicy.ts
+++ b/packages/shared/src/backoffPolicy.ts
@@ -22,33 +22,28 @@ export interface BackoffStateSnapshot {
 }
 
 export class BackoffPolicy {
-  private readonly baseDelayMs: number;
-  private readonly maxDelayMs: number;
+  private baseDelayMs!: number;
+  private maxDelayMs!: number;
   private readonly multiplier: number;
   private readonly jitterRatio: number;
   private readonly random: () => number;
-  private currentDelayMs: number;
+  private currentDelayMs = 0;
   private cooldownUntilMs = 0;
 
   constructor(options: BackoffPolicyOptions) {
-    if (!Number.isFinite(options.baseDelayMs) || options.baseDelayMs <= 0) {
-      throw new Error('BackoffPolicy requires a positive baseDelayMs');
-    }
-    if (!Number.isFinite(options.maxDelayMs) || options.maxDelayMs <= 0) {
-      throw new Error('BackoffPolicy requires a positive maxDelayMs');
-    }
-
-    this.baseDelayMs = options.baseDelayMs;
-    this.maxDelayMs = Math.max(options.maxDelayMs, options.baseDelayMs);
     this.multiplier = options.multiplier ?? 2;
     this.jitterRatio = Math.max(0, options.jitterRatio ?? 0);
     this.random = options.random ?? Math.random;
-    this.currentDelayMs = this.baseDelayMs;
+    this.applyOptions(options);
   }
 
   reset(): void {
     this.currentDelayMs = this.baseDelayMs;
     this.cooldownUntilMs = 0;
+  }
+
+  reconfigure(options: Pick<BackoffPolicyOptions, 'baseDelayMs' | 'maxDelayMs'>, nowMs = Date.now()): void {
+    this.applyOptions(options, nowMs);
   }
 
   recordSuccess(): void {
@@ -84,6 +79,25 @@ export class BackoffPolicy {
 
   getCooldownUntilMs(): number | undefined {
     return this.cooldownUntilMs > 0 ? this.cooldownUntilMs : undefined;
+  }
+
+  private applyOptions(options: Pick<BackoffPolicyOptions, 'baseDelayMs' | 'maxDelayMs'>, nowMs = Date.now()): void {
+    if (!Number.isFinite(options.baseDelayMs) || options.baseDelayMs <= 0) {
+      throw new Error('BackoffPolicy requires a positive baseDelayMs');
+    }
+    if (!Number.isFinite(options.maxDelayMs) || options.maxDelayMs <= 0) {
+      throw new Error('BackoffPolicy requires a positive maxDelayMs');
+    }
+
+    const remainingMs = this.getRemainingMs(nowMs);
+    this.baseDelayMs = options.baseDelayMs;
+    this.maxDelayMs = Math.max(options.maxDelayMs, options.baseDelayMs);
+    this.currentDelayMs = remainingMs > 0
+      ? Math.min(this.maxDelayMs, Math.max(this.baseDelayMs, this.currentDelayMs || this.baseDelayMs))
+      : this.baseDelayMs;
+    this.cooldownUntilMs = remainingMs > 0
+      ? nowMs + Math.min(remainingMs, this.maxDelayMs)
+      : 0;
   }
 }
 

--- a/packages/shared/src/backoffPolicy.ts
+++ b/packages/shared/src/backoffPolicy.ts
@@ -81,6 +81,10 @@ export class BackoffPolicy {
     return this.cooldownUntilMs > 0 ? this.cooldownUntilMs : undefined;
   }
 
+  getBaseDelayMs(): number {
+    return this.baseDelayMs;
+  }
+
   private applyOptions(options: Pick<BackoffPolicyOptions, 'baseDelayMs' | 'maxDelayMs'>, nowMs = Date.now()): void {
     if (!Number.isFinite(options.baseDelayMs) || options.baseDelayMs <= 0) {
       throw new Error('BackoffPolicy requires a positive baseDelayMs');
@@ -92,9 +96,7 @@ export class BackoffPolicy {
     const remainingMs = this.getRemainingMs(nowMs);
     this.baseDelayMs = options.baseDelayMs;
     this.maxDelayMs = Math.max(options.maxDelayMs, options.baseDelayMs);
-    this.currentDelayMs = remainingMs > 0
-      ? Math.min(this.maxDelayMs, Math.max(this.baseDelayMs, this.currentDelayMs || this.baseDelayMs))
-      : this.baseDelayMs;
+    this.currentDelayMs = Math.min(this.maxDelayMs, Math.max(this.baseDelayMs, this.currentDelayMs || this.baseDelayMs));
     this.cooldownUntilMs = remainingMs > 0
       ? nowMs + Math.min(remainingMs, this.maxDelayMs)
       : 0;

--- a/packages/shared/src/backoffPolicy.ts
+++ b/packages/shared/src/backoffPolicy.ts
@@ -1,0 +1,124 @@
+export interface BackoffPolicyOptions {
+  /** Base delay to reset to after a successful request. */
+  baseDelayMs: number;
+  /** Upper bound for any computed cooldown. */
+  maxDelayMs: number;
+  /** Multiplier applied after each throttled failure. Defaults to 2. */
+  multiplier?: number;
+  /** Optional positive jitter ratio added on top of computed backoff. */
+  jitterRatio?: number;
+  /** Override randomness for deterministic tests. */
+  random?: () => number;
+}
+
+export interface BackoffApplyOptions {
+  nowMs?: number;
+  retryAfterMs?: number;
+}
+
+export interface BackoffStateSnapshot {
+  delayMs: number;
+  cooldownUntilMs: number;
+}
+
+export class BackoffPolicy {
+  private readonly baseDelayMs: number;
+  private readonly maxDelayMs: number;
+  private readonly multiplier: number;
+  private readonly jitterRatio: number;
+  private readonly random: () => number;
+  private currentDelayMs: number;
+  private cooldownUntilMs = 0;
+
+  constructor(options: BackoffPolicyOptions) {
+    if (!Number.isFinite(options.baseDelayMs) || options.baseDelayMs <= 0) {
+      throw new Error('BackoffPolicy requires a positive baseDelayMs');
+    }
+    if (!Number.isFinite(options.maxDelayMs) || options.maxDelayMs <= 0) {
+      throw new Error('BackoffPolicy requires a positive maxDelayMs');
+    }
+
+    this.baseDelayMs = options.baseDelayMs;
+    this.maxDelayMs = Math.max(options.maxDelayMs, options.baseDelayMs);
+    this.multiplier = options.multiplier ?? 2;
+    this.jitterRatio = Math.max(0, options.jitterRatio ?? 0);
+    this.random = options.random ?? Math.random;
+    this.currentDelayMs = this.baseDelayMs;
+  }
+
+  reset(): void {
+    this.currentDelayMs = this.baseDelayMs;
+    this.cooldownUntilMs = 0;
+  }
+
+  recordSuccess(): void {
+    this.reset();
+  }
+
+  recordFailure(options: BackoffApplyOptions = {}): BackoffStateSnapshot {
+    const nowMs = options.nowMs ?? Date.now();
+    const retryAfterMs = Math.max(0, options.retryAfterMs ?? 0);
+    const exponentialDelayMs = Math.min(this.maxDelayMs, this.currentDelayMs * this.multiplier);
+    let delayMs = Math.min(this.maxDelayMs, Math.max(retryAfterMs, exponentialDelayMs));
+
+    if (this.jitterRatio > 0) {
+      delayMs = Math.min(this.maxDelayMs, Math.ceil(delayMs * (1 + (this.random() * this.jitterRatio))));
+    }
+
+    this.currentDelayMs = delayMs;
+    this.cooldownUntilMs = Math.max(this.cooldownUntilMs, nowMs + delayMs);
+
+    return {
+      delayMs,
+      cooldownUntilMs: this.cooldownUntilMs,
+    };
+  }
+
+  isCoolingDown(nowMs = Date.now()): boolean {
+    return this.getRemainingMs(nowMs) > 0;
+  }
+
+  getRemainingMs(nowMs = Date.now()): number {
+    return Math.max(0, this.cooldownUntilMs - nowMs);
+  }
+
+  getCooldownUntilMs(): number | undefined {
+    return this.cooldownUntilMs > 0 ? this.cooldownUntilMs : undefined;
+  }
+}
+
+export function parseRetryAfterHeader(value: string | null | undefined, nowMs = Date.now()): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const seconds = Number(trimmed);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return Math.round(seconds * 1000);
+  }
+
+  const parsedDate = Date.parse(trimmed);
+  if (Number.isNaN(parsedDate)) {
+    return undefined;
+  }
+
+  return Math.max(0, parsedDate - nowMs);
+}
+
+export function parseRateLimitResetHeader(value: string | null | undefined): number | undefined {
+  if (!value) {
+    return undefined;
+  }
+
+  const seconds = Number(value.trim());
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return undefined;
+  }
+
+  return Math.round(seconds * 1000);
+}

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -236,6 +236,8 @@ export abstract class BaseProvider {
   private refreshTimer: ReturnType<typeof setTimeout> | undefined;
   private periodicRefreshIntervalMs: number | undefined;
   private periodicBackoffPolicy: BackoffPolicy | undefined;
+  protected periodicBackoffJitterRatio = 0.1;
+  protected periodicBackoffRandom: () => number = Math.random;
   private _lastRefreshTime = 0;
   private _lastRefreshAttemptTime = 0;
   protected _isRefreshing = false;
@@ -361,7 +363,8 @@ export abstract class BaseProvider {
     this.periodicBackoffPolicy = new BackoffPolicy({
       baseDelayMs: this.periodicRefreshIntervalMs,
       maxDelayMs: 60 * 60 * 1000,
-      jitterRatio: 0,
+      jitterRatio: this.periodicBackoffJitterRatio,
+      random: this.periodicBackoffRandom,
     });
     this._lastRefreshTime = startTime;
     this._lastRefreshAttemptTime = startTime;

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -1,3 +1,5 @@
+import { BackoffPolicy } from './backoffPolicy';
+import { isPollingBackoffError } from './pollingErrors';
 import type { ProviderRefreshOptions } from './apiTypes';
 import type { CancellationTokenLike } from './runWatcher';
 
@@ -233,6 +235,7 @@ export abstract class BaseProvider {
 
   private refreshTimer: ReturnType<typeof setTimeout> | undefined;
   private periodicRefreshIntervalMs: number | undefined;
+  private periodicBackoffPolicy: BackoffPolicy | undefined;
   private _lastRefreshTime = 0;
   private _lastRefreshAttemptTime = 0;
   protected _isRefreshing = false;
@@ -288,9 +291,12 @@ export abstract class BaseProvider {
     if (this.refreshTimer) {
       clearTimeout(this.refreshTimer);
     }
-    const elapsedMs = Date.now() - this._lastRefreshAttemptTime;
+    const now = Date.now();
+    const elapsedMs = now - this._lastRefreshAttemptTime;
     const intervalsElapsed = Math.floor(elapsedMs / requiredIntervalMs) + 1;
-    const delayMs = (intervalsElapsed * requiredIntervalMs) - elapsedMs;
+    const intervalDelayMs = (intervalsElapsed * requiredIntervalMs) - elapsedMs;
+    const backoffDelayMs = this.periodicBackoffPolicy?.getRemainingMs(now) ?? 0;
+    const delayMs = Math.max(intervalDelayMs, backoffDelayMs);
     this.refreshTimer = setTimeout(() => {
       this.refreshTimer = undefined;
       if (this._disposed) {
@@ -352,6 +358,11 @@ export abstract class BaseProvider {
     const clampedInterval = Math.max(interval, 60);
     const startTime = Date.now();
     this.periodicRefreshIntervalMs = clampedInterval * 1000;
+    this.periodicBackoffPolicy = new BackoffPolicy({
+      baseDelayMs: this.periodicRefreshIntervalMs,
+      maxDelayMs: 60 * 60 * 1000,
+      jitterRatio: 0,
+    });
     this._lastRefreshTime = startTime;
     this._lastRefreshAttemptTime = startTime;
     this.scheduleNextPeriodicRefresh();
@@ -363,6 +374,7 @@ export abstract class BaseProvider {
       this.refreshTimer = undefined;
     }
     this.periodicRefreshIntervalMs = undefined;
+    this.periodicBackoffPolicy = undefined;
   }
 
   /** Runs a background refresh with a concurrency guard to prevent overlapping calls. */
@@ -374,6 +386,12 @@ export abstract class BaseProvider {
     try {
       await this.doBackgroundRefresh();
       this.markRefreshSuccess();
+      this.periodicBackoffPolicy?.recordSuccess();
+    } catch (error) {
+      if (isPollingBackoffError(error)) {
+        this.periodicBackoffPolicy?.recordFailure({ retryAfterMs: error.retryAfterMs });
+      }
+      throw error;
     } finally {
       this._isRefreshing = false;
     }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -6,6 +6,10 @@ export { createLoggerService, LogLevel, resolveLogLevel, serializeArg } from './
 export type { Logger, LogOutput, LoggerService } from './logger';
 export { BaseProvider } from './baseProvider';
 export type { ProviderItem, ProviderItemAuthor, ProviderItemCapabilities, Disposable, Event, EventEmitterLike, GitWorkInfo, ProviderBadge, RelatedItemRef, ResolvedUrlResult, WindowStateProvider } from './baseProvider';
+export { BackoffPolicy, parseRateLimitResetHeader, parseRetryAfterHeader } from './backoffPolicy';
+export type { BackoffApplyOptions, BackoffPolicyOptions, BackoffStateSnapshot } from './backoffPolicy';
+export { PollingBackoffError, isPollingBackoffError } from './pollingErrors';
+export type { PollingBackoffErrorOptions } from './pollingErrors';
 export { isSafeUrl, isValidUrlSegment, isValidGitHubRepo, isValidRepoSlug, sanitizeUrlSegment, safeDecodeComponent } from './urlValidation';
 export type { RecoverableError, RecoverableErrorAction } from './recoverableError';
 export { isRecoverableError } from './recoverableError';

--- a/packages/shared/src/pollingErrors.ts
+++ b/packages/shared/src/pollingErrors.ts
@@ -21,5 +21,21 @@ export class PollingBackoffError extends Error {
 }
 
 export function isPollingBackoffError(error: unknown): error is PollingBackoffError {
-  return error instanceof PollingBackoffError;
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const candidate = error as {
+    name?: unknown;
+    message?: unknown;
+    backoffKey?: unknown;
+    statusCode?: unknown;
+    retryAfterMs?: unknown;
+  };
+
+  return candidate.name === 'PollingBackoffError'
+    && typeof candidate.message === 'string'
+    && typeof candidate.backoffKey === 'string'
+    && typeof candidate.statusCode === 'number'
+    && (candidate.retryAfterMs === undefined || typeof candidate.retryAfterMs === 'number');
 }

--- a/packages/shared/src/pollingErrors.ts
+++ b/packages/shared/src/pollingErrors.ts
@@ -1,0 +1,25 @@
+export interface PollingBackoffErrorOptions {
+  message: string;
+  backoffKey: string;
+  statusCode: number;
+  retryAfterMs?: number;
+}
+
+export class PollingBackoffError extends Error {
+  readonly backoffKey: string;
+  readonly statusCode: number;
+  readonly retryAfterMs?: number;
+
+  constructor(options: PollingBackoffErrorOptions) {
+    super(options.message);
+    this.name = 'PollingBackoffError';
+    this.backoffKey = options.backoffKey;
+    this.statusCode = options.statusCode;
+    this.retryAfterMs = options.retryAfterMs;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export function isPollingBackoffError(error: unknown): error is PollingBackoffError {
+  return error instanceof PollingBackoffError;
+}

--- a/packages/shared/src/prWatcher.ts
+++ b/packages/shared/src/prWatcher.ts
@@ -14,6 +14,8 @@ export interface PRIdentifier {
   url: string;
   /** Repository identifier (e.g. "owner/repo") */
   repo: string;
+  /** Optional shared rate-limit/backoff bucket for watches hitting the same upstream host. */
+  backoffKey?: string;
 }
 
 /**

--- a/packages/shared/src/runWatcher.ts
+++ b/packages/shared/src/runWatcher.ts
@@ -44,6 +44,8 @@ export interface RunIdentifier {
   url: string;
   /** Optional repository identifier (e.g. "owner/repo") */
   repo?: string;
+  /** Optional shared rate-limit/backoff bucket for watches hitting the same upstream host. */
+  backoffKey?: string;
 }
 
 /**

--- a/packages/shared/src/test/backoffPolicy.test.ts
+++ b/packages/shared/src/test/backoffPolicy.test.ts
@@ -32,6 +32,16 @@ describe('BackoffPolicy', () => {
     expect(policy.recordFailure({ nowMs: 0 }).delayMs).toBe(25_000);
     expect(policy.recordFailure({ nowMs: 0 }).delayMs).toBe(25_000);
   });
+
+  it('preserves exponential progress when reconfigured outside an active cooldown', () => {
+    const policy = new BackoffPolicy({ baseDelayMs: 15_000, maxDelayMs: 120_000, jitterRatio: 0, random: () => 0 });
+
+    expect(policy.recordFailure({ nowMs: 0 }).delayMs).toBe(30_000);
+
+    policy.reconfigure({ baseDelayMs: 30_000, maxDelayMs: 120_000 }, 30_000);
+
+    expect(policy.recordFailure({ nowMs: 30_000 }).delayMs).toBe(60_000);
+  });
 });
 
 describe('parseRetryAfterHeader', () => {

--- a/packages/shared/src/test/backoffPolicy.test.ts
+++ b/packages/shared/src/test/backoffPolicy.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { BackoffPolicy, parseRateLimitResetHeader, parseRetryAfterHeader } from '../backoffPolicy';
+
+describe('BackoffPolicy', () => {
+  it('resets to the base delay after success', () => {
+    const policy = new BackoffPolicy({ baseDelayMs: 1_000, maxDelayMs: 60_000, jitterRatio: 0, random: () => 0 });
+
+    const first = policy.recordFailure({ nowMs: 0 });
+    expect(first.delayMs).toBe(2_000);
+
+    policy.recordSuccess();
+
+    const second = policy.recordFailure({ nowMs: 0 });
+    expect(second.delayMs).toBe(2_000);
+  });
+
+  it('honors Retry-After when it exceeds exponential backoff', () => {
+    const policy = new BackoffPolicy({ baseDelayMs: 15_000, maxDelayMs: 60 * 60 * 1000, jitterRatio: 0, random: () => 0 });
+
+    const state = policy.recordFailure({ nowMs: 5_000, retryAfterMs: 60_000 });
+
+    expect(state.delayMs).toBe(60_000);
+    expect(state.cooldownUntilMs).toBe(65_000);
+    expect(policy.isCoolingDown(64_999)).toBe(true);
+    expect(policy.isCoolingDown(65_000)).toBe(false);
+  });
+
+  it('caps exponential backoff at the configured maximum', () => {
+    const policy = new BackoffPolicy({ baseDelayMs: 10_000, maxDelayMs: 25_000, jitterRatio: 0, random: () => 0 });
+
+    expect(policy.recordFailure({ nowMs: 0 }).delayMs).toBe(20_000);
+    expect(policy.recordFailure({ nowMs: 0 }).delayMs).toBe(25_000);
+    expect(policy.recordFailure({ nowMs: 0 }).delayMs).toBe(25_000);
+  });
+});
+
+describe('parseRetryAfterHeader', () => {
+  it('parses delta seconds', () => {
+    expect(parseRetryAfterHeader('60')).toBe(60_000);
+  });
+
+  it('parses HTTP-date values', () => {
+    const nowMs = Date.UTC(2025, 0, 1, 0, 0, 0);
+    const retryAfter = new Date(nowMs + 45_000).toUTCString();
+
+    expect(parseRetryAfterHeader(retryAfter, nowMs)).toBe(45_000);
+  });
+});
+
+describe('parseRateLimitResetHeader', () => {
+  it('parses GitHub epoch-second reset values', () => {
+    expect(parseRateLimitResetHeader('1735689900')).toBe(1_735_689_900_000);
+  });
+});

--- a/packages/shared/src/test/baseProvider.test.ts
+++ b/packages/shared/src/test/baseProvider.test.ts
@@ -77,9 +77,11 @@ class TestProvider extends BaseProvider {
 describe('BaseProvider', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 

--- a/packages/shared/src/test/baseProvider.test.ts
+++ b/packages/shared/src/test/baseProvider.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BaseProvider, ProviderItem, EventEmitterLike, WindowStateProvider, Disposable } from '../baseProvider';
+import { PollingBackoffError } from '../pollingErrors';
 
 
 /** Minimal EventEmitter stub for testing. */
@@ -398,6 +399,31 @@ describe('BaseProvider', () => {
 
       // Second tick — should fire normally
       await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(2);
+
+      provider.dispose();
+    });
+
+    it('backs off periodic refreshes after a throttled failure', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      provider.refreshError = new PollingBackoffError({
+        message: 'Rate limited',
+        backoffKey: 'api.github.com',
+        statusCode: 429,
+        retryAfterMs: 120_000,
+      });
+
+      provider.startPeriodicRefresh(60);
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      provider.refreshError = undefined;
+
+      await vi.advanceTimersByTimeAsync(119_000);
+      expect(provider.backgroundRefreshCalls).toBe(1);
+
+      await vi.advanceTimersByTimeAsync(1_000);
       expect(provider.backgroundRefreshCalls).toBe(2);
 
       provider.dispose();

--- a/packages/shared/src/test/pollingErrors.test.ts
+++ b/packages/shared/src/test/pollingErrors.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { PollingBackoffError, isPollingBackoffError } from '../pollingErrors';
+
+describe('isPollingBackoffError', () => {
+  it('recognizes PollingBackoffError instances', () => {
+    expect(isPollingBackoffError(new PollingBackoffError({
+      message: 'Rate limited',
+      backoffKey: 'api.github.com',
+      statusCode: 429,
+      retryAfterMs: 60_000,
+    }))).toBe(true);
+  });
+
+  it('recognizes structural polling backoff errors across package boundaries', () => {
+    const crossPackageShape = {
+      name: 'PollingBackoffError',
+      message: 'Rate limited',
+      backoffKey: 'api.github.com',
+      statusCode: 429,
+      retryAfterMs: 60_000,
+    };
+
+    expect(isPollingBackoffError(crossPackageShape)).toBe(true);
+  });
+
+  it('rejects incomplete lookalikes', () => {
+    expect(isPollingBackoffError({ name: 'PollingBackoffError', backoffKey: 'api.github.com' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared backoff helpers and a polling backoff error type for rate-limit-aware retries
- teach watch pools to share per-host cooldowns and honor Retry-After / rate-limit reset responses
- apply the same backoff handling to periodic provider refreshes and cover the behavior with regression tests

## Testing
- npm run build
- npm run test

Closes #667
