### PR TITLE
Document polling backoff API for extension authors

### DIFF
--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -17,7 +17,7 @@ Your extension must declare a dependency on DevDocket so that VS Code activates 
 
 ### Installing `@devdocket/shared`
 
-The `@devdocket/shared` package provides the TypeScript types and base classes (`ProviderItem`, `BaseProvider`, `Event`, `Disposable`, etc.) needed to build providers and actions with full type safety.
+The `@devdocket/shared` package provides the TypeScript types, base classes, and polling helpers (`ProviderItem`, `BaseProvider`, `Event`, `Disposable`, `BackoffPolicy`, `parseRetryAfterHeader`, `parseRateLimitResetHeader`, `PollingBackoffError`, `isPollingBackoffError`, etc.) needed to build providers and actions with full type safety.
 
 The package is published to the GitHub Packages npm registry. Add a `.npmrc` file to your project to configure the `@devdocket` scope:
 
@@ -36,10 +36,15 @@ npm install @devdocket/shared
 You can then import types directly instead of redefining them:
 
 ```ts
-import { BaseProvider, type ProviderItem } from '@devdocket/shared';
+import {
+  BaseProvider,
+  PollingBackoffError,
+  parseRetryAfterHeader,
+  type ProviderItem,
+} from '@devdocket/shared';
 ```
 
-`ProviderItem` is the provider item type emitted by providers.
+`ProviderItem` is the provider item type emitted by providers. The same package also exports the polling backoff primitives providers can use to react to `Retry-After` and rate-limit headers without reimplementing their own cooldown logic. `parseRetryAfterHeader()` returns a delay in milliseconds; `parseRateLimitResetHeader()` returns an absolute reset timestamp in milliseconds that providers should convert to a delay before passing it as `retryAfterMs`.
 
 ### Acquiring the API
 
