### PR TITLE
Fix empty AI review output handling

### DIFF
--- a/.changeset/fix-ai-review-empty-output.md
+++ b/.changeset/fix-ai-review-empty-output.md
@@ -1,0 +1,5 @@
+---
+"devdocket-ai-reviewer": patch
+---
+
+Ensure AI code reviews always request a substantive body and surface a clear warning instead of opening a header-only review when the language model returns no content.

--- a/.changeset/fix-ai-review-empty-output.md
+++ b/.changeset/fix-ai-review-empty-output.md
@@ -2,4 +2,4 @@
 "devdocket-ai-reviewer": patch
 ---
 
-Ensure AI code reviews always request a substantive body and surface a clear warning instead of opening a header-only review when the language model returns no content.
+Ensure AI code reviews and related AI Reviewer flows always request a substantive body and surface a clear warning instead of opening a header-only response when the language model returns no content.

--- a/packages/ai-reviewer/src/aiReviewAction.ts
+++ b/packages/ai-reviewer/src/aiReviewAction.ts
@@ -409,6 +409,14 @@ ${displayList || '(file list unavailable — use devdocket-getDiff to get the st
         }
 
         if (!hasToolCalls) {
+          if (result.trim() === this.outputHeader.trim()) {
+            this.log.error(`AI Code Review: model returned no review content after ${iterations} iteration(s)`);
+            vscode.window.showWarningMessage(
+              'AI Code Review: The language model returned no content. Try again, switch models, or check whether the PR is too large to review.',
+            );
+            return undefined;
+          }
+
           this.log.info(`No tool calls in iteration ${iterations} — analysis complete`);
           break;
         }

--- a/packages/ai-reviewer/src/aiReviewAction.ts
+++ b/packages/ai-reviewer/src/aiReviewAction.ts
@@ -343,6 +343,7 @@ ${displayList || '(file list unavailable — use devdocket-getDiff to get the st
           break;
         }
 
