### PR TITLE
Debounce inbox and read state writes

### DIFF
--- a/.changeset/perf-debounce-inbox-readstate-writes.md
+++ b/.changeset/perf-debounce-inbox-readstate-writes.md
@@ -1,0 +1,5 @@
+---
+"devdocket": patch
+---
+
+Debounce inbox-state and read-state persistence so rapid user actions coalesce into fewer JSON rewrites. Pending writes may remain in memory for up to 250 ms, but are explicitly flushed during shutdown, cache invalidation, and pruning.

--- a/packages/core/src/extension.ts
+++ b/packages/core/src/extension.ts
@@ -38,6 +38,8 @@ export { logger } from './services/logger';
 
 let watcherServiceForDeactivation: WatcherService | undefined;
 let workGraphForDeactivation: WorkGraph | undefined;
+let inboxStateStoreForDeactivation: InboxStateStore | undefined;
+let readStateStoreForDeactivation: ReadStateStore | undefined;
 
 /** Wrap an event callback so unhandled errors (sync or async) are logged instead of crashing. */
 function safeHandler<T extends unknown[]>(label: string, fn: (...args: T) => void | Promise<void>): (...args: T) => void {
@@ -118,6 +120,7 @@ async function migrateInboxState(workGraph: WorkGraph, stateStore: InboxStateSto
   if (itemsToMigrate.length > 0) {
     try {
       await stateStore.setStates(itemsToMigrate);
+      await stateStore.flush();
       logger.info(`Migrated ${itemsToMigrate.length} items to accepted state`);
     } catch (err) {
       logger.error('Migration failed', err);
@@ -526,14 +529,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
   const bumpStateVersion = () => stateVersion.bump();
   let mainProvider: MainViewProvider | undefined;
   wg.onDidChange(safeHandler('sv:workGraph', (event) => event.source === 'externalReload' ? Promise.resolve() : bumpStateVersion()));
-  ss.onDidChange(safeHandler('sv:stateStore', () => bumpStateVersion()));
-  readStateStore.onDidChange(safeHandler('sv:readState', () => bumpStateVersion()));
+  ss.onDidPersist(safeHandler('sv:stateStore', () => bumpStateVersion()));
+  readStateStore.onDidPersist(safeHandler('sv:readState', () => bumpStateVersion()));
   stateVersion.onDidExternalStateChange(safeHandler('sv:external', async () => {
     logger.debug('External state change detected — invalidating caches');
     await wg.invalidateAndReload();
-    ss.invalidateCache();
+    await ss.invalidateCache();
     await ss.load();
-    readStateStore.invalidateCache();
+    await readStateStore.invalidateCache();
     await readStateStore.load();
     mainProvider?.scheduleRefresh('discovered');
   }));
@@ -652,6 +655,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
 
   workGraphForDeactivation = wg;
   watcherServiceForDeactivation = ws;
+  inboxStateStoreForDeactivation = ss;
+  readStateStoreForDeactivation = readStateStore;
   logger.info(`DevDocket activated in ${Math.round(performance.now() - activationStart)}ms`);
   return api;
 }
@@ -659,20 +664,26 @@ export async function activate(context: vscode.ExtensionContext): Promise<DevDoc
 /**
  * Deactivate the DevDocket extension.
  *
- * Flush queued work-item and watch persistence before VS Code disposes
+ * Flush queued work-item, inbox/read-state, and watch persistence before VS Code disposes
  * subscriptions so recent edits and dismissals survive window reloads.
  */
 export async function deactivate(): Promise<void> {
   const workGraph = workGraphForDeactivation;
   const watcherService = watcherServiceForDeactivation;
+  const inboxStateStore = inboxStateStoreForDeactivation;
+  const readStateStore = readStateStoreForDeactivation;
   workGraphForDeactivation = undefined;
   watcherServiceForDeactivation = undefined;
+  inboxStateStoreForDeactivation = undefined;
+  readStateStoreForDeactivation = undefined;
   workGraph?.beginShutdown();
   watcherService?.beginShutdown();
 
   const results = await Promise.allSettled([
     workGraph?.flushPersistence(),
     watcherService?.flushPersistence(),
+    inboxStateStore?.flush(),
+    readStateStore?.flush(),
   ]);
 
   for (const result of results) {

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -144,21 +144,20 @@ export class InboxStateStore {
       this.persistTimer = undefined;
     }
 
-    if (this.flushInProgress) {
+    while (true) {
+      if (this.flushInProgress) {
+        await this.flushInProgress;
+        continue;
+      }
+
+      if (!this.hasPendingPersist()) {
+        return;
+      }
+
+      this.flushInProgress = this.persist().finally(() => {
+        this.flushInProgress = undefined;
+      });
       await this.flushInProgress;
-    }
-
-    if (!this.hasPendingPersist()) {
-      return;
-    }
-
-    this.flushInProgress = this.persist().finally(() => {
-      this.flushInProgress = undefined;
-    });
-    await this.flushInProgress;
-
-    if (this.hasPendingPersist()) {
-      await this.flush();
     }
   }
 

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -73,13 +73,21 @@ export class InboxStateStore {
   private readonly cache = new Map<string, PersistedInboxStateRecord>();
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   readonly onDidChange = this._onDidChange.event;
+  private readonly _onDidPersist = new vscode.EventEmitter<void>();
+  readonly onDidPersist = this._onDidPersist.event;
   private loaded = false;
+  private persistTimer: ReturnType<typeof setTimeout> | undefined;
+  private flushInProgress: Promise<void> | undefined;
+  private disposed = false;
   /** Keys modified locally since the last load/persist. */
   private dirtyKeys = new Set<string>();
   /** Keys removed locally since the last load/persist. */
   private removedKeys = new Set<string>();
 
-  constructor(private readonly fileStore: FileStore<unknown[]>) {}
+  constructor(
+    private readonly fileStore: FileStore<unknown[]>,
+    private readonly persistDebounceMs = 250,
+  ) {}
 
   private key(providerId: string, externalId: string): string {
     return `${providerId}::${externalId}`;
@@ -106,12 +114,70 @@ export class InboxStateStore {
     return this.cache.get(this.key(providerId, externalId))?.resurfaceVersion;
   }
 
+  private hasPendingPersist(): boolean {
+    return this.dirtyKeys.size > 0 || this.removedKeys.size > 0;
+  }
+
+  private schedulePersist(): Promise<void> {
+    if (this.disposed) {
+      return Promise.resolve();
+    }
+
+    if (this.persistDebounceMs <= 0) {
+      return this.flush();
+    }
+
+    if (this.persistTimer) {
+      clearTimeout(this.persistTimer);
+    }
+    this.persistTimer = setTimeout(() => {
+      this.persistTimer = undefined;
+      void this.flush().catch(err => logger.error('Failed to flush debounced inbox state persistence', err));
+    }, this.persistDebounceMs);
+    return Promise.resolve();
+  }
+
+  /** Flushes any pending debounced persistence immediately. */
+  async flush(): Promise<void> {
+    if (this.persistTimer) {
+      clearTimeout(this.persistTimer);
+      this.persistTimer = undefined;
+    }
+
+    if (this.flushInProgress) {
+      await this.flushInProgress;
+    }
+
+    if (!this.hasPendingPersist()) {
+      return;
+    }
+
+    this.flushInProgress = this.persist().finally(() => {
+      this.flushInProgress = undefined;
+    });
+    await this.flushInProgress;
+
+    if (this.hasPendingPersist()) {
+      await this.flush();
+    }
+  }
+
   /**
    * Re-reads from disk, merges remote records with local mutations, and writes
    * the merged result. Untouched keys adopt the remote view, locally changed
    * keys win, and locally removed keys stay removed.
    */
   private async persist(): Promise<void> {
+    const dirtyKeys = new Set(this.dirtyKeys);
+    const removedKeys = new Set(this.removedKeys);
+    const dirtyRecords = new Map<string, PersistedInboxStateRecord>();
+    for (const k of dirtyKeys) {
+      const local = this.cache.get(k);
+      if (local) {
+        dirtyRecords.set(k, local);
+      }
+    }
+
     const snapshot = await this.parseFromFileStore();
     const merged = new Map<string, PersistedInboxStateRecord>();
 
@@ -125,15 +191,12 @@ export class InboxStateStore {
       }
     }
 
-    for (const k of this.removedKeys) {
+    for (const k of removedKeys) {
       merged.delete(k);
     }
 
-    for (const k of this.dirtyKeys) {
-      const local = this.cache.get(k);
-      if (local) {
-        merged.set(k, local);
-      }
+    for (const [k, local] of dirtyRecords) {
+      merged.set(k, local);
     }
 
     const trimmed = trimByAge(Array.from(merged.values()), {
@@ -142,12 +205,38 @@ export class InboxStateStore {
       getKey: record => this.key(record.providerId, record.externalId),
     });
     await this.fileStore.write(trimmed);
+
+    for (const [k, record] of dirtyRecords) {
+      if (this.cache.get(k) === record) {
+        this.dirtyKeys.delete(k);
+      }
+    }
+    for (const k of removedKeys) {
+      if (!this.cache.has(k)) {
+        this.removedKeys.delete(k);
+      }
+    }
+
+    const remainingDirty = new Map<string, PersistedInboxStateRecord>();
+    for (const k of this.dirtyKeys) {
+      const local = this.cache.get(k);
+      if (local) {
+        remainingDirty.set(k, local);
+      }
+    }
+    const remainingRemoved = new Set(this.removedKeys);
+
     this.cache.clear();
     for (const record of trimmed) {
       this.cache.set(this.key(record.providerId, record.externalId), record);
     }
-    this.dirtyKeys.clear();
-    this.removedKeys.clear();
+    for (const k of remainingRemoved) {
+      this.cache.delete(k);
+    }
+    for (const [k, record] of remainingDirty) {
+      this.cache.set(k, record);
+    }
+    this._onDidPersist.fire();
   }
 
   /** Parse and validate inbox state records from the backing JSON file. */
@@ -222,7 +311,7 @@ export class InboxStateStore {
     this.cache.set(k, newRecord);
     this.dirtyKeys.add(k);
     this.removedKeys.delete(k);
-    await this.persist();
+    await this.schedulePersist();
     this._onDidChange.fire();
   }
 
@@ -264,7 +353,7 @@ export class InboxStateStore {
       changed = true;
     }
     if (!changed) { return; }
-    await this.persist();
+    await this.schedulePersist();
     this._onDidChange.fire();
   }
 
@@ -331,7 +420,10 @@ export class InboxStateStore {
       }
     }
 
-    if (activeProviderIds.size === 0) { return 0; }
+    if (activeProviderIds.size === 0) {
+      await this.flush();
+      return 0;
+    }
 
     const staleKeys: string[] = [];
     for (const [k, record] of this.cache) {
@@ -340,7 +432,10 @@ export class InboxStateStore {
       }
     }
 
-    if (staleKeys.length === 0) { return 0; }
+    if (staleKeys.length === 0) {
+      await this.flush();
+      return 0;
+    }
 
     for (const k of staleKeys) {
       this.cache.delete(k);
@@ -348,21 +443,30 @@ export class InboxStateStore {
       this.dirtyKeys.delete(k);
     }
 
-    await this.persist();
+    await this.flush();
     this._onDidChange.fire();
     return staleKeys.length;
   }
 
-  /** Disposes the change event emitter. */
-  dispose(): void {
-    this._onDidChange.dispose();
+  /** Flushes pending persistence and disposes the change event emitter. */
+  async dispose(): Promise<void> {
+    try {
+      await this.flush();
+    } finally {
+      this.disposed = true;
+      this._onDidChange.dispose();
+      this._onDidPersist.dispose();
+    }
   }
 
   /**
    * Invalidates the in-memory cache so the next mutation re-reads from disk.
    * Used for cross-window change propagation.
    */
-  invalidateCache(): void {
+  async invalidateCache(): Promise<void> {
+    if (this.hasPendingPersist()) {
+      await this.flush();
+    }
     this.cache.clear();
     this.dirtyKeys.clear();
     this.removedKeys.clear();

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -277,7 +277,8 @@ export class InboxStateStore {
   }
 
   /**
-   * Sets the inbox state for a single discovered item and persists to disk.
+   * Sets the inbox state for a single discovered item and queues persistence.
+   * Call `flush()` when the queued write must be durable before continuing.
    *
    * Note: `resurfaceVersion` is only settable via `setStates()`, not here.
    * This method preserves any existing `resurfaceVersion` from the previous record.
@@ -316,7 +317,8 @@ export class InboxStateStore {
   }
 
   /**
-   * Sets the inbox state for multiple discovered items in a single write.
+   * Sets inbox state for multiple discovered items and queues one coalesced write.
+   * Call `flush()` when the queued write must be durable before continuing.
    */
   async setStates(items: Array<{ providerId: string; externalId: string; state: InboxState; version?: string; resurfaceVersion?: string }>): Promise<void> {
     if (!this.loaded) { await this.load(); }

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -452,6 +452,8 @@ export class InboxStateStore {
   async dispose(): Promise<void> {
     try {
       await this.flush();
+    } catch (err) {
+      logger.error('Failed to flush inbox state during dispose', err);
     } finally {
       this.disposed = true;
       this._onDidChange.dispose();

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -132,7 +132,12 @@ export class InboxStateStore {
     }
     this.persistTimer = setTimeout(() => {
       this.persistTimer = undefined;
-      void this.flush().catch(err => logger.error('Failed to flush debounced inbox state persistence', err));
+      void this.flush().catch(err => {
+        logger.error('Failed to flush debounced inbox state persistence', err);
+        if (this.hasPendingPersist() && !this.disposed) {
+          void this.schedulePersist();
+        }
+      });
     }, this.persistDebounceMs);
     return Promise.resolve();
   }

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -450,12 +450,12 @@ export class InboxStateStore {
 
   /** Flushes pending persistence and disposes the change event emitter. */
   async dispose(): Promise<void> {
+    this.disposed = true;
     try {
       await this.flush();
     } catch (err) {
       logger.error('Failed to flush inbox state during dispose', err);
     } finally {
-      this.disposed = true;
       this._onDidChange.dispose();
       this._onDidPersist.dispose();
     }

--- a/packages/core/src/storage/inboxStateStore.ts
+++ b/packages/core/src/storage/inboxStateStore.ts
@@ -14,6 +14,7 @@ import { trimByAge } from './trimByAge';
 /** Possible states for a provider-discovered item in the inbox workflow. */
 const inboxStates = ['unseen', 'accepted', 'dismissed'] as const;
 const MAX_TOTAL_ENTRIES = 5_000;
+const MAX_DEBOUNCED_PERSIST_RETRIES = 5;
 
 export type InboxState = (typeof inboxStates)[number];
 
@@ -79,6 +80,7 @@ export class InboxStateStore {
   private persistTimer: ReturnType<typeof setTimeout> | undefined;
   private flushInProgress: Promise<void> | undefined;
   private disposed = false;
+  private debouncedPersistFailures = 0;
   /** Keys modified locally since the last load/persist. */
   private dirtyKeys = new Set<string>();
   /** Keys removed locally since the last load/persist. */
@@ -118,9 +120,13 @@ export class InboxStateStore {
     return this.dirtyKeys.size > 0 || this.removedKeys.size > 0;
   }
 
-  private schedulePersist(): Promise<void> {
+  private schedulePersist(isRetry = false): Promise<void> {
     if (this.disposed) {
       return Promise.resolve();
+    }
+
+    if (!isRetry) {
+      this.debouncedPersistFailures = 0;
     }
 
     if (this.persistDebounceMs <= 0) {
@@ -134,8 +140,9 @@ export class InboxStateStore {
       this.persistTimer = undefined;
       void this.flush().catch(err => {
         logger.error('Failed to flush debounced inbox state persistence', err);
-        if (this.hasPendingPersist() && !this.disposed) {
-          void this.schedulePersist();
+        if (this.hasPendingPersist() && !this.disposed && this.debouncedPersistFailures < MAX_DEBOUNCED_PERSIST_RETRIES) {
+          this.debouncedPersistFailures++;
+          void this.schedulePersist(true);
         }
       });
     }, this.persistDebounceMs);
@@ -209,6 +216,7 @@ export class InboxStateStore {
       getKey: record => this.key(record.providerId, record.externalId),
     });
     await this.fileStore.write(trimmed);
+    this.debouncedPersistFailures = 0;
 
     for (const [k, record] of dirtyRecords) {
       if (this.cache.get(k) === record) {

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -78,21 +78,20 @@ export class ReadStateStore {
       this.persistTimer = undefined;
     }
 
-    if (this.flushInProgress) {
+    while (true) {
+      if (this.flushInProgress) {
+        await this.flushInProgress;
+        continue;
+      }
+
+      if (!this.hasPendingPersist()) {
+        return;
+      }
+
+      this.flushInProgress = this.persist().finally(() => {
+        this.flushInProgress = undefined;
+      });
       await this.flushInProgress;
-    }
-
-    if (!this.hasPendingPersist()) {
-      return;
-    }
-
-    this.flushInProgress = this.persist().finally(() => {
-      this.flushInProgress = undefined;
-    });
-    await this.flushInProgress;
-
-    if (this.hasPendingPersist()) {
-      await this.flush();
     }
   }
 

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -5,6 +5,7 @@ import type { FileStore } from './fileStore';
 import { trimByAge } from './trimByAge';
 
 const MAX_TOTAL_ENTRIES = 5_000;
+const MAX_DEBOUNCED_PERSIST_RETRIES = 5;
 
 interface PersistedReadStateRecord {
   key: string;
@@ -29,6 +30,7 @@ export class ReadStateStore {
   private persistTimer: ReturnType<typeof setTimeout> | undefined;
   private flushInProgress: Promise<void> | undefined;
   private disposed = false;
+  private debouncedPersistFailures = 0;
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   /** Fires whenever the set of read keys changes (add, addMany, deleteMany, prune). */
   readonly onDidChange = this._onDidChange.event;
@@ -52,9 +54,13 @@ export class ReadStateStore {
     return this.addedSinceLoad.size > 0 || this.removedSinceLoad.size > 0;
   }
 
-  private schedulePersist(): Promise<void> {
+  private schedulePersist(isRetry = false): Promise<void> {
     if (this.disposed) {
       return Promise.resolve();
+    }
+
+    if (!isRetry) {
+      this.debouncedPersistFailures = 0;
     }
 
     if (this.persistDebounceMs <= 0) {
@@ -68,8 +74,9 @@ export class ReadStateStore {
       this.persistTimer = undefined;
       void this.flush().catch(err => {
         logger.error('Failed to flush debounced read state persistence', err);
-        if (this.hasPendingPersist() && !this.disposed) {
-          void this.schedulePersist();
+        if (this.hasPendingPersist() && !this.disposed && this.debouncedPersistFailures < MAX_DEBOUNCED_PERSIST_RETRIES) {
+          this.debouncedPersistFailures++;
+          void this.schedulePersist(true);
         }
       });
     }, this.persistDebounceMs);
@@ -149,6 +156,7 @@ export class ReadStateStore {
       },
     );
     await this.fileStore.write(trimmed);
+    this.debouncedPersistFailures = 0;
 
     for (const [key, createdAt] of addedRecords) {
       if (this.items.get(key) === createdAt) {

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -366,6 +366,8 @@ export class ReadStateStore {
   async dispose(): Promise<void> {
     try {
       await this.flush();
+    } catch (err) {
+      logger.error('Failed to flush read state during dispose', err);
     } finally {
       this.disposed = true;
       this._onDidChange.dispose();

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -364,12 +364,12 @@ export class ReadStateStore {
   }
 
   async dispose(): Promise<void> {
+    this.disposed = true;
     try {
       await this.flush();
     } catch (err) {
       logger.error('Failed to flush read state during dispose', err);
     } finally {
-      this.disposed = true;
       this._onDidChange.dispose();
       this._onDidPersist.dispose();
     }

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -231,7 +231,7 @@ export class ReadStateStore {
     return { records: Array.from(deduped.values()), available };
   }
 
-  /** Returns true only when the key is newly added. Persists automatically. */
+  /** Returns true only when the key is newly added and queues persistence. Call `flush()` when durability is required before continuing. */
   async add(key: string): Promise<boolean> {
     if (!this.loaded) { await this.load(); }
     if (this.items.has(key)) { return false; }
@@ -243,7 +243,7 @@ export class ReadStateStore {
     return true;
   }
 
-  /** Adds multiple keys in a single write. Returns newly added keys that remain persisted after capacity trimming. */
+  /** Adds multiple keys, queues one coalesced write, and returns newly added keys that remain in memory after capacity trimming. Call `flush()` when durability is required before continuing. */
   async addMany(keys: string[]): Promise<string[]> {
     if (keys.length === 0) { return []; }
     if (!this.loaded) { await this.load(); }

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -26,18 +26,74 @@ interface ReadStateSnapshot {
 export class ReadStateStore {
   private readonly items = new Map<string, number>();
   private loaded = false;
+  private persistTimer: ReturnType<typeof setTimeout> | undefined;
+  private flushInProgress: Promise<void> | undefined;
+  private disposed = false;
   private readonly _onDidChange = new vscode.EventEmitter<void>();
   /** Fires whenever the set of read keys changes (add, addMany, deleteMany, prune). */
   readonly onDidChange = this._onDidChange.event;
+  private readonly _onDidPersist = new vscode.EventEmitter<void>();
+  readonly onDidPersist = this._onDidPersist.event;
   /** Keys added locally since the last load or persist — ensures local additions survive remote merges. */
   private readonly addedSinceLoad = new Set<string>();
   /** Keys removed locally since the last load or persist — prevents re-adding from stale remote data. */
   private readonly removedSinceLoad = new Set<string>();
 
-  constructor(private readonly fileStore: FileStore<unknown[]>) {}
+  constructor(
+    private readonly fileStore: FileStore<unknown[]>,
+    private readonly persistDebounceMs = 250,
+  ) {}
 
   has(key: string): boolean {
     return this.items.has(key);
+  }
+
+  private hasPendingPersist(): boolean {
+    return this.addedSinceLoad.size > 0 || this.removedSinceLoad.size > 0;
+  }
+
+  private schedulePersist(): Promise<void> {
+    if (this.disposed) {
+      return Promise.resolve();
+    }
+
+    if (this.persistDebounceMs <= 0) {
+      return this.flush();
+    }
+
+    if (this.persistTimer) {
+      clearTimeout(this.persistTimer);
+    }
+    this.persistTimer = setTimeout(() => {
+      this.persistTimer = undefined;
+      void this.flush().catch(err => logger.error('Failed to flush debounced read state persistence', err));
+    }, this.persistDebounceMs);
+    return Promise.resolve();
+  }
+
+  /** Flushes any pending debounced persistence immediately. */
+  async flush(): Promise<void> {
+    if (this.persistTimer) {
+      clearTimeout(this.persistTimer);
+      this.persistTimer = undefined;
+    }
+
+    if (this.flushInProgress) {
+      await this.flushInProgress;
+    }
+
+    if (!this.hasPendingPersist()) {
+      return;
+    }
+
+    this.flushInProgress = this.persist().finally(() => {
+      this.flushInProgress = undefined;
+    });
+    await this.flushInProgress;
+
+    if (this.hasPendingPersist()) {
+      await this.flush();
+    }
   }
 
   /**
@@ -45,26 +101,36 @@ export class ReadStateStore {
    * keys, and writes the merged result.
    */
   private async persist(): Promise<void> {
+    const addedKeys = new Set(this.addedSinceLoad);
+    const removedKeys = new Set(this.removedSinceLoad);
+    const addedRecords = new Map<string, number>();
+    for (const key of addedKeys) {
+      const createdAt = this.items.get(key);
+      if (createdAt !== undefined) {
+        addedRecords.set(key, createdAt);
+      }
+    }
+
     const snapshot = await this.parseFromFileStore();
     const remoteKeys = new Set(snapshot.records.map(record => record.key));
     const merged = new Map<string, number>();
 
     if (snapshot.available) {
       for (const remote of snapshot.records) {
-        if (!this.removedSinceLoad.has(remote.key)) {
+        if (!removedKeys.has(remote.key)) {
           merged.set(remote.key, remote.createdAt);
         }
       }
     } else {
       for (const [key, createdAt] of this.items) {
-        if (!this.removedSinceLoad.has(key)) {
+        if (!removedKeys.has(key)) {
           merged.set(key, createdAt);
         }
       }
     }
 
     for (const [key, createdAt] of this.items) {
-      if (!this.removedSinceLoad.has(key) && (!snapshot.available || this.addedSinceLoad.has(key) || remoteKeys.has(key))) {
+      if (!removedKeys.has(key) && (!snapshot.available || addedKeys.has(key) || remoteKeys.has(key))) {
         const existingCreatedAt = merged.get(key);
         merged.set(key, existingCreatedAt === undefined ? createdAt : Math.min(existingCreatedAt, createdAt));
       }
@@ -79,12 +145,38 @@ export class ReadStateStore {
       },
     );
     await this.fileStore.write(trimmed);
+
+    for (const [key, createdAt] of addedRecords) {
+      if (this.items.get(key) === createdAt) {
+        this.addedSinceLoad.delete(key);
+      }
+    }
+    for (const key of removedKeys) {
+      if (!this.items.has(key)) {
+        this.removedSinceLoad.delete(key);
+      }
+    }
+
+    const remainingAdded = new Map<string, number>();
+    for (const key of this.addedSinceLoad) {
+      const createdAt = this.items.get(key);
+      if (createdAt !== undefined) {
+        remainingAdded.set(key, createdAt);
+      }
+    }
+    const remainingRemoved = new Set(this.removedSinceLoad);
+
     this.items.clear();
     for (const record of trimmed) {
       this.items.set(record.key, record.createdAt);
     }
-    this.addedSinceLoad.clear();
-    this.removedSinceLoad.clear();
+    for (const key of remainingRemoved) {
+      this.items.delete(key);
+    }
+    for (const [key, createdAt] of remainingAdded) {
+      this.items.set(key, createdAt);
+    }
+    this._onDidPersist.fire();
   }
 
   private async parseFromFileStore(): Promise<ReadStateSnapshot> {
@@ -146,7 +238,7 @@ export class ReadStateStore {
     this.items.set(key, Date.now());
     this.addedSinceLoad.add(key);
     this.removedSinceLoad.delete(key);
-    await this.persist();
+    await this.schedulePersist();
     this._onDidChange.fire();
     return true;
   }
@@ -165,7 +257,7 @@ export class ReadStateStore {
       }
     }
     if (newlyAdded.length > 0) {
-      await this.persist();
+      await this.schedulePersist();
       this._onDidChange.fire();
     }
     return newlyAdded.filter(key => this.items.has(key));
@@ -186,7 +278,7 @@ export class ReadStateStore {
       }
     }
     if (changed) {
-      await this.persist();
+      await this.schedulePersist();
       this._onDidChange.fire();
     }
   }
@@ -211,7 +303,10 @@ export class ReadStateStore {
       }
     }
 
-    if (activeProviderIds.size === 0) { return 0; }
+    if (activeProviderIds.size === 0) {
+      await this.flush();
+      return 0;
+    }
 
     const staleKeys: string[] = [];
     for (const key of this.items.keys()) {
@@ -223,14 +318,18 @@ export class ReadStateStore {
       }
     }
 
-    if (staleKeys.length === 0) { return 0; }
+    if (staleKeys.length === 0) {
+      await this.flush();
+      return 0;
+    }
 
     for (const key of staleKeys) {
       this.items.delete(key);
+      this.addedSinceLoad.delete(key);
       this.removedSinceLoad.add(key);
     }
 
-    await this.persist();
+    await this.flush();
     this._onDidChange.fire();
     return staleKeys.length;
   }
@@ -264,15 +363,24 @@ export class ReadStateStore {
     this.loaded = true;
   }
 
-  dispose(): void {
-    this._onDidChange.dispose();
+  async dispose(): Promise<void> {
+    try {
+      await this.flush();
+    } finally {
+      this.disposed = true;
+      this._onDidChange.dispose();
+      this._onDidPersist.dispose();
+    }
   }
 
   /**
    * Invalidates the in-memory cache so the next access re-reads from disk.
    * Used for cross-window change propagation.
    */
-  invalidateCache(): void {
+  async invalidateCache(): Promise<void> {
+    if (this.hasPendingPersist()) {
+      await this.flush();
+    }
     this.items.clear();
     this.addedSinceLoad.clear();
     this.removedSinceLoad.clear();

--- a/packages/core/src/storage/readStateStore.ts
+++ b/packages/core/src/storage/readStateStore.ts
@@ -66,7 +66,12 @@ export class ReadStateStore {
     }
     this.persistTimer = setTimeout(() => {
       this.persistTimer = undefined;
-      void this.flush().catch(err => logger.error('Failed to flush debounced read state persistence', err));
+      void this.flush().catch(err => {
+        logger.error('Failed to flush debounced read state persistence', err);
+        if (this.hasPendingPersist() && !this.disposed) {
+          void this.schedulePersist();
+        }
+      });
     }, this.persistDebounceMs);
     return Promise.resolve();
   }

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -1173,6 +1173,44 @@ describe('InboxStateStore', () => {
       }
     });
 
+    it('retries failed timer-triggered flushes with the dirty payload', async () => {
+      vi.useFakeTimers();
+      let persisted: unknown[] | undefined;
+      let writes = 0;
+      const fileStore = {
+        read: vi.fn(async () => persisted),
+        write: vi.fn(async (value: unknown[]) => {
+          writes++;
+          if (writes === 1) {
+            throw new Error('locked');
+          }
+          persisted = value;
+        }),
+      };
+      const debouncedStore = new InboxStateStore(fileStore);
+
+      try {
+        await debouncedStore.setState('gh', 'issue-1', 'accepted');
+
+        await vi.advanceTimersByTimeAsync(250);
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(fileStore.write).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(250);
+        await debouncedStore.flush();
+
+        expect(fileStore.write).toHaveBeenCalledTimes(2);
+        expect(persisted).toEqual([expect.objectContaining({ providerId: 'gh', externalId: 'issue-1', inboxState: 'accepted' })]);
+
+        await vi.advanceTimersByTimeAsync(250);
+        expect(fileStore.write).toHaveBeenCalledTimes(2);
+      } finally {
+        await debouncedStore.dispose();
+        vi.useRealTimers();
+      }
+    });
+
     it('flushes pending writes before invalidating the cache', async () => {
       vi.useFakeTimers();
       let persisted: unknown[] | undefined;

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -1119,6 +1119,7 @@ describe('InboxStateStore', () => {
         expect(fileStore.write).not.toHaveBeenCalled();
         expect(persistListener).not.toHaveBeenCalled();
         await vi.advanceTimersByTimeAsync(250);
+        await debouncedStore.flush();
 
         expect(fileStore.write).toHaveBeenCalledTimes(1);
         expect(persistListener).toHaveBeenCalledTimes(1);

--- a/packages/core/src/test/inboxStateStore.test.ts
+++ b/packages/core/src/test/inboxStateStore.test.ts
@@ -22,7 +22,7 @@ describe('InboxStateStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fileSystem = useMockFileSystem();
-    store = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    store = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
   });
 
   afterEach(() => {
@@ -77,7 +77,7 @@ describe('InboxStateStore', () => {
     const listener = vi.fn();
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(999);
 
-    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
     store2.onDidChange(listener);
 
     try {
@@ -134,7 +134,7 @@ describe('InboxStateStore', () => {
     await store.setState('gh', 'issue-1', 'accepted');
     await store.setState('gh', 'issue-2', 'dismissed');
 
-    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
     await store2.load();
 
     expect(store2.getState('gh', 'issue-1')).toBe('accepted');
@@ -165,7 +165,7 @@ describe('InboxStateStore', () => {
     ]);
     const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(654);
 
-    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
     await store2.load();
     await store2.setState('gh', 'issue-1', 'dismissed');
 
@@ -187,7 +187,7 @@ describe('InboxStateStore', () => {
       { providerId: 'gh', externalId: 'legacy', inboxState: 'accepted' },
     ]);
 
-    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
     const records = await store2.loadAll();
 
     expect(records).toEqual([
@@ -204,7 +204,7 @@ describe('InboxStateStore', () => {
       { providerId: 'gh', externalId: 'other', inboxState: 'unseen', createdAt: 3 },
     ]);
 
-    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
     const records = await store2.loadAll();
 
     expect(records).toEqual([
@@ -221,7 +221,7 @@ describe('InboxStateStore', () => {
       { providerId: 'gh', externalId: 'keep', inboxState: 'accepted', createdAt: 1 },
     ]);
 
-    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
     await store2.load();
     await vscode.workspace.fs.delete(fileUri);
     await store2.setState('gh', 'fresh', 'dismissed');
@@ -239,7 +239,7 @@ describe('InboxStateStore', () => {
     ]);
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
 
-    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
     await store2.load();
     fileSystem.writeJson(fileUri, { invalid: true });
     await store2.setState('gh', 'fresh', 'dismissed');
@@ -259,7 +259,7 @@ describe('InboxStateStore', () => {
     ]);
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
 
-    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+    const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
     await store2.load();
     fileSystem.writeJson(fileUri, [42]);
     await store2.setState('gh', 'fresh', 'dismissed');
@@ -282,7 +282,7 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'issue-2', inboxState: 'accepted' },
       ]);
 
-      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       const records = await store2.loadAll();
       expect(records).toHaveLength(1);
       expect(records[0].externalId).toBe('issue-2');
@@ -295,7 +295,7 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'issue-2', inboxState: 'accepted' },
       ]);
 
-      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       const records = await store2.loadAll();
       expect(records).toHaveLength(1);
       expect(records[0].externalId).toBe('issue-2');
@@ -308,7 +308,7 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'issue-2', inboxState: 'accepted' },
       ]);
 
-      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       const records = await store2.loadAll();
       expect(records).toHaveLength(1);
       expect(records[0].externalId).toBe('issue-2');
@@ -318,7 +318,7 @@ describe('InboxStateStore', () => {
     it('should return empty for non-array data', async () => {
       fileSystem.writeJson(fileUri, { not: 'an array' });
 
-      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       const records = await store2.loadAll();
       expect(records).toEqual([]);
       store2.dispose();
@@ -332,7 +332,7 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'issue-1', inboxState: 'accepted' },
       ]);
 
-      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       const records = await store2.loadAll();
       expect(records).toHaveLength(1);
       expect(records[0].externalId).toBe('issue-1');
@@ -461,7 +461,7 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'issue-1', inboxState: 'dismissed' },
       ]);
 
-      store.invalidateCache();
+      await store.invalidateCache();
       await store.load();
 
       expect(store.getState('gh', 'issue-1')).toBe('dismissed');
@@ -470,8 +470,8 @@ describe('InboxStateStore', () => {
 
   describe('merge-on-write', () => {
     it('preserves remote additions while persisting local changes', async () => {
-      const windowA = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
-      const windowB = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const windowA = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
+      const windowB = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       await windowA.load();
 
       await windowB.setState('gh', 'remote', 'accepted');
@@ -494,8 +494,8 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'shared', inboxState: 'unseen' },
       ]);
 
-      const windowA = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
-      const windowB = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const windowA = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
+      const windowB = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       await windowA.load();
       await windowB.load();
 
@@ -514,8 +514,8 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'shared', inboxState: 'unseen' },
       ]);
 
-      const windowA = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
-      const windowB = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const windowA = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
+      const windowB = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       await windowA.load();
       await windowB.load();
 
@@ -545,7 +545,7 @@ describe('InboxStateStore', () => {
           fileSystem.writeJson(fileUri, value);
         }),
       };
-      const failingStore = new InboxStateStore(failingFileStore);
+      const failingStore = new InboxStateStore(failingFileStore, 0);
       await failingStore.load();
 
       await expect(failingStore.setState('gh', 'shared', 'accepted')).rejects.toThrow('quota exceeded');
@@ -581,7 +581,7 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'pre-existing', inboxState: 'unseen' },
       ]);
 
-      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       await freshStore.setState('gh', 'new-item', 'accepted');
 
       expect(freshStore.getState('gh', 'pre-existing')).toBe('unseen');
@@ -594,7 +594,7 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'pre-existing', inboxState: 'dismissed' },
       ]);
 
-      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       await freshStore.setStates([
         { providerId: 'gh', externalId: 'new-item', state: 'unseen' },
       ]);
@@ -669,7 +669,7 @@ describe('InboxStateStore', () => {
       expect(store.getState('gh', 'item-1199')).toBe('unseen');
 
       // Verify persistence by reloading from a fresh instance
-      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       await store2.load();
       const reloaded = await store2.loadAll();
       expect(reloaded).toHaveLength(1200);
@@ -719,7 +719,7 @@ describe('InboxStateStore', () => {
       ]);
       const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(20);
 
-      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       await freshStore.load();
       await freshStore.setState('gh', 'pr-1', 'accepted', 'sha-new');
 
@@ -746,7 +746,7 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'pr-1', inboxState: 'accepted', version: 'sha-disk' },
       ]);
 
-      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       await freshStore.load();
       expect(freshStore.getVersion('gh', 'pr-1')).toBe('sha-disk');
       freshStore.dispose();
@@ -766,7 +766,7 @@ describe('InboxStateStore', () => {
       ]);
       const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(75);
 
-      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       await freshStore.load();
       await freshStore.setStates([
         { providerId: 'gh', externalId: 'pr-1', state: 'dismissed' },
@@ -789,7 +789,7 @@ describe('InboxStateStore', () => {
       const listener = vi.fn();
       const nowSpy = vi.spyOn(Date, 'now').mockReturnValue(99);
 
-      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       freshStore.onDidChange(listener);
       await freshStore.load();
       await freshStore.setStates([
@@ -823,7 +823,7 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'pr-2', inboxState: 'accepted', version: 'valid' },
       ]);
 
-      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       const records = await freshStore.loadAll();
       expect(records).toHaveLength(1);
       expect(records[0].externalId).toBe('pr-2');
@@ -888,7 +888,7 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'pr-1', inboxState: 'accepted', resurfaceVersion: 'rv-disk' },
       ]);
 
-      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       await freshStore.load();
       expect(freshStore.getResurfaceVersion('gh', 'pr-1')).toBe('rv-disk');
       freshStore.dispose();
@@ -900,7 +900,7 @@ describe('InboxStateStore', () => {
         { providerId: 'gh', externalId: 'pr-2', inboxState: 'accepted', resurfaceVersion: 'valid' },
       ]);
 
-      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const freshStore = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       const records = await freshStore.loadAll();
       expect(records).toHaveLength(1);
       expect(records[0].externalId).toBe('pr-2');
@@ -943,7 +943,7 @@ describe('InboxStateStore', () => {
         createdAt: i,
       })));
 
-      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'));
+      const store2 = new InboxStateStore(new JsonFileStore(fileUri, 'inbox-state.json'), 0);
       await store2.load();
 
       expect(await store2.loadAll()).toHaveLength(5_000);
@@ -1095,6 +1095,135 @@ describe('InboxStateStore', () => {
 
       const pruned = await store.prune(activeItems);
       expect(pruned).toBe(2);
+    });
+  });
+
+
+  describe('debounced persistence', () => {
+    it('coalesces multiple rapid setState calls into one persisted write', async () => {
+      vi.useFakeTimers();
+      let persisted: unknown[] | undefined;
+      const fileStore = {
+        read: vi.fn(async () => persisted),
+        write: vi.fn(async (value: unknown[]) => { persisted = value; }),
+      };
+      const debouncedStore = new InboxStateStore(fileStore);
+      const persistListener = vi.fn();
+      debouncedStore.onDidPersist(persistListener);
+
+      try {
+        await debouncedStore.setState('gh', 'issue-1', 'unseen');
+        await debouncedStore.setState('gh', 'issue-2', 'accepted');
+        await debouncedStore.setState('gh', 'issue-3', 'dismissed');
+
+        expect(fileStore.write).not.toHaveBeenCalled();
+        expect(persistListener).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(250);
+
+        expect(fileStore.write).toHaveBeenCalledTimes(1);
+        expect(persistListener).toHaveBeenCalledTimes(1);
+        expect(persisted).toHaveLength(3);
+      } finally {
+        await debouncedStore.dispose();
+        vi.useRealTimers();
+      }
+    });
+
+    it('exposes latest in-memory state before the debounce flush', async () => {
+      vi.useFakeTimers();
+      const fileStore = {
+        read: vi.fn(async () => undefined as unknown[] | undefined),
+        write: vi.fn(async (_value: unknown[]) => undefined),
+      };
+      const debouncedStore = new InboxStateStore(fileStore);
+
+      try {
+        await debouncedStore.setState('gh', 'issue-1', 'unseen');
+        await debouncedStore.setState('gh', 'issue-1', 'accepted');
+
+        expect(debouncedStore.getState('gh', 'issue-1')).toBe('accepted');
+        expect((await debouncedStore.loadAll())[0]).toMatchObject({ providerId: 'gh', externalId: 'issue-1', inboxState: 'accepted' });
+        expect(fileStore.write).not.toHaveBeenCalled();
+      } finally {
+        await debouncedStore.dispose();
+        vi.useRealTimers();
+      }
+    });
+
+    it('flushes pending writes when disposed', async () => {
+      vi.useFakeTimers();
+      let persisted: unknown[] | undefined;
+      const fileStore = {
+        read: vi.fn(async () => persisted),
+        write: vi.fn(async (value: unknown[]) => { persisted = value; }),
+      };
+      const debouncedStore = new InboxStateStore(fileStore);
+
+      try {
+        await debouncedStore.setState('gh', 'issue-1', 'accepted');
+        expect(fileStore.write).not.toHaveBeenCalled();
+
+        await debouncedStore.dispose();
+
+        expect(fileStore.write).toHaveBeenCalledTimes(1);
+        expect(persisted).toEqual([expect.objectContaining({ providerId: 'gh', externalId: 'issue-1', inboxState: 'accepted' })]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('flushes pending writes before invalidating the cache', async () => {
+      vi.useFakeTimers();
+      let persisted: unknown[] | undefined;
+      const fileStore = {
+        read: vi.fn(async () => persisted),
+        write: vi.fn(async (value: unknown[]) => { persisted = value; }),
+      };
+      const debouncedStore = new InboxStateStore(fileStore);
+
+      try {
+        await debouncedStore.setState('gh', 'local', 'accepted');
+        persisted = [{ providerId: 'gh', externalId: 'remote', inboxState: 'dismissed', createdAt: 1 }];
+
+        await debouncedStore.invalidateCache();
+        await debouncedStore.load();
+
+        expect(debouncedStore.getState('gh', 'local')).toBe('accepted');
+        expect(debouncedStore.getState('gh', 'remote')).toBe('dismissed');
+        expect(fileStore.write).toHaveBeenCalledTimes(1);
+      } finally {
+        await debouncedStore.dispose();
+        vi.useRealTimers();
+      }
+    });
+
+    it('flushes synchronously when prune returns', async () => {
+      vi.useFakeTimers();
+      let persisted: unknown[] | undefined;
+      const fileStore = {
+        read: vi.fn(async () => persisted),
+        write: vi.fn(async (value: unknown[]) => { persisted = value; }),
+      };
+      const debouncedStore = new InboxStateStore(fileStore);
+
+      try {
+        await debouncedStore.setStates([
+          { providerId: 'gh', externalId: 'keep', state: 'accepted' },
+          { providerId: 'gh', externalId: 'stale', state: 'accepted' },
+        ]);
+        expect(fileStore.write).not.toHaveBeenCalled();
+
+        const pruned = await debouncedStore.prune(new Map([
+          ['gh', [{ externalId: 'keep', title: 'Keep' }]],
+        ]));
+
+        expect(pruned).toBe(1);
+        expect(fileStore.write).toHaveBeenCalledTimes(1);
+        expect(persisted).toEqual([expect.objectContaining({ providerId: 'gh', externalId: 'keep' })]);
+      } finally {
+        await debouncedStore.dispose();
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -17,7 +17,7 @@ describe('ReadStateStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     fileSystem = useMockFileSystem();
-    store = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+    store = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
   });
 
   afterEach(() => {
@@ -86,7 +86,7 @@ describe('ReadStateStore', () => {
     await store.add('gh::1');
     await store.add('jira::2');
 
-    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
     await store2.load();
     expect(store2.has('gh::1')).toBe(true);
     expect(store2.has('jira::2')).toBe(true);
@@ -109,7 +109,7 @@ describe('ReadStateStore', () => {
   it('preserves createdAt timestamps across reload and rewrite', async () => {
     fileSystem.writeJson(fileUri, [{ key: 'gh::legacy', createdAt: 123 }]);
 
-    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
     await store2.load();
     await store2.add('gh::new');
 
@@ -123,7 +123,7 @@ describe('ReadStateStore', () => {
   it('loads legacy string entries without createdAt timestamps', async () => {
     fileSystem.writeJson(fileUri, ['gh::legacy']);
 
-    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
     await store2.load();
 
     expect(store2.has('gh::legacy')).toBe(true);
@@ -137,7 +137,7 @@ describe('ReadStateStore', () => {
       { key: 'gh::other', createdAt: 3 },
     ]);
 
-    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
     await store2.load();
     await store2.add('gh::fresh');
 
@@ -153,7 +153,7 @@ describe('ReadStateStore', () => {
   it('should skip non-string elements in the array', async () => {
     fileSystem.writeJson(fileUri, ['valid::1', 42, null, true, 'valid::2', { obj: true }]);
 
-    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+    const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
     await store2.load();
     const keys = [...store2.keys()].sort();
     expect(keys).toEqual(['valid::1', 'valid::2']);
@@ -171,7 +171,7 @@ describe('ReadStateStore', () => {
   it('should auto-load when deleteMany() is called before load()', async () => {
     fileSystem.writeJson(fileUri, ['gh::existing', 'gh::remove']);
 
-    const freshStore = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+    const freshStore = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
     await freshStore.deleteMany(['gh::remove']);
 
     expect(freshStore.has('gh::existing')).toBe(true);
@@ -181,7 +181,7 @@ describe('ReadStateStore', () => {
   it('should auto-load when add() is called before load()', async () => {
     fileSystem.writeJson(fileUri, ['gh::existing']);
 
-    const freshStore = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+    const freshStore = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
     await freshStore.add('gh::new');
 
     expect(freshStore.has('gh::existing')).toBe(true);
@@ -223,8 +223,8 @@ describe('ReadStateStore', () => {
 
   describe('merge-on-write', () => {
     it('preserves remote additions while persisting local changes', async () => {
-      const windowA = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
-      const windowB = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      const windowA = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
+      const windowB = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
       await windowA.load();
 
       await windowB.add('gh::remote');
@@ -239,8 +239,8 @@ describe('ReadStateStore', () => {
     it('keeps locally removed keys deleted while preserving remote additions', async () => {
       fileSystem.writeJson(fileUri, ['gh::keep', 'gh::remove']);
 
-      const windowA = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
-      const windowB = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      const windowA = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
+      const windowB = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
       await windowA.load();
       await windowB.load();
 
@@ -257,12 +257,12 @@ describe('ReadStateStore', () => {
     it('allows remote re-additions after a successful persist', async () => {
       fileSystem.writeJson(fileUri, ['gh::shared']);
 
-      const windowA = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      const windowA = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
       await windowA.load();
 
       await windowA.deleteMany(['gh::shared']);
 
-      const windowB = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      const windowB = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
       await windowB.load();
       await windowB.add('gh::shared');
 
@@ -279,7 +279,7 @@ describe('ReadStateStore', () => {
 
       fileSystem.writeJson(fileUri, ['gh::issue-2']);
 
-      store.invalidateCache();
+      await store.invalidateCache();
       await store.load();
 
       expect([...store.keys()]).toEqual(['gh::issue-2']);
@@ -315,7 +315,7 @@ describe('ReadStateStore', () => {
         createdAt: i,
       })));
 
-      const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
       await store2.load();
 
       expect([...store2.keys()]).toHaveLength(5_000);
@@ -344,8 +344,8 @@ describe('ReadStateStore', () => {
     });
 
     it('does not resurrect keys evicted by another window', async () => {
-      const windowA = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
-      const windowB = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      const windowA = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
+      const windowB = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
 
       fileSystem.writeJson(fileUri, Array.from({ length: 6_000 }, (_, i) => ({
         key: `gh::issue-${i}`,
@@ -368,7 +368,7 @@ describe('ReadStateStore', () => {
 
     it('keeps cached keys when the remote snapshot is temporarily unavailable', async () => {
       fileSystem.writeJson(fileUri, ['gh::keep']);
-      const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
       await store2.load();
       await vscode.workspace.fs.delete(fileUri);
 
@@ -381,7 +381,7 @@ describe('ReadStateStore', () => {
     it('keeps cached keys when the remote snapshot is malformed', async () => {
       fileSystem.writeJson(fileUri, ['gh::keep']);
       const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
-      const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
       await store2.load();
       fileSystem.writeJson(fileUri, { invalid: true });
 
@@ -396,7 +396,7 @@ describe('ReadStateStore', () => {
     it('keeps cached keys when the remote snapshot is an invalid array', async () => {
       fileSystem.writeJson(fileUri, ['gh::keep']);
       const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
-      const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      const store2 = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
       await store2.load();
       fileSystem.writeJson(fileUri, [42]);
 
@@ -492,7 +492,7 @@ describe('ReadStateStore', () => {
     it('lazy-loads on first call', async () => {
       fileSystem.writeJson(fileUri, ['gh::keep', 'gh::stale']);
 
-      const freshStore = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      const freshStore = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
       const activeItems = new Map<string, ProviderItem[]>([
         ['gh', [{ externalId: 'keep', title: 'Keep' }]],
       ]);
@@ -509,7 +509,7 @@ describe('ReadStateStore', () => {
     it('ignores legacy stored keys without the provider delimiter', async () => {
       fileSystem.writeJson(fileUri, ['legacy-key', 'gh::stale']);
 
-      const freshStore = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'));
+      const freshStore = new ReadStateStore(new JsonFileStore(fileUri, 'read-state.json'), 0);
       const activeItems = new Map<string, ProviderItem[]>([
         ['gh', [{ externalId: 'keep', title: 'Keep' }]],
       ]);
@@ -536,6 +536,134 @@ describe('ReadStateStore', () => {
       expect(store.has('provider-a::keep')).toBe(true);
       expect(store.has('provider-a::stale')).toBe(false);
       expect(store.has('provider-b::stale')).toBe(true);
+    });
+  });
+
+
+  describe('debounced persistence', () => {
+    it('coalesces multiple rapid mutations into one persisted write', async () => {
+      vi.useFakeTimers();
+      let persisted: unknown[] | undefined;
+      const fileStore = {
+        read: vi.fn(async () => persisted),
+        write: vi.fn(async (value: unknown[]) => { persisted = value; }),
+      };
+      const debouncedStore = new ReadStateStore(fileStore);
+      const persistListener = vi.fn();
+      debouncedStore.onDidPersist(persistListener);
+
+      try {
+        await debouncedStore.add('gh::issue-1');
+        await debouncedStore.addMany(['gh::issue-2', 'gh::issue-3']);
+        await debouncedStore.deleteMany(['gh::issue-2']);
+
+        expect(fileStore.write).not.toHaveBeenCalled();
+        expect(persistListener).not.toHaveBeenCalled();
+        await vi.advanceTimersByTimeAsync(250);
+
+        expect(fileStore.write).toHaveBeenCalledTimes(1);
+        expect(persistListener).toHaveBeenCalledTimes(1);
+        expect((persisted as Array<{ key: string }>).map(record => record.key).sort()).toEqual(['gh::issue-1', 'gh::issue-3']);
+      } finally {
+        await debouncedStore.dispose();
+        vi.useRealTimers();
+      }
+    });
+
+    it('exposes latest in-memory keys before the debounce flush', async () => {
+      vi.useFakeTimers();
+      const fileStore = {
+        read: vi.fn(async () => undefined as unknown[] | undefined),
+        write: vi.fn(async (_value: unknown[]) => undefined),
+      };
+      const debouncedStore = new ReadStateStore(fileStore);
+
+      try {
+        await debouncedStore.add('gh::issue-1');
+        await debouncedStore.add('gh::issue-2');
+        await debouncedStore.deleteMany(['gh::issue-1']);
+
+        expect(debouncedStore.has('gh::issue-1')).toBe(false);
+        expect(debouncedStore.has('gh::issue-2')).toBe(true);
+        expect([...debouncedStore.keys()]).toEqual(['gh::issue-2']);
+        expect(fileStore.write).not.toHaveBeenCalled();
+      } finally {
+        await debouncedStore.dispose();
+        vi.useRealTimers();
+      }
+    });
+
+    it('flushes pending writes when disposed', async () => {
+      vi.useFakeTimers();
+      let persisted: unknown[] | undefined;
+      const fileStore = {
+        read: vi.fn(async () => persisted),
+        write: vi.fn(async (value: unknown[]) => { persisted = value; }),
+      };
+      const debouncedStore = new ReadStateStore(fileStore);
+
+      try {
+        await debouncedStore.add('gh::issue-1');
+        expect(fileStore.write).not.toHaveBeenCalled();
+
+        await debouncedStore.dispose();
+
+        expect(fileStore.write).toHaveBeenCalledTimes(1);
+        expect(persisted).toEqual([expect.objectContaining({ key: 'gh::issue-1' })]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('flushes pending writes before invalidating the cache', async () => {
+      vi.useFakeTimers();
+      let persisted: unknown[] | undefined;
+      const fileStore = {
+        read: vi.fn(async () => persisted),
+        write: vi.fn(async (value: unknown[]) => { persisted = value; }),
+      };
+      const debouncedStore = new ReadStateStore(fileStore);
+
+      try {
+        await debouncedStore.add('gh::local');
+        persisted = [{ key: 'gh::remote', createdAt: 1 }];
+
+        await debouncedStore.invalidateCache();
+        await debouncedStore.load();
+
+        expect(debouncedStore.has('gh::local')).toBe(true);
+        expect(debouncedStore.has('gh::remote')).toBe(true);
+        expect(fileStore.write).toHaveBeenCalledTimes(1);
+      } finally {
+        await debouncedStore.dispose();
+        vi.useRealTimers();
+      }
+    });
+
+    it('flushes synchronously when prune returns', async () => {
+      vi.useFakeTimers();
+      let persisted: unknown[] | undefined;
+      const fileStore = {
+        read: vi.fn(async () => persisted),
+        write: vi.fn(async (value: unknown[]) => { persisted = value; }),
+      };
+      const debouncedStore = new ReadStateStore(fileStore);
+
+      try {
+        await debouncedStore.addMany(['gh::keep', 'gh::stale']);
+        expect(fileStore.write).not.toHaveBeenCalled();
+
+        const pruned = await debouncedStore.prune(new Map<string, ProviderItem[]>([
+          ['gh', [{ externalId: 'keep', title: 'Keep' }]],
+        ]));
+
+        expect(pruned).toBe(1);
+        expect(fileStore.write).toHaveBeenCalledTimes(1);
+        expect(persisted).toEqual([expect.objectContaining({ key: 'gh::keep' })]);
+      } finally {
+        await debouncedStore.dispose();
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -616,6 +616,44 @@ describe('ReadStateStore', () => {
       }
     });
 
+    it('retries failed timer-triggered flushes with the dirty payload', async () => {
+      vi.useFakeTimers();
+      let persisted: unknown[] | undefined;
+      let writes = 0;
+      const fileStore = {
+        read: vi.fn(async () => persisted),
+        write: vi.fn(async (value: unknown[]) => {
+          writes++;
+          if (writes === 1) {
+            throw new Error('locked');
+          }
+          persisted = value;
+        }),
+      };
+      const debouncedStore = new ReadStateStore(fileStore);
+
+      try {
+        await debouncedStore.add('gh::issue-1');
+
+        await vi.advanceTimersByTimeAsync(250);
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(fileStore.write).toHaveBeenCalledTimes(1);
+
+        await vi.advanceTimersByTimeAsync(250);
+        await debouncedStore.flush();
+
+        expect(fileStore.write).toHaveBeenCalledTimes(2);
+        expect(persisted).toEqual([expect.objectContaining({ key: 'gh::issue-1' })]);
+
+        await vi.advanceTimersByTimeAsync(250);
+        expect(fileStore.write).toHaveBeenCalledTimes(2);
+      } finally {
+        await debouncedStore.dispose();
+        vi.useRealTimers();
+      }
+    });
+
     it('flushes pending writes before invalidating the cache', async () => {
       vi.useFakeTimers();
       let persisted: unknown[] | undefined;

--- a/packages/core/src/test/readStateStore.test.ts
+++ b/packages/core/src/test/readStateStore.test.ts
@@ -560,6 +560,7 @@ describe('ReadStateStore', () => {
         expect(fileStore.write).not.toHaveBeenCalled();
         expect(persistListener).not.toHaveBeenCalled();
         await vi.advanceTimersByTimeAsync(250);
+        await debouncedStore.flush();
 
         expect(fileStore.write).toHaveBeenCalledTimes(1);
         expect(persistListener).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Summary
- Debounce inbox-state and read-state JSON persistence so bursts coalesce into one write.
- Add explicit flush support for shutdown, pruning, migration, and cache invalidation.
- Add coverage for debounced coalescing, immediate in-memory reads, dispose flush, invalidate flush, and prune flush.

## Validation
- npm run build && npm run test
- superpowers:code-reviewer clean

Closes #638
