### PR TITLE
Potential fix for code scanning alert no. 3: Double escaping or unescaping

### DIFF
--- a/packages/ado/src/adoWorkItemProvider.ts
+++ b/packages/ado/src/adoWorkItemProvider.ts
@@ -763,12 +763,12 @@ export class AdoWorkItemProvider extends BaseProvider {
       .replace(/<br\s*\/?>/gi, '\n')
       .replace(/<\/p>/gi, '\n')
       .replace(/<[^>]+>/g, '')
-      .replace(/&amp;/g, '&')
       .replace(/&lt;/g, '<')
       .replace(/&gt;/g, '>')
       .replace(/&quot;/g, '"')
       .replace(/&#39;/g, "'")
       .replace(/&nbsp;/g, ' ')
+      .replace(/&amp;/g, '&')
       .replace(/\n{3,}/g, '\n\n')
       .trim();
   }


### PR DESCRIPTION
Potential fix for [https://github.com/devdocket/devdocket/security/code-scanning/3](https://github.com/devdocket/devdocket/security/code-scanning/3)

To fix this without changing intended functionality, keep the same manual decode approach but reorder replacements in `stripHtml` so `&amp;` is unescaped **after** all other named/numeric entities handled by this function.

In `packages/ado/src/adoWorkItemProvider.ts`, within `private stripHtml(html: string): string`, move:
```ts
.replace(/&amp;/g, '&')
```
to after the other entity replacements (`&lt;`, `&gt;`, `&quot;`, `&#39;`, `&nbsp;`). No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
