### PR TITLE
Memoize related items index

### DIFF
--- a/.changeset/perf-memoize-related-items-index.md
+++ b/.changeset/perf-memoize-related-items-index.md
@@ -1,0 +1,5 @@
+---
+"devdocket": patch
+---
+
+Memoize the related-items index across unchanged sidebar refreshes and skip unnecessary reverse related-item scans when no pull request refs are present.

--- a/packages/core/src/services/relatedItems.ts
+++ b/packages/core/src/services/relatedItems.ts
@@ -201,10 +201,10 @@ function getRelatedItemsIndexSignature(providerItems: Map<string, ProviderItem[]
 }
 
 function getWorkGraphSignature(workGraph: WorkGraph): string {
-  const getChangeVersion = (workGraph as Partial<Pick<WorkGraph, 'getChangeVersion'>>).getChangeVersion;
-  const changeVersion = getChangeVersion?.call(workGraph);
-  if (changeVersion !== undefined) {
-    return `v:${changeVersion}`;
+  const getRelatedItemsVersion = (workGraph as Partial<Pick<WorkGraph, 'getRelatedItemsVersion'>>).getRelatedItemsVersion;
+  const relatedItemsVersion = getRelatedItemsVersion?.call(workGraph);
+  if (relatedItemsVersion !== undefined) {
+    return `v:${relatedItemsVersion}`;
   }
 
   let hash = 2166136261;

--- a/packages/core/src/services/relatedItems.ts
+++ b/packages/core/src/services/relatedItems.ts
@@ -5,7 +5,21 @@ import type { ProviderRegistry } from './providerRegistry';
 import type { WorkGraph } from './workGraph';
 import { logger } from './logger';
 
+/** Cached related-item lookup. Treat the map and arrays as immutable. */
 export type RelatedItemsIndex = Map<string, ResolvedRelatedItem[]>;
+
+interface RelatedItemsIndexSignature {
+  value: string;
+  hasAnyRelatedItems: boolean;
+  hasPrRelatedItems: boolean;
+}
+
+interface RelatedItemsIndexCacheEntry {
+  signature: string;
+  index: RelatedItemsIndex;
+}
+
+let relatedItemsIndexCache = new WeakMap<WorkGraph, RelatedItemsIndexCacheEntry>();
 
 interface ResolvedRelatedItemWithSort extends ResolvedRelatedItem {
   externalId: string;
@@ -62,6 +76,18 @@ function buildRelatedItemsIndexForDiscovered(
   providerItems: Map<string, ProviderItem[]>,
   workGraph: WorkGraph,
 ): RelatedItemsIndex {
+  const signature = getRelatedItemsIndexSignature(providerItems, workGraph);
+  const cached = relatedItemsIndexCache.get(workGraph);
+  if (cached?.signature === signature.value) {
+    return cached.index;
+  }
+
+  if (!signature.hasAnyRelatedItems) {
+    const emptyIndex: RelatedItemsIndex = new Map();
+    relatedItemsIndexCache.set(workGraph, { signature: signature.value, index: emptyIndex });
+    return emptyIndex;
+  }
+
   const providerItemsByRef = buildProviderItemsByRef(providerItems, workGraph);
   const workingIndex = new Map<string, Map<string, ResolvedRelatedItemWithSort>>();
   let totalRefCount = 0;
@@ -89,23 +115,25 @@ function buildRelatedItemsIndexForDiscovered(
     }
   }
 
-  for (const [providerId, items] of providerItems) {
-    for (const candidate of items) {
-      if (candidate.itemType !== 'pr' || !candidate.relatedItems?.length) {
-        continue;
-      }
-
-      for (const ref of candidate.relatedItems) {
-        const target = resolveProviderItemTarget(providerId, candidate.externalId, candidate.itemType, ref.relation, workGraph, 'reverse', candidate.title);
-        if (!target) {
+  if (signature.hasPrRelatedItems) {
+    for (const [providerId, items] of providerItems) {
+      for (const candidate of items) {
+        if (candidate.itemType !== 'pr' || !candidate.relatedItems?.length) {
           continue;
         }
 
-        for (const match of providerItemsByRef.get(getRefKey(ref.itemType, ref.externalId)) ?? []) {
-          if (match.providerId === providerId && match.externalId === candidate.externalId) {
+        for (const ref of candidate.relatedItems) {
+          const target = resolveProviderItemTarget(providerId, candidate.externalId, candidate.itemType, ref.relation, workGraph, 'reverse', candidate.title);
+          if (!target) {
             continue;
           }
-          upsertResolved(getOrCreateResolvedSet(workingIndex, match.providerId, match.externalId), target);
+
+          for (const match of providerItemsByRef.get(getRefKey(ref.itemType, ref.externalId)) ?? []) {
+            if (match.providerId === providerId && match.externalId === candidate.externalId) {
+              continue;
+            }
+            upsertResolved(getOrCreateResolvedSet(workingIndex, match.providerId, match.externalId), target);
+          }
         }
       }
     }
@@ -122,7 +150,94 @@ function buildRelatedItemsIndexForDiscovered(
       publicIndex.set(key, relatedItems);
     }
   }
+  relatedItemsIndexCache.set(workGraph, { signature: signature.value, index: publicIndex });
   return publicIndex;
+}
+
+export function clearRelatedItemsIndexCacheForTests(): void {
+  relatedItemsIndexCache = new WeakMap<WorkGraph, RelatedItemsIndexCacheEntry>();
+}
+
+function getRelatedItemsIndexSignature(providerItems: Map<string, ProviderItem[]>, workGraph: WorkGraph): RelatedItemsIndexSignature {
+  let hash = 2166136261;
+  let itemCount = 0;
+  let refCount = 0;
+  let hasAnyRelatedItems = false;
+  let hasPrRelatedItems = false;
+
+  for (const [providerId, items] of providerItems) {
+    hash = appendHashPart(hash, providerId);
+    hash = appendHashPart(hash, items.length);
+    for (const item of items) {
+      itemCount++;
+      const relatedItems = item.relatedItems ?? [];
+      hash = appendHashPart(hash, item.externalId);
+      hash = appendHashPart(hash, item.itemType);
+      hash = appendHashPart(hash, item.version);
+      hash = appendHashPart(hash, item.resurfaceVersion);
+      hash = appendHashPart(hash, item.title);
+      hash = appendHashPart(hash, relatedItems.length);
+
+      if (relatedItems.length > 0) {
+        hasAnyRelatedItems = true;
+        hasPrRelatedItems ||= item.itemType === 'pr';
+      }
+
+      for (const ref of relatedItems) {
+        refCount++;
+        hash = appendHashPart(hash, ref.externalId);
+        hash = appendHashPart(hash, ref.itemType);
+        hash = appendHashPart(hash, ref.relation);
+      }
+    }
+  }
+
+  const workGraphSignature = getWorkGraphSignature(workGraph);
+  return {
+    value: `${itemCount}:${refCount}:${hasPrRelatedItems ? 1 : 0}:${hash.toString(36)}:${workGraphSignature}`,
+    hasAnyRelatedItems,
+    hasPrRelatedItems,
+  };
+}
+
+function getWorkGraphSignature(workGraph: WorkGraph): string {
+  const getChangeVersion = (workGraph as Partial<Pick<WorkGraph, 'getChangeVersion'>>).getChangeVersion;
+  const changeVersion = getChangeVersion?.call(workGraph);
+  if (changeVersion !== undefined) {
+    return `v:${changeVersion}`;
+  }
+
+  let hash = 2166136261;
+  let provenanceCount = 0;
+  for (const item of workGraph.getAll()) {
+    if (!item.providerId || !item.externalId) {
+      continue;
+    }
+    provenanceCount++;
+    hash = appendHashPart(hash, item.id);
+    hash = appendHashPart(hash, item.providerId);
+    hash = appendHashPart(hash, item.externalId);
+    hash = appendHashPart(hash, item.itemType);
+    hash = appendHashPart(hash, item.title);
+  }
+  return `h:${provenanceCount}:${hash.toString(36)}`;
+}
+
+function appendHashPart(hash: number, value: unknown): number {
+  const text = value === undefined ? '<undefined>' : String(value);
+  hash = appendHashText(hash, String(text.length));
+  hash = appendHashText(hash, ':');
+  hash = appendHashText(hash, text);
+  return appendHashText(hash, ';');
+}
+
+function appendHashText(hash: number, text: string): number {
+  let next = hash;
+  for (let index = 0; index < text.length; index++) {
+    next ^= text.charCodeAt(index);
+    next = Math.imul(next, 16777619) >>> 0;
+  }
+  return next;
 }
 
 function resolveReverseRefsForUndiscovered(

--- a/packages/core/src/services/relatedItems.ts
+++ b/packages/core/src/services/relatedItems.ts
@@ -206,29 +206,7 @@ function getRelatedItemsIndexSignature(providerItems: Map<string, ProviderItem[]
 }
 
 function getWorkGraphSignature(workGraph: WorkGraph): string {
-  const getRelatedItemsVersion = (workGraph as Partial<Pick<WorkGraph, 'getRelatedItemsVersion'>>).getRelatedItemsVersion;
-  const relatedItemsVersion = getRelatedItemsVersion?.call(workGraph);
-  if (relatedItemsVersion !== undefined) {
-    return `v:${relatedItemsVersion}`;
-  }
-
-  // Older test doubles may not expose the version token. The fallback is a coarser
-  // proxy over work-item identity and title so tests still invalidate on provenance
-  // or label changes; production WorkGraph instances take the token path above.
-  let hash = 2166136261;
-  let provenanceCount = 0;
-  for (const item of workGraph.getAll()) {
-    if (!item.providerId || !item.externalId) {
-      continue;
-    }
-    provenanceCount++;
-    hash = appendHashPart(hash, item.id);
-    hash = appendHashPart(hash, item.providerId);
-    hash = appendHashPart(hash, item.externalId);
-    hash = appendHashPart(hash, item.itemType);
-    hash = appendHashPart(hash, item.title);
-  }
-  return `h:${provenanceCount}:${hash.toString(36)}`;
+  return `v:${workGraph.getRelatedItemsVersion()}`;
 }
 
 function appendHashPart(hash: number, value: unknown): number {

--- a/packages/core/src/services/relatedItems.ts
+++ b/packages/core/src/services/relatedItems.ts
@@ -165,6 +165,11 @@ function getRelatedItemsIndexSignature(providerItems: Map<string, ProviderItem[]
   let hasAnyRelatedItems = false;
   let hasPrRelatedItems = false;
 
+  // The index resolves by provider/externalId provenance, item type/title, version tokens,
+  // and related-item refs. Hash every field that can change matching or labels; unrelated
+  // ProviderItem fields would only add cache churn, while omitting one of these fields could
+  // reuse stale relationships. The providerItems Map and item arrays keep stable order for an
+  // unchanged snapshot; if they are reordered, the order-sensitive signature safely misses.
   for (const [providerId, items] of providerItems) {
     hash = appendHashPart(hash, providerId);
     hash = appendHashPart(hash, items.length);
@@ -207,6 +212,9 @@ function getWorkGraphSignature(workGraph: WorkGraph): string {
     return `v:${relatedItemsVersion}`;
   }
 
+  // Older test doubles may not expose the version token. The fallback is a coarser
+  // proxy over work-item identity and title so tests still invalidate on provenance
+  // or label changes; production WorkGraph instances take the token path above.
   let hash = 2166136261;
   let provenanceCount = 0;
   for (const item of workGraph.getAll()) {
@@ -225,6 +233,9 @@ function getWorkGraphSignature(workGraph: WorkGraph): string {
 
 function appendHashPart(hash: number, value: unknown): number {
   const text = value === undefined ? '<undefined>' : String(value);
+  // Length-prefix each segment so embedded separators cannot create boundary-shift
+  // collisions (for example ['a;b', 'c'] versus ['a', 'b;c']). The outer item/ref counts
+  // also make empty inputs distinct from hashes that happen to match.
   hash = appendHashText(hash, String(text.length));
   hash = appendHashText(hash, ':');
   hash = appendHashText(hash, text);

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -150,7 +150,10 @@ export class WorkGraph {
     return Array.from(this.items.values());
   }
 
-  /** Cache-invalidation token for derived related-item lookups. */
+  /**
+   * Cache-invalidation token for related-item indexes. It only changes when work-item
+   * membership or titles change because related-item matching and labels ignore other fields.
+   */
   getRelatedItemsVersion(): number {
     return this.relatedItemsVersion;
   }

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -38,6 +38,7 @@ export class WorkGraph {
   private readonly duplicateProvenanceCounts: Map<string, number> = new Map();
   /** Lazily-built index of items grouped by state; nulled on any mutation to {@link items}. */
   private stateCache: Map<WorkItemState, WorkItem[]> | null = null;
+  private changeVersion = 0;
   private currentMutation: Promise<void> = Promise.resolve();
   private shutdownRequested = false;
   private readonly _onDidChange = new vscode.EventEmitter<WorkGraphChangeEvent>();
@@ -148,8 +149,14 @@ export class WorkGraph {
     return Array.from(this.items.values());
   }
 
+  /** Cache-invalidation token that may increase more often than user-visible mutations. */
+  getChangeVersion(): number {
+    return this.changeVersion;
+  }
+
   private invalidateStateCache(): void {
     this.stateCache = null;
+    this.changeVersion++;
   }
 
   private getOrBuildStateCache(): Map<WorkItemState, WorkItem[]> {

--- a/packages/core/src/services/workGraph.ts
+++ b/packages/core/src/services/workGraph.ts
@@ -38,7 +38,7 @@ export class WorkGraph {
   private readonly duplicateProvenanceCounts: Map<string, number> = new Map();
   /** Lazily-built index of items grouped by state; nulled on any mutation to {@link items}. */
   private stateCache: Map<WorkItemState, WorkItem[]> | null = null;
-  private changeVersion = 0;
+  private relatedItemsVersion = 0;
   private currentMutation: Promise<void> = Promise.resolve();
   private shutdownRequested = false;
   private readonly _onDidChange = new vscode.EventEmitter<WorkGraphChangeEvent>();
@@ -100,6 +100,7 @@ export class WorkGraph {
       }
     }
     this.invalidateStateCache();
+    this.invalidateRelatedItemsCache();
     logger.debug(`Loaded ${items.length} work items from store`);
     await this.backfillSortOrder();
   }
@@ -149,14 +150,17 @@ export class WorkGraph {
     return Array.from(this.items.values());
   }
 
-  /** Cache-invalidation token that may increase more often than user-visible mutations. */
-  getChangeVersion(): number {
-    return this.changeVersion;
+  /** Cache-invalidation token for derived related-item lookups. */
+  getRelatedItemsVersion(): number {
+    return this.relatedItemsVersion;
+  }
+
+  private invalidateRelatedItemsCache(): void {
+    this.relatedItemsVersion++;
   }
 
   private invalidateStateCache(): void {
     this.stateCache = null;
-    this.changeVersion++;
   }
 
   private getOrBuildStateCache(): Map<WorkItemState, WorkItem[]> {
@@ -252,6 +256,7 @@ export class WorkGraph {
       }
     }
     this.invalidateStateCache();
+    this.invalidateRelatedItemsCache();
     this.emitDidChange();
     logger.info(`Created work item: ${item.id}`);
     return item;
@@ -321,6 +326,9 @@ export class WorkGraph {
     await this.store.save(updated);
     this.items.set(id, updated);
     this.invalidateStateCache();
+    if (updated.title !== item.title) {
+      this.invalidateRelatedItemsCache();
+    }
     this.emitDidChange();
     logger.info(`Updated work item: ${id}`);
   }
@@ -646,6 +654,7 @@ export class WorkGraph {
     }
     this.items.delete(id);
     this.invalidateStateCache();
+    this.invalidateRelatedItemsCache();
     if (!options?.silent) {
       this.emitDidChange();
     }

--- a/packages/core/src/test/mainViewProvider.test.ts
+++ b/packages/core/src/test/mainViewProvider.test.ts
@@ -85,6 +85,7 @@ function createMockWorkGraph(initialItems: WorkItem[] = []) {
 
   return {
     getAll: vi.fn(() => Array.from(items.values())),
+    getRelatedItemsVersion: vi.fn(() => 1),
     getItemsByState: vi.fn((...states: WorkItemState[]) => Array.from(items.values()).filter(item => states.includes(item.state))),
     getItem: vi.fn((id: string) => items.get(id)),
     findItemByProvenance: vi.fn((providerId: string, externalId: string) => Array.from(items.values()).find(

--- a/packages/core/src/test/relatedItems.test.ts
+++ b/packages/core/src/test/relatedItems.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ProviderItem } from '../api/types';
 import { WorkItemState, type WorkItem } from '../models/workItem';
-import { buildRelatedItemsIndex, resolveRelatedItemsFor } from '../services/relatedItems';
+import { buildRelatedItemsIndex, clearRelatedItemsIndexCacheForTests, resolveRelatedItemsFor } from '../services/relatedItems';
 import { logger } from '../services/logger';
 
 vi.mock('../services/logger', () => ({
@@ -12,6 +12,11 @@ vi.mock('../services/logger', () => ({
     error: vi.fn(),
   },
 }));
+
+beforeEach(() => {
+  clearRelatedItemsIndexCacheForTests();
+  vi.mocked(logger.debug).mockClear();
+});
 
 function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
   const now = Date.now();
@@ -301,8 +306,101 @@ describe('resolveRelatedItemsFor', () => {
     ]);
   });
 
+  it('reuses the cached index when provider items and work graph are unchanged', () => {
+    const issue = makeWorkItem({ id: 'issue-1', providerId: 'github-issues', externalId: 'owner/repo#2' });
+    const pr = makeWorkItem({ id: 'pr-1', providerId: 'github-my-prs', externalId: 'owner/repo#10' });
+    const registry = makeRegistry(new Map([
+      ['github-issues', [{ externalId: 'owner/repo#2', title: 'Issue', itemType: 'issue' }]],
+      ['github-my-prs', [{ externalId: 'owner/repo#10', title: 'PR', itemType: 'pr', relatedItems: [{ externalId: 'owner/repo#2', itemType: 'issue', relation: 'closes' }] }]],
+    ]));
+    const workGraph = {
+      getChangeVersion: vi.fn(() => 1),
+      getAll: vi.fn(() => [issue, pr]),
+      findItemByProvenance: vi.fn((providerId: string, externalId: string) => [issue, pr].find(
+        item => item.providerId === providerId && item.externalId === externalId,
+      )),
+    } as any;
+
+    const firstIndex = buildRelatedItemsIndex(registry, workGraph);
+    const callCountAfterFirstBuild = workGraph.findItemByProvenance.mock.calls.length;
+    const secondIndex = buildRelatedItemsIndex(registry, workGraph);
+
+    expect(secondIndex).toBe(firstIndex);
+    expect(callCountAfterFirstBuild).toBeGreaterThan(0);
+    expect(workGraph.findItemByProvenance.mock.calls.length).toBe(callCountAfterFirstBuild);
+  });
+
+  it('invalidates the cached index when provider inputs change', () => {
+    const issue = makeWorkItem({ id: 'issue-1', providerId: 'github-issues', externalId: 'owner/repo#2' });
+    const pr = makeWorkItem({ id: 'pr-1', providerId: 'github-my-prs', externalId: 'owner/repo#10' });
+    const prDiscovered: ProviderItem = {
+      externalId: 'owner/repo#10',
+      title: 'PR',
+      itemType: 'pr',
+      version: '1',
+      relatedItems: [{ externalId: 'owner/repo#2', itemType: 'issue', relation: 'closes' }],
+    };
+    const registry = makeRegistry(new Map([
+      ['github-issues', [{ externalId: 'owner/repo#2', title: 'Issue', itemType: 'issue' }]],
+      ['github-my-prs', [prDiscovered]],
+    ]));
+    const workGraph = makeWorkGraph([issue, pr]);
+
+    const firstIndex = buildRelatedItemsIndex(registry, workGraph);
+    prDiscovered.version = '2';
+    const secondIndex = buildRelatedItemsIndex(registry, workGraph);
+
+    expect(secondIndex).not.toBe(firstIndex);
+    expect(resolveRelatedItemsFor(pr, registry, workGraph, secondIndex)).toEqual([
+      { targetItemId: 'issue-1', targetTitle: 'Item', targetExternalId: 'owner/repo#2', targetKind: 'workItem', label: 'Closes Item', relation: 'closes', itemType: 'issue' },
+    ]);
+  });
+
+  it('returns an empty index without scanning work graph items when no provider item has related refs', () => {
+    const registry = makeRegistry(new Map([
+      ['github-issues', [{ externalId: 'owner/repo#2', title: 'Issue', itemType: 'issue' }]],
+      ['github-my-prs', [{ externalId: 'owner/repo#10', title: 'PR', itemType: 'pr' }]],
+    ]));
+    const workGraph = {
+      getChangeVersion: vi.fn(() => 1),
+      getAll: vi.fn(() => { throw new Error('workGraph.getAll should not be called'); }),
+      findItemByProvenance: vi.fn(() => { throw new Error('workGraph.findItemByProvenance should not be called'); }),
+    } as any;
+
+    const index = buildRelatedItemsIndex(registry, workGraph);
+
+    expect(index.size).toBe(0);
+    expect(workGraph.getAll).not.toHaveBeenCalled();
+    expect(workGraph.findItemByProvenance).not.toHaveBeenCalled();
+  });
+
+  it('resolves non-PR forward refs without doing reverse PR resolution work', () => {
+    const source = makeWorkItem({ id: 'source-1', providerId: 'custom-provider', externalId: 'source-with-refs' });
+    const issue = makeWorkItem({ id: 'issue-1', providerId: 'github-issues', externalId: 'owner/repo#2' });
+    const items = [source, issue];
+    const registry = makeRegistry(new Map([
+      ['custom-provider', [{ externalId: 'source-with-refs', title: 'Source', relatedItems: [{ externalId: 'owner/repo#2', itemType: 'issue', relation: 'linked' }] }]],
+      ['github-my-prs', [{ externalId: 'owner/repo#10', title: 'PR', itemType: 'pr' }]],
+      ['github-issues', [{ externalId: 'owner/repo#2', title: 'Issue', itemType: 'issue' }]],
+    ]));
+    const workGraph = {
+      getChangeVersion: vi.fn(() => 1),
+      getAll: vi.fn(() => items),
+      findItemByProvenance: vi.fn((providerId: string, externalId: string) => items.find(
+        item => item.providerId === providerId && item.externalId === externalId,
+      )),
+    } as any;
+
+    const index = buildRelatedItemsIndex(registry, workGraph);
+
+    expect(resolveRelatedItemsFor(source, registry, workGraph, index)).toEqual([
+      { targetItemId: 'issue-1', targetTitle: 'Item', targetExternalId: 'owner/repo#2', targetKind: 'workItem', label: 'Linked to Item', relation: 'linked', itemType: 'issue' },
+    ]);
+    expect(index.has(JSON.stringify(['github-my-prs', 'owner/repo#10']))).toBe(false);
+    expect(workGraph.findItemByProvenance).toHaveBeenCalledTimes(1);
+  });
+
   it('logs strict misses when related refs are not discovered locally', () => {
-    vi.mocked(logger.debug).mockClear();
     const pr = makeWorkItem({ id: 'pr-1', providerId: 'github-my-prs', externalId: 'owner/repo#10' });
     const registry = makeRegistry(new Map([
       ['github-my-prs', [{ externalId: 'owner/repo#10', title: 'PR', itemType: 'pr', relatedItems: [{ externalId: 'owner/repo#404', itemType: 'issue', relation: 'closes' }] }]],

--- a/packages/core/src/test/relatedItems.test.ts
+++ b/packages/core/src/test/relatedItems.test.ts
@@ -39,6 +39,7 @@ function makeRegistry(discovered: Map<string, ProviderItem[]>) {
 
 function makeWorkGraph(items: WorkItem[] = []) {
   return {
+    getRelatedItemsVersion: vi.fn(() => 1),
     getAll: vi.fn(() => items),
     findItemByProvenance: vi.fn((providerId: string, externalId: string) => items.find(
       item => item.providerId === providerId && item.externalId === externalId,

--- a/packages/core/src/test/relatedItems.test.ts
+++ b/packages/core/src/test/relatedItems.test.ts
@@ -330,7 +330,7 @@ describe('resolveRelatedItemsFor', () => {
     expect(workGraph.findItemByProvenance.mock.calls.length).toBe(callCountAfterFirstBuild);
   });
 
-  it('invalidates the cached index when provider inputs change', () => {
+  it('invalidates the cached index when provider versions or related refs change', () => {
     const issue = makeWorkItem({ id: 'issue-1', providerId: 'github-issues', externalId: 'owner/repo#2' });
     const pr = makeWorkItem({ id: 'pr-1', providerId: 'github-my-prs', externalId: 'owner/repo#10' });
     const prDiscovered: ProviderItem = {
@@ -348,12 +348,16 @@ describe('resolveRelatedItemsFor', () => {
 
     const firstIndex = buildRelatedItemsIndex(registry, workGraph);
     prDiscovered.version = '2';
-    const secondIndex = buildRelatedItemsIndex(registry, workGraph);
+    const versionChangedIndex = buildRelatedItemsIndex(registry, workGraph);
+    prDiscovered.relatedItems = [];
+    const refsChangedIndex = buildRelatedItemsIndex(registry, workGraph);
 
-    expect(secondIndex).not.toBe(firstIndex);
-    expect(resolveRelatedItemsFor(pr, registry, workGraph, secondIndex)).toEqual([
+    expect(versionChangedIndex).not.toBe(firstIndex);
+    expect(resolveRelatedItemsFor(pr, registry, workGraph, versionChangedIndex)).toEqual([
       { targetItemId: 'issue-1', targetTitle: 'Item', targetExternalId: 'owner/repo#2', targetKind: 'workItem', label: 'Closes Item', relation: 'closes', itemType: 'issue' },
     ]);
+    expect(refsChangedIndex).not.toBe(versionChangedIndex);
+    expect(resolveRelatedItemsFor(pr, registry, workGraph, refsChangedIndex)).toEqual([]);
   });
 
   it('returns an empty index without scanning work graph items when no provider item has related refs', () => {

--- a/packages/core/src/test/relatedItems.test.ts
+++ b/packages/core/src/test/relatedItems.test.ts
@@ -314,7 +314,7 @@ describe('resolveRelatedItemsFor', () => {
       ['github-my-prs', [{ externalId: 'owner/repo#10', title: 'PR', itemType: 'pr', relatedItems: [{ externalId: 'owner/repo#2', itemType: 'issue', relation: 'closes' }] }]],
     ]));
     const workGraph = {
-      getChangeVersion: vi.fn(() => 1),
+      getRelatedItemsVersion: vi.fn(() => 1),
       getAll: vi.fn(() => [issue, pr]),
       findItemByProvenance: vi.fn((providerId: string, externalId: string) => [issue, pr].find(
         item => item.providerId === providerId && item.externalId === externalId,
@@ -362,7 +362,7 @@ describe('resolveRelatedItemsFor', () => {
       ['github-my-prs', [{ externalId: 'owner/repo#10', title: 'PR', itemType: 'pr' }]],
     ]));
     const workGraph = {
-      getChangeVersion: vi.fn(() => 1),
+      getRelatedItemsVersion: vi.fn(() => 1),
       getAll: vi.fn(() => { throw new Error('workGraph.getAll should not be called'); }),
       findItemByProvenance: vi.fn(() => { throw new Error('workGraph.findItemByProvenance should not be called'); }),
     } as any;
@@ -384,7 +384,7 @@ describe('resolveRelatedItemsFor', () => {
       ['github-issues', [{ externalId: 'owner/repo#2', title: 'Issue', itemType: 'issue' }]],
     ]));
     const workGraph = {
-      getChangeVersion: vi.fn(() => 1),
+      getRelatedItemsVersion: vi.fn(() => 1),
       getAll: vi.fn(() => items),
       findItemByProvenance: vi.fn((providerId: string, externalId: string) => items.find(
         item => item.providerId === providerId && item.externalId === externalId,

--- a/packages/core/src/test/webviewPanelSerializers.test.ts
+++ b/packages/core/src/test/webviewPanelSerializers.test.ts
@@ -69,6 +69,7 @@ function createMockWorkGraph(items: WorkItem[] = []) {
   const itemMap = new Map(items.map(item => [item.id, item]));
   return {
     getAll: vi.fn(() => Array.from(itemMap.values())),
+    getRelatedItemsVersion: vi.fn(() => 1),
     getItem: vi.fn((id: string) => itemMap.get(id)),
     findItemByProvenance: vi.fn((providerId: string, externalId: string) =>
       Array.from(itemMap.values()).find(item => item.providerId === providerId && item.externalId === externalId)),

--- a/packages/core/src/test/workGraph.test.ts
+++ b/packages/core/src/test/workGraph.test.ts
@@ -108,6 +108,37 @@ describe('WorkGraph', () => {
     expect(updated?.title).toBe('Updated');
   });
 
+  it('increments related-items version only for title and membership changes', async () => {
+    const initialVersion = graph.getRelatedItemsVersion();
+
+    const first = await graph.createItem({ title: 'Original', notes: 'Notes' });
+    expect(graph.getRelatedItemsVersion()).toBe(initialVersion + 1);
+
+    await graph.updateItem(first.id, { notes: 'Updated notes' });
+    expect(graph.getRelatedItemsVersion()).toBe(initialVersion + 1);
+
+    await graph.updateItem(first.id, { description: 'Updated description' });
+    expect(graph.getRelatedItemsVersion()).toBe(initialVersion + 1);
+
+    await graph.updateItem(first.id, { url: 'https://example.com/updated' });
+    expect(graph.getRelatedItemsVersion()).toBe(initialVersion + 1);
+
+    await graph.transitionState(first.id, WorkItemState.InProgress);
+    expect(graph.getRelatedItemsVersion()).toBe(initialVersion + 1);
+
+    await graph.updateItem(first.id, { title: 'Updated title' });
+    expect(graph.getRelatedItemsVersion()).toBe(initialVersion + 2);
+
+    const second = await graph.createItem({ title: 'Second' });
+    expect(graph.getRelatedItemsVersion()).toBe(initialVersion + 3);
+
+    await graph.moveToTop(second.id);
+    expect(graph.getRelatedItemsVersion()).toBe(initialVersion + 3);
+
+    await graph.deleteItem(second.id);
+    expect(graph.getRelatedItemsVersion()).toBe(initialVersion + 4);
+  });
+
   it('serializes concurrent mutations so state and field updates both survive', async () => {
     useMockFileSystem();
     const fileUri = vscode.Uri.file('C:\\test\\workgraph-items.json');

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -74,6 +74,7 @@ function createMockWorkGraph(primaryItem?: WorkItem, relatedByProvenance: Record
 
   return {
     getAll: vi.fn(() => Array.from(items.values())),
+    getRelatedItemsVersion: vi.fn(() => 1),
     getItem: vi.fn((id: string) => items.get(id)),
     updateItem: vi.fn(applyPatch),
     updateItemDuringShutdown: vi.fn(applyPatch),


### PR DESCRIPTION
## Summary

- Memoize the related-items index across unchanged sidebar refresh inputs.
- Skip related-item index rebuild work when no items have refs and skip reverse PR resolution when no PR has refs.
- Add focused tests and a changeset for the performance improvement.

## Tests

- npm run build && npm run test

Closes #637
