### PR TITLE
Abort stale provider refreshes during reconfiguration

### DIFF
--- a/.changeset/fix-provider-rebuild-races.md
+++ b/.changeset/fix-provider-rebuild-races.md
@@ -1,0 +1,7 @@
+---
+"@devdocket/shared": patch
+"devdocket-github": patch
+"devdocket-ado": patch
+---
+
+Abort in-flight provider refreshes before rebuilding GitHub and Azure DevOps providers on configuration changes so disposed providers cannot emit stale results after replacement.

--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -81,57 +81,56 @@ export class AdoWorkItemProvider extends BaseProvider {
    * Prompts for authentication if no session exists.
    */
   async refresh(token?: vscode.CancellationToken, options?: ProviderRefreshOptions): Promise<void> {
-    if (this._isRefreshing) {
+    if (this._isRefreshing || this.isDisposedOrShuttingDown) {
       return;
     }
 
     this._isRefreshing = true;
-    const abortController = new AbortController();
-    const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
     const interactive = options?.interactive ?? true;
     try {
-      logger.info('Fetching assigned ADO work items...');
-      if (token?.isCancellationRequested) {
-        return;
-      }
+      await this.runAbortableRefresh(async (signal) => {
+        logger.info('Fetching assigned ADO work items...');
 
-      let session: vscode.AuthenticationSession | undefined;
-      try {
-        session = await getAdoSession({
-          interactive,
-          signal: abortController.signal,
-        });
-      } catch (err) {
-        if (err instanceof Error && err.name === 'AbortError') {
-          throw err;
+        let session: vscode.AuthenticationSession | undefined;
+        try {
+          session = await getAdoSession({
+            interactive,
+            signal,
+          });
+        } catch (err) {
+          if (err instanceof Error && err.name === 'AbortError') {
+            throw err;
+          }
+          session = undefined;
         }
-        session = undefined;
-      }
 
-      if (token?.isCancellationRequested) {
-        return;
-      }
-      if (!session) {
-        this._onDidDiscoverItems.fire([]);
-        return;
-      }
+        if (token?.isCancellationRequested || signal.aborted) {
+          return;
+        }
+        if (!session) {
+          this.publishDiscoveredItems([]);
+          return;
+        }
 
-      await this.fetchAndPublishWorkItems(session.accessToken, interactive, abortController.signal);
-      this.markRefreshSuccess();
+        await this.fetchAndPublishWorkItems(session.accessToken, interactive, signal);
+        if (!this.isDisposedOrShuttingDown && !token?.isCancellationRequested && !signal.aborted) {
+          this.markRefreshSuccess();
+        }
+      }, token);
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError') {
-        logger.debug('ADO work items fetch aborted due to cancellation');
+      const isExpectedAbort = err instanceof Error && err.name === 'AbortError' && (this.isExpectedAbortError(err) || token?.isCancellationRequested);
+      if (isExpectedAbort) {
+        logger.debug('ADO work items fetch aborted during refresh');
       } else {
-        this._onDidDiscoverItems.fire([]);
+        this.publishDiscoveredItems([]);
         logger.error('Failed to fetch work items:', err);
       }
     } finally {
-      cancelListener?.dispose();
       this._isRefreshing = false;
     }
   }
 
-  protected async doBackgroundRefresh(): Promise<void> {
+  protected async doBackgroundRefresh(signal?: AbortSignal): Promise<void> {
     try {
       logger.info('Fetching assigned ADO work items...');
       const session = await vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], {
@@ -139,13 +138,16 @@ export class AdoWorkItemProvider extends BaseProvider {
       }).catch(() => null);
 
       if (!session) {
-        this._onDidDiscoverItems.fire([]);
+        this.publishDiscoveredItems([]);
         return;
       }
 
-      await this.fetchAndPublishWorkItems(session.accessToken, false);
+      await this.fetchAndPublishWorkItems(session.accessToken, false, signal);
     } catch (err) {
-      this._onDidDiscoverItems.fire([]);
+      if (err instanceof Error && err.name === 'AbortError' && signal?.aborted) {
+        throw err;
+      }
+      this.publishDiscoveredItems([]);
       logger.error('Failed to fetch work items:', err);
     }
   }
@@ -202,7 +204,7 @@ export class AdoWorkItemProvider extends BaseProvider {
       }
     }
 
-    this._onDidDiscoverItems.fire(allItems);
+    this.publishDiscoveredItems(allItems);
     logger.info(`Discovered ${allItems.length} ADO work items`);
 
     if (failures.length > 0) {

--- a/packages/ado/src/baseAdoPrProvider.ts
+++ b/packages/ado/src/baseAdoPrProvider.ts
@@ -77,58 +77,57 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
   }
 
   async refresh(token?: vscode.CancellationToken, options?: ProviderRefreshOptions): Promise<void> {
-    if (this._isRefreshing) {
+    if (this._isRefreshing || this.isDisposedOrShuttingDown) {
       return;
     }
 
     this._isRefreshing = true;
-    const abortController = new AbortController();
-    const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
     const interactive = options?.interactive ?? true;
     try {
-      logger.info(`Fetching ADO ${this.logLabel}...`);
-      if (token?.isCancellationRequested) {
-        return;
-      }
+      await this.runAbortableRefresh(async (signal) => {
+        logger.info(`Fetching ADO ${this.logLabel}...`);
 
-      let session: vscode.AuthenticationSession | undefined;
-      try {
-        session = await getAdoSession({
-          interactive,
-          signal: abortController.signal,
-        });
-      } catch (err) {
-        if (err instanceof Error && err.name === 'AbortError') {
-          throw err;
+        let session: vscode.AuthenticationSession | undefined;
+        try {
+          session = await getAdoSession({
+            interactive,
+            signal,
+          });
+        } catch (err) {
+          if (err instanceof Error && err.name === 'AbortError') {
+            throw err;
+          }
+          session = undefined;
         }
-        session = undefined;
-      }
 
-      if (token?.isCancellationRequested) {
-        return;
-      }
-      if (!session) {
-        this._onDidDiscoverItems.fire([]);
-        return;
-      }
+        if (token?.isCancellationRequested || signal.aborted) {
+          return;
+        }
+        if (!session) {
+          this.publishDiscoveredItems([]);
+          return;
+        }
 
-      await this.fetchAndPublishPrs(session.accessToken, interactive, session.account.id, abortController.signal);
-      this.markRefreshSuccess();
+        await this.fetchAndPublishPrs(session.accessToken, interactive, session.account.id, signal);
+        if (!this.isDisposedOrShuttingDown && !token?.isCancellationRequested && !signal.aborted) {
+          this.markRefreshSuccess();
+        }
+      }, token);
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError' && abortController.signal.aborted && token?.isCancellationRequested) {
-        logger.debug(`ADO ${this.logLabel} fetch aborted due to cancellation`);
+      const isExpectedAbort = err instanceof Error && err.name === 'AbortError' && (this.isExpectedAbortError(err) || token?.isCancellationRequested);
+      if (isExpectedAbort) {
+        logger.debug(`ADO ${this.logLabel} fetch aborted during refresh`);
       } else {
         logger.error(`Failed to fetch ${this.logLabel}:`, err);
-        this._onDidDiscoverItems.fire([]);
+        this.publishDiscoveredItems([]);
         throw err;
       }
     } finally {
-      cancelListener?.dispose();
       this._isRefreshing = false;
     }
   }
 
-  protected async doBackgroundRefresh(): Promise<void> {
+  protected async doBackgroundRefresh(signal?: AbortSignal): Promise<void> {
     try {
       logger.info(`Fetching ADO ${this.logLabel}...`);
       const session = await vscode.authentication.getSession('microsoft', [ADO_AUTH_SCOPE], {
@@ -136,14 +135,17 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
       }).catch(() => null);
 
       if (!session) {
-        this._onDidDiscoverItems.fire([]);
+        this.publishDiscoveredItems([]);
         return;
       }
 
-      await this.fetchAndPublishPrs(session.accessToken, false, session.account.id);
+      await this.fetchAndPublishPrs(session.accessToken, false, session.account.id, signal);
     } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError' && signal?.aborted) {
+        throw err;
+      }
       logger.error(`Failed to fetch ${this.logLabel}:`, err);
-      this._onDidDiscoverItems.fire([]);
+      this.publishDiscoveredItems([]);
       throw err;
     }
   }
@@ -218,7 +220,7 @@ export abstract class BaseAdoPrProvider extends BaseProvider {
     const dedupedItems = this.dedupeItems(allItems);
     await this.postProcessItems(dedupedItems, accessToken, signal);
 
-    this._onDidDiscoverItems.fire(dedupedItems);
+    this.publishDiscoveredItems(dedupedItems);
     logger.info(`Discovered ${dedupedItems.length} ADO ${this.logLabel}`);
 
     const messages: string[] = [];

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -8,6 +8,8 @@ import { parseAdoProjectsConfig } from './configParser';
 import { validateRefreshInterval, type DevDocketApi } from '@devdocket/shared';
 import { logger, setLogger } from './logger';
 
+type ConfigurableAdoProvider = AdoWorkItemProvider | AdoPrReviewProvider | AdoMyPrsProvider;
+
 const OPEN_SETTINGS = 'Open Settings';
 const ADO_PROJECTS_SETTING = 'devDocketAdo.projects';
 
@@ -40,10 +42,25 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   }
 
   let orgWarningShown = false;
+  let configurableProviders: ConfigurableAdoProvider[] = [];
   let configurableDisposables: vscode.Disposable[] = [];
-  const disposeConfigurableDisposables = () => {
-    const disposablesToDispose = configurableDisposables;
+  const takeCurrentConfigurables = () => {
+    const providers = configurableProviders;
+    const disposables = configurableDisposables;
+    configurableProviders = [];
     configurableDisposables = [];
+    return { providers, disposables };
+  };
+  const disposeConfigurableDisposables = async () => {
+    const { providers: providersToShutdown, disposables: disposablesToDispose } = takeCurrentConfigurables();
+
+    const shutdownResults = await Promise.allSettled(providersToShutdown.map(provider => provider.shutdown()));
+    shutdownResults.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        logger.error(`Failed to shut down ADO provider ${providersToShutdown[index]?.id ?? index}`, result.reason);
+      }
+    });
+
     for (const disposable of disposablesToDispose) {
       disposable.dispose();
     }
@@ -61,8 +78,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     prWatcherRegistered = true;
   }
 
-  const configureProviders = () => {
-    disposeConfigurableDisposables();
+  const configureProviders = async () => {
+    await disposeConfigurableDisposables();
 
     const config = vscode.workspace.getConfiguration('devDocketAdo');
     const projects = config.get<string[]>('projects', []);
@@ -102,20 +119,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const workItemProvider = new AdoWorkItemProvider(orgConfigs);
     const prProvider = new AdoPrReviewProvider(orgConfigs);
     const myPrsProvider = new AdoMyPrsProvider(orgConfigs);
+    const nextProviders: ConfigurableAdoProvider[] = [workItemProvider, prProvider, myPrsProvider];
 
-    workItemProvider.startPeriodicRefresh(intervalSeconds);
-    prProvider.startPeriodicRefresh(intervalSeconds);
-    myPrsProvider.startPeriodicRefresh(intervalSeconds);
+    for (const provider of nextProviders) {
+      provider.startPeriodicRefresh(intervalSeconds);
+    }
 
-    const nextDisposables: vscode.Disposable[] = [
+    configurableProviders = nextProviders;
+    configurableDisposables = [
       api.registerProvider(workItemProvider),
       api.registerProvider(prProvider),
       api.registerProvider(myPrsProvider),
-      workItemProvider,
-      prProvider,
-      myPrsProvider,
+      ...nextProviders,
     ];
-    configurableDisposables = nextDisposables;
 
     const parts = ['3 ADO providers'];
     if (watcherRegistered) { parts.push('1 watcher'); }
@@ -123,9 +139,26 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     logger.info(`Registered ${parts.join(' + ')}`);
   };
 
-  context.subscriptions.push({ dispose: disposeConfigurableDisposables });
+  let configureProvidersPromise = Promise.resolve();
+  const queueConfigureProviders = () => {
+    configureProvidersPromise = configureProvidersPromise
+      .then(() => configureProviders())
+      .catch(error => {
+        logger.error('Failed to configure ADO providers', error);
+      });
+    return configureProvidersPromise;
+  };
 
-  configureProviders();
+  context.subscriptions.push({
+    dispose: () => {
+      const { disposables } = takeCurrentConfigurables();
+      for (const disposable of disposables) {
+        disposable.dispose();
+      }
+    },
+  });
+
+  await queueConfigureProviders();
 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration(e => {
@@ -133,7 +166,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         e.affectsConfiguration('devDocketAdo.projects') ||
         e.affectsConfiguration('devDocketAdo.refreshIntervalSeconds')
       ) {
-        configureProviders();
+        void queueConfigureProviders();
       }
     }),
   );

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -42,6 +42,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   }
 
   let orgWarningShown = false;