@@ -148,7 +153,10 @@ interface DevDocketProvider {
   /**
    * Called by DevDocket during initial registration/activation (for initial
    * discovery) and whenever the user requests a manual refresh. Must be safe
-   * to call multiple times and during extension activation.
+   * to call multiple times and during extension activation. Providers that
+   * extend `BaseProvider` can throw `PollingBackoffError` from their
+   * non-interactive/background refresh path to tell DevDocket's periodic
+   * polling schedule to wait longer before the next automatic refresh.
    */
   refresh(token?: vscode.CancellationToken): Promise<void>;
 

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -17,7 +17,7 @@ Your extension must declare a dependency on DevDocket so that VS Code activates 
 
 ### Installing `@devdocket/shared`
 
-The `@devdocket/shared` package provides the TypeScript types, base classes, and polling helpers (`ProviderItem`, `BaseProvider`, `Event`, `Disposable`, `BackoffPolicy`, `parseRetryAfterHeader`, `parseRateLimitResetHeader`, `PollingBackoffError`, `isPollingBackoffError`, etc.) needed to build providers and actions with full type safety.
+The `@devdocket/shared` package provides the TypeScript types, shared models, and base classes (`ProviderItem`, `BaseProvider`, `Event`, `Disposable`, etc.) needed to build providers and actions with full type safety.
 
 The package is published to the GitHub Packages npm registry. Add a `.npmrc` file to your project to configure the `@devdocket` scope:
 
@@ -36,15 +36,10 @@ npm install @devdocket/shared
 You can then import types directly instead of redefining them:
 
 ```ts
-import {
-  BaseProvider,
-  PollingBackoffError,
-  parseRetryAfterHeader,
-  type ProviderItem,
-} from '@devdocket/shared';
+import { BaseProvider, type ProviderItem } from '@devdocket/shared';
 ```
 
-`ProviderItem` is the provider item type emitted by providers. The same package also exports the polling backoff primitives providers can use to react to `Retry-After` and rate-limit headers without reimplementing their own cooldown logic. `parseRetryAfterHeader()` returns a delay in milliseconds; `parseRateLimitResetHeader()` returns an absolute reset timestamp in milliseconds that providers should convert to a delay before passing it as `retryAfterMs`.
+`ProviderItem` is the provider item type emitted by providers. If your provider later needs optional throttling support, see [Handling rate limits and throttling](#handling-rate-limits-and-throttling) below.
 
 ### Acquiring the API
 
@@ -153,10 +148,9 @@ interface DevDocketProvider {
   /**
    * Called by DevDocket during initial registration/activation (for initial
    * discovery) and whenever the user requests a manual refresh. Must be safe
-   * to call multiple times and during extension activation. Providers that
-   * also extend `BaseProvider` can separately throw `PollingBackoffError`
-   * from `doBackgroundRefresh()` to delay the periodic schedule started by
-   * `startPeriodicRefresh()`.
+   * to call multiple times and during extension activation. See "Handling
+   * rate limits and throttling" below for the optional `BaseProvider`
+   * backoff flow used by periodic background refresh.
    */
   refresh(token?: vscode.CancellationToken): Promise<void>;
 
@@ -384,6 +378,17 @@ const provider = new MyProvider();
 const disposable = api.registerProvider(provider);
 context.subscriptions.push(disposable);
 ```
+
+### Handling rate limits and throttling
+
+This support is optional. If your provider extends `BaseProvider` and uses `startPeriodicRefresh()`, it can opt into the shared backoff flow for 429/503-style responses instead of implementing its own cooldown scheduler.
+
+- Throw `PollingBackoffError` from `doBackgroundRefresh()` when the upstream service asks callers to wait.
+- Use `parseRetryAfterHeader()` when the service sends `Retry-After`.
+- Use `parseRateLimitResetHeader()` when the service sends a reset timestamp, then convert that timestamp to a delay before assigning it to `retryAfterMs`.
+- `BaseProvider` automatically delays the next scheduled periodic refresh and returns to the normal interval after a successful background refresh.
+
+For a concrete provider example, see [Handling rate limits and throttling](./provider-api.md#handling-rate-limits-and-throttling) in the provider guide.
 
 ## Actions
 

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -154,10 +154,9 @@ interface DevDocketProvider {
    * Called by DevDocket during initial registration/activation (for initial
    * discovery) and whenever the user requests a manual refresh. Must be safe
    * to call multiple times and during extension activation. Providers that
-   * extend `BaseProvider` can throw `PollingBackoffError` from their
-   * non-interactive/background refresh path so the provider-owned periodic
-   * schedule created by `startPeriodicRefresh()` waits longer before the next
-   * automatic refresh.
+   * also extend `BaseProvider` can separately throw `PollingBackoffError`
+   * from `doBackgroundRefresh()` to delay the periodic schedule started by
+   * `startPeriodicRefresh()`.
    */
   refresh(token?: vscode.CancellationToken): Promise<void>;
 

--- a/docs/extension-api.md
+++ b/docs/extension-api.md
@@ -155,8 +155,9 @@ interface DevDocketProvider {
    * discovery) and whenever the user requests a manual refresh. Must be safe
    * to call multiple times and during extension activation. Providers that
    * extend `BaseProvider` can throw `PollingBackoffError` from their
-   * non-interactive/background refresh path to tell DevDocket's periodic
-   * polling schedule to wait longer before the next automatic refresh.
+   * non-interactive/background refresh path so the provider-owned periodic
+   * schedule created by `startPeriodicRefresh()` waits longer before the next
+   * automatic refresh.
    */
   refresh(token?: vscode.CancellationToken): Promise<void>;
 

--- a/docs/provider-api.md
+++ b/docs/provider-api.md
@@ -95,13 +95,18 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 ### 3. Install `@devdocket/shared` (recommended) or re-declare types
 
-The `@devdocket/shared` package provides the TypeScript types and the `BaseProvider` base class needed to build providers and actions with full type safety. It is published to the GitHub Packages npm registry — see [the Extension API guide](./extension-api.md#installing-devdocketshared) for the `.npmrc` setup and authentication notes.
+The `@devdocket/shared` package provides the TypeScript types, the `BaseProvider` base class, and polling backoff helpers needed to build providers and actions with full type safety. It is published to the GitHub Packages npm registry — see [the Extension API guide](./extension-api.md#installing-devdocketshared) for the `.npmrc` setup and authentication notes.
 
 ```ts
-import { BaseProvider, type ProviderItem } from '@devdocket/shared';
+import {
+  BaseProvider,
+  PollingBackoffError,
+  parseRetryAfterHeader,
+  type ProviderItem,
+} from '@devdocket/shared';
 ```
 
-`ProviderItem` is the name for items emitted by providers. Provider code should import and emit `ProviderItem`.
+`ProviderItem` is the name for items emitted by providers. Provider code should import and emit `ProviderItem`. Providers that poll rate-limited APIs can also import `PollingBackoffError` and the header-parsing helpers so periodic background refreshes automatically slow down when the upstream service asks them to.
 
 If you would rather avoid the GitHub Packages dependency, you can re-declare the small subset of interfaces your extension needs. Copy the following declarations into your provider code:
 
@@ -363,7 +368,7 @@ class JiraProvider implements DevDocketProvider {
 
 ### Periodic Refresh Pattern
 
-For providers that poll an external API, set up a `setInterval` timer. Clamp the interval to a reasonable minimum (e.g., 60 seconds) and guard against overlapping refreshes.
+For providers that extend `BaseProvider`, call `startPeriodicRefresh()` with a validated interval instead of building your own timer loop. `BaseProvider` clamps the configured interval to a reasonable minimum (60 seconds), skips overlapping refreshes, and layers automatic backoff on top of the normal schedule when `doBackgroundRefresh()` throws a `PollingBackoffError`.
 
 The `@devdocket/shared` package provides a `validateRefreshInterval(value, logger?)` helper that validates and clamps user-configured intervals. It handles non-numeric values, enforces a 60-second minimum, and returns 0 (disabled) for zero/negative input:
 
@@ -376,6 +381,8 @@ const intervalSeconds = validateRefreshInterval(
 );
 provider.startPeriodicRefresh(intervalSeconds);
 ```
+
+After a successful background refresh, the provider returns to its normal interval. If a background refresh throws `PollingBackoffError`, `BaseProvider` delays the next scheduled refresh until both the normal interval and the requested backoff window have elapsed.
 
 Typical refresh guard pattern:
 
@@ -563,6 +570,48 @@ Good patterns: `owner/repo#123`, `PROJECT-42`, `ticket/12345`
 - Cache API responses where appropriate
 - Guard against overlapping refreshes with a boolean flag
 - Clamp periodic intervals to a reasonable minimum (≥ 60 seconds)
+
+### Rate limiting & backoff
+
+If your provider extends `BaseProvider`, you can tell the periodic scheduler to slow down instead of hammering a throttled API. Catch rate-limit or temporary-unavailability responses in your background refresh path, parse `Retry-After` when the service sends it, and throw `PollingBackoffError`.
+
+Inside your `BaseProvider` subclass:
+
+```ts
+import {
+  PollingBackoffError,
+  parseRetryAfterHeader,
+} from '@devdocket/shared';
+
+protected async doBackgroundRefresh(): Promise<void> {
+  const response = await fetch('https://api.example.com/issues');
+
+  if (!response.ok) {
+    if (response.status === 429 || response.status === 503) {
+      const retryAfterMs = parseRetryAfterHeader(
+        response.headers.get('retry-after'),
+      );
+
+      throw new PollingBackoffError({
+        message: response.status === 429
+          ? 'Example API throttled background refresh.'
+          : 'Example API is temporarily unavailable.',
+        backoffKey: 'api.example.com',
+        statusCode: response.status,
+        retryAfterMs,
+      });
+    }
+
+    throw new Error(
+      `Example API error: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  // ...publish refreshed items...
+}
+```
+
+`BaseProvider` automatically applies that backoff to the next periodic refresh. Use a stable `backoffKey` for the upstream quota bucket you are protecting (for example, a host name or host/org combination). If `retryAfterMs` is omitted, the shared backoff policy falls back to exponential backoff and returns to the normal interval after a successful refresh. If your API exposes a reset timestamp header instead of `Retry-After` (for example, GitHub's `x-ratelimit-reset`), use `parseRateLimitResetHeader()` and convert the returned timestamp into a delay before assigning it to `retryAfterMs`.
 
 ### Don't store provider item data
 
@@ -978,4 +1027,4 @@ interface Event<T> {
 - [`packages/github`](../packages/github/src/) — Production provider implementation (GitHub Issues, PR reviews)
 - [`packages/ado`](../packages/ado/src/) — Azure DevOps provider implementation (work items, PR reviews)
 - [`packages/ai-reviewer`](../packages/ai-reviewer/src/) — Action-only extension that adds AI-powered code review and walkthroughs for GitHub and Azure DevOps PR items
-- [`packages/shared`](../packages/shared/src/) — Shared package published as `@devdocket/shared` to the GitHub Packages npm registry. Includes `BaseProvider` (an abstract base class that handles periodic refresh, concurrency guards, and disposal), `validateRefreshInterval`, URL validation, and logging utilities. See [the Extension API guide](./extension-api.md#installing-devdocketshared) for installation; the [Re-declare types](#3-install-devdocketshared-recommended-or-re-declare-types) section above shows the equivalent type declarations if you prefer to avoid the dependency.
+- [`packages/shared`](../packages/shared/src/) — Shared package published as `@devdocket/shared` to the GitHub Packages npm registry. Includes `BaseProvider` (an abstract base class that handles periodic refresh, concurrency guards, disposal, and automatic polling backoff), `PollingBackoffError`, the `Retry-After` / rate-limit header helpers, `validateRefreshInterval`, URL validation, and logging utilities. See [the Extension API guide](./extension-api.md#installing-devdocketshared) for installation; the [Re-declare types](#3-install-devdocketshared-recommended-or-re-declare-types) section above shows the equivalent type declarations if you prefer to avoid the dependency.

--- a/docs/provider-api.md
+++ b/docs/provider-api.md
@@ -106,7 +106,7 @@ import {
 } from '@devdocket/shared';
 ```
 
-`ProviderItem` is the name for items emitted by providers. Provider code should import and emit `ProviderItem`. Providers that poll rate-limited APIs can also import `PollingBackoffError` and the header-parsing helpers so periodic background refreshes automatically slow down when the upstream service asks them to.
+`ProviderItem` is the name for items emitted by providers. Provider code should import and emit `ProviderItem`. Providers that extend `BaseProvider` can also import `PollingBackoffError` and the header-parsing helpers so the periodic schedule started by `startPeriodicRefresh()` automatically slows down when the upstream service asks them to.
 
 If you would rather avoid the GitHub Packages dependency, you can re-declare the small subset of interfaces your extension needs. Copy the following declarations into your provider code:
 

--- a/docs/provider-api.md
+++ b/docs/provider-api.md
@@ -95,18 +95,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
 ### 3. Install `@devdocket/shared` (recommended) or re-declare types
 
-The `@devdocket/shared` package provides the TypeScript types, the `BaseProvider` base class, and polling backoff helpers needed to build providers and actions with full type safety. It is published to the GitHub Packages npm registry — see [the Extension API guide](./extension-api.md#installing-devdocketshared) for the `.npmrc` setup and authentication notes.
+The `@devdocket/shared` package provides the TypeScript types and the `BaseProvider` base class needed to build providers and actions with full type safety. It is published to the GitHub Packages npm registry — see [the Extension API guide](./extension-api.md#installing-devdocketshared) for the `.npmrc` setup and authentication notes.
 
 ```ts
-import {
-  BaseProvider,
-  PollingBackoffError,
-  parseRetryAfterHeader,
-  type ProviderItem,
-} from '@devdocket/shared';
+import { BaseProvider, type ProviderItem } from '@devdocket/shared';
 ```
 
-`ProviderItem` is the name for items emitted by providers. Provider code should import and emit `ProviderItem`. Providers that extend `BaseProvider` can also import `PollingBackoffError` and the header-parsing helpers so the periodic schedule started by `startPeriodicRefresh()` automatically slows down when the upstream service asks them to.
+`ProviderItem` is the name for items emitted by providers. Provider code should import and emit `ProviderItem`. If you later need optional throttling support for periodic refresh, see [Handling rate limits and throttling](#handling-rate-limits-and-throttling) below.
 
 If you would rather avoid the GitHub Packages dependency, you can re-declare the small subset of interfaces your extension needs. Copy the following declarations into your provider code:
 
@@ -368,7 +363,7 @@ class JiraProvider implements DevDocketProvider {
 
 ### Periodic Refresh Pattern
 
-For providers that extend `BaseProvider`, call `startPeriodicRefresh()` with a validated interval instead of building your own timer loop. `BaseProvider` clamps the configured interval to a reasonable minimum (60 seconds), skips overlapping refreshes, and layers automatic backoff on top of the normal schedule when `doBackgroundRefresh()` throws a `PollingBackoffError`.
+For providers that extend `BaseProvider`, call `startPeriodicRefresh()` with a validated interval instead of building your own timer loop. `BaseProvider` clamps the configured interval to a reasonable minimum (60 seconds) and skips overlapping refreshes. If your provider also needs to react to throttling responses, see [Handling rate limits and throttling](#handling-rate-limits-and-throttling) below.
 
 The `@devdocket/shared` package provides a `validateRefreshInterval(value, logger?)` helper that validates and clamps user-configured intervals. It handles non-numeric values, enforces a 60-second minimum, and returns 0 (disabled) for zero/negative input:
 
@@ -382,7 +377,7 @@ const intervalSeconds = validateRefreshInterval(
 provider.startPeriodicRefresh(intervalSeconds);
 ```
 
-After a successful background refresh, the provider returns to its normal interval. If a background refresh throws `PollingBackoffError`, `BaseProvider` delays the next scheduled refresh until both the normal interval and the requested backoff window have elapsed.
+After a successful background refresh, the provider returns to its normal interval. If you opt into the shared throttling flow described below, `BaseProvider` can also delay the next scheduled refresh until both the normal interval and the requested backoff window have elapsed.
 
 Typical refresh guard pattern:
 
@@ -571,7 +566,7 @@ Good patterns: `owner/repo#123`, `PROJECT-42`, `ticket/12345`
 - Guard against overlapping refreshes with a boolean flag
 - Clamp periodic intervals to a reasonable minimum (≥ 60 seconds)
 
-### Rate limiting & backoff
+### Handling rate limits and throttling
 
 If your provider extends `BaseProvider`, you can tell the periodic scheduler to slow down instead of hammering a throttled API. Catch rate-limit or temporary-unavailability responses in your background refresh path, parse `Retry-After` when the service sends it, and throw `PollingBackoffError`.
 
@@ -1027,4 +1022,4 @@ interface Event<T> {
 - [`packages/github`](../packages/github/src/) — Production provider implementation (GitHub Issues, PR reviews)
 - [`packages/ado`](../packages/ado/src/) — Azure DevOps provider implementation (work items, PR reviews)
 - [`packages/ai-reviewer`](../packages/ai-reviewer/src/) — Action-only extension that adds AI-powered code review and walkthroughs for GitHub and Azure DevOps PR items
-- [`packages/shared`](../packages/shared/src/) — Shared package published as `@devdocket/shared` to the GitHub Packages npm registry. Includes `BaseProvider` (an abstract base class that handles periodic refresh, concurrency guards, disposal, and automatic polling backoff), `PollingBackoffError`, the `Retry-After` / rate-limit header helpers, `validateRefreshInterval`, URL validation, and logging utilities. See [the Extension API guide](./extension-api.md#installing-devdocketshared) for installation; the [Re-declare types](#3-install-devdocketshared-recommended-or-re-declare-types) section above shows the equivalent type declarations if you prefer to avoid the dependency.
+- [`packages/shared`](../packages/shared/src/) — Shared package published as `@devdocket/shared` to the GitHub Packages npm registry. Includes `BaseProvider`, `validateRefreshInterval`, URL validation, logging utilities, and other optional helpers such as the polling-throttling APIs documented above. See [the Extension API guide](./extension-api.md#installing-devdocketshared) for installation; the [Re-declare types](#3-install-devdocketshared-recommended-or-re-declare-types) section above shows the equivalent type declarations if you prefer to avoid the dependency.

--- a/packages/shared/src/backoffPolicy.ts
+++ b/packages/shared/src/backoffPolicy.ts
@@ -1,3 +1,4 @@
+/** Configuration for a {@link BackoffPolicy}. */
 export interface BackoffPolicyOptions {
   /** Base delay to reset to after a successful request. */
   baseDelayMs: number;
@@ -11,16 +12,25 @@ export interface BackoffPolicyOptions {
   random?: () => number;
 }
 
+/** Optional inputs when applying a throttling event to a {@link BackoffPolicy}. */
 export interface BackoffApplyOptions {
+  /** Reference time for calculating the new cooldown window. */
   nowMs?: number;
+  /** Cooldown duration in milliseconds requested by the upstream service. */
   retryAfterMs?: number;
 }
 
+/** Snapshot of the current cooldown after a throttled failure is recorded. */
 export interface BackoffStateSnapshot {
   delayMs: number;
   cooldownUntilMs: number;
 }
 
+/**
+ * Tracks exponential polling backoff for one upstream quota bucket.
+ * Call {@link recordFailure} when the service throttles a request and {@link recordSuccess}
+ * after a successful retry to return to the base interval.
+ */
 export class BackoffPolicy {
   private baseDelayMs!: number;
   private maxDelayMs!: number;
@@ -103,6 +113,12 @@ export class BackoffPolicy {
   }
 }
 
+/**
+ * Parses an HTTP `Retry-After` header into a cooldown duration in milliseconds.
+ * @param value Header value as either delta-seconds or an HTTP-date.
+ * @param nowMs Reference time used when `value` is an HTTP-date.
+ * @returns The requested delay in milliseconds, or `undefined` when the header is absent or invalid.
+ */
 export function parseRetryAfterHeader(value: string | null | undefined, nowMs = Date.now()): number | undefined {
   if (!value) {
     return undefined;
@@ -126,6 +142,12 @@ export function parseRetryAfterHeader(value: string | null | undefined, nowMs = 
   return Math.max(0, parsedDate - nowMs);
 }
 
+/**
+ * Parses a rate-limit reset header that reports a Unix timestamp in seconds.
+ * @param value Header value containing the reset time in Unix seconds.
+ * @returns The reset time as a Unix timestamp in milliseconds, or `undefined` when the header is absent or invalid.
+ * Convert the result to a delay (for example, `Math.max(0, resetAtMs - Date.now())`) before passing it as `retryAfterMs`.
+ */
 export function parseRateLimitResetHeader(value: string | null | undefined): number | undefined {
   if (!value) {
     return undefined;

--- a/packages/shared/src/baseProvider.ts
+++ b/packages/shared/src/baseProvider.ts
@@ -348,6 +348,11 @@ export abstract class BaseProvider {
     this.scheduleNextPeriodicRefresh();
   }
 
+  /**
+   * Starts periodic background refresh using the supplied interval as the base schedule.
+   * If {@link doBackgroundRefresh} throws a {@link PollingBackoffError}, the next scheduled
+   * run is automatically delayed until the backoff window has elapsed.
+   */
   startPeriodicRefresh(intervalSeconds: number): void {
     if (this._disposed) {
       return;
@@ -380,7 +385,11 @@ export abstract class BaseProvider {
     this.periodicBackoffPolicy = undefined;
   }
 
-  /** Runs a background refresh with a concurrency guard to prevent overlapping calls. */
+  /**
+   * Runs one background refresh with a concurrency guard to prevent overlapping calls.
+   * When the refresh throws {@link PollingBackoffError}, the active periodic schedule records
+   * the requested cooldown before the error is rethrown to the provider's error handler.
+   */
   async refreshInBackground(): Promise<void> {
     if (this._isRefreshing || this._disposed) {
       return;

--- a/packages/shared/src/pollingErrors.ts
+++ b/packages/shared/src/pollingErrors.ts
@@ -1,10 +1,19 @@
+/** Options for constructing a {@link PollingBackoffError}. */
 export interface PollingBackoffErrorOptions {
+  /** Human-readable explanation suitable for logs or surfaced warnings. */
   message: string;
+  /** Stable key identifying the upstream quota bucket that should cool down together. */
   backoffKey: string;
+  /** HTTP status code that triggered the backoff request, typically 429 or 503. */
   statusCode: number;
+  /** Optional cooldown duration derived from upstream headers such as `Retry-After`. */
   retryAfterMs?: number;
 }
 
+/**
+ * Error thrown by providers and watchers to signal that polling should back off.
+ * Consumers can inspect {@link retryAfterMs} and {@link backoffKey} to coordinate cooldowns.
+ */
 export class PollingBackoffError extends Error {
   readonly backoffKey: string;
   readonly statusCode: number;
@@ -20,6 +29,11 @@ export class PollingBackoffError extends Error {
   }
 }
 
+/**
+ * Returns whether an unknown error has the shape of a {@link PollingBackoffError}.
+ * @param error Candidate error value to inspect.
+ * @returns `true` when the value includes the fields required to coordinate polling backoff.
+ */
 export function isPollingBackoffError(error: unknown): error is PollingBackoffError {
   if (!error || typeof error !== 'object') {
     return false;


### PR DESCRIPTION
## Summary
- document the polling backoff APIs added in PR #671 for third-party provider authors
- explain how `BaseProvider` automatically delays periodic refreshes when `doBackgroundRefresh()` throws `PollingBackoffError`
- add JSDoc for the shared backoff helpers and error types so generated API docs describe the new behavior clearly

## Details
PR #671 added new public API surface to `@devdocket/shared` for polling backoff, but the extension-author docs in `docs/` were not updated at the same time. This PR closes that documentation gap by:
- updating `docs/provider-api.md` with a rate limiting and backoff section, including a concrete `Retry-After` / `PollingBackoffError` example
- updating `docs/extension-api.md` to list the new shared exports and note how provider refresh code can signal backoff
- expanding JSDoc in `packages/shared` so the shared API surface explains the backoff scheduler, helper return values, and `PollingBackoffError` fields

## Validation
- `npm run build`
- `npm run test`

## Changeset
No changeset required. This PR is docs/JSDoc only and changes no runtime behavior.
