### PR TITLE
Enforce DevDocket bot identity for local agents and migrate scheduled workflows to GitHub App token

### DIFF
--- a/.github/actions/create-copilot-issue/action.yml
+++ b/.github/actions/create-copilot-issue/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: true
   copilot-assign-token:
     description: >
-      PAT with permissions for the agent_assignment API.
+      Token with permissions for the agent_assignment API.
       Falls back to github-token if not provided.
     required: false
     default: ''

--- a/.github/workflows/automated-refactoring.yml
+++ b/.github/workflows/automated-refactoring.yml
@@ -23,6 +23,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DEVDOCKET_BOT_APP_ID }}
+          private-key: ${{ secrets.DEVDOCKET_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Download code-refactorer skill
         run: |
           curl -sSfL \
@@ -112,5 +120,5 @@ jobs:
 
             If you find no refactoring opportunities, close the issue with an explanation.
             If you apply refactorings, create a PR with a clear description.
-          copilot-assign-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          copilot-assign-token: ${{ steps.app-token.outputs.token }}
+          github-token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/weekly-performance-review.yml
+++ b/.github/workflows/weekly-performance-review.yml
@@ -1,10 +1,9 @@
 name: Weekly Performance Review
 
 # Authentication: this workflow runs GitHub Copilot CLI in programmatic mode.
-# Configure the shared COPILOT_CLI_PAT repository secret with a licensed Copilot
-# user's PAT that can make Copilot requests and create issues. Rotate that one
-# secret when the service identity changes; both COPILOT_GITHUB_TOKEN and GH_TOKEN
-# are sourced from it so Copilot CLI and gh authenticate as the same identity.
+# COPILOT_CLI_PAT is still required for Copilot CLI requests until #621 migrates
+# this review to an agentic workflow. Issue creation via gh uses the short-lived
+# DevDocket bot GitHub App token minted below.
 on:
   # Run every Thursday at 10:00 AM UTC (offset from implementation and UX reviews)
   schedule:
@@ -38,12 +37,19 @@ jobs:
       - name: Install Copilot CLI
         run: npm install -g @github/copilot
 
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DEVDOCKET_BOT_APP_ID }}
+          private-key: ${{ secrets.DEVDOCKET_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Run weekly performance review
         env:
-          # Shared PAT for both Copilot CLI and gh. Rotate COPILOT_CLI_PAT instead
-          # of configuring workflow-specific tokens.
+          # COPILOT_CLI_PAT remains only for Copilot CLI auth until #621 removes it.
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_PAT }}
-          GH_TOKEN: ${{ secrets.COPILOT_CLI_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -o pipefail
           copilot -p "$(cat .github/prompts/weekly-performance-review.md)" \

--- a/.github/workflows/weekly-review.yml
+++ b/.github/workflows/weekly-review.yml
@@ -1,10 +1,9 @@
 name: Weekly Review
 
 # Authentication: this workflow runs GitHub Copilot CLI in programmatic mode.
-# Configure the shared COPILOT_CLI_PAT repository secret with a licensed Copilot
-# user's PAT that can make Copilot requests and create issues. Rotate that one
-# secret when the service identity changes; both COPILOT_GITHUB_TOKEN and GH_TOKEN
-# are sourced from it so Copilot CLI and gh authenticate as the same identity.
+# COPILOT_CLI_PAT is still required for Copilot CLI requests until #621 migrates
+# this review to an agentic workflow. Issue creation via gh uses the short-lived
+# DevDocket bot GitHub App token minted below.
 on:
   # Run every Monday at 9:00 AM UTC
   schedule:
@@ -39,12 +38,19 @@ jobs:
       - name: Install Copilot CLI
         run: npm install -g @github/copilot
 
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DEVDOCKET_BOT_APP_ID }}
+          private-key: ${{ secrets.DEVDOCKET_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Run weekly review
         env:
-          # Shared PAT for both Copilot CLI and gh. Rotate COPILOT_CLI_PAT instead
-          # of configuring workflow-specific tokens.
+          # COPILOT_CLI_PAT remains only for Copilot CLI auth until #621 removes it.
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_PAT }}
-          GH_TOKEN: ${{ secrets.COPILOT_CLI_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -o pipefail
           copilot -p "$(cat .github/prompts/weekly-review.md)" \

--- a/.github/workflows/weekly-ux-review.yml
+++ b/.github/workflows/weekly-ux-review.yml
@@ -1,10 +1,9 @@
 name: Weekly UX Review
 
 # Authentication: this workflow runs GitHub Copilot CLI in programmatic mode.
-# Configure the shared COPILOT_CLI_PAT repository secret with a licensed Copilot
-# user's PAT that can make Copilot requests and create issues. Rotate that one
-# secret when the service identity changes; both COPILOT_GITHUB_TOKEN and GH_TOKEN
-# are sourced from it so Copilot CLI and gh authenticate as the same identity.
+# COPILOT_CLI_PAT is still required for Copilot CLI requests until #621 migrates
+# this review to an agentic workflow. Issue creation via gh uses the short-lived
+# DevDocket bot GitHub App token minted below.
 on:
   # Run every Wednesday at 10:00 AM UTC (offset from implementation review)
   schedule:
@@ -38,12 +37,19 @@ jobs:
       - name: Install Copilot CLI
         run: npm install -g @github/copilot
 
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.DEVDOCKET_BOT_APP_ID }}
+          private-key: ${{ secrets.DEVDOCKET_BOT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
       - name: Run weekly UX review
         env:
-          # Shared PAT for both Copilot CLI and gh. Rotate COPILOT_CLI_PAT instead
-          # of configuring workflow-specific tokens.
+          # COPILOT_CLI_PAT remains only for Copilot CLI auth until #621 removes it.
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_PAT }}
-          GH_TOKEN: ${{ secrets.COPILOT_CLI_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -o pipefail
           copilot -p "$(cat .github/prompts/weekly-ux-review.md)" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # DevDocket VS Code Extension Agent Instructions
 
-> **⚠️ BEFORE making any code changes:** Create a git worktree and feature branch. Never modify files directly in the main working tree. See [Use git worktrees for feature branches](#use-git-worktrees-for-feature-branches).
+> **⚠️ BEFORE making any code changes:** (1) Create a git worktree and feature branch — never modify files directly in the main working tree (see [Use git worktrees for feature branches](#use-git-worktrees-for-feature-branches)). (2) Start a DevDocket bot session so commits, pushes, and `gh` calls are attributed to the bot, not to the developer (see [DevDocket bot identity for local Copilot CLI work](#devdocket-bot-identity-for-local-copilot-cli-work)).
 
 ## Build & Test
 
@@ -190,6 +190,7 @@ When creating pull requests in an environment with [GitHub Copilot CLI](https://
 Key rules:
 - **Never skip or shortcut the process.** Every PR goes through all phases. Do NOT push branches or create PRs via `gh pr create` until the `create-pr` skill's Phase 1 (local loop) is complete.
 - **Invoke the `create-pr` skill before creating any PR.** The skill must be loaded and its phases followed in order. Never hand-roll `gh pr create` or `git push` without the skill orchestrating it.
+- **Ensure a DevDocket bot session is active before pushing or running any `gh` command that creates/modifies remote state** (PRs, issues, comments, reviews, labels, assignments). See [DevDocket bot identity for local Copilot CLI work](#devdocket-bot-identity-for-local-copilot-cli-work). If the bot session cannot be started (missing App ID / private key), STOP and ask the user how to proceed — do NOT silently fall back to the developer's identity.
 - **Any code change re-triggers the local loop** — whether from code review, Copilot feedback, CI fix, or conflict resolution.
 - **Use `superpowers:code-reviewer` agent** for code review, not a generic code-review agent.
 - **Add a `.changeset/*.md` file when the PR changes user-facing behavior of a publishable package.** See [Releases & Changesets](#releases--changesets) for the required format, when a changeset is and isn't needed, and the exact package names to use.
@@ -320,9 +321,22 @@ The core extension must not rely on anything from the other extensions (github, 
 
 ### DevDocket bot identity for local Copilot CLI work
 
-When a Copilot CLI agent does work on a developer's behalf, the resulting commits, PRs, and issues should be attributed to the DevDocket bot (the same GitHub App identity used by the Changesets workflow), not to the developer.
+When a Copilot CLI agent does work on a developer's behalf, the resulting commits, PRs, and issues **must** be attributed to the DevDocket bot (the same GitHub App identity used by the Changesets workflow), not to the developer.
 
-A helper script mints a short-lived (≤ 1 hour) installation access token from the bot's GitHub App and configures the current shell to use that identity for subsequent `gh` and `git` calls:
+**When to start a bot session (mandatory):**
+
+Agents MUST run the bot-session helper at the very start of any task that will:
+
+- make a `git commit` in the worktree, or
+- run a `gh` command that creates or modifies remote state — including (but not limited to) `gh pr create`, `gh pr comment`, `gh pr review`, `gh pr edit`, `gh issue create`, `gh issue comment`, `gh issue edit`, `gh api` calls with `-X POST/PATCH/PUT/DELETE`, `gh release create`, etc.
+
+Read-only `gh` calls (`gh issue view`, `gh pr view`, `gh pr diff`, `gh run list`, `gh api` GETs) do not require a bot session, but it's fine to start one preemptively. When in doubt, start the session before doing anything that could touch remote state.
+
+The session must be started **before** any committing/pushing/PR work. Starting it after the fact does not re-attribute prior commits.
+
+**Helper script:**
+
+A helper mints a short-lived (≤ 1 hour) installation access token from the bot's GitHub App and configures the current shell to use that identity for subsequent `gh` and `git` calls:
 
 ```bash
 # bash / zsh
@@ -333,6 +347,19 @@ node scripts/start-bot-session.mjs --shell=powershell | Invoke-Expression
 ```
 
 The script assumes the App's private key lives at `keys/devdocket-bot.pem` and that either the `DEVDOCKET_BOT_APP_ID` environment variable is set or the numeric App ID is written to `keys/devdocket-bot.app-id`. The `keys/` directory is git-ignored — never commit the PEM or App ID. After running the helper, the working tree's `user.name` / `user.email` and `GH_TOKEN` / `GITHUB_TOKEN` point at the bot for the lifetime of that shell; opening a new shell reverts to the developer's normal identity.
+
+**Verify the session is active** before proceeding:
+
+```bash
+git config user.email   # should end in @users.noreply.github.com (bot's noreply address)
+gh api user --jq .login # should return the bot account login, not your personal login
+```
+
+If either check fails (e.g., still shows the developer's identity), the bot session is not active and the helper either errored out or its output was not applied to the current shell — fix that before continuing.
+
+**If the bot session cannot be started** (helper prints "App ID not found", missing PEM, expired key, etc.): STOP. Do not fall back to the developer's identity. Report the failure to the user and ask how to proceed — typically the user needs to populate `keys/devdocket-bot.app-id` and `keys/devdocket-bot.pem` (or set `DEVDOCKET_BOT_APP_ID`) for their environment.
+
+**Sub-agents:** The orchestrating agent is responsible for starting the bot session in each worktree before dispatching sub-agents that will commit/push/`gh`-create. Sub-agents inherit the parent shell's environment only when they share it; if a sub-agent runs in a separately spawned shell, that shell must independently run the helper (or the orchestrator must export the resulting env vars to it).
 
 Note: commits made in the working tree will be **authored** by the bot, but `git push` over HTTPS still uses the developer's stored credential helper — so the *pusher* recorded on GitHub is the developer. Use `gh pr create` / `gh issue create` / other `gh` subcommands for remote actions that need bot attribution; those consume `GH_TOKEN` directly.
 

--- a/scripts/start-bot-session.mjs
+++ b/scripts/start-bot-session.mjs
@@ -86,7 +86,7 @@ async function ghApi(path, { method = "GET", token, accept, body } = {}) {
     method,
     headers: {
       Accept: accept ?? "application/vnd.github+json",
-      Authorization: `Bearer ${token}`,
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
       "User-Agent": "devdocket-start-bot-session",
       "X-GitHub-Api-Version": "2022-11-28",
       ...(body ? { "Content-Type": "application/json" } : {}),
@@ -198,7 +198,7 @@ async function main() {
   const slug = appMeta.slug;
   if (!slug) fail("GitHub App metadata missing `slug`.");
 
-  const botUser = await ghApi(`/users/${slug}%5Bbot%5D`, { token: jwt });
+  const botUser = await ghApi(`/users/${slug}%5Bbot%5D`);
   const botUserId = botUser.id;
   if (!botUserId) fail(`Could not resolve numeric user id for ${slug}[bot].`);
 


### PR DESCRIPTION
## Summary

Two complementary changes, both supporting the GitHub App–based bot identity:

### 1. Workflow migration (commit `2a17317`) — Closes #622

Migrate scheduled-issue-creation workflows from the user-tied `COPILOT_CLI_PAT` / `COPILOT_ASSIGN_TOKEN` PATs to the DevDocket bot GitHub App, using short-lived installation tokens minted via `actions/create-github-app-token@v1`.

Files migrated:
- `.github/workflows/weekly-review.yml`
- `.github/workflows/weekly-performance-review.yml`
- `.github/workflows/weekly-ux-review.yml`
- `.github/workflows/automated-refactoring.yml`
- `.github/actions/create-copilot-issue/action.yml`

The only remaining `COPILOT_CLI_PAT` references are for Copilot CLI auth itself (env var `COPILOT_GITHUB_TOKEN`), correctly scoped to #621. Each workflow notes this with an inline comment.

### 2. Agent-side enforcement and helper fix (commit `1100f35`)

Without these, agents were silently falling back to the developer's identity when running locally — the very problem #622 is solving on the workflow side.

- **`AGENTS.md`** — make bot-session usage mandatory and explicit:
  - Added bot-session startup to the top-of-file pre-work checklist alongside worktree setup.
  - Added an explicit PR-workflow rule: ensure a bot session is active before pushing or running any `gh` command that creates/modifies remote state, and STOP rather than fall back to the developer's identity if the helper fails.
  - Replaced soft "should be attributed to" language with `must`, listed exactly which `gh` subcommands trigger the requirement, documented verification commands (`git config user.email`, `gh api user --jq .login`), described what to do when the helper fails, and explained how sub-agents inherit (or don't inherit) the parent's bot environment.
- **`scripts/start-bot-session.mjs`** — fix 401 on `/users/<slug>[bot]` lookup. The script was passing the App JWT to that endpoint, but GitHub doesn't accept App JWT auth there and returned `401 Bad credentials`, blocking every bot-session attempt. The fix makes `ghApi`'s `token` argument optional and calls the user-lookup endpoint without a token (it's public).

## Testing

- Ran `node scripts/start-bot-session.mjs --shell=powershell | Invoke-Expression` end-to-end: minted an installation token, `git config user.email` resolved to the bot's noreply address, this PR's `1100f35` commit was authored by `devdocket-bot[bot]`.
- AGENTS.md and workflow changes are documentation / CI; no automated tests apply.
- No `.changeset/*.md` added — workflow / agent-process changes are not user-facing for any publishable package.

Closes #622

(Recreated from closed #683.)