+  let isDisposed = false;
   let configurableProviders: ConfigurableAdoProvider[] = [];
   let configurableDisposables: vscode.Disposable[] = [];
   const takeCurrentConfigurables = () => {
@@ -151,6 +152,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   context.subscriptions.push({
     dispose: () => {
+      isDisposed = true;
       const { disposables } = takeCurrentConfigurables();
       for (const disposable of disposables) {
         disposable.dispose();

--- a/packages/ado/src/extension.ts
+++ b/packages/ado/src/extension.ts
@@ -81,6 +81,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   const configureProviders = async () => {
     await disposeConfigurableDisposables();
+    if (isDisposed) {
+      return;
+    }
 
     const config = vscode.workspace.getConfiguration('devDocketAdo');
     const projects = config.get<string[]>('projects', []);
@@ -143,7 +146,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   let configureProvidersPromise = Promise.resolve();
   const queueConfigureProviders = () => {
     configureProvidersPromise = configureProvidersPromise
-      .then(() => configureProviders())
+      .then(() => {
+        if (isDisposed) {
+          return;
+        }
+        return configureProviders();
+      })
       .catch(error => {
         logger.error('Failed to configure ADO providers', error);
       });

--- a/packages/ado/src/test/configEdgeCases.test.ts
+++ b/packages/ado/src/test/configEdgeCases.test.ts
@@ -342,8 +342,7 @@ describe('ADO provider config edge cases', () => {
         listener({ affectsConfiguration: (k: string) => k === 'devDocketAdo.projects' });
       }
 
-      // New providers registered
-      expect(mockRegisterProvider).toHaveBeenCalledTimes(6);
+      await vi.waitFor(() => expect(mockRegisterProvider).toHaveBeenCalledTimes(6));
     });
 
     it('reconfigures providers on refreshInterval change', async () => {
@@ -359,7 +358,7 @@ describe('ADO provider config edge cases', () => {
         });
       }
 
-      expect(mockRegisterProvider).toHaveBeenCalledTimes(6);
+      await vi.waitFor(() => expect(mockRegisterProvider).toHaveBeenCalledTimes(6));
     });
   });
 });

--- a/packages/ado/src/test/extension.test.ts
+++ b/packages/ado/src/test/extension.test.ts
@@ -174,6 +174,7 @@ describe('extension activation', () => {
     const providerDisposeSpies = providers.map((provider: any) => vi.spyOn(provider, 'dispose'));
 
     disposeContextSubscriptions();
+    await new Promise(resolve => setTimeout(resolve, 0));
 
     for (const registration of providerRegistrationDisposables) {
       expect(registration.dispose).toHaveBeenCalledTimes(1);
@@ -185,12 +186,18 @@ describe('extension activation', () => {
     expect(prWatcherDisposable.dispose).toHaveBeenCalledTimes(1);
   });
 
-  it('disposes and replaces configurable providers when ADO configuration changes', async () => {
+  it('waits for provider shutdown before replacing ADO providers on config changes', async () => {
     await activate(mockContext);
 
     const firstRegistrations = [...providerRegistrationDisposables];
     const firstProviders = mockApi.registerProvider.mock.calls.map(([provider]: any[]) => provider);
     const firstProviderDisposeSpies = firstProviders.map((provider: any) => vi.spyOn(provider, 'dispose'));
+
+    let resolveShutdown!: () => void;
+    const shutdownGate = new Promise<void>(resolve => {
+      resolveShutdown = resolve;
+    });
+    const firstShutdownSpy = vi.spyOn(firstProviders[0], 'shutdown').mockReturnValue(shutdownGate);
 
     for (const [listener] of vi.mocked(workspace.onDidChangeConfiguration).mock.calls) {
       listener({
@@ -198,7 +205,13 @@ describe('extension activation', () => {
       });
     }
 
-    expect(mockApi.registerProvider).toHaveBeenCalledTimes(6);
+    await Promise.resolve();
+    expect(firstShutdownSpy).toHaveBeenCalledTimes(1);
+    expect(mockApi.registerProvider).toHaveBeenCalledTimes(3);
+
+    resolveShutdown();
+    await vi.waitFor(() => expect(mockApi.registerProvider).toHaveBeenCalledTimes(6));
+
     for (const registration of firstRegistrations) {
       expect(registration.dispose).toHaveBeenCalledTimes(1);
     }
@@ -207,6 +220,30 @@ describe('extension activation', () => {
     }
     expect(mockApi.registerRunWatcher).toHaveBeenCalledTimes(1);
     expect(mockApi.registerPRWatcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('replaces ADO providers even when shutdown rejects', async () => {
+    await activate(mockContext);
+
+    const firstRegistrations = [...providerRegistrationDisposables];
+    const firstProviders = mockApi.registerProvider.mock.calls.map(([provider]: any[]) => provider);
+    const firstProviderDisposeSpies = firstProviders.map((provider: any) => vi.spyOn(provider, 'dispose'));
+    vi.spyOn(firstProviders[0], 'shutdown').mockRejectedValue(new Error('shutdown failed'));
+
+    for (const [listener] of vi.mocked(workspace.onDidChangeConfiguration).mock.calls) {
+      listener({
+        affectsConfiguration: (key: string) => key === 'devDocketAdo.refreshIntervalSeconds',
+      });
+    }
+
+    await vi.waitFor(() => expect(mockApi.registerProvider).toHaveBeenCalledTimes(6));
+
+    for (const registration of firstRegistrations) {
+      expect(registration.dispose).toHaveBeenCalledTimes(1);
+    }
+    for (const providerDisposeSpy of firstProviderDisposeSpies) {
+      expect(providerDisposeSpy).toHaveBeenCalledTimes(1);
+    }
   });
 
   it('does not register providers when no organization is configured', async () => {

--- a/packages/ado/src/test/extension.test.ts
+++ b/packages/ado/src/test/extension.test.ts
@@ -246,6 +246,30 @@ describe('extension activation', () => {
     }
   });
 
+  it('does not register replacement ADO providers after disposal starts', async () => {
+    await activate(mockContext);
+
+    const firstProviders = mockApi.registerProvider.mock.calls.map(([provider]: any[]) => provider);
+    let resolveShutdown!: () => void;
+    const shutdownGate = new Promise<void>(resolve => {
+      resolveShutdown = resolve;
+    });
+    vi.spyOn(firstProviders[0], 'shutdown').mockReturnValue(shutdownGate);
+
+    for (const [listener] of vi.mocked(workspace.onDidChangeConfiguration).mock.calls) {
+      listener({
+        affectsConfiguration: (key: string) => key === 'devDocketAdo.projects',
+      });
+    }
+
+    await Promise.resolve();
+    disposeContextSubscriptions();
+    resolveShutdown();
+
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(mockApi.registerProvider).toHaveBeenCalledTimes(3);
+  });
+
   it('does not register providers when no organization is configured', async () => {
     vi.mocked(workspace.getConfiguration).mockImplementation((section?: string) => {
       if (section === 'devDocketAdo') {

--- a/packages/github/src/baseGithubProvider.ts
+++ b/packages/github/src/baseGithubProvider.ts
@@ -44,51 +44,51 @@ export abstract class BaseGitHubProvider extends BaseProvider {
   }
 
   async refresh(token?: vscode.CancellationToken, options?: ProviderRefreshOptions): Promise<void> {
-    if (this._isRefreshing) {
+    if (this._isRefreshing || this.isDisposedOrShuttingDown) {
       return;
     }
 
     this._isRefreshing = true;
-    const abortController = new AbortController();
-    const cancelListener = token?.onCancellationRequested?.(() => abortController.abort());
     const interactive = options?.interactive ?? true;
     try {
-      if (token?.isCancellationRequested) {
-        return;
-      }
-
-      let session: vscode.AuthenticationSession | undefined;
-      try {
-        session = await getGitHubSession(this.getAuthenticationScopes(), {
-          interactive,
-          signal: abortController.signal,
-        });
-      } catch (err) {
-        if (err instanceof Error && err.name === 'AbortError') {
-          throw err;
+      await this.runAbortableRefresh(async (signal) => {
+        let session: vscode.AuthenticationSession | undefined;
+        try {
+          session = await getGitHubSession(this.getAuthenticationScopes(), {
+            interactive,
+            signal,
+          });
+        } catch (err) {
+          if (err instanceof Error && err.name === 'AbortError') {
+            throw err;
+          }
+          const message = err instanceof Error ? err.message : String(err);
+          logger.error('GitHub authentication failed', err);
+          this.showGitHubAuthenticationWarning(`DevDocket GitHub: Authentication failed — ${message}`);
+          return;
         }
-        const message = err instanceof Error ? err.message : String(err);
-        logger.error('GitHub authentication failed', err);
-        this.showGitHubAuthenticationWarning(`DevDocket GitHub: Authentication failed — ${message}`);
-        return;
-      }
 
-      if (!session || token?.isCancellationRequested) {
+        if (token?.isCancellationRequested || signal.aborted) {
+          return;
+        }
         if (!session) {
           if (interactive) {
             logger.info('User cancelled GitHub authentication');
           } else {
             logger.debug('No cached GitHub session available for non-interactive refresh');
           }
+          return;
         }
-        return;
-      }
 
-      await this.fetchAndPublish(session.accessToken, interactive, abortController.signal);
-      this.markRefreshSuccess();
+        await this.fetchAndPublish(session.accessToken, interactive, signal);
+        if (!this.isDisposedOrShuttingDown && !token?.isCancellationRequested && !signal.aborted) {
+          this.markRefreshSuccess();
+        }
+      }, token);
     } catch (err) {
-      if (err instanceof Error && err.name === 'AbortError' && abortController.signal.aborted && token?.isCancellationRequested) {
-        logger.debug(`${this.label} fetch aborted due to cancellation`);
+      const isExpectedAbort = err instanceof Error && err.name === 'AbortError' && (this.isExpectedAbortError(err) || token?.isCancellationRequested);
+      if (isExpectedAbort) {
+        logger.debug(`${this.label} fetch aborted during refresh`);
       } else {
         if (err instanceof GitHubSsoError) {
           this.showGitHubSsoNotification(err, () => this.refresh(undefined, { interactive: true }), !interactive);
@@ -96,12 +96,11 @@ export abstract class BaseGitHubProvider extends BaseProvider {
         logger.error(`Failed to fetch ${this.label}`, err);
       }
     } finally {
-      cancelListener?.dispose();
       this._isRefreshing = false;
     }
   }
 
-  protected async doBackgroundRefresh(): Promise<void> {
+  protected async doBackgroundRefresh(signal?: AbortSignal): Promise<void> {
     let session: vscode.AuthenticationSession | undefined;
     try {
       session = await vscode.authentication.getSession('github', this.getAuthenticationScopes(), {
@@ -118,8 +117,11 @@ export abstract class BaseGitHubProvider extends BaseProvider {
     }
 
     try {
-      await this.fetchAndPublish(session.accessToken, false);
+      await this.fetchAndPublish(session.accessToken, false, signal);
     } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError' && signal?.aborted) {
+        throw err;
+      }
       if (err instanceof GitHubSsoError) {
         this.showGitHubSsoNotification(err, () => this.refreshInBackground(), true);
       }
@@ -199,7 +201,7 @@ export abstract class BaseGitHubProvider extends BaseProvider {
    * Publish GitHub items after applying repository filters at the provider boundary.
    */
   protected publishProviderItems(items: ProviderItem[], patterns: RepoPattern[] = this.getConfiguredPatterns()): void {
-    this._onDidDiscoverItems.fire(this.applyConfiguredRepoFilter(items, patterns));
+    this.publishDiscoveredItems(this.applyConfiguredRepoFilter(items, patterns));
   }
 
   /**

--- a/packages/github/src/extension.ts
+++ b/packages/github/src/extension.ts
@@ -9,6 +9,8 @@ import { GitHubMentionsProvider } from './githubMentionsProvider';
 import { validateRefreshInterval, type DevDocketApi } from '@devdocket/shared';
 import { logger, setLogger } from './logger';
 
+type ConfigurableGitHubProvider = GitHubIssueProvider | GitHubPrReviewProvider | GitHubMyPrsProvider | GitHubMentionsProvider;
+
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   const log = vscode.window.createOutputChannel('DevDocket GitHub', { log: true });
   context.subscriptions.push(log);
@@ -30,37 +32,55 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     return;
   }
 
-  // Register the GitHub issue provider
   const issueProvider = new GitHubIssueProvider();
-
-  // Register the GitHub PR review provider
   const prReviewProvider = new GitHubPrReviewProvider();
-
-  // Register the My PRs provider (authored PRs with status tracking)
   const myPrsProvider = new GitHubMyPrsProvider();
-
-  // Register the GitHub Mentions provider (@mentioned issues and PRs)
   const mentionsProvider = new GitHubMentionsProvider(context);
-
-  const providers = [issueProvider, prReviewProvider, myPrsProvider, mentionsProvider];
-  const configureProviders = () => {
-    const config = vscode.workspace.getConfiguration('devDocketGithub');
-    const intervalSeconds = validateRefreshInterval(
-      config.get<number>('refreshIntervalSeconds', 300), logger,
-    );
-    for (const provider of providers) {
-      provider.startPeriodicRefresh(intervalSeconds);
-    }
-  };
-
-  configureProviders();
-
-  context.subscriptions.push(
+  const configurableProviders: ConfigurableGitHubProvider[] = [issueProvider, prReviewProvider, myPrsProvider, mentionsProvider];
+  const configurableDisposables: vscode.Disposable[] = [
     api.registerProvider(issueProvider), issueProvider,
     api.registerProvider(prReviewProvider), prReviewProvider,
     api.registerProvider(myPrsProvider), myPrsProvider,
     api.registerProvider(mentionsProvider), mentionsProvider,
-  );
+  ];
+
+  const disposeConfigurableDisposables = () => {
+    for (const disposable of configurableDisposables) {
+      disposable.dispose();
+    }
+  };
+
+  const applyRefreshInterval = async () => {
+    const config = vscode.workspace.getConfiguration('devDocketGithub');
+    const intervalSeconds = validateRefreshInterval(
+      config.get<number>('refreshIntervalSeconds', 300), logger,
+    );
+
+    const abortResults = await Promise.allSettled(configurableProviders.map(provider => provider.abortInFlight()));
+    abortResults.forEach((result, index) => {
+      if (result.status === 'rejected') {
+        logger.error(`Failed to abort in-flight refresh for GitHub provider ${configurableProviders[index]?.id ?? index}`, result.reason);
+      }
+    });
+
+    for (const provider of configurableProviders) {
+      provider.startPeriodicRefresh(intervalSeconds);
+    }
+  };
+
+  let configureProvidersPromise = Promise.resolve();
+  const queueRefreshIntervalUpdate = () => {
+    configureProvidersPromise = configureProvidersPromise
+      .then(() => applyRefreshInterval())
+      .catch(error => {
+        logger.error('Failed to update GitHub provider refresh interval', error);
+      });
+    return configureProvidersPromise;
+  };
+
+  context.subscriptions.push({ dispose: disposeConfigurableDisposables });
+
+  await queueRefreshIntervalUpdate();
 
   let watcherCount = 0;
   if (typeof api.registerRunWatcher === 'function') {
@@ -80,7 +100,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration(e => {
       if (e.affectsConfiguration('devDocketGithub.refreshIntervalSeconds')) {
-        configureProviders();
+        void queueRefreshIntervalUpdate();
       }
     }),
   );

--- a/packages/github/src/test/extension.test.ts
+++ b/packages/github/src/test/extension.test.ts
@@ -125,7 +125,7 @@ describe('GitHub extension activation', () => {
     expect(mockApi.registerProvider).not.toHaveBeenCalled();
   });
 
-  it('pushes provider, registration, and watcher disposables onto subscriptions', async () => {
+  it('pushes watcher registrations and configurable lifecycle owner onto subscriptions', async () => {
     await activate(mockContext);
 
     const providerIds = mockApi.registerProvider.mock.calls.map(([provider]: any[]) => provider.id);
@@ -140,39 +140,76 @@ describe('GitHub extension activation', () => {
     expect(runWatcherIds).toEqual(['github-actions', 'github-advanced-security']);
     expect(mockApi.registerPRWatcher).toHaveBeenCalledTimes(1);
 
-    const subscribedProviderIds = disposables
-      .filter(disposable => providerIds.includes(disposable?.id))
-      .map(disposable => disposable.id);
-    expect(subscribedProviderIds).toEqual(providerIds);
-    for (const registration of providerRegistrationDisposables) {
-      expect(disposables).toContain(registration);
-    }
     for (const registration of runWatcherDisposables) {
       expect(disposables).toContain(registration);
     }
     expect(disposables).toContain(prWatcherDisposable);
     expect(disposables).toContain(configChangeDisposable);
-    expect(disposables).toHaveLength(13);
+    expect(disposables).toHaveLength(6);
+
+    const lifecycleOwner = disposables.find(disposable =>
+      disposable !== prWatcherDisposable &&
+      disposable !== configChangeDisposable &&
+      !runWatcherDisposables.includes(disposable) &&
+      disposable?.dispose &&
+      !('appendLine' in disposable),
+    );
+    expect(lifecycleOwner).toBeDefined();
   });
 
-  it('updates provider refresh intervals when GitHub refresh interval config changes', async () => {
+  it('waits for in-flight refresh aborts before updating GitHub refresh intervals', async () => {
     refreshIntervalSeconds = 120;
     await activate(mockContext);
 
     const providers = mockApi.registerProvider.mock.calls.map(([provider]: any[]) => provider);
-    const startPeriodicRefreshSpies = providers.map((provider: any) =>
-      vi.spyOn(provider, 'startPeriodicRefresh'),
-    );
+    const startPeriodicRefreshSpies = providers.map((provider: any) => vi.spyOn(provider, 'startPeriodicRefresh'));
     expect(configChangeListener).toBeDefined();
+
+    let resolveAbort!: () => void;
+    const abortGate = new Promise<void>(resolve => {
+      resolveAbort = resolve;
+    });
+    const firstAbortSpy = vi.spyOn(providers[0], 'abortInFlight').mockReturnValue(abortGate);
 
     refreshIntervalSeconds = 240;
     configChangeListener?.({
       affectsConfiguration: (section: string) => section === 'devDocketGithub.refreshIntervalSeconds',
     });
 
+    await Promise.resolve();
+    expect(firstAbortSpy).toHaveBeenCalledTimes(1);
     for (const spy of startPeriodicRefreshSpies) {
-      expect(spy).toHaveBeenCalledWith(240);
+      expect(spy).not.toHaveBeenCalledWith(240);
     }
+    expect(mockApi.registerProvider).toHaveBeenCalledTimes(4);
+
+    resolveAbort();
+    await vi.waitFor(() => {
+      for (const spy of startPeriodicRefreshSpies) {
+        expect(spy).toHaveBeenCalledWith(240);
+      }
+    });
+    expect(mockApi.registerProvider).toHaveBeenCalledTimes(4);
+  });
+
+  it('updates GitHub refresh intervals even when aborting in-flight refreshes rejects', async () => {
+    refreshIntervalSeconds = 120;
+    await activate(mockContext);
+
+    const providers = mockApi.registerProvider.mock.calls.map(([provider]: any[]) => provider);
+    const startPeriodicRefreshSpies = providers.map((provider: any) => vi.spyOn(provider, 'startPeriodicRefresh'));
+    vi.spyOn(providers[0], 'abortInFlight').mockRejectedValue(new Error('abort failed'));
+
+    refreshIntervalSeconds = 240;
+    configChangeListener?.({
+      affectsConfiguration: (section: string) => section === 'devDocketGithub.refreshIntervalSeconds',
+    });
+
+    await vi.waitFor(() => {
+      for (const spy of startPeriodicRefreshSpies) {
+        expect(spy).toHaveBeenCalledWith(240);
+      }
+    });
     expect(mockApi.registerProvider).toHaveBeenCalledTimes(4);
   });
 

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -1,5 +1,8 @@
 import type { ProviderRefreshOptions } from './apiTypes';
 import type { CancellationTokenLike } from './runWatcher';
+import { createAbortError } from './signalUtils';
+
+const expectedAbortErrors = new WeakSet<object>();
 
 // Minimal re-declarations to avoid depending on the vscode module
 
@@ -218,6 +221,10 @@ export interface EventEmitterLike<T> {
   dispose(): void;
 }
 
+type CancellationTokenWithEvents = CancellationTokenLike & {
+  readonly onCancellationRequested?: (listener: () => void) => Disposable;
+};
+
 /**
  * Base class for DevDocket providers that need periodic refresh.
  * Owns the EventEmitter lifecycle, refresh timer, concurrency guard, and dispose logic.
@@ -237,6 +244,11 @@ export abstract class BaseProvider {
   private _lastRefreshAttemptTime = 0;
   protected _isRefreshing = false;
   private _disposed = false;
+  private _shuttingDown = false;
+  private _shutdownPromise: Promise<void> | undefined;
+  private _activeRefreshAbortController: AbortController | undefined;
+  private _activeRefreshPromise: Promise<unknown> | undefined;
+  private _abortRequested = false;
 
   private _windowState: WindowStateProvider | undefined;
   private _windowStateSub: Disposable | undefined;
@@ -278,7 +290,7 @@ export abstract class BaseProvider {
   }
 
   private scheduleNextPeriodicRefresh(): void {
-    if (this._disposed) {
+    if (this._disposed || this._shuttingDown) {
       return;
     }
     const requiredIntervalMs = this.getRequiredRefreshIntervalMs();
@@ -293,7 +305,7 @@ export abstract class BaseProvider {
     const delayMs = (intervalsElapsed * requiredIntervalMs) - elapsedMs;
     this.refreshTimer = setTimeout(() => {
       this.refreshTimer = undefined;
-      if (this._disposed) {
+      if (this._disposed || this._shuttingDown) {
         return;
       }
       if (this._isRefreshing) {
@@ -306,7 +318,7 @@ export abstract class BaseProvider {
 
   private refreshOnFocusIfStale(): void {
     const focusedIntervalMs = this.periodicRefreshIntervalMs;
-    if (this._disposed || !focusedIntervalMs || this._isRefreshing || !this._windowState?.isFocused) {
+    if (this._disposed || this._shuttingDown || !focusedIntervalMs || this._isRefreshing || !this._windowState?.isFocused) {
       return;
     }
     if (Date.now() - this._lastRefreshTime <= focusedIntervalMs) {
@@ -326,7 +338,7 @@ export abstract class BaseProvider {
    * when the focused polling interval has already elapsed.
    */
   setWindowState(provider: WindowStateProvider): void {
-    if (this._disposed) {
+    if (this._disposed || this._shuttingDown) {
       return;
     }
     this._windowStateSub?.dispose();
@@ -340,8 +352,67 @@ export abstract class BaseProvider {
     this.scheduleNextPeriodicRefresh();
   }
 
+  protected async runAbortableRefresh<T>(
+    work: (signal: AbortSignal) => Promise<T>,
+    token?: CancellationTokenWithEvents,
+  ): Promise<T> {
+    const abortController = new AbortController();
+    const abort = () => {
+      if (!abortController.signal.aborted) {
+        abortController.abort(createAbortError());
+      }
+    };
+
+    if (this._disposed || this._shuttingDown || token?.isCancellationRequested) {
+      abort();
+    }
+
+    const tokenSubscription = token?.onCancellationRequested?.(abort);
+    const refreshPromise = Promise.resolve().then(() => work(abortController.signal));
+    this._activeRefreshAbortController = abortController;
+    this._activeRefreshPromise = refreshPromise;
+
+    try {
+      return await refreshPromise;
+    } catch (error) {
+      const isExpectedAbort = error instanceof Error && error.name === 'AbortError' && this.isAbortExpected;
+      if (isExpectedAbort) {
+        expectedAbortErrors.add(error);
+      }
+      throw error;
+    } finally {
+      tokenSubscription?.dispose();
+      if (this._activeRefreshAbortController === abortController) {
+        this._activeRefreshAbortController = undefined;
+      }
+      if (this._activeRefreshPromise === refreshPromise) {
+        this._activeRefreshPromise = undefined;
+        this._abortRequested = false;
+      }
+    }
+  }
+
+  protected publishDiscoveredItems(items: ProviderItem[]): void {
+    if (this._disposed || this._shuttingDown) {
+      return;
+    }
+    this._onDidDiscoverItems.fire(items);
+  }
+
+  protected get isDisposedOrShuttingDown(): boolean {
+    return this._disposed || this._shuttingDown;
+  }
+
+  protected get isAbortExpected(): boolean {
+    return this.isDisposedOrShuttingDown || this._abortRequested;
+  }
+
+  protected isExpectedAbortError(error: unknown): boolean {
+    return typeof error === 'object' && error !== null && expectedAbortErrors.has(error);
+  }
+
   startPeriodicRefresh(intervalSeconds: number): void {
-    if (this._disposed) {
+    if (this._disposed || this._shuttingDown) {
       return;
     }
     this.stopPeriodicRefresh();
@@ -365,22 +436,62 @@ export abstract class BaseProvider {
     this.periodicRefreshIntervalMs = undefined;
   }
 
+  /** Aborts the active refresh, if any, and waits for it to settle without entering shutdown. */
+  async abortInFlight(): Promise<void> {
+    const refreshPromise = this._activeRefreshPromise;
+    if (this._activeRefreshAbortController && !this._activeRefreshAbortController.signal.aborted) {
+      this._abortRequested = true;
+      this._activeRefreshAbortController.abort(createAbortError());
+    }
+    if (!refreshPromise) {
+      return;
+    }
+    try {
+      await refreshPromise;
+    } catch {
+      // Shutdown should not fail because an in-flight refresh was aborted or already failing.
+    }
+  }
+
+  /** Stops periodic refresh, aborts any in-flight work, and resolves once shutdown is complete. */
+  async shutdown(): Promise<void> {
+    if (this._shutdownPromise) {
+      return this._shutdownPromise;
+    }
+
+    this._shuttingDown = true;
+    this._shutdownPromise = (async () => {
+      this.stopPeriodicRefresh();
+      this._windowStateSub?.dispose();
+      this._windowStateSub = undefined;
+      await this.abortInFlight();
+    })();
+    return this._shutdownPromise;
+  }
+
   /** Runs a background refresh with a concurrency guard to prevent overlapping calls. */
   async refreshInBackground(): Promise<void> {
-    if (this._isRefreshing || this._disposed) {
+    if (this._isRefreshing || this._disposed || this._shuttingDown) {
       return;
     }
     this._isRefreshing = true;
     try {
-      await this.doBackgroundRefresh();
-      this.markRefreshSuccess();
+      await this.runAbortableRefresh(signal => this.doBackgroundRefresh(signal));
+      if (!this.isAbortExpected) {
+        this.markRefreshSuccess();
+      }
+    } catch (error) {
+      const isExpectedAbort = error instanceof Error && error.name === 'AbortError' && this.isExpectedAbortError(error);
+      if (!isExpectedAbort) {
+        throw error;
+      }
     } finally {
       this._isRefreshing = false;
     }
   }
 
   /** Override to provide the background refresh implementation. */
-  protected abstract doBackgroundRefresh(): Promise<void>;
+  protected abstract doBackgroundRefresh(signal?: AbortSignal): Promise<void>;
 
   abstract refresh(token?: CancellationTokenLike, options?: ProviderRefreshOptions): Promise<void>;
 
@@ -389,8 +500,7 @@ export abstract class BaseProvider {
       return;
     }
     this._disposed = true;
-    this.stopPeriodicRefresh();
-    this._windowStateSub?.dispose();
     this._onDidDiscoverItems.dispose();
+    void this.shutdown().catch(() => {});
   }
 }

--- a/packages/shared/src/test/baseProvider.test.ts
+++ b/packages/shared/src/test/baseProvider.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { BaseProvider, ProviderItem, EventEmitterLike, WindowStateProvider, Disposable } from '../baseProvider';
+import { createAbortError } from '../signalUtils';
 
 
 /** Minimal EventEmitter stub for testing. */
@@ -46,6 +47,7 @@ class TestProvider extends BaseProvider {
   refreshCalls = 0;
   backgroundRefreshCalls = 0;
   refreshError: Error | undefined;
+  abortOnSignal = false;
   /** Set to a deferred promise to simulate an in-flight refresh. */
   refreshGate: { promise: Promise<void>; resolve: () => void } | undefined;
 
@@ -58,18 +60,27 @@ class TestProvider extends BaseProvider {
     if (this.refreshError) {
       throw this.refreshError;
     }
-    this._onDidDiscoverItems.fire([{ externalId: 'item-1', title: 'Item 1' }]);
+    this.publishDiscoveredItems([{ externalId: 'item-1', title: 'Item 1' }]);
   }
 
-  protected async doBackgroundRefresh(): Promise<void> {
+  protected async doBackgroundRefresh(signal?: AbortSignal): Promise<void> {
     this.backgroundRefreshCalls++;
     if (this.refreshGate) {
-      await this.refreshGate.promise;
+      if (this.abortOnSignal && signal) {
+        await Promise.race([
+          this.refreshGate.promise,
+          new Promise<never>((_, reject) => {
+            signal.addEventListener('abort', () => reject(createAbortError()), { once: true });
+          }),
+        ]);
+      } else {
+        await this.refreshGate.promise;
+      }
     }
     if (this.refreshError) {
       throw this.refreshError;
     }
-    this._onDidDiscoverItems.fire([{ externalId: 'bg-1', title: 'BG Item' }]);
+    this.publishDiscoveredItems([{ externalId: 'bg-1', title: 'BG Item' }]);
   }
 }
 
@@ -282,6 +293,56 @@ describe('BaseProvider', () => {
       expect(provider.backgroundRefreshCalls).toBe(0);
     });
 
+    it('waits for in-flight refreshes to finish before shutdown resolves', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      let resolveGate!: () => void;
+      provider.refreshGate = {
+        promise: new Promise<void>(resolve => { resolveGate = resolve; }),
+        resolve: () => resolveGate(),
+      };
+
+      const refreshPromise = provider.refreshInBackground();
+      await Promise.resolve();
+      const shutdownPromise = provider.shutdown();
+
+      let shutdownResolved = false;
+      void shutdownPromise.then(() => {
+        shutdownResolved = true;
+      });
+      await Promise.resolve();
+      expect(shutdownResolved).toBe(false);
+
+      resolveGate();
+      await refreshPromise;
+      await shutdownPromise;
+      expect(shutdownResolved).toBe(true);
+
+      provider.dispose();
+    });
+
+    it('suppresses discovery events after shutdown begins', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      const listener = vi.fn();
+      provider.onDidDiscoverItems(listener);
+
+      let resolveGate!: () => void;
+      provider.refreshGate = {
+        promise: new Promise<void>(resolve => { resolveGate = resolve; }),
+        resolve: () => resolveGate(),
+      };
+
+      const refreshPromise = provider.refreshInBackground();
+      await Promise.resolve();
+      const shutdownPromise = provider.shutdown();
+      resolveGate();
+
+      await refreshPromise;
+      await shutdownPromise;
+
+      expect(listener).not.toHaveBeenCalled();
+      provider.dispose();
+    });
+
     it('does not subscribe to window state after dispose', () => {
       const provider = new TestProvider(createMockEmitter());
       const windowState = createMockWindowState();
@@ -337,6 +398,27 @@ describe('BaseProvider', () => {
       await provider.refreshInBackground();
       expect(provider.backgroundRefreshCalls).toBe(2);
 
+      provider.dispose();
+    });
+
+    it('does not route expected aborts through the background error handler', async () => {
+      const provider = new TestProvider(createMockEmitter());
+      provider.abortOnSignal = true;
+      const errors: unknown[] = [];
+      provider.setErrorHandler((err) => errors.push(err));
+
+      let resolveGate!: () => void;
+      provider.refreshGate = {
+        promise: new Promise<void>(resolve => { resolveGate = resolve; }),
+        resolve: () => resolveGate(),
+      };
+
+      const refreshPromise = provider.refreshInBackground();
+      await Promise.resolve();
+      await provider.abortInFlight();
+      await refreshPromise;
+
+      expect(errors).toHaveLength(0);
       provider.dispose();
     });
   });


### PR DESCRIPTION
## Summary
- add abortable shutdown and in-flight refresh tracking to `BaseProvider`
- await ADO provider shutdown before rebuilding on config changes and abort GitHub in-flight refreshes before interval updates
- add regression coverage for stale event suppression, serialized reconfiguration, and shutdown/abort failure handling

## Testing
- `npm run build`
- `npm run test`

Closes #666
