### PR TITLE
Filter editor provider refreshes

### DIFF
--- a/.changeset/perf-editor-panel-filter-provider-items.md
+++ b/.changeset/perf-editor-panel-filter-provider-items.md
@@ -1,0 +1,5 @@
+---
+"devdocket": patch
+---
+
+Reduce unnecessary editor panel refreshes by filtering provider-item updates to the work item currently shown in the editor.

--- a/packages/core/src/services/providerRegistry.ts
+++ b/packages/core/src/services/providerRegistry.ts
@@ -65,8 +65,8 @@ export class ProviderRegistry {
   private readonly syntheticProviderItems = new Map<string, Map<string, ProviderItem>>();
   private allProviderItemsCache: Map<string, ProviderItem[]> | undefined;
   private readonly rehydratedImportedItems = new Map<string, Set<string>>();
-  private readonly _onDidChangeProviderItems = new vscode.EventEmitter<void>();
-  /** Fired whenever any provider's provider items change. */
+  private readonly _onDidChangeProviderItems = new vscode.EventEmitter<string | undefined>();
+  /** Fired whenever any provider's provider items change, with the provider ID when known. */
   readonly onDidChangeProviderItems = this._onDidChangeProviderItems.event;
   private readonly _onDidRegisterProvider = new vscode.EventEmitter<void>();
   /** Fired when a new provider is registered. */
@@ -218,14 +218,14 @@ export class ProviderRegistry {
     this._loadingProviders.add(provider.id);
     this.invalidateProviderItemCaches(provider.id);
     this._onDidRegisterProvider.fire();
-    this._onDidChangeProviderItems.fire();
+    this._onDidChangeProviderItems.fire(provider.id);
     this.refreshWithTimeout(provider, undefined, false)
       .finally(() => {
         const producedItemsDuringInitialRefresh = this.initialRefreshProducedItems.has(provider.id);
         this.initialRefreshProducedItems.delete(provider.id);
         this._loadingProviders.delete(provider.id);
         if (!this._disposed) {
-          this._onDidChangeProviderItems.fire();
+          this._onDidChangeProviderItems.fire(provider.id);
           if (!producedItemsDuringInitialRefresh) {
             this.queueRehydrateSyntheticProviderItems(provider);
           }
@@ -249,7 +249,7 @@ export class ProviderRegistry {
       this._rehydrateQueues.delete(provider.id);
       this.invalidateProviderItemCaches(provider.id);
       if (!this._disposed) {
-        this._onDidChangeProviderItems.fire();
+        this._onDidChangeProviderItems.fire(provider.id);
       }
     });
   }
@@ -325,7 +325,7 @@ export class ProviderRegistry {
     this.markImportedItemRehydrated(providerId, item.externalId);
     syntheticItems.set(item.externalId, { ...item });
     this.invalidateProviderItemCaches(providerId);
-    this._onDidChangeProviderItems.fire();
+    this._onDidChangeProviderItems.fire(providerId);
   }
 
   private markImportedItemRehydrated(providerId: string, externalId: string): void {
@@ -799,7 +799,7 @@ export class ProviderRegistry {
       }
     }
     if (!this._disposed) {
-      this._onDidChangeProviderItems.fire();
+      this._onDidChangeProviderItems.fire(providerId);
       this._onDidRefreshProvider.fire(providerId);
       const provider = this.providers.get(providerId);
       if (provider) {

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -108,7 +108,7 @@ function createMockWorkGraph(primaryItem?: WorkItem, relatedByProvenance: Record
 }
 
 function createMockProviderRegistry(discoveredByProvider: Record<string, any[]> = {}) {
-  const discoveredEmitter = new EventEmitter<void>();
+  const discoveredEmitter = new EventEmitter<string | undefined>();
   const registerEmitter = new EventEmitter<void>();
 
   const registry: any = {
@@ -118,7 +118,7 @@ function createMockProviderRegistry(discoveredByProvider: Record<string, any[]> 
     getProviderLabel: vi.fn((providerId: string) => providerId === 'github' ? 'GitHub' : providerId),
     onDidChangeProviderItems: discoveredEmitter.event,
     onDidRegisterProvider: registerEmitter.event,
-    _fireProviderItemsChange: () => discoveredEmitter.fire(),
+    _fireProviderItemsChange: (providerId?: string) => discoveredEmitter.fire(providerId),
     _fireRegisterProvider: () => registerEmitter.fire(),
   };
   registry.findProviderItem = vi.fn((providerId: string, externalId: string) =>
@@ -349,6 +349,83 @@ describe('WorkItemEditorPanel', () => {
         relatedItems: [expect.objectContaining({ targetItemId: 'peer-1', label: 'Closes Peer' })],
       }),
     }));
+  });
+
+  it('does not update when a provider-items event is for a different provider', () => {
+    const item = makeItem({ providerId: 'github-my-prs', externalId: 'owner/repo#42' });
+    const providerRegistry = createMockProviderRegistry({
+      'github-my-prs': [{ externalId: 'owner/repo#42', title: 'Primary', state: 'open' }],
+      'github-issues': [{ externalId: 'owner/repo#99', title: 'Peer', state: 'active' }],
+    });
+    const { mock } = openPanel(item, createMockWorkGraph(item), providerRegistry);
+    vi.mocked(mock.panel.webview.postMessage).mockClear();
+
+    providerRegistry._fireProviderItemsChange('github-issues');
+
+    expect(mock.panel.webview.postMessage).not.toHaveBeenCalled();
+  });
+
+  it('updates when a related provider item changes', () => {
+    const item = makeItem({ providerId: 'github-my-prs', externalId: 'owner/repo#42' });
+    const providerRegistry = createMockProviderRegistry({
+      'github-my-prs': [{ externalId: 'owner/repo#42', title: 'Primary', state: 'open', relatedItems: [{ externalId: 'owner/repo#99', itemType: 'issue', relation: 'closes' }] }],
+      'github-issues': [{ externalId: 'owner/repo#99', title: 'Peer', state: 'active', itemType: 'issue' }],
+    });
+    const { mock } = openPanel(item, createMockWorkGraph(item), providerRegistry);
+    vi.mocked(mock.panel.webview.postMessage).mockClear();
+    providerRegistry.getProviderItems.mockImplementation((providerId: string) => {
+      if (providerId === 'github-issues') {
+        return [{ externalId: 'owner/repo#99', title: 'Peer', state: 'closed', itemType: 'issue' }];
+      }
+      return [{ externalId: 'owner/repo#42', title: 'Primary', state: 'open', relatedItems: [{ externalId: 'owner/repo#99', itemType: 'issue', relation: 'closes' }] }];
+    });
+    providerRegistry.getAllProviderItems.mockReturnValue(new Map([
+      ['github-my-prs', [{ externalId: 'owner/repo#42', title: 'Primary', state: 'open', relatedItems: [{ externalId: 'owner/repo#99', itemType: 'issue', relation: 'closes' }] }]],
+      ['github-issues', [{ externalId: 'owner/repo#99', title: 'Peer', state: 'closed', itemType: 'issue' }]],
+    ]));
+
+    providerRegistry._fireProviderItemsChange('github-issues');
+
+    expect(mock.panel.webview.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'updateEditorItem',
+    }));
+  });
+
+  it('updates when its provider item changes', () => {
+    const item = makeItem({ providerId: 'github-my-prs', externalId: 'owner/repo#42' });
+    const providerRegistry = createMockProviderRegistry({
+      'github-my-prs': [{ externalId: 'owner/repo#42', title: 'Primary', state: 'open' }],
+    });
+    const { mock } = openPanel(item, createMockWorkGraph(item), providerRegistry);
+    vi.mocked(mock.panel.webview.postMessage).mockClear();
+    providerRegistry.getProviderItems.mockReturnValue([
+      { externalId: 'owner/repo#42', title: 'Primary', state: 'closed' },
+    ]);
+    providerRegistry.getAllProviderItems.mockReturnValue(new Map([
+      ['github-my-prs', [{ externalId: 'owner/repo#42', title: 'Primary', state: 'closed' }]],
+    ]));
+
+    providerRegistry._fireProviderItemsChange('github-my-prs');
+
+    expect(mock.panel.webview.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'updateEditorItem',
+    }));
+  });
+
+  it('does not update when its provider item is unchanged', () => {
+    const item = makeItem({ providerId: 'github-my-prs', externalId: 'owner/repo#42' });
+    const providerRegistry = createMockProviderRegistry({
+      'github-my-prs': [{ externalId: 'owner/repo#42', title: 'Primary', state: 'open' }],
+    });
+    const { mock } = openPanel(item, createMockWorkGraph(item), providerRegistry);
+    vi.mocked(mock.panel.webview.postMessage).mockClear();
+    providerRegistry.getProviderItems.mockReturnValue([
+      { state: 'open', title: 'Primary', externalId: 'owner/repo#42' },
+    ]);
+
+    providerRegistry._fireProviderItemsChange('github-my-prs');
+
+    expect(mock.panel.webview.postMessage).not.toHaveBeenCalled();
   });
 
   it('includes CI watch data for watched PRs across provider IDs', () => {

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -435,6 +435,29 @@ describe('WorkItemEditorPanel', () => {
     }));
   });
 
