### PR TITLE
Source DevDocket bot App ID and private key exclusively from env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,3 @@ webview-dist/
 # OS files
 .DS_Store
 Thumbs.db
-
-# DevDocket bot App private key + App ID (see scripts/start-bot-session.mjs)
-keys/
-# Defense in depth: also ignore App private keys / App-id files anywhere.
-*.pem
-devdocket-bot.app-id

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -346,7 +346,28 @@ eval "$(node scripts/start-bot-session.mjs --shell=bash)"
 node scripts/start-bot-session.mjs --shell=powershell | Invoke-Expression
 ```
 
-The script assumes the App's private key lives at `keys/devdocket-bot.pem` and that either the `DEVDOCKET_BOT_APP_ID` environment variable is set or the numeric App ID is written to `keys/devdocket-bot.app-id`. The `keys/` directory is git-ignored — never commit the PEM or App ID. After running the helper, the working tree's `user.name` / `user.email` and `GH_TOKEN` / `GITHUB_TOKEN` point at the bot for the lifetime of that shell; opening a new shell reverts to the developer's normal identity.
+The script requires two environment variables, which must be exported before running it:
+
+- `DEVDOCKET_BOT_APP_ID` — the numeric GitHub App ID.
+- `DEVDOCKET_BOT_APP_PRIVATE_KEY` — the GitHub App private key (PEM contents, including the `-----BEGIN/END PRIVATE KEY-----` markers).
+
+These match the names of the GitHub Actions repository secrets used by the bot's GitHub Actions workflows, so the same values can be reused locally. The script does not read or write any on-disk key material. After running the helper, the working tree's `user.name` / `user.email` and `GH_TOKEN` / `GITHUB_TOKEN` point at the bot for the lifetime of that shell; opening a new shell reverts to the developer's normal identity.
+
+Recommended export idioms for the (multi-line) PEM:
+
+```bash
+# bash / zsh
+export DEVDOCKET_BOT_APP_ID=123456
+export DEVDOCKET_BOT_APP_PRIVATE_KEY="$(cat path/to/devdocket-bot.pem)"
+```
+
+```powershell
+# PowerShell
+$env:DEVDOCKET_BOT_APP_ID = '123456'
+$env:DEVDOCKET_BOT_APP_PRIVATE_KEY = Get-Content -Raw path\to\devdocket-bot.pem
+```
+
+If your secret store delivers the PEM as a single line with literal `\n` escapes (common with 1Password / Vault / CI UI copy-paste), the helper auto-normalizes them to real newlines.
 
 **Verify the session is active** before proceeding:
 
@@ -360,7 +381,7 @@ If either check fails (e.g., still shows the developer's identity), the bot sess
 
 > **Note:** an installation token returns 403 on `GET /user` ("Resource not accessible by integration"), so do NOT use `gh api user` to verify. Use a repo-scoped call like the one above instead. A 403 from `gh api user` after starting a bot session is expected, not a failure.
 
-**If the bot session cannot be started** (helper prints "App ID not found", missing PEM, expired key, etc.): STOP. Do not fall back to the developer's identity. Report the failure to the user and ask how to proceed — typically the user needs to populate `keys/devdocket-bot.app-id` and `keys/devdocket-bot.pem` (or set `DEVDOCKET_BOT_APP_ID`) for their environment.
+**If the bot session cannot be started** (helper prints "App ID not found", "Private key not found", expired key, etc.): STOP. Do not fall back to the developer's identity. Report the failure to the user and ask how to proceed — typically the user needs to export `DEVDOCKET_BOT_APP_ID` and `DEVDOCKET_BOT_APP_PRIVATE_KEY` in their environment.
 
 **⚠️ Bot session env vars do NOT persist across sync shell invocations.** Many Copilot CLI shell tools (e.g., `powershell` in sync mode) create a fresh shell per call and discard `$env:GH_TOKEN` / `$env:GITHUB_TOKEN` set by a previous call. The `git config` changes made by the helper are persistent in the worktree (they live in `.git/config`), so commits stay bot-authored — but `gh` calls in a fresh shell will use the developer's cached `gh auth` credential and create PRs/comments/issues under the developer's account.
 

--- a/scripts/start-bot-session.mjs
+++ b/scripts/start-bot-session.mjs
@@ -14,17 +14,16 @@
 //
 // If --shell is omitted, the script picks bash on POSIX and powershell on Windows.
 //
-// Required inputs (none of which are committed):
-//   keys/devdocket-bot.pem        GitHub App private key (PEM, RS256).
-//   keys/devdocket-bot.app-id     Numeric GitHub App ID — OR set the
-//                                 DEVDOCKET_BOT_APP_ID env var instead.
+// Required environment variables (none of which are committed):
+//   DEVDOCKET_BOT_APP_ID           Numeric GitHub App ID.
+//   DEVDOCKET_BOT_APP_PRIVATE_KEY  GitHub App private key contents (PEM, RS256).
 //
-// The `keys/` directory is git-ignored. Developers place their copy of the
-// App's private key there. The script never reads or writes the key outside
-// that directory.
+// These match the names of the GitHub Actions repository secrets used by the
+// changesets / weekly-review workflows, so the same values can be reused.
+// Developers must export both env vars before running the helper; the script
+// no longer reads or writes any on-disk key material.
 
 import { createSign } from "node:crypto";
-import { readFileSync, existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -33,9 +32,6 @@ const REPO_NAME = "devdocket";
 
 const scriptDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(scriptDir, "..");
-const keysDir = resolve(repoRoot, "keys");
-const pemPath = resolve(keysDir, "devdocket-bot.pem");
-const appIdPath = resolve(keysDir, "devdocket-bot.app-id");
 
 function fail(msg) {
   process.stderr.write(`start-bot-session: ${msg}\n`);
@@ -103,15 +99,10 @@ async function ghApi(path, { method = "GET", token, accept, body } = {}) {
 }
 
 function loadAppId() {
-  const fromEnv = process.env.DEVDOCKET_BOT_APP_ID;
-  const raw = fromEnv && fromEnv.trim()
-    ? fromEnv.trim()
-    : existsSync(appIdPath)
-      ? readFileSync(appIdPath, "utf8").trim()
-      : "";
+  const raw = (process.env.DEVDOCKET_BOT_APP_ID ?? "").trim();
   if (!raw) {
     fail(
-      `App ID not found. Set DEVDOCKET_BOT_APP_ID or write the numeric App ID to ${appIdPath}.`,
+      "App ID not found. Export DEVDOCKET_BOT_APP_ID with the numeric GitHub App ID.",
     );
   }
   if (!/^[0-9]+$/.test(raw)) {
@@ -123,12 +114,25 @@ function loadAppId() {
 }
 
 function loadPrivateKey() {
-  if (!existsSync(pemPath)) {
+  let raw = process.env.DEVDOCKET_BOT_APP_PRIVATE_KEY ?? "";
+  if (!raw.trim()) {
     fail(
-      `Private key not found at ${pemPath}. Download the DevDocket bot App's PEM and place it there.`,
+      "Private key not found. Export DEVDOCKET_BOT_APP_PRIVATE_KEY with the GitHub App private key (PEM contents).",
     );
   }
