### PR TITLE
Batch JsonTaskStore persistence writes

### DIFF
--- a/.changeset/perf-json-task-store-batching.md
+++ b/.changeset/perf-json-task-store-batching.md
@@ -1,0 +1,5 @@
+---
+"devdocket": patch
+---
+
+Batch JsonTaskStore writes so rapid work item updates flush as a single disk write, and flush queued work item persistence during extension shutdown to avoid losing recent changes.

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -660,8 +660,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
 /**
  * Deactivate the DevDocket extension.
  *
- * Flush queued watch persistence before VS Code disposes subscriptions so
- * dismissals survive window reloads.
+ * Flush queued work-item and watch persistence before VS Code disposes
+ * subscriptions so recent edits and dismissals survive window reloads.
  */
 export async function deactivate(): Promise<void> {
   const workGraph = workGraphForDeactivation;

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -37,6 +37,7 @@ export type { DevDocketApi, DevDocketProvider, DevDocketAction, ProviderItem, Di
 export { logger } from './services/logger';
 
 let watcherServiceForDeactivation: WatcherService | undefined;
+let workGraphForDeactivation: WorkGraph | undefined;
 
 /** Wrap an event callback so unhandled errors (sync or async) are logged instead of crashing. */
 function safeHandler<T extends unknown[]>(label: string, fn: (...args: T) => void | Promise<void>): (...args: T) => void {
@@ -650,6 +651,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   registerCommands(context, wg, ar, ss, readStateStore, pr, labelCache, wr, pwr, ws, watchPanelProvider, editorPanelDependencies, incomingPreviewPanelManager, () => mainProvider.toggleSearch());
   logger.info(`Command registration took ${Math.round(performance.now() - commandRegStart)}ms`);
 
+  workGraphForDeactivation = wg;
   watcherServiceForDeactivation = ws;
   logger.info(`DevDocket activated in ${Math.round(performance.now() - activationStart)}ms`);
   return api;
@@ -662,8 +664,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
  * dismissals survive window reloads.
  */
 export async function deactivate(): Promise<void> {
+  const workGraph = workGraphForDeactivation;
   const watcherService = watcherServiceForDeactivation;
+  workGraphForDeactivation = undefined;
   watcherServiceForDeactivation = undefined;
+  workGraph?.beginShutdown();
   watcherService?.beginShutdown();
-  await watcherService?.flushPersistence();
+
+  const results = await Promise.allSettled([
+    workGraph?.flushPersistence(),
+    watcherService?.flushPersistence(),
+  ]);
+
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      logger.error('Failed to flush persisted state during deactivate', result.reason);
+    }
+  }
 }

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -39,6 +39,7 @@ export class WorkGraph {
   /** Lazily-built index of items grouped by state; nulled on any mutation to {@link items}. */
   private stateCache: Map<WorkItemState, WorkItem[]> | null = null;
   private currentMutation: Promise<void> = Promise.resolve();
+  private shutdownRequested = false;
   private readonly _onDidChange = new vscode.EventEmitter<WorkGraphChangeEvent>();
   private readonly _onDidTransitionState = new vscode.EventEmitter<{ itemId: string; item: WorkItem; oldState: string; newState: string }>();
   /**
@@ -57,12 +58,15 @@ export class WorkGraph {
     this._onDidChange.fire({ source });
   }
 
-  private async withLock<T>(work: () => Promise<T>): Promise<T> {
+  private async withLock<T>(work: () => Promise<T>, options?: { allowDuringShutdown?: boolean }): Promise<T> {
     const prev = this.currentMutation;
     let release!: () => void;
     this.currentMutation = new Promise<void>(resolve => { release = resolve; });
     try {
       await prev;
+      if (this.shutdownRequested && !options?.allowDuringShutdown) {
+        throw new Error('WorkGraph is shutting down');
+      }
       return await work();
     } finally {
       release();
@@ -678,6 +682,16 @@ export class WorkGraph {
       : entries;
   }
 
+  beginShutdown(): void {
+    this.shutdownRequested = true;
+  }
+
+  async flushPersistence(): Promise<void> {
+    await this.withLock(async () => {
+      await this.store.flush?.();
+    }, { allowDuringShutdown: true });
+  }
+
   dispose(): void {
     this._onDidChange.dispose();
     this._onDidTransitionState.dispose();
@@ -690,7 +704,7 @@ export class WorkGraph {
    */
   async invalidateAndReload(): Promise<void> {
     return this.withLock(async () => {
-      this.store.invalidateCache?.();
+      await this.store.invalidateCache?.();
       try {
         await this.load();
         this.emitDidChange('externalReload');

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -255,6 +255,10 @@ export class WorkGraph {
     return this.withLock(() => this.doUpdateItem(id, patch, options));
   }
 
+  async updateItemDuringShutdown(id: string, patch: Partial<WorkItemInput>, options?: UpdateItemOptions): Promise<void> {
+    return this.withLock(() => this.doUpdateItem(id, patch, options), { allowDuringShutdown: true });
+  }
+
   private async doUpdateItem(id: string, patch: Partial<WorkItemInput>, options?: UpdateItemOptions): Promise<void> {
     const item = this.items.get(id);
     if (!item) {

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -78,8 +78,17 @@ export class JsonTaskStore implements ITaskStore {
   private syncedUpdatedAt = new Map<string, number>();
   /** Local delete tombstones used to suppress stale reintroductions from other windows. */
   private deletedUpdatedAt = new Map<string, number>();
+  private persistTimer: ReturnType<typeof setTimeout> | undefined;
+  private persistQueued = false;
+  private persistInFlight = false;
+  private persistRunQueued = false;
+  private persistChain: Promise<void> = Promise.resolve();
+  private lastPersistError: unknown;
 
-  constructor(private readonly fileStore: FileStore<unknown[]>) {}
+  constructor(
+    private readonly fileStore: FileStore<unknown[]>,
+    private readonly options: { persistDelayMs?: number } = {},
+  ) {}
 
   async loadAll(): Promise<WorkItem[]> {
     if (this.cache !== null) {
@@ -100,31 +109,100 @@ export class JsonTaskStore implements ITaskStore {
     return this.cache;
   }
 
+  private getPersistDelayMs(): number {
+    return this.options.persistDelayMs ?? 25;
+  }
+
+  private schedulePersist(): void {
+    this.persistQueued = true;
+    if (this.persistTimer || this.persistInFlight) {
+      return;
+    }
+
+    this.persistTimer = setTimeout(() => {
+      this.persistTimer = undefined;
+      this.enqueuePersistRun();
+    }, this.getPersistDelayMs());
+  }
+
+  private enqueuePersistRun(): void {
+    if (this.persistInFlight || this.persistRunQueued) {
+      return;
+    }
+
+    this.persistRunQueued = true;
+    const run = this.persistChain
+      .catch(() => undefined)
+      .then(() => this.runPersistLoop());
+
+    run.then(
+      () => {
+        this.persistRunQueued = false;
+        if (this.persistChain === run) {
+          this.lastPersistError = undefined;
+        }
+      },
+      (err) => {
+        this.persistRunQueued = false;
+        this.lastPersistError = err;
+        logger.error('Failed to persist work items', err);
+      },
+    );
+
+    this.persistChain = run;
+  }
+
+  private async runPersistLoop(): Promise<void> {
+    if (this.persistInFlight) {
+      return;
+    }
+
+    this.persistInFlight = true;
+    try {
+      while (this.persistQueued) {
+        this.persistQueued = false;
+        await this.persistOnce();
+      }
+    } finally {
+      this.persistInFlight = false;
+      if (this.persistQueued && !this.persistTimer) {
+        this.persistTimer = setTimeout(() => {
+          this.persistTimer = undefined;
+          this.enqueuePersistRun();
+        }, this.getPersistDelayMs());
+      }
+    }
+  }
+
   /**
    * Re-reads from disk, adopts untouched remote state, overlays local mutations,
    * and writes the merged result. Local edits use `updatedAt` last-writer-wins
    * for shared items, locally removed items stay deleted, and untouched local
    * items disappear when another window deletes them remotely.
    */
-  private async persist(): Promise<void> {
+  private async persistOnce(): Promise<void> {
     if (this.cache === null) {
       await this.loadAll();
     }
-    const local = this.getCache();
+    const localSnapshot = new Map(this.getCache());
+    const dirtyIdsSnapshot = new Set(this.dirtyIds);
+    const removedIdsSnapshot = new Set(this.removedIds);
+    const syncedUpdatedAtSnapshot = new Map(this.syncedUpdatedAt);
+    const deletedUpdatedAtSnapshot = new Map(this.deletedUpdatedAt);
     const remoteItems = await this.parseFromFileStore();
     const remoteById = new Map(remoteItems.map(item => [item.id, item]));
     const merged = new Map<string, WorkItem>();
 
     for (const remote of remoteItems) {
-      const deletedAt = this.deletedUpdatedAt.get(remote.id);
+      const deletedAt = deletedUpdatedAtSnapshot.get(remote.id);
       if (deletedAt !== undefined && remote.updatedAt <= deletedAt) {
         continue;
       }
       merged.set(remote.id, remote);
     }
 
-    for (const [id, localItem] of local) {
-      if (this.dirtyIds.has(id) || this.removedIds.has(id)) {
+    for (const [id, localItem] of localSnapshot) {
+      if (dirtyIdsSnapshot.has(id) || removedIdsSnapshot.has(id)) {
         continue;
       }
 
@@ -133,22 +211,22 @@ export class JsonTaskStore implements ITaskStore {
         continue;
       }
 
-      const syncedUpdatedAt = this.syncedUpdatedAt.get(id);
+      const syncedUpdatedAt = syncedUpdatedAtSnapshot.get(id);
       if (syncedUpdatedAt !== undefined && localItem.updatedAt !== syncedUpdatedAt) {
         merged.set(id, localItem);
       }
     }
 
-    for (const id of this.removedIds) {
+    for (const id of removedIdsSnapshot) {
       const remoteItem = merged.get(id);
-      const deletedAt = this.deletedUpdatedAt.get(id);
+      const deletedAt = deletedUpdatedAtSnapshot.get(id);
       if (remoteItem && deletedAt !== undefined && remoteItem.updatedAt <= deletedAt) {
         merged.delete(id);
       }
     }
 
-    for (const id of this.dirtyIds) {
-      const localItem = local.get(id);
+    for (const id of dirtyIdsSnapshot) {
+      const localItem = localSnapshot.get(id);
       if (!localItem) {
         continue;
       }
@@ -159,16 +237,67 @@ export class JsonTaskStore implements ITaskStore {
     }
 
     await this.fileStore.write(Array.from(merged.values()));
-    this.cache = merged;
-    this.syncedUpdatedAt = new Map(Array.from(merged.values(), item => [item.id, item.updatedAt]));
+
+    const currentCache = this.getCache();
+    for (const [id, snapshotItem] of localSnapshot) {
+      if (currentCache.get(id) !== snapshotItem) {
+        continue;
+      }
+
+      const persistedItem = merged.get(id);
+      if (persistedItem) {
+        currentCache.set(id, persistedItem);
+      } else {
+        currentCache.delete(id);
+      }
+    }
+
+    for (const [id, persistedItem] of merged) {
+      if (!currentCache.has(id) && !this.removedIds.has(id)) {
+        currentCache.set(id, persistedItem);
+      }
+    }
+
+    for (const [id, snapshotItem] of localSnapshot) {
+      if (dirtyIdsSnapshot.has(id)) {
+        const currentItem = currentCache.get(id);
+        const persistedItem = merged.get(id);
+        if (currentItem === persistedItem && persistedItem !== undefined) {
+          this.syncedUpdatedAt.set(id, persistedItem.updatedAt);
+          this.dirtyIds.delete(id);
+        } else if (currentItem === snapshotItem && persistedItem === undefined) {
+          this.syncedUpdatedAt.delete(id);
+          this.dirtyIds.delete(id);
+        }
+      }
+    }
+
+    for (const id of removedIdsSnapshot) {
+      if (!currentCache.has(id)) {
+        this.syncedUpdatedAt.delete(id);
+        this.removedIds.delete(id);
+      }
+    }
+
+    for (const [id, persistedItem] of merged) {
+      const currentItem = currentCache.get(id);
+      if (currentItem === persistedItem && !this.dirtyIds.has(id) && !this.removedIds.has(id)) {
+        this.syncedUpdatedAt.set(id, persistedItem.updatedAt);
+      }
+    }
+
+    for (const id of Array.from(this.syncedUpdatedAt.keys())) {
+      if (!merged.has(id) && !this.dirtyIds.has(id) && !this.removedIds.has(id)) {
+        this.syncedUpdatedAt.delete(id);
+      }
+    }
+
     for (const [id, deletedAt] of Array.from(this.deletedUpdatedAt.entries())) {
       const mergedItem = merged.get(id);
       if (mergedItem && mergedItem.updatedAt > deletedAt) {
         this.deletedUpdatedAt.delete(id);
       }
     }
-    this.dirtyIds.clear();
-    this.removedIds.clear();
   }
 
   /** Parse and validate work items from the backing JSON file. */
@@ -195,7 +324,7 @@ export class JsonTaskStore implements ITaskStore {
     this.dirtyIds.add(item.id);
     this.removedIds.delete(item.id);
     this.deletedUpdatedAt.delete(item.id);
-    await this.persist();
+    this.schedulePersist();
   }
 
   async saveAll(items: WorkItem[]): Promise<void> {
@@ -206,7 +335,7 @@ export class JsonTaskStore implements ITaskStore {
       this.removedIds.delete(item.id);
       this.deletedUpdatedAt.delete(item.id);
     }
-    await this.persist();
+    this.schedulePersist();
   }
 
   async delete(id: string): Promise<void> {
@@ -217,14 +346,45 @@ export class JsonTaskStore implements ITaskStore {
     this.getCache().delete(id);
     this.removedIds.add(id);
     this.dirtyIds.delete(id);
-    await this.persist();
+    this.schedulePersist();
+  }
+
+  async flush(): Promise<void> {
+    if (this.persistTimer) {
+      clearTimeout(this.persistTimer);
+      this.persistTimer = undefined;
+      this.enqueuePersistRun();
+    }
+
+    while (true) {
+      if (this.persistQueued && !this.persistInFlight && !this.persistRunQueued) {
+        this.enqueuePersistRun();
+      }
+
+      const persistChain = this.persistChain;
+      await persistChain;
+
+      if (this.lastPersistError !== undefined) {
+        throw this.lastPersistError;
+      }
+
+      if (!this.persistTimer && !this.persistQueued && !this.persistInFlight && persistChain === this.persistChain) {
+        return;
+      }
+      if (this.persistTimer) {
+        clearTimeout(this.persistTimer);
+        this.persistTimer = undefined;
+        this.enqueuePersistRun();
+      }
+    }
   }
 
   /**
    * Invalidates the in-memory cache so the next access re-reads from disk.
    * Used for cross-window change propagation.
    */
-  invalidateCache(): void {
+  async invalidateCache(): Promise<void> {
+    await this.flush();
     this.cache = null;
     this.syncedUpdatedAt.clear();
     this.deletedUpdatedAt.clear();

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -257,12 +257,6 @@ export class JsonTaskStore implements ITaskStore {
       }
     }
 
-    for (const [id, persistedItem] of merged) {
-      if (!currentCache.has(id) && !this.removedIds.has(id)) {
-        currentCache.set(id, persistedItem);
-      }
-    }
-
     for (const [id, snapshotItem] of localSnapshot) {
       if (dirtyIdsSnapshot.has(id)) {
         const currentItem = currentCache.get(id);

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -280,6 +280,12 @@ export class JsonTaskStore implements ITaskStore {
     }
 
     for (const [id, persistedItem] of merged) {
+      if (!currentCache.has(id) && !this.removedIds.has(id)) {
+        currentCache.set(id, persistedItem);
+      }
+    }
+
+    for (const [id, persistedItem] of merged) {
       const currentItem = currentCache.get(id);
       if (currentItem === persistedItem && !this.dirtyIds.has(id) && !this.removedIds.has(id)) {
         this.syncedUpdatedAt.set(id, persistedItem.updatedAt);

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -115,7 +115,7 @@ export class JsonTaskStore implements ITaskStore {
 
   private schedulePersist(): void {
     this.persistQueued = true;
-    if (this.persistTimer || this.persistInFlight) {
+    if (this.persistTimer || this.persistInFlight || this.persistRunQueued) {
       return;
     }
 

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -161,7 +161,12 @@ export class JsonTaskStore implements ITaskStore {
     try {
       while (this.persistQueued) {
         this.persistQueued = false;
-        await this.persistOnce();
+        try {
+          await this.persistOnce();
+        } catch (err) {
+          this.persistQueued = true;
+          throw err;
+        }
       }
     } finally {
       this.persistInFlight = false;

--- a/packages/core/src/storage/jsonTaskStore.ts
+++ b/packages/core/src/storage/jsonTaskStore.ts
@@ -1,3 +1,4 @@
+import * as vscode from 'vscode';
 import { WorkItem, WorkItemState } from '../models/workItem';
 import { ITaskStore } from './taskStore';
 import { logger } from '../services/logger';
@@ -84,6 +85,7 @@ export class JsonTaskStore implements ITaskStore {
   private persistRunQueued = false;
   private persistChain: Promise<void> = Promise.resolve();
   private lastPersistError: unknown;
+  private persistFailureNotified = false;
 
   constructor(
     private readonly fileStore: FileStore<unknown[]>,
@@ -141,11 +143,21 @@ export class JsonTaskStore implements ITaskStore {
         if (this.persistChain === run) {
           this.lastPersistError = undefined;
         }
+        if (this.persistFailureNotified) {
+          this.persistFailureNotified = false;
+          logger.info('Work item persistence recovered.');
+        }
       },
       (err) => {
         this.persistRunQueued = false;
         this.lastPersistError = err;
         logger.error('Failed to persist work items', err);
+        if (!this.persistFailureNotified) {
+          this.persistFailureNotified = true;
+          void vscode.window.showWarningMessage(
+            'DevDocket could not save work items. Recent work item edits may be lost when the window reloads.',
+          );
+        }
       },
     );
 

--- a/packages/core/src/storage/taskStore.ts
+++ b/packages/core/src/storage/taskStore.ts
@@ -2,11 +2,11 @@ import { WorkItem } from '../models/workItem';
 
 export interface ITaskStore {
   loadAll(): Promise<WorkItem[]>;
-  /** Stage a mutation in memory. Call flush() to await disk durability. */
+  /** Stage a mutation in memory. If supported, call flush() to await disk durability. */
   save(item: WorkItem): Promise<void>;
-  /** Stage a batch mutation in memory. Call flush() to await disk durability. */
+  /** Stage a batch mutation in memory. If supported, call flush() to await disk durability. */
   saveAll(items: WorkItem[]): Promise<void>;
-  /** Stage a deletion in memory. Call flush() to await disk durability. */
+  /** Stage a deletion in memory. If supported, call flush() to await disk durability. */
   delete(id: string): Promise<void>;
   flush?(): Promise<void>;
   invalidateCache?(): void | Promise<void>;

--- a/packages/core/src/storage/taskStore.ts
+++ b/packages/core/src/storage/taskStore.ts
@@ -2,8 +2,12 @@ import { WorkItem } from '../models/workItem';
 
 export interface ITaskStore {
   loadAll(): Promise<WorkItem[]>;
+  /** Stage a mutation in memory. Call flush() to await disk durability. */
   save(item: WorkItem): Promise<void>;
+  /** Stage a batch mutation in memory. Call flush() to await disk durability. */
   saveAll(items: WorkItem[]): Promise<void>;
+  /** Stage a deletion in memory. Call flush() to await disk durability. */
   delete(id: string): Promise<void>;
-  invalidateCache?(): void;
+  flush?(): Promise<void>;
+  invalidateCache?(): void | Promise<void>;
 }

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -488,6 +488,29 @@ describe('JsonTaskStore', () => {
       vi.useRealTimers();
     });
 
+    it('rehydrates newer remote items into cache after a queued delete loses to a newer update', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-21T02:00:00Z'));
+      store = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'), { persistDelayMs: 25 });
+
+      await store.save(makeItem({ id: 'shared', title: 'Original', updatedAt: 1000 }));
+      await store.flush();
+      await store.delete('shared');
+
+      fileSystem.writeJson(fileUri, [
+        makeItem({ id: 'shared', title: 'Remote resurrected', updatedAt: Date.now() + 1 }),
+      ]);
+
+      await store.flush();
+
+      const items = await store.loadAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('shared');
+      expect(items[0].title).toBe('Remote resurrected');
+
+      vi.useRealTimers();
+    });
+
     it('invalidateCache forces re-read on next access', async () => {
       await store.save(makeItem({ id: 'a', title: 'Original' }));
       await store.flush();

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -337,6 +337,9 @@ describe('JsonTaskStore', () => {
       await store.save(makeItem({ id: 'failing-write', updatedAt: 1000 }));
 
       await expect(store.flush()).rejects.toThrow('disk full');
+      expect(vscode.window.showWarningMessage).toHaveBeenCalledWith(
+        'DevDocket could not save work items. Recent work item edits may be lost when the window reloads.',
+      );
       expect(fileSystem.readJson<WorkItem[]>(fileUri)).toBeUndefined();
 
       await store.flush();

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -330,7 +330,7 @@ describe('JsonTaskStore', () => {
       expect(items[0].title).toBe('Queued update');
     });
 
-    it('surfaces persist failures from flush', async () => {
+    it('retries staged work on a later flush after a transient persist failure', async () => {
       const diskFull = new Error('disk full');
       (vscode.workspace.fs.writeFile as ReturnType<typeof vi.fn>).mockRejectedValueOnce(diskFull);
 
@@ -339,12 +339,11 @@ describe('JsonTaskStore', () => {
       await expect(store.flush()).rejects.toThrow('disk full');
       expect(fileSystem.readJson<WorkItem[]>(fileUri)).toBeUndefined();
 
-      await store.save(makeItem({ id: 'failing-write', title: 'Recovered', updatedAt: 2000 }));
       await store.flush();
 
       const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       expect(persisted).toHaveLength(1);
-      expect(persisted[0].title).toBe('Recovered');
+      expect(persisted[0].id).toBe('failing-write');
     });
   });
 

--- a/packages/core/src/test/jsonTaskStore.test.ts
+++ b/packages/core/src/test/jsonTaskStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as vscode from 'vscode';
 import { JsonTaskStore } from '../storage/jsonTaskStore';
 import { JsonFileStore } from '../storage/fileStore';
@@ -14,6 +14,11 @@ describe('JsonTaskStore', () => {
     vi.clearAllMocks();
     fileSystem = useMockFileSystem();
     store = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
+  });
+
+  afterEach(async () => {
+    await store.flush();
+    vi.useRealTimers();
   });
 
   function makeItem(overrides: Partial<WorkItem> = {}): WorkItem {
@@ -123,6 +128,7 @@ describe('JsonTaskStore', () => {
         makeItem({ id: 'x', title: 'X' }),
         makeItem({ id: 'y', title: 'Y' }),
       ]);
+      await store.flush();
 
       const persisted = fileSystem.readJson<WorkItem[]>(fileUri);
       expect(persisted).toHaveLength(2);
@@ -143,6 +149,7 @@ describe('JsonTaskStore', () => {
 
   it('persists data to the backing JSON file', async () => {
     await store.save(makeItem());
+    await store.flush();
     const persisted = fileSystem.readJson<WorkItem[]>(fileUri);
     expect(persisted).toHaveLength(1);
     expect(persisted![0].id).toBe('test-1');
@@ -151,6 +158,7 @@ describe('JsonTaskStore', () => {
   it('loads from a fresh store instance sharing the same file', async () => {
     await store.save(makeItem({ id: 'a' }));
     await store.save(makeItem({ id: 'b' }));
+    await store.flush();
 
     const store2 = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
     const items = await store2.loadAll();
@@ -286,10 +294,65 @@ describe('JsonTaskStore', () => {
     });
   });
 
+  describe('persistence batching', () => {
+    it('coalesces back-to-back mutations into a single disk write', async () => {
+      vi.useFakeTimers();
+      store = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'), { persistDelayMs: 25 });
+
+      await store.save(makeItem({ id: 'batched', title: 'First', updatedAt: 1000 }));
+      await store.save(makeItem({ id: 'batched', title: 'Second', updatedAt: 2000 }));
+
+      expect(vscode.workspace.fs.writeFile).not.toHaveBeenCalled();
+      expect(vscode.workspace.fs.rename).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(25);
+      await store.flush();
+
+      const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0].title).toBe('Second');
+      expect(vscode.workspace.fs.writeFile).toHaveBeenCalledTimes(1);
+      expect(vscode.workspace.fs.rename).toHaveBeenCalledTimes(1);
+    });
+
+    it('flushes queued mutations so a fresh store can load them after reactivation', async () => {
+      const queuedStore = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'), { persistDelayMs: 60_000 });
+
+      await queuedStore.save(makeItem({ id: 'queued', title: 'Queued update', updatedAt: 1000 }));
+      expect(fileSystem.readJson<WorkItem[]>(fileUri)).toBeUndefined();
+
+      await queuedStore.flush();
+
+      const reactivatedStore = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
+      const items = await reactivatedStore.loadAll();
+      expect(items).toHaveLength(1);
+      expect(items[0].id).toBe('queued');
+      expect(items[0].title).toBe('Queued update');
+    });
+
+    it('surfaces persist failures from flush', async () => {
+      const diskFull = new Error('disk full');
+      (vscode.workspace.fs.writeFile as ReturnType<typeof vi.fn>).mockRejectedValueOnce(diskFull);
+
+      await store.save(makeItem({ id: 'failing-write', updatedAt: 1000 }));
+
+      await expect(store.flush()).rejects.toThrow('disk full');
+      expect(fileSystem.readJson<WorkItem[]>(fileUri)).toBeUndefined();
+
+      await store.save(makeItem({ id: 'failing-write', title: 'Recovered', updatedAt: 2000 }));
+      await store.flush();
+
+      const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
+      expect(persisted).toHaveLength(1);
+      expect(persisted[0].title).toBe('Recovered');
+    });
+  });
+
   describe('merge-on-write (multi-window safety)', () => {
     it('preserves items added by another window during persist', async () => {
       // Window A creates item1
       await store.save(makeItem({ id: 'item1', title: 'Window A item', updatedAt: 1000 }));
+      await store.flush();
 
       // Simulate another window adding item2 directly to the shared JSON file
       const current = fileSystem.readJson<WorkItem[]>(fileUri) ?? [];
@@ -300,6 +363,7 @@ describe('JsonTaskStore', () => {
 
       // Window A saves item3 — should preserve item2 from remote
       await store.save(makeItem({ id: 'item3', title: 'Another A item', updatedAt: 3000 }));
+      await store.flush();
 
       const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       expect(persisted).toHaveLength(3);
@@ -308,6 +372,7 @@ describe('JsonTaskStore', () => {
 
     it('keeps locally modified item when it has later updatedAt', async () => {
       await store.save(makeItem({ id: 'shared', title: 'Original', updatedAt: 1000 }));
+      await store.flush();
 
       // Another window writes an older version
       fileSystem.writeJson(fileUri, [
@@ -316,6 +381,7 @@ describe('JsonTaskStore', () => {
 
       // Window A updates the item
       await store.save(makeItem({ id: 'shared', title: 'Local newer', updatedAt: 2000 }));
+      await store.flush();
 
       const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       expect(persisted).toHaveLength(1);
@@ -324,6 +390,7 @@ describe('JsonTaskStore', () => {
 
     it('takes remote item when it has later updatedAt', async () => {
       await store.save(makeItem({ id: 'shared', title: 'Original', updatedAt: 1000 }));
+      await store.flush();
 
       // Another window writes a newer version
       fileSystem.writeJson(fileUri, [
@@ -332,6 +399,7 @@ describe('JsonTaskStore', () => {
 
       // Window A saves an unrelated item — merge should pick up remote's newer version
       await store.save(makeItem({ id: 'other', title: 'Other', updatedAt: 3000 }));
+      await store.flush();
 
       const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       const shared = persisted.find(i => i.id === 'shared');
@@ -340,7 +408,9 @@ describe('JsonTaskStore', () => {
 
     it('does not restore locally deleted items from remote', async () => {
       await store.save(makeItem({ id: 'to-delete', title: 'Delete me', updatedAt: 1000 }));
+      await store.flush();
       await store.delete('to-delete');
+      await store.flush();
 
       // Remote still has the item (from before the delete)
       fileSystem.writeJson(fileUri, [
@@ -349,6 +419,7 @@ describe('JsonTaskStore', () => {
 
       // Window A saves something else — should not restore deleted item
       await store.save(makeItem({ id: 'new', title: 'New', updatedAt: 2000 }));
+      await store.flush();
 
       const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       expect(persisted).toHaveLength(1);
@@ -360,13 +431,17 @@ describe('JsonTaskStore', () => {
       vi.setSystemTime(new Date('2026-05-21T02:00:00Z'));
 
       await store.save(makeItem({ id: 'shared', title: 'Original', updatedAt: 1000 }));
+      await store.flush();
 
       const windowB = new JsonTaskStore(new JsonFileStore(fileUri, 'workitems.json'));
       await windowB.loadAll();
       await windowB.save(makeItem({ id: 'shared', title: 'Remote update', updatedAt: 2000 }));
+      await windowB.flush();
 
       await store.delete('shared');
+      await store.flush();
       await store.save(makeItem({ id: 'other', title: 'Other', updatedAt: 3000 }));
+      await store.flush();
 
       const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       expect(persisted.map(item => item.id).sort()).toEqual(['other']);
@@ -376,12 +451,14 @@ describe('JsonTaskStore', () => {
 
     it('honors remote deletions for untouched items', async () => {
       await store.save(makeItem({ id: 'shared', title: 'Shared', updatedAt: 1000 }));
+      await store.flush();
 
       // Another window deletes the item entirely.
       fileSystem.writeJson(fileUri, []);
 
       // This window only changes an unrelated item, so the deleted item should stay deleted.
       await store.save(makeItem({ id: 'other', title: 'Other', updatedAt: 2000 }));
+      await store.flush();
 
       const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       expect(persisted).toHaveLength(1);
@@ -393,13 +470,16 @@ describe('JsonTaskStore', () => {
       vi.setSystemTime(new Date('2026-05-21T02:00:00Z'));
 
       await store.save(makeItem({ id: 'shared', title: 'Original', updatedAt: 1000 }));
+      await store.flush();
       await store.delete('shared');
+      await store.flush();
 
       fileSystem.writeJson(fileUri, [
         makeItem({ id: 'shared', title: 'Remote newer', updatedAt: Date.now() + 1 }),
       ]);
 
       await store.save(makeItem({ id: 'other', title: 'Other', updatedAt: Date.now() + 2 }));
+      await store.flush();
 
       const persisted = fileSystem.readJson<WorkItem[]>(fileUri)!;
       expect(persisted.map(item => item.id).sort()).toEqual(['other', 'shared']);
@@ -410,13 +490,14 @@ describe('JsonTaskStore', () => {
 
     it('invalidateCache forces re-read on next access', async () => {
       await store.save(makeItem({ id: 'a', title: 'Original' }));
+      await store.flush();
 
       // Another window modifies the data
       fileSystem.writeJson(fileUri, [
         makeItem({ id: 'a', title: 'Modified by other window' }),
       ]);
 
-      store.invalidateCache();
+      await store.invalidateCache();
       const items = await store.loadAll();
       expect(items).toHaveLength(1);
       expect(items[0].title).toBe('Modified by other window');

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -126,6 +126,8 @@ describe('WorkGraph', () => {
     expect(updated?.title).toBe('B');
     expect(updated?.activityLog?.map(entry => entry.type)).toEqual(['created', 'state-changed', 'updated']);
 
+    await realGraph.flushPersistence();
+
     const freshGraph = new WorkGraph(new JsonTaskStore(new JsonFileStore(fileUri, 'workgraph-items.json')));
     await freshGraph.load();
     const persisted = freshGraph.getItem(item.id);

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -63,17 +63,20 @@ function createMockWorkGraph(primaryItem?: WorkItem, relatedByProvenance: Record
     items.set(item.id, { ...item });
   }
 
+  const applyPatch = async (id: string, patch: Record<string, unknown>) => {
+    const current = items.get(id);
+    if (!current) {
+      throw new Error(`Missing item ${id}`);
+    }
+    items.set(id, { ...current, ...patch, updatedAt: Date.now() });
+    changeEmitter.fire();
+  };
+
   return {
     getAll: vi.fn(() => Array.from(items.values())),
     getItem: vi.fn((id: string) => items.get(id)),
-    updateItem: vi.fn(async (id: string, patch: Record<string, unknown>) => {
-      const current = items.get(id);
-      if (!current) {
-        throw new Error(`Missing item ${id}`);
-      }
-      items.set(id, { ...current, ...patch, updatedAt: Date.now() });
-      changeEmitter.fire();
-    }),
+    updateItem: vi.fn(applyPatch),
+    updateItemDuringShutdown: vi.fn(applyPatch),
     transitionState: vi.fn(async (id: string, targetState: WorkItemState) => {
       const current = items.get(id);
       if (!current) {
@@ -567,11 +570,12 @@ describe('WorkItemEditorPanel', () => {
     mock.simulateDispose();
 
     await vi.waitFor(() => {
-      expect(workGraph.updateItem).toHaveBeenCalledWith('item-1', {
+      expect(workGraph.updateItemDuringShutdown).toHaveBeenCalledWith('item-1', {
         title: 'Updated before close',
         notes: 'Draft notes',
       });
     });
+    expect(workGraph.updateItem).not.toHaveBeenCalled();
   });
 
   it('saves manual notes without requiring title or URL fields', async () => {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -445,6 +445,11 @@ export class WorkItemEditorPanel {
       return;
     }
 
+    if (this.disposed) {
+      await this.workGraph.updateItemDuringShutdown(this.itemId, patch);
+      return;
+    }
+
     await this.workGraph.updateItem(this.itemId, patch);
   }
 


### PR DESCRIPTION
## Summary
- batch JsonTaskStore persistence behind a short debounce so rapid work item mutations share one disk write
- add explicit flush support, wire WorkGraph shutdown flushing, and drain queued writes during extension deactivation
- keep merge-on-write semantics for cross-window updates while surfacing flush failures and covering the new behavior with regression tests

## Reasoning / benchmark
- before this change, every save/saveAll/delete immediately rewrote the full work item payload
- after this change, back-to-back mutations within the debounce window coalesce into one write; the new regression test verifies two rapid saves produce a single writeFile/rename pair
- queued writes are flushed on shutdown so reactivation reloads the latest data instead of dropping buffered mutations

## Testing
- npm run build
- npm run test

Closes #633