+  it('updates when provider item function-valued capabilities change', () => {
+    const item = makeItem({ providerId: 'github-my-prs', externalId: 'owner/repo#42' });
+    const providerRegistry = createMockProviderRegistry({
+      'github-my-prs': [{
+        externalId: 'owner/repo#42',
+        title: 'Primary',
+        state: 'open',
+        capabilities: { gitWork: () => Promise.resolve({ kind: 'pr' }) },
+      }],
+    });
+    const { mock } = openPanel(item, createMockWorkGraph(item), providerRegistry);
+    vi.mocked(mock.panel.webview.postMessage).mockClear();
+    providerRegistry.getProviderItems.mockReturnValue([
+      { externalId: 'owner/repo#42', title: 'Primary', state: 'open', capabilities: {} },
+    ]);
+
+    providerRegistry._fireProviderItemsChange('github-my-prs');
+
+    expect(mock.panel.webview.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'updateEditorItem',
+    }));
+  });
+
   it('does not update when its provider item is unchanged', () => {
     const item = makeItem({ providerId: 'github-my-prs', externalId: 'owner/repo#42' });
     const providerRegistry = createMockProviderRegistry({

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -369,19 +369,19 @@ describe('WorkItemEditorPanel', () => {
     const item = makeItem({ providerId: 'github-my-prs', externalId: 'owner/repo#42' });
     const providerRegistry = createMockProviderRegistry({
       'github-my-prs': [{ externalId: 'owner/repo#42', title: 'Primary', state: 'open', relatedItems: [{ externalId: 'owner/repo#99', itemType: 'issue', relation: 'closes' }] }],
-      'github-issues': [{ externalId: 'owner/repo#99', title: 'Peer', state: 'active', itemType: 'issue' }],
+      'github-issues': [{ externalId: 'owner/repo#99', title: 'Peer', state: 'active' }],
     });
     const { mock } = openPanel(item, createMockWorkGraph(item), providerRegistry);
     vi.mocked(mock.panel.webview.postMessage).mockClear();
     providerRegistry.getProviderItems.mockImplementation((providerId: string) => {
       if (providerId === 'github-issues') {
-        return [{ externalId: 'owner/repo#99', title: 'Peer', state: 'closed', itemType: 'issue' }];
+        return [{ externalId: 'owner/repo#99', title: 'Peer', state: 'closed' }];
       }
       return [{ externalId: 'owner/repo#42', title: 'Primary', state: 'open', relatedItems: [{ externalId: 'owner/repo#99', itemType: 'issue', relation: 'closes' }] }];
     });
     providerRegistry.getAllProviderItems.mockReturnValue(new Map([
       ['github-my-prs', [{ externalId: 'owner/repo#42', title: 'Primary', state: 'open', relatedItems: [{ externalId: 'owner/repo#99', itemType: 'issue', relation: 'closes' }] }]],
-      ['github-issues', [{ externalId: 'owner/repo#99', title: 'Peer', state: 'closed', itemType: 'issue' }]],
+      ['github-issues', [{ externalId: 'owner/repo#99', title: 'Peer', state: 'closed' }]],
     ]));
 
     providerRegistry._fireProviderItemsChange('github-issues');

--- a/packages/core/src/test/workItemEditorPanel.test.ts
+++ b/packages/core/src/test/workItemEditorPanel.test.ts
@@ -391,6 +391,29 @@ describe('WorkItemEditorPanel', () => {
     }));
   });
 
+  it('updates when a related item in the same provider changes', () => {
+    const item = makeItem({ providerId: 'github-my-prs', externalId: 'owner/repo#42' });
+    const primary = { externalId: 'owner/repo#42', title: 'Primary', state: 'open', relatedItems: [{ externalId: 'owner/repo#99', itemType: 'issue', relation: 'closes' }] };
+    const providerRegistry = createMockProviderRegistry({
+      'github-my-prs': [primary, { externalId: 'owner/repo#99', title: 'Peer', state: 'active', itemType: 'issue' }],
+    });
+    const { mock } = openPanel(item, createMockWorkGraph(item), providerRegistry);
+    vi.mocked(mock.panel.webview.postMessage).mockClear();
+    providerRegistry.getProviderItems.mockReturnValue([
+      primary,
+      { externalId: 'owner/repo#99', title: 'Peer', state: 'closed', itemType: 'issue' },
+    ]);
+    providerRegistry.getAllProviderItems.mockReturnValue(new Map([
+      ['github-my-prs', [primary, { externalId: 'owner/repo#99', title: 'Peer', state: 'closed', itemType: 'issue' }]],
+    ]));
+
+    providerRegistry._fireProviderItemsChange('github-my-prs');
+
+    expect(mock.panel.webview.postMessage).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'updateEditorItem',
+    }));
+  });
+
   it('updates when its provider item changes', () => {
     const item = makeItem({ providerId: 'github-my-prs', externalId: 'owner/repo#42' });
     const providerRegistry = createMockProviderRegistry({

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -594,7 +594,7 @@ export class WorkItemEditorPanel {
 
     const relatedKeys = new Set(relatedRefs.map(ref => providerItemSnapshotKey(ref.itemType, ref.externalId)));
     const relatedItems = this.providerRegistry.getProviderItems(providerId)
-      .filter(candidate => relatedKeys.has(providerItemSnapshotKey(candidate.itemType, candidate.externalId)))
+      .filter(candidate => providerItemMatchesRelatedKeys(candidate, relatedKeys))
       .sort((left, right) => providerItemSnapshotKey(left.itemType, left.externalId).localeCompare(providerItemSnapshotKey(right.itemType, right.externalId)));
     return relatedItems.length > 0 ? stableStringify(relatedItems) : undefined;
   }
@@ -848,6 +848,14 @@ function stableStringify(value: unknown): string {
 
 function providerItemSnapshotKey(itemType: ProviderItem['itemType'], externalId: string): string {
   return `${itemType ?? ''}\u0000${externalId}`;
+}
+
+function providerItemMatchesRelatedKeys(item: ProviderItem, relatedKeys: Set<string>): boolean {
+  if (item.itemType) {
+    return relatedKeys.has(providerItemSnapshotKey(item.itemType, item.externalId));
+  }
+  return relatedKeys.has(providerItemSnapshotKey('issue', item.externalId))
+    || relatedKeys.has(providerItemSnapshotKey('pr', item.externalId));
 }
 
 function toStableJson(value: unknown): unknown {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -865,6 +865,15 @@ function providerItemMatchesRelatedKeys(item: ProviderItem, relatedKeys: Set<str
 }
 
 function toStableJson(value: unknown): unknown {
+  if (typeof value === 'function') {
+    return '[Function]';
+  }
+  if (typeof value === 'undefined') {
+    return '[Undefined]';
+  }
+  if (typeof value === 'symbol') {
+    return value.toString();
+  }
   if (value === null || typeof value !== 'object') {
     return value;
   }

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -95,6 +95,8 @@ export class WorkItemEditorPanel {
   private lastDisplayedState: WorkItemState | undefined;
   private lastDisplayedGroup: string | undefined;
   private lastManagedState: boolean | undefined;
+  private lastProviderItemSnapshot: string | undefined;
+  private lastRelatedProviderItemSnapshots = new Map<string, string>();
   private lastDisplayedCIWatchSignature: string | undefined;
   private lastDisplayedCIWatchRunKeys = new Set<string>();
 
@@ -233,8 +235,8 @@ export class WorkItemEditorPanel {
       this.update();
     });
 
-    this.providerChangeSub = this.providerRegistry.onDidChangeProviderItems(() => {
-      this.update();
+    this.providerChangeSub = this.providerRegistry.onDidChangeProviderItems((providerId) => {
+      this.refreshForProviderItemsChange(providerId);
     });
 
     this.actionRegistrySub = this.actionRegistry.onDidChangeRegistrations(() => {
@@ -333,6 +335,23 @@ export class WorkItemEditorPanel {
 
   private isProviderManaged(item: WorkItem): boolean {
     return !!(item.providerId && this.providerRegistry.getProvider(item.providerId));
+  }
+
+  private refreshForProviderItemsChange(providerId?: string): void {
+    if (this.disposed) { return; }
+    const item = this.workGraph.getItem(this.itemId);
+    if (!item?.providerId || !item.externalId) { return; }
+    if (providerId !== undefined && providerId !== item.providerId) {
+      const nextRelatedSnapshot = this.buildRelatedProviderItemSnapshot(item, providerId);
+      if (nextRelatedSnapshot === this.lastRelatedProviderItemSnapshots.get(providerId)) { return; }
+      this.update();
+      return;
+    }
+
+    const nextSnapshot = this.buildProviderItemSnapshot(item);
+    if (nextSnapshot === this.lastProviderItemSnapshot) { return; }
+
+    this.update();
   }
 
   private refreshForPRWatchChange(): void {
@@ -457,6 +476,8 @@ export class WorkItemEditorPanel {
     const item = this.workGraph.getItem(this.itemId);
     if (!item) {
       this.htmlInitialized = false;
+      this.lastProviderItemSnapshot = undefined;
+      this.lastRelatedProviderItemSnapshots.clear();
       this.lastDisplayedCIWatchSignature = undefined;
       this.lastDisplayedCIWatchRunKeys.clear();
       this.panel.webview.html = '<html><body><p>Item not found.</p></body></html>';
@@ -473,6 +494,8 @@ export class WorkItemEditorPanel {
     this.lastDisplayedState = item.state;
     this.lastDisplayedGroup = item.group;
     this.lastManagedState = editorItem.isProviderManaged;
+    this.lastProviderItemSnapshot = this.buildProviderItemSnapshot(item);
+    this.lastRelatedProviderItemSnapshots = this.buildRelatedProviderItemSnapshots(item);
     this.panel.title = `Edit: ${item.title}`;
 
     if (!this.htmlInitialized) {
@@ -540,6 +563,39 @@ export class WorkItemEditorPanel {
     }
 
     return this.providerRegistry.findProviderItem(item.providerId, item.externalId);
+  }
+
+  private buildProviderItemSnapshot(item: WorkItem): string | undefined {
+    const providerItem = this.getProviderItem(item);
+    return providerItem ? stableStringify(providerItem) : undefined;
+  }
+
+  private buildRelatedProviderItemSnapshots(item: WorkItem): Map<string, string> {
+    const snapshots = new Map<string, string>();
+    const providerItem = this.getProviderItem(item);
+    if (!providerItem?.relatedItems?.length) {
+      return snapshots;
+    }
+
+    for (const providerId of this.providerRegistry.getAllProviderItems().keys()) {
+      const snapshot = this.buildRelatedProviderItemSnapshot(item, providerId, providerItem);
+      if (snapshot !== undefined) {
+        snapshots.set(providerId, snapshot);
+      }
+    }
+    return snapshots;
+  }
+
+  private buildRelatedProviderItemSnapshot(item: WorkItem, providerId: string, providerItem = this.getProviderItem(item)): string | undefined {
+    const relatedRefs = providerItem?.relatedItems;
+    if (!relatedRefs?.length) {
+      return undefined;
+    }
+
+    const relatedItems = this.providerRegistry.getProviderItems(providerId)
+      .filter(candidate => relatedRefs.some(ref => ref.externalId === candidate.externalId && ref.itemType === candidate.itemType))
+      .sort((left, right) => `${left.itemType ?? ''}\u0000${left.externalId}`.localeCompare(`${right.itemType ?? ''}\u0000${right.externalId}`));
+    return relatedItems.length > 0 ? stableStringify(relatedItems) : undefined;
   }
 
   private buildCIWatchData(item: WorkItem): EditorItemData['ciWatch'] {
@@ -783,6 +839,29 @@ function setsEqual(left: Set<string>, right: Set<string>): boolean {
     }
   }
   return true;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(toStableJson(value));
+}
+
+function toStableJson(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (Array.isArray(value)) {
+    return value.map(toStableJson);
+  }
+
+  const record = value as Record<string, unknown>;
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(record).sort()) {
+    sorted[key] = toStableJson(record[key]);
+  }
+  return sorted;
 }
 
 function toEditorRunState(state: WatchedRun['status']['overallState']): NonNullable<EditorItemData['ciWatch']>['runs'][number]['state'] {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -848,8 +848,8 @@ function setsEqual(left: Set<string>, right: Set<string>): boolean {
   return true;
 }
 
-function stableStringify(value: unknown): string {
-  return JSON.stringify(toStableJson(value));
+function stableStringify(value: object): string {
+  return JSON.stringify(toStableJson(value)) ?? '';
 }
 
 function providerItemSnapshotKey(itemType: ProviderItem['itemType'], externalId: string): string {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -592,9 +592,10 @@ export class WorkItemEditorPanel {
       return undefined;
     }
 
+    const relatedKeys = new Set(relatedRefs.map(ref => providerItemSnapshotKey(ref.itemType, ref.externalId)));
     const relatedItems = this.providerRegistry.getProviderItems(providerId)
-      .filter(candidate => relatedRefs.some(ref => ref.externalId === candidate.externalId && ref.itemType === candidate.itemType))
-      .sort((left, right) => `${left.itemType ?? ''}\u0000${left.externalId}`.localeCompare(`${right.itemType ?? ''}\u0000${right.externalId}`));
+      .filter(candidate => relatedKeys.has(providerItemSnapshotKey(candidate.itemType, candidate.externalId)))
+      .sort((left, right) => providerItemSnapshotKey(left.itemType, left.externalId).localeCompare(providerItemSnapshotKey(right.itemType, right.externalId)));
     return relatedItems.length > 0 ? stableStringify(relatedItems) : undefined;
   }
 
@@ -843,6 +844,10 @@ function setsEqual(left: Set<string>, right: Set<string>): boolean {
 
 function stableStringify(value: unknown): string {
   return JSON.stringify(toStableJson(value));
+}
+
+function providerItemSnapshotKey(itemType: ProviderItem['itemType'], externalId: string): string {
+  return `${itemType ?? ''}\u0000${externalId}`;
 }
 
 function toStableJson(value: unknown): unknown {

--- a/packages/core/src/views/workItemEditorPanel.ts
+++ b/packages/core/src/views/workItemEditorPanel.ts
@@ -349,7 +349,13 @@ export class WorkItemEditorPanel {
     }
 
     const nextSnapshot = this.buildProviderItemSnapshot(item);
-    if (nextSnapshot === this.lastProviderItemSnapshot) { return; }
+    const nextRelatedSnapshot = this.buildRelatedProviderItemSnapshot(item, item.providerId);
+    if (
+      nextSnapshot === this.lastProviderItemSnapshot
+      && nextRelatedSnapshot === this.lastRelatedProviderItemSnapshots.get(item.providerId)
+    ) {
+      return;
+    }
 
     this.update();
   }


### PR DESCRIPTION
## Summary
- Filter editor panel provider-item refreshes by the changed provider and cached item snapshots.
- Preserve refreshes for related provider items so related item data stays current.
- Add regression coverage for unrelated, changed, and unchanged provider-item events.

## Validation
- npm run build && npm run test

Closes #635