-  return readFileSync(pemPath, "utf8");
+  // Some secret stores (1Password, Vault, CI UIs) deliver multi-line PEMs as a
+  // single line with literal two-character `\n` escapes. createSign().sign()
+  // would then throw an opaque DECODER error. Normalize to real newlines so the
+  // common copy/paste path "just works".
+  if (raw.includes("\\n") && !raw.includes("\n")) {
+    raw = raw.replace(/\\n/g, "\n");
+  }
+  if (!raw.includes("-----BEGIN") || !raw.includes("PRIVATE KEY-----")) {
+    fail(
+      "DEVDOCKET_BOT_APP_PRIVATE_KEY does not look like a PEM-encoded private key (missing BEGIN/END markers).",
+    );
+  }
+  return raw;
 }
 
 function emitEnv(shell, vars) {


### PR DESCRIPTION
## Summary

Refactors `scripts/start-bot-session.mjs` so the DevDocket bot App ID and private key are read **exclusively** from environment variables — no more `keys/` on-disk lookup.

- `DEVDOCKET_BOT_APP_ID` — numeric GitHub App ID (was already supported as an alternative to `keys/devdocket-bot.app-id`; now required).
- `DEVDOCKET_BOT_APP_PRIVATE_KEY` — GitHub App private key, PEM contents (replaces `keys/devdocket-bot.pem`).

These match the existing GitHub Actions repository-secret names used by the bot's workflows (`changesets`, `automated-refactoring`, `weekly-review`, `weekly-performance-review`, `weekly-ux-review`), so a developer can reuse the same values locally.

## Changes

- `scripts/start-bot-session.mjs`
  - Removed `keysDir` / `pemPath` / `appIdPath` constants and the `readFileSync` / `existsSync` filesystem fallbacks.
  - `loadAppId` now requires `DEVDOCKET_BOT_APP_ID` and fails with an actionable message if unset.
  - `loadPrivateKey` now requires `DEVDOCKET_BOT_APP_PRIVATE_KEY`, validates that it looks like a PEM, and auto-normalizes literal `\n` escapes to real newlines (common when copy/pasting from 1Password / Vault / CI secret UIs — without this the script would throw an opaque `DECODER routines::unsupported` error).
- `AGENTS.md` — updated the setup section and "if the bot session cannot be started" troubleshooting paragraph to describe the env-var workflow, including recommended `$(cat key.pem)` / `Get-Content -Raw` export idioms.
- `.gitignore` — removed `keys/`, `*.pem`, and `devdocket-bot.app-id` entries (no longer relevant since the script never touches disk).

## Verification

- `npm run build` ✓
- `npm run test` ✓
- Smoke-tested all failure modes manually:
  - missing `DEVDOCKET_BOT_APP_ID` → clear error
  - missing `DEVDOCKET_BOT_APP_PRIVATE_KEY` → clear error
  - non-PEM `DEVDOCKET_BOT_APP_PRIVATE_KEY` → marker-check error
  - PEM with literal `\n` escapes → normalized, marker check passes
