### PR TITLE
Debounce watch persistence writes

### DIFF
--- a/.changeset/perf-debounce-watch-persistence.md
+++ b/.changeset/perf-debounce-watch-persistence.md
@@ -1,0 +1,5 @@
+---
+"devdocket": patch
+---
+
+Debounce watch persistence writes and skip saves when only poll timestamps change, reducing repeated full-envelope rewrites during CI polling.

--- a/packages/core/src/services/watchPersistence.ts
+++ b/packages/core/src/services/watchPersistence.ts
@@ -2,10 +2,47 @@ import * as vscode from 'vscode';
 import { WatchStore } from '../storage/watchStore';
 import type { WatchedPR, WatchedRun } from './watcherService';
 
-function clonePersistedSnapshot(runs: WatchedRun[], prs: WatchedPR[]): { runs: WatchedRun[]; prs: WatchedPR[] } {
+interface WatchSnapshot {
+  runs: WatchedRun[];
+  prs: WatchedPR[];
+}
+
+interface SaveOptions {
+  immediate?: boolean;
+}
+
+const DEFAULT_DEBOUNCE_MS = 750;
+
+function clonePersistedSnapshot(runs: WatchedRun[], prs: WatchedPR[]): WatchSnapshot {
   // Watch persistence is JSON-backed, so cloning through JSON preserves the queued
   // snapshot without keeping references to later in-memory mutations.
-  return JSON.parse(JSON.stringify({ runs, prs })) as { runs: WatchedRun[]; prs: WatchedPR[] };
+  return JSON.parse(JSON.stringify({ runs, prs })) as WatchSnapshot;
+}
+
+function omitLastPolledAt(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(omitLastPolledAt);
+  }
+
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const [key, childValue] of Object.entries(value)) {
+    if (key !== 'lastPolledAt') {
+      result[key] = omitLastPolledAt(childValue);
+    }
+  }
+  return result;
+}
+
+function snapshotsEqualIgnoringLastPolledAt(left: WatchSnapshot | undefined, right: WatchSnapshot): boolean {
+  if (!left) {
+    return false;
+  }
+
+  return JSON.stringify(omitLastPolledAt(left)) === JSON.stringify(omitLastPolledAt(right));
 }
 
 type WatcherLogger = {
@@ -22,10 +59,14 @@ export class WatchPersistence {
   private readonly pendingPRWatchKeys = new Set<string>();
   private persistFailureNotified = false;
   private pendingSave: Promise<void> = Promise.resolve();
+  private pendingSnapshot: WatchSnapshot | undefined;
+  private lastPersistedSnapshot: WatchSnapshot | undefined;
+  private debounceTimer: NodeJS.Timeout | undefined;
 
   constructor(
     private readonly watchStore: WatchStore,
     private readonly logger: WatcherLogger,
+    private readonly debounceMs = DEFAULT_DEBOUNCE_MS,
   ) {}
 
   async loadAll(getPRWatchKey: (pr: WatchedPR) => string): Promise<{ runs: WatchedRun[]; prs: WatchedPR[] }> {
@@ -36,6 +77,7 @@ export class WatchPersistence {
       ...data.prs.map(getPRWatchKey),
     ]);
     this.pendingPRWatchKeys.clear();
+    this.lastPersistedSnapshot = clonePersistedSnapshot(data.runs, data.prs);
     return data;
   }
 
@@ -61,31 +103,59 @@ export class WatchPersistence {
     this.pendingPRWatchKeys.add(key);
   }
 
-  saveAll(runs: WatchedRun[], prs: WatchedPR[]): void {
-    const snapshot = clonePersistedSnapshot(runs, prs);
-    this.pendingSave = this.pendingSave
-      .catch(() => undefined)
-      .then(() => this.persistSnapshot(snapshot))
-      .catch(() => undefined);
+  saveAll(runs: WatchedRun[], prs: WatchedPR[], options: SaveOptions = {}): Promise<void> | void {
+    this.pendingSnapshot = clonePersistedSnapshot(runs, prs);
+
+    if (options.immediate) {
+      return this.flush();
+    }
+
+    if (!this.debounceTimer) {
+      this.debounceTimer = setTimeout(() => {
+        this.debounceTimer = undefined;
+        void this.flush();
+      }, this.debounceMs);
+    }
   }
 
   async flush(): Promise<void> {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = undefined;
+    }
+
     while (true) {
+      const snapshot = this.pendingSnapshot;
+      this.pendingSnapshot = undefined;
+
+      if (snapshot) {
+        this.pendingSave = this.pendingSave
+          .catch(() => undefined)
+          .then(() => this.persistSnapshot(snapshot))
+          .catch(() => undefined);
+      }
+
       const pendingSave = this.pendingSave;
       try {
         await pendingSave;
       } catch {
         // saveAll already surfaced the failure; flushing is best-effort.
       }
-      if (pendingSave === this.pendingSave) {
+
+      if (!this.pendingSnapshot && pendingSave === this.pendingSave) {
         return;
       }
     }
   }
 
-  private async persistSnapshot(snapshot: { runs: WatchedRun[]; prs: WatchedPR[] }): Promise<void> {
+  private async persistSnapshot(snapshot: WatchSnapshot): Promise<void> {
+    if (snapshotsEqualIgnoringLastPolledAt(this.lastPersistedSnapshot, snapshot)) {
+      return;
+    }
+
     try {
       await this.watchStore.saveAll(snapshot.runs, snapshot.prs);
+      this.lastPersistedSnapshot = snapshot;
       if (this.persistFailureNotified) {
         this.persistFailureNotified = false;
         this.logger.info('Watch persistence recovered.');
@@ -103,6 +173,7 @@ export class WatchPersistence {
   }
 
   dispose(): void {
+    void this.flush();
     this.persistedPRWatchKeys = undefined;
     this.pendingPRWatchKeys.clear();
   }

--- a/packages/core/src/services/watchPersistence.ts
+++ b/packages/core/src/services/watchPersistence.ts
@@ -110,19 +110,11 @@ export class WatchPersistence {
       return this.flush();
     }
 
-    if (!this.debounceTimer) {
-      this.debounceTimer = setTimeout(() => {
-        this.debounceTimer = undefined;
-        void this.flush();
-      }, this.debounceMs);
-    }
+    this.scheduleDebouncedFlush();
   }
 
   async flush(): Promise<void> {
-    if (this.debounceTimer) {
-      clearTimeout(this.debounceTimer);
-      this.debounceTimer = undefined;
-    }
+    this.clearDebounceTimer();
 
     while (true) {
       const snapshot = this.pendingSnapshot;
@@ -145,6 +137,21 @@ export class WatchPersistence {
       if (!this.pendingSnapshot && pendingSave === this.pendingSave) {
         return;
       }
+    }
+  }
+
+  private scheduleDebouncedFlush(): void {
+    this.clearDebounceTimer();
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = undefined;
+      void this.flush();
+    }, this.debounceMs);
+  }
+
+  private clearDebounceTimer(): void {
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = undefined;
     }
   }
 

--- a/packages/core/src/services/watchPersistence.ts
+++ b/packages/core/src/services/watchPersistence.ts
@@ -7,11 +7,6 @@ interface WatchSnapshot {
   prs: WatchedPR[];
 }
 
-interface PendingWatchSnapshot {
-  runs: WatchedRun[];
-  prs: WatchedPR[];
-}
-
 interface SaveOptions {
   immediate?: boolean;
 }
@@ -64,7 +59,7 @@ export class WatchPersistence {
   private readonly pendingPRWatchKeys = new Set<string>();
   private persistFailureNotified = false;
   private pendingSave: Promise<void> = Promise.resolve();
-  private pendingSnapshot: PendingWatchSnapshot | undefined;
+  private pendingSnapshot: WatchSnapshot | undefined;
   private lastPersistedSnapshot: WatchSnapshot | undefined;
   private debounceTimer: NodeJS.Timeout | undefined;
 

--- a/packages/core/src/services/watchPersistence.ts
+++ b/packages/core/src/services/watchPersistence.ts
@@ -7,6 +7,11 @@ interface WatchSnapshot {
   prs: WatchedPR[];
 }
 
+interface PendingWatchSnapshot {
+  runs: WatchedRun[];
+  prs: WatchedPR[];
+}
+
 interface SaveOptions {
   immediate?: boolean;
 }
@@ -59,7 +64,7 @@ export class WatchPersistence {
   private readonly pendingPRWatchKeys = new Set<string>();
   private persistFailureNotified = false;
   private pendingSave: Promise<void> = Promise.resolve();
-  private pendingSnapshot: WatchSnapshot | undefined;
+  private pendingSnapshot: PendingWatchSnapshot | undefined;
   private lastPersistedSnapshot: WatchSnapshot | undefined;
   private debounceTimer: NodeJS.Timeout | undefined;
 
@@ -104,7 +109,7 @@ export class WatchPersistence {
   }
 
   saveAll(runs: WatchedRun[], prs: WatchedPR[], options: SaveOptions = {}): Promise<void> | void {
-    this.pendingSnapshot = clonePersistedSnapshot(runs, prs);
+    this.pendingSnapshot = { runs, prs };
 
     if (options.immediate) {
       return this.flush();
@@ -117,7 +122,9 @@ export class WatchPersistence {
     this.clearDebounceTimer();
 
     while (true) {
-      const snapshot = this.pendingSnapshot;
+      const snapshot = this.pendingSnapshot
+        ? clonePersistedSnapshot(this.pendingSnapshot.runs, this.pendingSnapshot.prs)
+        : undefined;
       this.pendingSnapshot = undefined;
 
       if (snapshot) {

--- a/packages/core/src/services/watcherService.ts
+++ b/packages/core/src/services/watcherService.ts
@@ -165,7 +165,7 @@ export class WatcherService implements vscode.Disposable {
     }
 
     if (hadLiveWatches && (restored > 0 || restoredPRs > 0)) {
-      this.persistWatches();
+      await this.persistWatches({ immediate: true });
     }
   }
 
@@ -192,7 +192,7 @@ export class WatcherService implements vscode.Disposable {
     }
 
     if (!options?.suppressPersist) {
-      this.persistWatches();
+      void this.persistWatches({ immediate: true });
     }
     return result.watch;
   }
@@ -229,7 +229,7 @@ export class WatcherService implements vscode.Disposable {
 
     this._onDidChangePRWatches.fire();
     this._onDidChangeWatchedRuns.fire(this.getAllWatches());
-    this.persistWatches();
+    void this.persistWatches({ immediate: true });
     return result.watch;
   }
 
@@ -243,7 +243,7 @@ export class WatcherService implements vscode.Disposable {
         this._onDidChangePRWatches.fire();
       }
       this._onDidChangeWatchedRuns.fire(this.getAllWatches());
-      this.persistWatches();
+      void this.persistWatches({ immediate: true });
     }
   }
 
@@ -257,7 +257,7 @@ export class WatcherService implements vscode.Disposable {
     if (result.dismissed) {
       this._onDidChangePRWatches.fire();
       this._onDidChangeWatchedRuns.fire(this.getAllWatches());
-      this.persistWatches();
+      void this.persistWatches({ immediate: true });
     }
   }
 
@@ -279,7 +279,7 @@ export class WatcherService implements vscode.Disposable {
       this.logger.info(`Dismissed ${dismissedCount} completed watch(es)`);
       this._onDidChangePRWatches.fire();
       this._onDidChangeWatchedRuns.fire(this.getAllWatches());
-      this.persistWatches();
+      void this.persistWatches({ immediate: true });
     }
     return dismissedCount;
   }
@@ -497,7 +497,7 @@ export class WatcherService implements vscode.Disposable {
 
       const anyChanged = prResult.prChanged || prResult.childRunChanged || runChanged;
       if (anyChanged) {
-        this.persistWatches();
+        void this.persistWatches();
       }
 
       if (!this.runPool.hasPollableWatches() && !this.prPool.hasPollablePRWatches()) {
@@ -508,8 +508,8 @@ export class WatcherService implements vscode.Disposable {
     }
   }
 
-  private persistWatches(): void {
-    this.persistence.saveAll(this.getAllWatches(), this.getAllPRWatches());
+  private async persistWatches(options?: { immediate?: boolean }): Promise<void> {
+    await this.persistence.saveAll(this.getAllWatches(), this.getAllPRWatches(), options);
   }
 
   beginShutdown(): void {

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -576,7 +576,7 @@ describe('WatcherService', () => {
       await service.flushPersistence();
 
       expect(watchStore.saveAll).toHaveBeenCalledTimes(1);
-      const [runs] = (watchStore.saveAll as ReturnType<typeof vi.fn>).mock.calls[0] as [WatchedRun[]];
+      const [runs] = (watchStore.saveAll as ReturnType<typeof vi.fn>).mock.calls[0] as [WatchedRun[], unknown[]];
       expect(runs[0].status.jobs[0].state).toBe('completed');
     });
 

--- a/packages/core/src/test/watcherService.test.ts
+++ b/packages/core/src/test/watcherService.test.ts
@@ -552,6 +552,105 @@ describe('WatcherService', () => {
       expect(flushed).toBe(true);
     });
 
+    it('coalesces a burst of poll changes into one debounced save', async () => {
+      const statuses: RunStatus[] = [
+        { overallState: 'running', conclusion: undefined, jobs: [] },
+        { overallState: 'running', conclusion: undefined, jobs: [{ name: 'build', state: 'running' }] },
+        { overallState: 'running', conclusion: undefined, jobs: [{ name: 'build', state: 'completed', conclusion: 'success' }] },
+      ];
+      let statusIndex = 0;
+      const watcher = createMockWatcher('test', async () => statuses[Math.min(statusIndex++, statuses.length - 1)]);
+      registry.register(watcher);
+
+      await service.startWatch(createIdentifier());
+      await service.flushPersistence();
+      (watchStore.saveAll as ReturnType<typeof vi.fn>).mockClear();
+
+      await (service as any).pollAllWatches();
+      await (service as any).pollAllWatches();
+
+      expect(watchStore.saveAll).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(749);
+      expect(watchStore.saveAll).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(1);
+      await service.flushPersistence();
+
+      expect(watchStore.saveAll).toHaveBeenCalledTimes(1);
+      const [runs] = (watchStore.saveAll as ReturnType<typeof vi.fn>).mock.calls[0] as [WatchedRun[]];
+      expect(runs[0].status.jobs[0].state).toBe('completed');
+    });
+
+    it('does not persist when only lastPolledAt changed since the loaded snapshot', async () => {
+      const persistedWatch: WatchedRun = {
+        identifier: createIdentifier(),
+        status: { overallState: 'running', jobs: [] },
+        watchedAt: '2026-01-01T00:00:00.000Z',
+        lastPolledAt: '2026-01-01T00:00:00.000Z',
+        dismissed: false,
+      };
+      (watchStore.loadAll as ReturnType<typeof vi.fn>).mockResolvedValue({ runs: [persistedWatch], prs: [] });
+      registry.register(createMockWatcher('test'));
+
+      await service.loadPersistedWatches();
+      (watchStore.saveAll as ReturnType<typeof vi.fn>).mockClear();
+
+      service.getAllWatches()[0].lastPolledAt = '2026-01-01T00:01:00.000Z';
+      await (service as any).persistWatches({ immediate: true });
+
+      expect(watchStore.saveAll).not.toHaveBeenCalled();
+    });
+
+    it('persists status and job changes even when lastPolledAt also changed', async () => {
+      const persistedWatch: WatchedRun = {
+        identifier: createIdentifier(),
+        status: { overallState: 'running', jobs: [] },
+        watchedAt: '2026-01-01T00:00:00.000Z',
+        lastPolledAt: '2026-01-01T00:00:00.000Z',
+        dismissed: false,
+      };
+      (watchStore.loadAll as ReturnType<typeof vi.fn>).mockResolvedValue({ runs: [persistedWatch], prs: [] });
+      registry.register(createMockWatcher('test'));
+
+      await service.loadPersistedWatches();
+      (watchStore.saveAll as ReturnType<typeof vi.fn>).mockClear();
+
+      const watch = service.getAllWatches()[0];
+      watch.lastPolledAt = '2026-01-01T00:01:00.000Z';
+      watch.status = { overallState: 'running', jobs: [{ name: 'build', state: 'completed', conclusion: 'success' }] };
+      await (service as any).persistWatches({ immediate: true });
+
+      expect(watchStore.saveAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('flushPersistence drains pending debounced saves without waiting for the timer', async () => {
+      const watcher = createMockWatcher('test');
+      registry.register(watcher);
+      await service.startWatch(createIdentifier());
+      await service.flushPersistence();
+      (watchStore.saveAll as ReturnType<typeof vi.fn>).mockClear();
+
+      service.getAllWatches()[0].status = { overallState: 'completed', conclusion: 'success', jobs: [] };
+      void (service as any).persistWatches();
+
+      await service.flushPersistence();
+
+      expect(watchStore.saveAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('dispose flushes pending debounced saves', async () => {
+      const watcher = createMockWatcher('test');
+      registry.register(watcher);
+      await service.startWatch(createIdentifier());
+      await service.flushPersistence();
+      (watchStore.saveAll as ReturnType<typeof vi.fn>).mockClear();
+
+      service.getAllWatches()[0].status = { overallState: 'completed', conclusion: 'success', jobs: [] };
+      void (service as any).persistWatches();
+      service.dispose();
+
+      await vi.waitFor(() => expect(watchStore.saveAll).toHaveBeenCalledTimes(1));
+    });
+
     it('loads persisted watches on loadPersistedWatches', async () => {
       const watcher = createMockWatcher('test');
       registry.register(watcher);


### PR DESCRIPTION
## Summary

- Debounce watch persistence so polling bursts coalesce into one save.
- Skip writes when only `lastPolledAt` changes from the last persisted snapshot.
- Flush pending watch saves on explicit user actions, `flushPersistence()`, and dispose/deactivation.
- Add coverage for debouncing, timestamp-only skips, status persistence, flush, and dispose behavior.

Closes #634

## Validation

- `npm run build && npm run test`
- `npx vitest run src/test/watcherService.test.ts --reporter=dot` from `packages/core`