+        let hasTextParts = false;
         let hasToolCalls = false;
         const assistantParts: (
           | vscode.LanguageModelTextPart
@@ -355,6 +356,7 @@ ${displayList || '(file list unavailable — use devdocket-getDiff to get the st
 
         for await (const part of chatResponse.stream) {
           if (part instanceof vscode.LanguageModelTextPart) {
+            hasTextParts = true;
             result += part.value;
             assistantParts.push(part);
           } else if (part instanceof vscode.LanguageModelToolCallPart) {
@@ -386,6 +388,14 @@ ${displayList || '(file list unavailable — use devdocket-getDiff to get the st
         this.log.debug(
           `Iteration ${iterations}: ${assistantParts.length} parts, ${toolResults.length} tool results`,
         );
+
+        if (iterations === 1 && !hasTextParts && !hasToolCalls) {
+          this.log.error('AI Code Review: model returned no content and no tool calls on the first iteration');
+          vscode.window.showWarningMessage(
+            'AI Code Review: The language model returned no content. Try again, switch models, or check whether the PR is too large to review.',
+          );
+          return undefined;
+        }
 
         if (assistantParts.length > 0) {
           loopMessages.push(vscode.LanguageModelChatMessage.Assistant(assistantParts));

--- a/packages/ai-reviewer/src/basePrAction.ts
+++ b/packages/ai-reviewer/src/basePrAction.ts
@@ -252,7 +252,7 @@ export abstract class BasePrAction implements DevDocketAction {
       let result = this.outputHeader;
       let hasText = false;
       for await (const chunk of response.text) {
-        if (chunk.length > 0) {
+        if (chunk.trim().length > 0) {
           hasText = true;
         }
         result += chunk;

--- a/packages/ai-reviewer/src/basePrAction.ts
+++ b/packages/ai-reviewer/src/basePrAction.ts
@@ -250,9 +250,22 @@ export abstract class BasePrAction implements DevDocketAction {
       const response = await model.sendRequest(messages, {}, token);
 
       let result = this.outputHeader;
+      let hasText = false;
       for await (const chunk of response.text) {
+        if (chunk.length > 0) {
+          hasText = true;
+        }
         result += chunk;
       }
+
+      if (!hasText) {
+        console.error(`${this.progressTitle}: model returned no content`);
+        vscode.window.showWarningMessage(
+          `${this.progressTitle}: The language model returned no content. Try again, switch models, or check whether the PR is too large to review.`,
+        );
+        return undefined;
+      }
+
       return result + truncationNote;
     } catch (err) {
       console.error(`${this.progressTitle}: analysis failed:`, err);

--- a/packages/ai-reviewer/src/defaultPrompt.ts
+++ b/packages/ai-reviewer/src/defaultPrompt.ts
@@ -61,8 +61,18 @@ If unsure between two levels, choose the higher one.
 
 ### Structure
 
+You must always produce a complete structured body after the review header. A header-only response is invalid. The body must include:
+
+1. A one-paragraph summary of what you reviewed, including the files, areas, or scope you examined.
+2. A findings section that always has content. If you find nothing to flag, write exactly **No issues found.** followed by a short rationale explaining why the reviewed changes appear safe.
+3. Optionally, a concise list of files or areas examined when that helps the reader understand the review coverage.
+
 \`\`\`
 ## 🤖 Code Review
+
+### Reviewed Scope
+
+<One paragraph summarizing the files, areas, and scope reviewed.>
 
 ### Holistic Assessment
 
@@ -82,7 +92,11 @@ If unsure between two levels, choose the higher one.
 
 <Explanation with specifics. Reference code, line numbers, evidence.>
 
-(Repeat for each finding. Group related findings under a single heading.)
+(Repeat for each finding. Group related findings under a single heading. If there are no findings, write: **No issues found.** <Short rationale.>)
+
+### Files / Areas Examined (optional)
+
+- <Path or area examined>
 \`\`\`
 
 ### Verdict Rules

--- a/packages/ai-reviewer/src/test/aiReviewAction.test.ts
+++ b/packages/ai-reviewer/src/test/aiReviewAction.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { window, workspace, authentication, lm, Uri, LanguageModelTextPart, mockLogOutputChannel } from 'vscode';
+import { window, workspace, authentication, lm, Uri, LanguageModelTextPart, LanguageModelToolCallPart, mockLogOutputChannel } from 'vscode';
 import { AiReviewAction, sanitizePrUrl } from '../aiReviewAction';
 import type { RepoManager } from '../repoManager';
 import type { DevDocketApi } from '../types';
@@ -753,6 +753,35 @@ describe('AiReviewAction', () => {
       expect(result).toBeUndefined();
       expect(mockLogOutputChannel.error).toHaveBeenCalledWith(
         'AI Code Review: model returned no content and no tool calls on the first iteration',
+      );
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        'AI Code Review: The language model returned no content. Try again, switch models, or check whether the PR is too large to review.',
+      );
+    });
+
+    it('returns undefined and warns when tool calls are followed by no review text', async () => {
+      const model = {
+        id: 'mock-model',
+        sendRequest: vi.fn()
+          .mockResolvedValueOnce({
+            stream: (async function* () {
+              yield new LanguageModelToolCallPart('call-1', 'devdocket-readFile', { path: 'src/file.ts' });
+            })(),
+          })
+          .mockResolvedValueOnce({
+            stream: (async function* () {})(),
+          }),
+      } as never;
+      const token = { isCancellationRequested: false, onCancellationRequested: vi.fn() };
+
+      const result = await action.analyzeWithTools(
+        'diff content', 'https://github.com/owner/repo/pull/42', worktreeInfo as never, model, token as never,
+      );
+
+      expect(result).toBeUndefined();
+      expect(model.sendRequest).toHaveBeenCalledTimes(2);
+      expect(mockLogOutputChannel.error).toHaveBeenCalledWith(
+        'AI Code Review: model returned no review content after 2 iteration(s)',
       );
       expect(window.showWarningMessage).toHaveBeenCalledWith(
         'AI Code Review: The language model returned no content. Try again, switch models, or check whether the PR is too large to review.',

--- a/packages/ai-reviewer/src/test/aiReviewAction.test.ts
+++ b/packages/ai-reviewer/src/test/aiReviewAction.test.ts
@@ -714,6 +714,30 @@ describe('AiReviewAction', () => {
       expect(userMsg.content).toContain('/mock/worktrees/pr-42');
       expect(userMsg.content).toContain('devdocket-readFile');
       expect(userMsg.content).toContain('devdocket-searchCode');
+      expect(userMsg.content).toContain('A one-paragraph summary of what you reviewed');
+      expect(userMsg.content).toContain('**No issues found.**');
+    });
+
+    it('returns undefined and warns when the first model stream has no text or tool calls', async () => {
+      const model = {
+        id: 'mock-model',
+        sendRequest: vi.fn().mockResolvedValue({
+          stream: (async function* () {})(),
+        }),
+      } as never;
+      const token = { isCancellationRequested: false, onCancellationRequested: vi.fn() };
+
+      const result = await action.analyzeWithTools(
+        'diff content', 'https://github.com/owner/repo/pull/42', worktreeInfo as never, model, token as never,
+      );
+
+      expect(result).toBeUndefined();
+      expect(mockLogOutputChannel.error).toHaveBeenCalledWith(
+        'AI Code Review: model returned no content and no tool calls on the first iteration',
+      );
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        'AI Code Review: The language model returned no content. Try again, switch models, or check whether the PR is too large to review.',
+      );
     });
 
     it('appends truncation note when diff exceeds limit and worktree is available', async () => {

--- a/packages/ai-reviewer/src/test/aiReviewAction.test.ts
+++ b/packages/ai-reviewer/src/test/aiReviewAction.test.ts
@@ -472,6 +472,25 @@ describe('AiReviewAction', () => {
       expect(window.showErrorMessage).toHaveBeenCalledWith('AI Code Review: Analysis failed');
     });
 
+    it('returns undefined and warns when the diff-only model response has no text', async () => {
+      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+      vi.mocked(lm.selectChatModels).mockResolvedValue([{
+        sendRequest: vi.fn().mockResolvedValue({
+          text: (async function* () {})(),
+        }),
+      }]);
+
+      const token = { isCancellationRequested: false, onCancellationRequested: vi.fn() };
+      const result = await action.analyzeWithAi('some diff', 'https://github.com/owner/repo/pull/42', token as never);
+
+      expect(result).toBeUndefined();
+      expect(consoleError).toHaveBeenCalledWith('AI Code Review: model returned no content');
+      expect(window.showWarningMessage).toHaveBeenCalledWith(
+        'AI Code Review: The language model returned no content. Try again, switch models, or check whether the PR is too large to review.',
+      );
+      consoleError.mockRestore();
+    });
+
     it('uses custom prompt when configured', async () => {
       const customPrompt = 'Focus only on security issues.';
       const customPromptBytes = new TextEncoder().encode(customPrompt);

--- a/packages/ai-reviewer/src/test/aiReviewAction.test.ts
+++ b/packages/ai-reviewer/src/test/aiReviewAction.test.ts
@@ -472,11 +472,13 @@ describe('AiReviewAction', () => {
       expect(window.showErrorMessage).toHaveBeenCalledWith('AI Code Review: Analysis failed');
     });
 
-    it('returns undefined and warns when the diff-only model response has no text', async () => {
+    it('returns undefined and warns when the diff-only model response has no substantive text', async () => {
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
       vi.mocked(lm.selectChatModels).mockResolvedValue([{
         sendRequest: vi.fn().mockResolvedValue({
-          text: (async function* () {})(),
+          text: (async function* () {
+            yield '\n  \t';
+          })(),
         }),
       }]);
 


### PR DESCRIPTION
## Summary

- Require AI review output to include reviewed scope and a findings body, including **No issues found.** with rationale when there are no findings.
- Detect an empty first model stream in the tool-enabled review loop, log it as an error, warn the user, and avoid opening a header-only panel.
- Add regression coverage and a patch changeset for the AI reviewer package.

## Validation

- npm run build && npm run test
- superpowers:code-reviewer local review: clean

Closes #678
